### PR TITLE
fix p256 => bn254 conversion

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -318,8 +318,6 @@ Symmetric key to derive nullifiers.
 
 `nullifier_pk := Poseidon(nullifier_secret)`
 
-`nullifier_secret` is a 31-byte big-endian value; at 31 bytes it is always `< Fr`, so it is a valid field element by construction. `nullifier_pk`, a 32-byte Poseidon output, must be serialized canonical BN254 (`< Fr`).
-
 **Methods:**
 
 - `nullifier_pk() -> [u8; 32]` — returns `nullifier_pk` (defined above).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -266,22 +266,28 @@ In compressed form the signing and nullifier public keys are compressed in an ow
 
 `CompressedShieldedAddress = (owner_hash, viewing_pk)`
 
-Raw public keys are encoded as 128-bit limbs and absorbed with 2-input Poseidon.
+## Pubkey Field Encoding
+
+A pubkey is encoded into a single BN254 field via nested 2-input Poseidon over 128-bit big-endian limbs. This `pk_field(pk)` is the canonical form used wherever a pubkey appears inside a Poseidon hash anywhere in this spec.
 
 ```
-P256:
-x_hash        = Poseidon(x_low_128, x_high_128)
-parity_x_hash = Poseidon(y_is_odd, x_hash)
-owner_hash    = Poseidon(parity_x_hash, nullifier_pk)
+P256 (33 B SEC1: parity || x_be32):
+  x_hash := Poseidon(x_low_128, x_high_128)
+  pk_field(pk) := Poseidon(y_is_odd, x_hash)
 
-Solana / Ed25519:
-pk_hash    = Poseidon(pk_low_128, pk_high_128)
-owner_hash = Poseidon(pk_hash, nullifier_pk)
+Solana / Ed25519 (32 B):
+  pk_field(pk) := Poseidon(pk_low_128, pk_high_128)
 ```
 
-SPP recomputes the P256 path from the witnessed point and the Solana path from the signer account.
+P256's extra `y_is_odd` layer means the two encodings cannot collide except via Poseidon preimage collision (~2⁻²⁵⁴); no explicit scheme tag is needed.
 
-Wherever a P256 pubkey (e.g. `user_viewing_pk`, `merge_authority_pubkey`) appears as an input to a Poseidon hash elsewhere in this spec, it is absorbed via the same chain: `Poseidon(y_is_odd, Poseidon(x_low_128, x_high_128))`.
+## Owner Hash
+
+```
+owner_hash := Poseidon(pk_field(signing_pk), nullifier_pk)
+```
+
+The proof recomputes `pk_field(signing_pk)` from a witnessed P256 point; for Solana / Ed25519 inputs, SPP supplies it from the verified signer account.
 
 # Signing Key
 
@@ -763,7 +769,7 @@ struct MergeEncryptedUtxo {
 | SolanaPubkeyHash | `Sha256BE(solana_signer)` derived by SPP from `payer` |
 | program_data_hash | instruction data |
 | policy_data_hash | instruction data |
-| solana_pk_hashes (one per input UTXO) | `Poseidon(pk_low_128, pk_high_128)` over the verified Solana signer's pubkey for Solana / Ed25519 inputs; `0` for P256 inputs. SPP derives this from the signer account. |
+| solana_pk_hashes (one per input UTXO) | `pk_field(solana_signer)` (see [Shielded Address](#shielded-address)) for Solana / Ed25519 inputs; `0` for P256 inputs. SPP derives this from the signer account. |
 
 See [UTXO Hash](#utxo-hash) and [Nullifier](#nullifier).
 
@@ -771,7 +777,7 @@ See [UTXO Hash](#utxo-hash) and [Nullifier](#nullifier).
 
 | Input | Description |
 | --- | --- |
-| owner signing key witness | P256 inputs witness canonical `(x, y)` and compressed-key parity. Solana / Ed25519 inputs use the public `solana_pk_hashes[i]`. |
+| owner signing key witness | P256 inputs witness canonical `(x, y)` and compressed-key parity, used to recompute `pk_field(signing_pk)` (see [Shielded Address](#shielded-address)). Solana / Ed25519 inputs use the public `solana_pk_hashes[i]`. |
 | `nullifier_pk` | owner's [Shielded Address](#shielded-address) nullifier commitment, a 32-byte field element |
 | `blinding`, `asset`, `amount`, `program_data_hash`, `policy_data_hash`, `policy_program_id` | UTXO body fields used to recompute `utxo_hash`; `blinding` also feeds the nullifier formula |
 | `utxo_merkle_path` | path proving `utxo_hash` is a leaf of the input's UTXO tree at the corresponding `utxo_tree_root` |
@@ -816,8 +822,8 @@ external_data_hash := Sha256BE(
 
 | Check | Description |
 | --- | --- |
-| Owner hash binding (per input) | The recomputed `owner_hash` (see [Shielded Address](#shielded-address)) must equal the input's `owner`, the value hashed into `utxo_hash` for the inclusion check. P256 inputs rebuild the nested chain (`x_hash → parity_x_hash → owner_hash`) from the witnessed point; Solana inputs use SPP's signer-derived `pk_hash`. |
-| UTXO Ownership | Spent input UTXOs must be authorized by their owner. The per-input `solana_pk_hashes` public input selects the path: `0` → P256 signature by `signing_pk` over `private_tx_hash`, checked by the proof; non-zero → the proof skips the P256 check and binds the input's owner to the signer-derived `pk_hash`, while SPP separately reads `in_utxo_signer_indices` and verifies the named Solana account is a transaction signer. See [UTXO Ownership Check](#utxo-ownership-check). |
+| Owner hash binding (per input) | The recomputed `owner_hash` (see [Shielded Address](#shielded-address)) must equal the input's `owner`, the value hashed into `utxo_hash` for the inclusion check. |
+| UTXO Ownership | Spent input UTXOs must be authorized by their owner. The per-input `solana_pk_hashes` public input selects the path: `0` → P256 signature by `signing_pk` over `private_tx_hash`, checked by the proof; non-zero → the proof skips the P256 check and binds the input's owner to the signer-derived `pk_field`, while SPP separately reads `in_utxo_signer_indices` and verifies the named Solana account is a transaction signer. See [UTXO Ownership Check](#utxo-ownership-check). |
 | Inclusion | Each spent input UTXO must be a leaf of the UTXO tree at its corresponding `utxo_tree_roots[i]`. |
 | Nullifier secret binding (per input) | The recomputed `nullifier_pk` (see [Nullifier Key](#nullifier-key)) must equal each input's `nullifier_pk` witness. Implication: all non-dummy inputs share `nullifier_pk`, and therefore the same owner. |
 | Nullifiers | Public nullifier per input equals the input's [nullifier](#nullifier). |
@@ -830,8 +836,8 @@ external_data_hash := Sha256BE(
 
 <a id="utxo-ownership-check"></a>
 **Utxo Ownership Check:**
-1. P256 signature over `private_tx_hash` verified in the SPP proof; the same point recomputes `parity_x_hash`. The hash covers every input, every output, the external-data hash, and `expiry_unix_ts`, so the proof cannot be replayed with different state.
-2. Ed25519 Solana signer checked by SPP. The non-zero entry in the public `solana_pk_hashes` array tells the circuit to skip the P256 signature check on the input and bind the input's owner to `pk_hash = Poseidon(pk_low_128, pk_high_128)` derived from the signer pubkey; SPP separately reads `in_utxo_signer_indices` from instruction data and verifies the named 32-byte Solana account is a signer of the transaction. The nullifier-secret binding is still checked by the proof for these inputs.
+1. P256 signature over `private_tx_hash` verified in the SPP proof; the same point recomputes `pk_field(signing_pk)` (see [Shielded Address](#shielded-address)). The hash covers every input, every output, the external-data hash, and `expiry_unix_ts`, so the proof cannot be replayed with different state.
+2. Ed25519 Solana signer checked by SPP. The non-zero entry in the public `solana_pk_hashes` array tells the circuit to skip the P256 signature check on the input and bind the input's owner to the SPP-derived `pk_field`; SPP separately reads `in_utxo_signer_indices` from instruction data and verifies the named 32-byte Solana account is a signer of the transaction. The nullifier-secret binding is still checked by the proof for these inputs.
 
 **Circuit Combinations**
 
@@ -874,7 +880,7 @@ ZK proof for [`merge_transact`](#merge_transact). Consolidates `N` input UTXOs o
 
 | Input | Description |
 | --- | --- |
-| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute the nested key chain `(x_hash, parity_x_hash)`. |
+| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity, used to recompute `pk_field(user_signing_pk)` (see [Shielded Address](#shielded-address)). |
 | `user_nullifier_pk` | shared owner's nullifier commitment, a 32-byte field element |
 | `nullifier_secret` | wallet's symmetric nullifier secret; held by the sync delegate that operates this merge service |
 | `user_viewing_pk` | owner's P256 viewing pubkey, bound at enable time via `enable_commitment` |
@@ -972,7 +978,7 @@ ZK proof for [`enable_merge_authority`](#enable_merge_authority). Hides the owne
 
 | Input | Description |
 | --- | --- |
-| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute the nested key chain `(x_hash, parity_x_hash)`. |
+| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity, used to recompute `pk_field(user_signing_pk)` (see [Shielded Address](#shielded-address)). |
 | `user_nullifier_pk` | owner's nullifier commitment, a 32-byte field element |
 | user_viewing_pk | owner's P256 viewing pk |
 | merge_authority_pubkey | merge authority P256 signing pk |
@@ -1003,7 +1009,7 @@ ZK proof for [`disable_merge_authority`](#disable_merge_authority). Symmetric to
 
 | Input | Description |
 | --- | --- |
-| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute the nested key chain `(x_hash, parity_x_hash)`. |
+| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity, used to recompute `pk_field(user_signing_pk)` (see [Shielded Address](#shielded-address)). |
 | `user_nullifier_pk` | owner's nullifier commitment, a 32-byte field element |
 | user_viewing_pk | matches the viewing pk of the enable being revoked |
 | merge_authority_pubkey | merge authority P256 signing pk |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -266,24 +266,16 @@ In compressed form the signing and nullifier public keys are compressed in an ow
 
 `CompressedShieldedAddress = (owner_hash, viewing_pk)`
 
-All Poseidon inputs are canonical BN254 field elements (`< Fr`).
-
-Opaque bytes are mapped with the Light-style convention:
-
-```
-HashToFieldBE(domain, fixed_width_parts...) :=
-    digest = Keccak256(domain || fixed_width_parts... || 0xff)
-    digest[0] = 0
-    digest as 32-byte big-endian field element
-```
-
-Variable-length inputs MUST be length-delimited before `HashToFieldBE`. Setting the high byte to zero is a truncation-to-field convention, not modular reduction.
+All Poseidon inputs are canonical BN254 field elements (`< Fr`). Raw public
+keys are never passed directly as one field element; they are split into
+64-bit big-endian limbs.
 
 ```
-owner_hash = Poseidon(OWNER_HASH_TAG, owner_scheme, owner_key_field, nullifier_pk)
+owner_hash = Poseidon(owner_scheme, key_word_0, key_word_1, key_word_2,
+                      key_word_3, key_word_4, nullifier_pk)
 ```
 
-`OWNER_SCHEME_P256 = 1` for P256 owners; `OWNER_SCHEME_SOLANA = 2` for Solana / Ed25519 owners. `OWNER_HASH_TAG` and `P256_OWNER_KEY_TAG` are fixed domain-separation field constants (concrete values TBD; tracked as a protocol-constants table). They MUST be distinct from each other and from all `DOM_SEP_*`, `ENABLE_TAG`, and `REVOKE_TAG` constants.
+`OWNER_SCHEME_P256 = 1` for P256 owners; `OWNER_SCHEME_SOLANA = 2` for Solana / Ed25519 owners.
 
 For P256 owners:
 
@@ -291,8 +283,9 @@ For P256 owners:
 compressed_signing_pk = SEC1 compressed P256 key: prefix || x_be32
 y_is_odd              = prefix & 1
 x_limb_i              = u64_be(x_be32[8*i .. 8*(i+1)]) for i = 0, 1, 2, 3
-p256_owner_key_field  = Poseidon(P256_OWNER_KEY_TAG, y_is_odd,
-                                  x_limb_0, x_limb_1, x_limb_2, x_limb_3)
+owner_hash            = Poseidon(OWNER_SCHEME_P256, y_is_odd,
+                                 x_limb_0, x_limb_1, x_limb_2, x_limb_3,
+                                 nullifier_pk)
 ```
 
 The proof witnesses the full P256 point `(x, y)`, checks it is canonical and on curve, verifies the signature, derives `y_is_odd`, and recomputes `owner_hash`.
@@ -300,10 +293,16 @@ The proof witnesses the full P256 point `(x, y)`, checks it is canonical and on 
 For Solana / Ed25519 owners:
 
 ```
-solana_owner_key_field = HashToFieldBE("zolana/owner/solana/v1", solana_pubkey)
+solana_limb_i = u64_be(solana_pubkey[8*i .. 8*(i+1)]) for i = 0, 1, 2, 3
+owner_hash    = Poseidon(OWNER_SCHEME_SOLANA, 0,
+                         solana_limb_0, solana_limb_1,
+                         solana_limb_2, solana_limb_3,
+                         nullifier_pk)
 ```
 
-SPP derives `solana_owner_key_field` from the signer account; the proof receives it as a public input bound into `owner_hash`.
+SPP derives `solana_limb_i` from the signer account; the proof receives the
+five Solana owner words `(0, solana_limb_0, ..., solana_limb_3)` as public
+inputs bound into `owner_hash`.
 
 # Signing Key
 
@@ -785,7 +784,7 @@ struct MergeEncryptedUtxo {
 | SolanaPubkeyHash | `Sha256BE(solana_signer)` derived by SPP from `payer` |
 | program_data_hash | instruction data |
 | policy_data_hash | instruction data |
-| solana_owner_key_fields (one per input UTXO) | `HashToFieldBE("zolana/owner/solana/v1", solana_pubkey)` for Solana / Ed25519 inputs; `0` for P256 inputs. SPP derives this from the verified Solana signer. |
+| solana_owner_key_words (five per input UTXO) | `(0, solana_limb_0, solana_limb_1, solana_limb_2, solana_limb_3)` for Solana / Ed25519 inputs; all zero for P256 inputs. SPP derives the limbs from the verified Solana signer. |
 
 See [UTXO Hash](#utxo-hash) and [Nullifier](#nullifier).
 
@@ -793,7 +792,7 @@ See [UTXO Hash](#utxo-hash) and [Nullifier](#nullifier).
 
 | Input | Description |
 | --- | --- |
-| owner signing key witness | P256 inputs witness canonical `(x, y)` and compressed-key parity. Solana / Ed25519 inputs use the public `solana_owner_key_fields[i]`. |
+| owner signing key witness | P256 inputs witness canonical `(x, y)` and compressed-key parity. Solana / Ed25519 inputs use the public `solana_owner_key_words[i]`. |
 | `nullifier_pk` | owner's [Shielded Address](#shielded-address) nullifier commitment, a 32-byte field element |
 | `blinding`, `asset`, `amount`, `program_data_hash`, `policy_data_hash`, `policy_program_id` | UTXO body fields used to recompute `utxo_hash`; `blinding` also feeds the nullifier formula |
 | `utxo_merkle_path` | path proving `utxo_hash` is a leaf of the input's UTXO tree at the corresponding `utxo_tree_root` |
@@ -838,8 +837,8 @@ external_data_hash := Sha256BE(
 
 | Check | Description |
 | --- | --- |
-| Owner hash binding (per input) | The recomputed `owner_hash` (see [Shielded Address](#shielded-address)) must equal the input's `owner`, the value hashed into `utxo_hash` for the inclusion check. P256 inputs recompute `owner_key_field` from the witnessed point; Solana inputs use SPP's signer-derived field. |
-| UTXO Ownership | Spent input UTXOs must be authorized by their owner. The per-input `solana_owner_key_fields` public input selects the path: `0` → P256 signature by `signing_pk` over `private_tx_hash`, checked by the proof; non-zero → the proof skips the P256 check and binds the input's owner to the signer-derived field, while SPP separately reads `in_utxo_signer_indices` and verifies the named Solana account is a transaction signer. See [UTXO Ownership Check](#utxo-ownership-check). |
+| Owner hash binding (per input) | The recomputed `owner_hash` (see [Shielded Address](#shielded-address)) must equal the input's `owner`, the value hashed into `utxo_hash` for the inclusion check. P256 inputs recompute the key words from the witnessed point; Solana inputs use SPP's signer-derived words. |
+| UTXO Ownership | Spent input UTXOs must be authorized by their owner. The per-input `solana_owner_key_words` public input selects the path: all-zero → P256 signature by `signing_pk` over `private_tx_hash`, checked by the proof; non-zero → the proof skips the P256 check and binds the input's owner to the signer-derived words, while SPP separately reads `in_utxo_signer_indices` and verifies the named Solana account is a transaction signer. See [UTXO Ownership Check](#utxo-ownership-check). |
 | Inclusion | Each spent input UTXO must be a leaf of the UTXO tree at its corresponding `utxo_tree_roots[i]`. |
 | Nullifier secret binding (per input) | The recomputed `nullifier_pk` (see [Nullifier Key](#nullifier-key)) must equal each input's `nullifier_pk` witness. Implication: all non-dummy inputs share `nullifier_pk`, and therefore the same owner. |
 | Nullifiers | Public nullifier per input equals the input's [nullifier](#nullifier). |
@@ -852,8 +851,8 @@ external_data_hash := Sha256BE(
 
 <a id="utxo-ownership-check"></a>
 **Utxo Ownership Check:**
-1. P256 signature over `private_tx_hash` verified in the SPP proof; the same point recomputes `p256_owner_key_field`. The hash covers every input, every output, the external-data hash, and `expiry_unix_ts`, so the proof cannot be replayed with different state.
-2. Ed25519 Solana signer checked by SPP. The non-zero entry in the public `solana_owner_key_fields` array tells the circuit to skip the P256 signature check on the input and bind the input's owner to `HashToFieldBE("zolana/owner/solana/v1", solana_pubkey)`; SPP separately reads `in_utxo_signer_indices` from instruction data and verifies the named 32-byte Solana account is a signer of the transaction. The nullifier-secret binding is still checked by the proof for these inputs.
+1. P256 signature over `private_tx_hash` verified in the SPP proof; the same point recomputes `(y_is_odd, x_limb_0, ..., x_limb_3)`. The hash covers every input, every output, the external-data hash, and `expiry_unix_ts`, so the proof cannot be replayed with different state.
+2. Ed25519 Solana signer checked by SPP. The non-zero entry in the public `solana_owner_key_words` array tells the circuit to skip the P256 signature check on the input and bind the input's owner to `(0, solana_limb_0, ..., solana_limb_3)` derived from the signer pubkey; SPP separately reads `in_utxo_signer_indices` from instruction data and verifies the named 32-byte Solana account is a signer of the transaction. The nullifier-secret binding is still checked by the proof for these inputs.
 
 **Circuit Combinations**
 
@@ -896,7 +895,7 @@ ZK proof for [`merge_transact`](#merge_transact). Consolidates `N` input UTXOs o
 
 | Input | Description |
 | --- | --- |
-| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute `p256_owner_key_field`. |
+| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute `(y_is_odd, x_limb_0, ..., x_limb_3)`. |
 | `user_nullifier_pk` | shared owner's nullifier commitment, a 32-byte field element |
 | `nullifier_secret` | wallet's symmetric nullifier secret; held by the sync delegate that operates this merge service |
 | `user_viewing_pk` | owner's P256 viewing pubkey, bound at enable time via `enable_commitment` |
@@ -994,7 +993,7 @@ ZK proof for [`enable_merge_authority`](#enable_merge_authority). Hides the owne
 
 | Input | Description |
 | --- | --- |
-| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute `p256_owner_key_field`. |
+| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute `(y_is_odd, x_limb_0, ..., x_limb_3)`. |
 | `user_nullifier_pk` | owner's nullifier commitment, a 32-byte field element |
 | user_viewing_pk | owner's P256 viewing pk |
 | merge_authority_pubkey | merge authority P256 signing pk |
@@ -1025,7 +1024,7 @@ ZK proof for [`disable_merge_authority`](#disable_merge_authority). Symmetric to
 
 | Input | Description |
 | --- | --- |
-| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute `p256_owner_key_field`. |
+| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute `(y_is_odd, x_limb_0, ..., x_limb_3)`. |
 | `user_nullifier_pk` | owner's nullifier commitment, a 32-byte field element |
 | user_viewing_pk | matches the viewing pk of the enable being revoked |
 | merge_authority_pubkey | merge authority P256 signing pk |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -250,7 +250,7 @@ Type aliases used in the `struct` definitions throughout this spec. Each is defi
 | `Signature` | `[u8; 64]` | A Solana (Ed25519) transaction signature. |
 | `ECDSASignature` | `[u8; 64]` | A P256 ECDSA signature (`r‖s`); authenticates an RPC request under the signer's key. |
 | `SPPProof` | `[u8; 192]` | Compressed Groth16 proof with commitment. |
-| `MergeAuthorityCiphertext` | `[u8; 89]` | AES-256-GCM ciphertext over `MergeAuthorityNotification` (73 B plaintext + 16 B GCM tag). |
+| `MergeAuthorityCiphertext` | `[u8; 122]` | AES-256-GCM ciphertext over `MergeAuthorityNotification` (106 B plaintext + 16 B GCM tag). |
 
 Raw fixed-size byte arrays keep their literal types where no alias adds clarity:
 
@@ -281,6 +281,8 @@ owner_hash = Poseidon(pk_hash, nullifier_pk)
 
 SPP recomputes the P256 path from the witnessed point and the Solana path from the signer account.
 
+Wherever a P256 pubkey (e.g. `user_viewing_pk`, `merge_authority_pubkey`) appears as an input to a Poseidon hash elsewhere in this spec, it is absorbed via the same chain: `Poseidon(y_is_odd, Poseidon(x_low_128, x_high_128))`.
+
 # Signing Key
 
 `(signing_sk, signing_pk)` — the spend-authorizing keypair. P256 for shielded users; Ed25519 for Solana-only owners whose ownership rails through SPP's Ed25519 signer check (see [UTXO Ownership Check](#utxo-ownership-check)).
@@ -306,7 +308,7 @@ Symmetric key to derive nullifiers.
 
 `nullifier_pk := Poseidon(nullifier_secret)`
 
-`nullifier_secret` is a 31-byte big-endian field element. Serialized `nullifier_pk` MUST be canonical BN254 (`< Fr`).
+`nullifier_secret` is a 31-byte big-endian field element. Serialized `nullifier_pk` must be canonical BN254 (`< Fr`).
 
 **Methods:**
 
@@ -1288,10 +1290,15 @@ struct EnableMergeAuthorityIxData {
 }
 
 /// Payload the service decrypts to learn which (user, slot) just enabled it.
-/// Carries the owner components not already visible in the event.
+/// Carries the owner components needed to recompute `owner_hash` and
+/// `enable_commitment`. `user_viewing_pk` is included because
+/// `recipient_bootstrap_view_tag` carries only the 32-byte x-coordinate
+/// (parity dropped), and the service needs the full compressed pubkey to
+/// perform verifiable encryption back to the user during merges.
 struct MergeAuthorityNotification {
     user_signing_pk: P256Pubkey,
     user_nullifier_pk: [u8; 32],
+    user_viewing_pk: P256Pubkey,
     number: u64,
 }
 ```
@@ -2002,7 +2009,7 @@ sequenceDiagram
     Note over Merge,Indexer: Discovery
     Merge->>Indexer: get_merge_authority_events(view_tag = merge_authority_pubkey)
     Indexer-->>Merge: enable event (tx_viewing_pk, ciphertext_authority)
-    Merge->>Merge: decrypt → (user_signing_pk, user_nullifier_pk, number)<br/>read user_viewing_pk from recipient_bootstrap_view_tag<br/>recompute owner_hash and enable_commitment, verify match<br/>add (owner_hash, number) to active set
+    Merge->>Merge: decrypt → (user_signing_pk, user_nullifier_pk, user_viewing_pk, number)<br/>recompute owner_hash and enable_commitment, verify match<br/>add (owner_hash, number) to active set
 
     Note over Wallet,Merge: Per-batch handover
     Wallet->>Wallet: select up to 8 fragmented UTXOs (same owner, same asset)<br/>derive merge_view_tag = get_merge_view_tag(merge_authority_pubkey, merge_count)<br/>advance per-service merge_count

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -318,7 +318,7 @@ Symmetric key to derive nullifiers.
 
 `nullifier_pk := Poseidon(nullifier_secret)`
 
-`nullifier_secret` is a 31-byte big-endian field element. Serialized `nullifier_pk` must be canonical BN254 (`< Fr`).
+`nullifier_secret` is a 31-byte big-endian value; at 31 bytes it is always `< Fr`, so it is a valid field element by construction. `nullifier_pk`, a 32-byte Poseidon output, must be serialized canonical BN254 (`< Fr`).
 
 **Methods:**
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -250,7 +250,7 @@ Type aliases used in the `struct` definitions throughout this spec. Each is defi
 | `Signature` | `[u8; 64]` | A Solana (Ed25519) transaction signature. |
 | `ECDSASignature` | `[u8; 64]` | A P256 ECDSA signature (`r‖s`); authenticates an RPC request under the signer's key. |
 | `SPPProof` | `[u8; 192]` | Compressed Groth16 proof with commitment. |
-| `MergeAuthorityCiphertext` | `[u8; 90]` | AES-256-GCM ciphertext over `MergeAuthorityNotification` (74 B plaintext + 16 B GCM tag). |
+| `MergeAuthorityCiphertext` | `[u8; 122]` | AES-256-GCM ciphertext over `MergeAuthorityNotification` (106 B plaintext + 16 B GCM tag). |
 
 Raw fixed-size byte arrays keep their literal types where no alias adds clarity:
 
@@ -266,7 +266,44 @@ In compressed form the signing and nullifier public keys are compressed in an ow
 
 `CompressedShieldedAddress = (owner_hash, viewing_pk)`
 
-`owner_hash = Poseidon(signing_pk_a, signing_pk_b, nullifier_pk)`
+All Poseidon inputs are canonical BN254 field elements (`< Fr`).
+
+Opaque bytes are mapped with the Light-style convention:
+
+```
+HashToFieldBE(domain, fixed_width_parts...) :=
+    digest = Keccak256(domain || fixed_width_parts... || 0xff)
+    digest[0] = 0
+    digest as 32-byte big-endian field element
+```
+
+Variable-length inputs MUST be length-delimited before `HashToFieldBE`. Setting the high byte to zero is a truncation-to-field convention, not modular reduction.
+
+```
+owner_hash = Poseidon(OWNER_HASH_TAG, owner_scheme, owner_key_field, nullifier_pk)
+```
+
+`OWNER_SCHEME_P256 = 1` for P256 owners; `OWNER_SCHEME_SOLANA = 2` for Solana / Ed25519 owners. `OWNER_HASH_TAG` and `P256_OWNER_KEY_TAG` are fixed domain-separation field constants (concrete values TBD; tracked as a protocol-constants table). They MUST be distinct from each other and from all `DOM_SEP_*`, `ENABLE_TAG`, and `REVOKE_TAG` constants.
+
+For P256 owners:
+
+```
+compressed_signing_pk = SEC1 compressed P256 key: prefix || x_be32
+y_is_odd              = prefix & 1
+x_limb_i              = u64_be(x_be32[8*i .. 8*(i+1)]) for i = 0, 1, 2, 3
+p256_owner_key_field  = Poseidon(P256_OWNER_KEY_TAG, y_is_odd,
+                                  x_limb_0, x_limb_1, x_limb_2, x_limb_3)
+```
+
+The proof witnesses the full P256 point `(x, y)`, checks it is canonical and on curve, verifies the signature, derives `y_is_odd`, and recomputes `owner_hash`.
+
+For Solana / Ed25519 owners:
+
+```
+solana_owner_key_field = HashToFieldBE("zolana/owner/solana/v1", solana_pubkey)
+```
+
+SPP derives `solana_owner_key_field` from the signer account; the proof receives it as a public input bound into `owner_hash`.
 
 # Signing Key
 
@@ -292,6 +329,8 @@ Symmetric key to derive nullifiers.
 `nullifier_secret := HKDF-SHA256(salt=∅, IKM=signing_sk_bytes, info="TSPP/nullifier", L=31)`
 
 `nullifier_pk := Poseidon(nullifier_secret)`
+
+`nullifier_secret` is a 31-byte big-endian integer and is therefore always `< Fr` (since 2²⁴⁸ < Fr). Serialized `nullifier_pk` MUST decode to a canonical BN254 field element (`< Fr`); checking only the top bits is insufficient.
 
 **Methods:**
 
@@ -438,8 +477,7 @@ struct Utxo {
     /// Constant separating UTXOs from other Poseidon-hashed records.
     domain: u16,
     /// Recipient's `owner_hash` from their [Shielded Address](#shielded-address).
-    /// Senders write this value directly; the spender supplies the preimage
-    /// components as proof witness.
+    /// Senders write this 32-byte value directly.
     owner: [u8; 32],
     /// Asset mint. SOL is Address::default().
     asset: Address,
@@ -747,7 +785,7 @@ struct MergeEncryptedUtxo {
 | SolanaPubkeyHash | `Sha256BE(solana_signer)` derived by SPP from `payer` |
 | program_data_hash | instruction data |
 | policy_data_hash | instruction data |
-| solana_owner_pubkeys (one per input UTXO) | `(low, high)` split of the Ed25519 Solana signer pubkey for Ed25519 inputs (SPP looks up the signer via `in_utxo_signer_indices` and confirms it signed the transaction); `(0, 0)` for P256 inputs. The non-zero / zero split serves as the Ed25519 vs P256 selector inside the circuit: P256 entries enable the P256 signature check; Ed25519 entries skip it and instead check `(low, high) == (signing_pk_a, signing_pk_b)` against the corresponding input UTXO — binding the input's owner to a Solana account SPP has verified as a signer. |
+| solana_owner_key_fields (one per input UTXO) | `HashToFieldBE("zolana/owner/solana/v1", solana_pubkey)` for Solana / Ed25519 inputs; `0` for P256 inputs. SPP derives this from the verified Solana signer. |
 
 See [UTXO Hash](#utxo-hash) and [Nullifier](#nullifier).
 
@@ -755,7 +793,7 @@ See [UTXO Hash](#utxo-hash) and [Nullifier](#nullifier).
 
 | Input | Description |
 | --- | --- |
-| `(signing_pk_a, signing_pk_b)` | components of the owner's signing pk in the [Shielded Address](#shielded-address) encoding (P256: `(x, y)`; Ed25519: `(low, high)`) |
+| owner signing key witness | P256 inputs witness canonical `(x, y)` and compressed-key parity. Solana / Ed25519 inputs use the public `solana_owner_key_fields[i]`. |
 | `nullifier_pk` | owner's [Shielded Address](#shielded-address) nullifier commitment, a 32-byte field element |
 | `blinding`, `asset`, `amount`, `program_data_hash`, `policy_data_hash`, `policy_program_id` | UTXO body fields used to recompute `utxo_hash`; `blinding` also feeds the nullifier formula |
 | `utxo_merkle_path` | path proving `utxo_hash` is a leaf of the input's UTXO tree at the corresponding `utxo_tree_root` |
@@ -792,14 +830,16 @@ external_data_hash := Sha256BE(
 )
 ```
 
+`Sha256BE` in field context means SHA-256 over the byte preimage, then `digest[0] = 0`, interpreted as a BN254 field element.
+
 `spp_instruction_discriminator` is the SPP discriminator byte of the instruction whose handler runs the proof verification (see [Instructions](#instructions)). SPP recomputes this value from the dispatched instruction and checks the proof's `external_data_hash` against it.
 
 **Checks**
 
 | Check | Description |
 | --- | --- |
-| Owner hash binding (per input) | The recomputed `owner_hash` (see [Shielded Address](#shielded-address)) must equal the input's `owner`, the value hashed into `utxo_hash` for the inclusion check. |
-| UTXO Ownership | Spent input UTXOs must be authorized by their owner. The per-input `solana_owner_pubkeys` public input selects the path: `(0, 0)` → P256 signature by `signing_pk` over `private_tx_hash`, checked by the proof; non-zero → the proof skips the P256 check and instead checks `(low, high) == (signing_pk_a, signing_pk_b)`, while SPP separately reads `in_utxo_signer_indices` and verifies the named Solana account is a transaction signer. See [UTXO Ownership Check](#utxo-ownership-check). |
+| Owner hash binding (per input) | The recomputed `owner_hash` (see [Shielded Address](#shielded-address)) must equal the input's `owner`, the value hashed into `utxo_hash` for the inclusion check. P256 inputs recompute `owner_key_field` from the witnessed point; Solana inputs use SPP's signer-derived field. |
+| UTXO Ownership | Spent input UTXOs must be authorized by their owner. The per-input `solana_owner_key_fields` public input selects the path: `0` → P256 signature by `signing_pk` over `private_tx_hash`, checked by the proof; non-zero → the proof skips the P256 check and binds the input's owner to the signer-derived field, while SPP separately reads `in_utxo_signer_indices` and verifies the named Solana account is a transaction signer. See [UTXO Ownership Check](#utxo-ownership-check). |
 | Inclusion | Each spent input UTXO must be a leaf of the UTXO tree at its corresponding `utxo_tree_roots[i]`. |
 | Nullifier secret binding (per input) | The recomputed `nullifier_pk` (see [Nullifier Key](#nullifier-key)) must equal each input's `nullifier_pk` witness. Implication: all non-dummy inputs share `nullifier_pk`, and therefore the same owner. |
 | Nullifiers | Public nullifier per input equals the input's [nullifier](#nullifier). |
@@ -812,8 +852,8 @@ external_data_hash := Sha256BE(
 
 <a id="utxo-ownership-check"></a>
 **Utxo Ownership Check:**
-1. P256 signature over `private_tx_hash` verified in the SPP proof. The hash covers every input, every output, the external-data hash, and `expiry_unix_ts`, so the proof cannot be replayed with different state.
-2. Ed25519 Solana signer checked by SPP. The non-zero entry in the public `solana_owner_pubkeys` array tells the circuit to skip the P256 signature check on the input and check the input's owner against the named pubkey; SPP separately reads `in_utxo_signer_indices` from instruction data and verifies the named 32-byte Solana account is a signer of the transaction. The nullifier-secret binding is still checked by the proof for these inputs.
+1. P256 signature over `private_tx_hash` verified in the SPP proof; the same point recomputes `p256_owner_key_field`. The hash covers every input, every output, the external-data hash, and `expiry_unix_ts`, so the proof cannot be replayed with different state.
+2. Ed25519 Solana signer checked by SPP. The non-zero entry in the public `solana_owner_key_fields` array tells the circuit to skip the P256 signature check on the input and bind the input's owner to `HashToFieldBE("zolana/owner/solana/v1", solana_pubkey)`; SPP separately reads `in_utxo_signer_indices` from instruction data and verifies the named 32-byte Solana account is a signer of the transaction. The nullifier-secret binding is still checked by the proof for these inputs.
 
 **Circuit Combinations**
 
@@ -856,7 +896,7 @@ ZK proof for [`merge_transact`](#merge_transact). Consolidates `N` input UTXOs o
 
 | Input | Description |
 | --- | --- |
-| `(user_signing_pk_a, user_signing_pk_b)` | components of the shared owner's P256 signing pk in the [Shielded Address](#shielded-address) encoding (P256 only — Solana / Ed25519 owners are out of scope for merge services) |
+| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute `p256_owner_key_field`. |
 | `user_nullifier_pk` | shared owner's nullifier commitment, a 32-byte field element |
 | `nullifier_secret` | wallet's symmetric nullifier secret; held by the sync delegate that operates this merge service |
 | `user_viewing_pk` | owner's P256 viewing pubkey, bound at enable time via `enable_commitment` |
@@ -878,7 +918,7 @@ ZK proof for [`merge_transact`](#merge_transact). Consolidates `N` input UTXOs o
 
 | Check | Description |
 | --- | --- |
-| Owner hash binding | `user_owner_hash` (see [Shielded Address](#shielded-address)) is recomputed by the proof from witness. |
+| Owner hash binding | `user_owner_hash` (see [Shielded Address](#shielded-address)) is recomputed by the proof from the witnessed P256 point. |
 | Ownership uniformity | Every input UTXO's `owner` equals `user_owner_hash`. |
 | Asset uniformity | Every input UTXO's `asset` equals the output's `asset`. |
 | Value conservation | `sum(inputs.amount) == output.amount`. |
@@ -954,7 +994,7 @@ ZK proof for [`enable_merge_authority`](#enable_merge_authority). Hides the owne
 
 | Input | Description |
 | --- | --- |
-| `(user_signing_pk_a, user_signing_pk_b)` | components of owner's P256 signing pk in the [Shielded Address](#shielded-address) encoding |
+| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute `p256_owner_key_field`. |
 | `user_nullifier_pk` | owner's nullifier commitment, a 32-byte field element |
 | user_viewing_pk | owner's P256 viewing pk |
 | merge_authority_pubkey | merge authority P256 signing pk |
@@ -965,7 +1005,7 @@ ZK proof for [`enable_merge_authority`](#enable_merge_authority). Hides the owne
 
 | Check | Description |
 | --- | --- |
-| Owner hash binding | `owner_hash` recomputed from the witness components; see [Shielded Address](#shielded-address). |
+| Owner hash binding | `owner_hash` recomputed from the witnessed P256 point; see [Shielded Address](#shielded-address). |
 | Commitment | `enable_commitment == Poseidon(ENABLE_TAG, owner_hash, user_viewing_pk, merge_authority_pubkey, number)`. |
 | User signature | P256 signature by `user_signing_pk` over the canonical pre-image verifies. Without this check anyone could insert commitments for an arbitrary owner. |
 
@@ -985,7 +1025,7 @@ ZK proof for [`disable_merge_authority`](#disable_merge_authority). Symmetric to
 
 | Input | Description |
 | --- | --- |
-| `(user_signing_pk_a, user_signing_pk_b)` | components of owner's P256 signing pk |
+| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute `p256_owner_key_field`. |
 | `user_nullifier_pk` | owner's nullifier commitment, a 32-byte field element |
 | user_viewing_pk | matches the viewing pk of the enable being revoked |
 | merge_authority_pubkey | merge authority P256 signing pk |
@@ -996,7 +1036,7 @@ ZK proof for [`disable_merge_authority`](#disable_merge_authority). Symmetric to
 
 | Check | Description |
 | --- | --- |
-| Owner hash binding | `owner_hash` recomputed from the witness components; see [Shielded Address](#shielded-address). |
+| Owner hash binding | `owner_hash` recomputed from the witnessed P256 point; see [Shielded Address](#shielded-address). |
 | Commitment | `revoke_commitment == Poseidon(REVOKE_TAG, owner_hash, user_viewing_pk, merge_authority_pubkey, number)`. |
 | User signature | P256 signature verifies, same rationale as the Enable Proof. |
 
@@ -1274,11 +1314,8 @@ struct EnableMergeAuthorityIxData {
 /// Payload the service decrypts to learn which (user, slot) just enabled it.
 /// Carries the components of the user's [Shielded Address](#shielded-address)
 /// so the merge service can recompute `owner_hash` for the merge proof witness.
-/// 74 B plaintext → 90 B ciphertext (after the 16-byte GCM tag); the size of
-/// the `ciphertext_authority` and `ciphertext_bootstrap` slots below.
 struct MergeAuthorityNotification {
-    user_signing_pk_a: [u8; 32],
-    user_signing_pk_b: [u8; 32],
+    user_signing_pk: P256Pubkey,
     user_nullifier_pk: [u8; 32],
     user_viewing_pk: P256Pubkey,
     number: u64,
@@ -1808,7 +1845,7 @@ struct GetRecordResponse {
 
 #### `register`
 
-Creates a record with the given owner P-256 pubkey (optional), nullifier pubkey, and viewing pubkey, no delegate, and no entries. Fails if a record for `owner` already exists. Registry rejects `nullifier_pk` whose top two bits are non-zero.
+Creates a record with the given owner P-256 pubkey (optional), nullifier pubkey, and viewing pubkey, no delegate, and no entries. Fails if a record for `owner` already exists. Registry rejects non-canonical `nullifier_pk` values (`>= Fr`).
 
 Authorized signer: `owner`.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -266,26 +266,18 @@ In compressed form the signing and nullifier public keys are compressed in an ow
 
 `CompressedShieldedAddress = (owner_hash, viewing_pk)`
 
-All Poseidon inputs are canonical BN254 field elements (`< Fr`). Raw public
-keys are never passed directly as one field element; they are split into
-64-bit big-endian limbs.
+All Poseidon inputs are canonical BN254 field elements (`< Fr`). Raw public keys are split into two 128-bit big-endian halves and absorbed by nested 2-input Poseidons (t=3), matching Light's Poseidon gadget set.
 
-```
-owner_hash = Poseidon(owner_scheme, key_word_0, key_word_1, key_word_2,
-                      key_word_3, key_word_4, nullifier_pk)
-```
-
-`OWNER_SCHEME_P256 = 1` for P256 owners; `OWNER_SCHEME_SOLANA = 2` for Solana / Ed25519 owners.
-
-For P256 owners:
+For P256 owners (SEC1-compressed: parity bit + `x`):
 
 ```
 compressed_signing_pk = SEC1 compressed P256 key: prefix || x_be32
 y_is_odd              = prefix & 1
-x_limb_i              = u64_be(x_be32[8*i .. 8*(i+1)]) for i = 0, 1, 2, 3
-owner_hash            = Poseidon(OWNER_SCHEME_P256, y_is_odd,
-                                 x_limb_0, x_limb_1, x_limb_2, x_limb_3,
-                                 nullifier_pk)
+x_low                 = u128_be(x_be32[0..16])
+x_high                = u128_be(x_be32[16..32])
+x_hash                = Poseidon(x_low, x_high)
+parity_x_hash         = Poseidon(y_is_odd, x_hash)
+owner_hash            = Poseidon(parity_x_hash, nullifier_pk)
 ```
 
 The proof witnesses the full P256 point `(x, y)`, checks it is canonical and on curve, verifies the signature, derives `y_is_odd`, and recomputes `owner_hash`.
@@ -293,16 +285,15 @@ The proof witnesses the full P256 point `(x, y)`, checks it is canonical and on 
 For Solana / Ed25519 owners:
 
 ```
-solana_limb_i = u64_be(solana_pubkey[8*i .. 8*(i+1)]) for i = 0, 1, 2, 3
-owner_hash    = Poseidon(OWNER_SCHEME_SOLANA, 0,
-                         solana_limb_0, solana_limb_1,
-                         solana_limb_2, solana_limb_3,
-                         nullifier_pk)
+pk_low     = u128_be(solana_pubkey[0..16])
+pk_high    = u128_be(solana_pubkey[16..32])
+pk_hash    = Poseidon(pk_low, pk_high)
+owner_hash = Poseidon(pk_hash, nullifier_pk)
 ```
 
-SPP derives `solana_limb_i` from the signer account; the proof receives the
-five Solana owner words `(0, solana_limb_0, ..., solana_limb_3)` as public
-inputs bound into `owner_hash`.
+SPP derives `(pk_low, pk_high)` from the signer account; the proof receives `pk_hash` as a public input bound into `owner_hash`.
+
+Scheme separation: a P256 owner's chain folds in an extra `parity_x_hash` layer that Solana's chain does not, so the two encodings cannot collide except via a Poseidon preimage collision (~2⁻²⁵⁴). No explicit scheme tag is needed.
 
 # Signing Key
 
@@ -784,7 +775,7 @@ struct MergeEncryptedUtxo {
 | SolanaPubkeyHash | `Sha256BE(solana_signer)` derived by SPP from `payer` |
 | program_data_hash | instruction data |
 | policy_data_hash | instruction data |
-| solana_owner_key_words (five per input UTXO) | `(0, solana_limb_0, solana_limb_1, solana_limb_2, solana_limb_3)` for Solana / Ed25519 inputs; all zero for P256 inputs. SPP derives the limbs from the verified Solana signer. |
+| solana_pk_hashes (one per input UTXO) | `Poseidon(pk_low_128, pk_high_128)` over the verified Solana signer's pubkey for Solana / Ed25519 inputs; `0` for P256 inputs. SPP derives this from the signer account. |
 
 See [UTXO Hash](#utxo-hash) and [Nullifier](#nullifier).
 
@@ -792,7 +783,7 @@ See [UTXO Hash](#utxo-hash) and [Nullifier](#nullifier).
 
 | Input | Description |
 | --- | --- |
-| owner signing key witness | P256 inputs witness canonical `(x, y)` and compressed-key parity. Solana / Ed25519 inputs use the public `solana_owner_key_words[i]`. |
+| owner signing key witness | P256 inputs witness canonical `(x, y)` and compressed-key parity. Solana / Ed25519 inputs use the public `solana_pk_hashes[i]`. |
 | `nullifier_pk` | owner's [Shielded Address](#shielded-address) nullifier commitment, a 32-byte field element |
 | `blinding`, `asset`, `amount`, `program_data_hash`, `policy_data_hash`, `policy_program_id` | UTXO body fields used to recompute `utxo_hash`; `blinding` also feeds the nullifier formula |
 | `utxo_merkle_path` | path proving `utxo_hash` is a leaf of the input's UTXO tree at the corresponding `utxo_tree_root` |
@@ -837,8 +828,8 @@ external_data_hash := Sha256BE(
 
 | Check | Description |
 | --- | --- |
-| Owner hash binding (per input) | The recomputed `owner_hash` (see [Shielded Address](#shielded-address)) must equal the input's `owner`, the value hashed into `utxo_hash` for the inclusion check. P256 inputs recompute the key words from the witnessed point; Solana inputs use SPP's signer-derived words. |
-| UTXO Ownership | Spent input UTXOs must be authorized by their owner. The per-input `solana_owner_key_words` public input selects the path: all-zero → P256 signature by `signing_pk` over `private_tx_hash`, checked by the proof; non-zero → the proof skips the P256 check and binds the input's owner to the signer-derived words, while SPP separately reads `in_utxo_signer_indices` and verifies the named Solana account is a transaction signer. See [UTXO Ownership Check](#utxo-ownership-check). |
+| Owner hash binding (per input) | The recomputed `owner_hash` (see [Shielded Address](#shielded-address)) must equal the input's `owner`, the value hashed into `utxo_hash` for the inclusion check. P256 inputs rebuild the nested chain (`x_hash → parity_x_hash → owner_hash`) from the witnessed point; Solana inputs use SPP's signer-derived `pk_hash`. |
+| UTXO Ownership | Spent input UTXOs must be authorized by their owner. The per-input `solana_pk_hashes` public input selects the path: `0` → P256 signature by `signing_pk` over `private_tx_hash`, checked by the proof; non-zero → the proof skips the P256 check and binds the input's owner to the signer-derived `pk_hash`, while SPP separately reads `in_utxo_signer_indices` and verifies the named Solana account is a transaction signer. See [UTXO Ownership Check](#utxo-ownership-check). |
 | Inclusion | Each spent input UTXO must be a leaf of the UTXO tree at its corresponding `utxo_tree_roots[i]`. |
 | Nullifier secret binding (per input) | The recomputed `nullifier_pk` (see [Nullifier Key](#nullifier-key)) must equal each input's `nullifier_pk` witness. Implication: all non-dummy inputs share `nullifier_pk`, and therefore the same owner. |
 | Nullifiers | Public nullifier per input equals the input's [nullifier](#nullifier). |
@@ -851,8 +842,8 @@ external_data_hash := Sha256BE(
 
 <a id="utxo-ownership-check"></a>
 **Utxo Ownership Check:**
-1. P256 signature over `private_tx_hash` verified in the SPP proof; the same point recomputes `(y_is_odd, x_limb_0, ..., x_limb_3)`. The hash covers every input, every output, the external-data hash, and `expiry_unix_ts`, so the proof cannot be replayed with different state.
-2. Ed25519 Solana signer checked by SPP. The non-zero entry in the public `solana_owner_key_words` array tells the circuit to skip the P256 signature check on the input and bind the input's owner to `(0, solana_limb_0, ..., solana_limb_3)` derived from the signer pubkey; SPP separately reads `in_utxo_signer_indices` from instruction data and verifies the named 32-byte Solana account is a signer of the transaction. The nullifier-secret binding is still checked by the proof for these inputs.
+1. P256 signature over `private_tx_hash` verified in the SPP proof; the same point recomputes `parity_x_hash`. The hash covers every input, every output, the external-data hash, and `expiry_unix_ts`, so the proof cannot be replayed with different state.
+2. Ed25519 Solana signer checked by SPP. The non-zero entry in the public `solana_pk_hashes` array tells the circuit to skip the P256 signature check on the input and bind the input's owner to `pk_hash = Poseidon(pk_low_128, pk_high_128)` derived from the signer pubkey; SPP separately reads `in_utxo_signer_indices` from instruction data and verifies the named 32-byte Solana account is a signer of the transaction. The nullifier-secret binding is still checked by the proof for these inputs.
 
 **Circuit Combinations**
 
@@ -895,7 +886,7 @@ ZK proof for [`merge_transact`](#merge_transact). Consolidates `N` input UTXOs o
 
 | Input | Description |
 | --- | --- |
-| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute `(y_is_odd, x_limb_0, ..., x_limb_3)`. |
+| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute the nested key chain `(x_hash, parity_x_hash)`. |
 | `user_nullifier_pk` | shared owner's nullifier commitment, a 32-byte field element |
 | `nullifier_secret` | wallet's symmetric nullifier secret; held by the sync delegate that operates this merge service |
 | `user_viewing_pk` | owner's P256 viewing pubkey, bound at enable time via `enable_commitment` |
@@ -993,7 +984,7 @@ ZK proof for [`enable_merge_authority`](#enable_merge_authority). Hides the owne
 
 | Input | Description |
 | --- | --- |
-| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute `(y_is_odd, x_limb_0, ..., x_limb_3)`. |
+| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute the nested key chain `(x_hash, parity_x_hash)`. |
 | `user_nullifier_pk` | owner's nullifier commitment, a 32-byte field element |
 | user_viewing_pk | owner's P256 viewing pk |
 | merge_authority_pubkey | merge authority P256 signing pk |
@@ -1024,7 +1015,7 @@ ZK proof for [`disable_merge_authority`](#disable_merge_authority). Symmetric to
 
 | Input | Description |
 | --- | --- |
-| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute `(y_is_odd, x_limb_0, ..., x_limb_3)`. |
+| user P256 signing key witness | Canonical P256 point `(x, y)` and compressed-key parity used to recompute the nested key chain `(x_hash, parity_x_hash)`. |
 | `user_nullifier_pk` | owner's nullifier commitment, a 32-byte field element |
 | user_viewing_pk | matches the viewing pk of the enable being revoked |
 | merge_authority_pubkey | merge authority P256 signing pk |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -257,6 +257,10 @@ Raw fixed-size byte arrays keep their literal types where no alias adds clarity:
 - `[u8; 32]` — a 32-byte value: a Poseidon or SHA-256 digest, a BN254 field element, or a view tag.
 - `[u8; 31]` — a blinding factor (held below the BN254 field modulus).
 
+Hashing conventions:
+
+- `Sha256BE` — SHA-256 over the byte preimage, then `digest[0] = 0`, interpreted as a BN254 field element. Zeroing the most-significant byte holds the result below the BN254 field modulus.
+
 # Shielded Address
 
 A shielded address consists of the signing public key, signs to spend UTXOs, the nullifier public key, ties the nullifier to a spent UTXO, and the viewing public key, encrypts the UTXO.
@@ -813,8 +817,6 @@ external_data_hash := Sha256BE(
     encrypted_utxos
 )
 ```
-
-`Sha256BE` in field context means SHA-256 over the byte preimage, then `digest[0] = 0`, interpreted as a BN254 field element.
 
 `spp_instruction_discriminator` is the SPP discriminator byte of the instruction whose handler runs the proof verification (see [Instructions](#instructions)). SPP recomputes this value from the dispatched instruction and checks the proof's `external_data_hash` against it.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -250,7 +250,7 @@ Type aliases used in the `struct` definitions throughout this spec. Each is defi
 | `Signature` | `[u8; 64]` | A Solana (Ed25519) transaction signature. |
 | `ECDSASignature` | `[u8; 64]` | A P256 ECDSA signature (`r‖s`); authenticates an RPC request under the signer's key. |
 | `SPPProof` | `[u8; 192]` | Compressed Groth16 proof with commitment. |
-| `MergeAuthorityCiphertext` | `[u8; 122]` | AES-256-GCM ciphertext over `MergeAuthorityNotification` (106 B plaintext + 16 B GCM tag). |
+| `MergeAuthorityCiphertext` | `[u8; 89]` | AES-256-GCM ciphertext over `MergeAuthorityNotification` (73 B plaintext + 16 B GCM tag). |
 
 Raw fixed-size byte arrays keep their literal types where no alias adds clarity:
 
@@ -266,34 +266,20 @@ In compressed form the signing and nullifier public keys are compressed in an ow
 
 `CompressedShieldedAddress = (owner_hash, viewing_pk)`
 
-All Poseidon inputs are canonical BN254 field elements (`< Fr`). Raw public keys are split into two 128-bit big-endian halves and absorbed by nested 2-input Poseidons (t=3), matching Light's Poseidon gadget set.
-
-For P256 owners (SEC1-compressed: parity bit + `x`):
+Raw public keys are encoded as 128-bit limbs and absorbed with 2-input Poseidon.
 
 ```
-compressed_signing_pk = SEC1 compressed P256 key: prefix || x_be32
-y_is_odd              = prefix & 1
-x_low                 = u128_be(x_be32[0..16])
-x_high                = u128_be(x_be32[16..32])
-x_hash                = Poseidon(x_low, x_high)
-parity_x_hash         = Poseidon(y_is_odd, x_hash)
-owner_hash            = Poseidon(parity_x_hash, nullifier_pk)
-```
+P256:
+x_hash        = Poseidon(x_low_128, x_high_128)
+parity_x_hash = Poseidon(y_is_odd, x_hash)
+owner_hash    = Poseidon(parity_x_hash, nullifier_pk)
 
-The proof witnesses the full P256 point `(x, y)`, checks it is canonical and on curve, verifies the signature, derives `y_is_odd`, and recomputes `owner_hash`.
-
-For Solana / Ed25519 owners:
-
-```
-pk_low     = u128_be(solana_pubkey[0..16])
-pk_high    = u128_be(solana_pubkey[16..32])
-pk_hash    = Poseidon(pk_low, pk_high)
+Solana / Ed25519:
+pk_hash    = Poseidon(pk_low_128, pk_high_128)
 owner_hash = Poseidon(pk_hash, nullifier_pk)
 ```
 
-SPP derives `(pk_low, pk_high)` from the signer account; the proof receives `pk_hash` as a public input bound into `owner_hash`.
-
-Scheme separation: a P256 owner's chain folds in an extra `parity_x_hash` layer that Solana's chain does not, so the two encodings cannot collide except via a Poseidon preimage collision (~2⁻²⁵⁴). No explicit scheme tag is needed.
+SPP recomputes the P256 path from the witnessed point and the Solana path from the signer account.
 
 # Signing Key
 
@@ -320,7 +306,7 @@ Symmetric key to derive nullifiers.
 
 `nullifier_pk := Poseidon(nullifier_secret)`
 
-`nullifier_secret` is a 31-byte big-endian integer and is therefore always `< Fr` (since 2²⁴⁸ < Fr). Serialized `nullifier_pk` MUST decode to a canonical BN254 field element (`< Fr`); checking only the top bits is insufficient.
+`nullifier_secret` is a 31-byte big-endian field element. Serialized `nullifier_pk` MUST be canonical BN254 (`< Fr`).
 
 **Methods:**
 
@@ -1302,12 +1288,10 @@ struct EnableMergeAuthorityIxData {
 }
 
 /// Payload the service decrypts to learn which (user, slot) just enabled it.
-/// Carries the components of the user's [Shielded Address](#shielded-address)
-/// so the merge service can recompute `owner_hash` for the merge proof witness.
+/// Carries the owner components not already visible in the event.
 struct MergeAuthorityNotification {
     user_signing_pk: P256Pubkey,
     user_nullifier_pk: [u8; 32],
-    user_viewing_pk: P256Pubkey,
     number: u64,
 }
 ```
@@ -2018,7 +2002,7 @@ sequenceDiagram
     Note over Merge,Indexer: Discovery
     Merge->>Indexer: get_merge_authority_events(view_tag = merge_authority_pubkey)
     Indexer-->>Merge: enable event (tx_viewing_pk, ciphertext_authority)
-    Merge->>Merge: decrypt → (user_signing_pk, user_nullifier_pk, user_viewing_pk, number)<br/>recompute owner_hash and enable_commitment, verify match<br/>add (owner_hash, number) to active set
+    Merge->>Merge: decrypt → (user_signing_pk, user_nullifier_pk, number)<br/>read user_viewing_pk from recipient_bootstrap_view_tag<br/>recompute owner_hash and enable_commitment, verify match<br/>add (owner_hash, number) to active set
 
     Note over Wallet,Merge: Per-batch handover
     Wallet->>Wallet: select up to 8 fragmented UTXOs (same owner, same asset)<br/>derive merge_view_tag = get_merge_view_tag(merge_authority_pubkey, merge_count)<br/>advance per-service merge_count


### PR DESCRIPTION
P256/Solana pubkeys are raw 32-byte values and cannot be passed directly into BN254 Poseidon. This updates the spec to use canonical hash-to-field encoding for opaque keys, binds P256 signatures to the derived owner key field, and requires nullifier_pk to be a canonical BN254 field element.