### PR TITLE
Add SPP program e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,6 +1980,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "light-account-checks"
 version = "0.8.0"
-source = "git+https://github.com/helius-labs/privacy-program-libs?branch=main#eecd83af918f0935875612d716213952a50d7475"
+source = "git+https://github.com/helius-labs/privacy-program-libs?rev=eecd83af918f0935875612d716213952a50d7475#eecd83af918f0935875612d716213952a50d7475"
 dependencies = [
  "pinocchio 0.10.2",
  "pinocchio-system 0.5.0",
@@ -2521,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "light-batched-merkle-tree"
 version = "0.11.0"
-source = "git+https://github.com/helius-labs/privacy-program-libs?branch=main#eecd83af918f0935875612d716213952a50d7475"
+source = "git+https://github.com/helius-labs/privacy-program-libs?rev=eecd83af918f0935875612d716213952a50d7475#eecd83af918f0935875612d716213952a50d7475"
 dependencies = [
  "aligned-sized",
  "borsh",
@@ -2545,7 +2551,7 @@ dependencies = [
 [[package]]
 name = "light-bloom-filter"
 version = "0.6.0"
-source = "git+https://github.com/helius-labs/privacy-program-libs?branch=main#eecd83af918f0935875612d716213952a50d7475"
+source = "git+https://github.com/helius-labs/privacy-program-libs?rev=eecd83af918f0935875612d716213952a50d7475#eecd83af918f0935875612d716213952a50d7475"
 dependencies = [
  "bitvec",
  "num-bigint 0.4.6",
@@ -2557,7 +2563,7 @@ dependencies = [
 [[package]]
 name = "light-compressed-account"
 version = "0.11.0"
-source = "git+https://github.com/helius-labs/privacy-program-libs?branch=main#eecd83af918f0935875612d716213952a50d7475"
+source = "git+https://github.com/helius-labs/privacy-program-libs?rev=eecd83af918f0935875612d716213952a50d7475#eecd83af918f0935875612d716213952a50d7475"
 dependencies = [
  "borsh",
  "light-hasher",
@@ -2573,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "light-hasher"
 version = "5.0.0"
-source = "git+https://github.com/helius-labs/privacy-program-libs?branch=main#eecd83af918f0935875612d716213952a50d7475"
+source = "git+https://github.com/helius-labs/privacy-program-libs?rev=eecd83af918f0935875612d716213952a50d7475#eecd83af918f0935875612d716213952a50d7475"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
@@ -2590,7 +2596,7 @@ dependencies = [
 [[package]]
 name = "light-indexed-array"
 version = "0.3.0"
-source = "git+https://github.com/helius-labs/privacy-program-libs?branch=main#eecd83af918f0935875612d716213952a50d7475"
+source = "git+https://github.com/helius-labs/privacy-program-libs?rev=eecd83af918f0935875612d716213952a50d7475#eecd83af918f0935875612d716213952a50d7475"
 dependencies = [
  "light-hasher",
  "num-bigint 0.4.6",
@@ -2601,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "light-macros"
 version = "2.2.0"
-source = "git+https://github.com/helius-labs/privacy-program-libs?branch=main#eecd83af918f0935875612d716213952a50d7475"
+source = "git+https://github.com/helius-labs/privacy-program-libs?rev=eecd83af918f0935875612d716213952a50d7475#eecd83af918f0935875612d716213952a50d7475"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2613,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "light-merkle-tree-metadata"
 version = "0.11.0"
-source = "git+https://github.com/helius-labs/privacy-program-libs?branch=main#eecd83af918f0935875612d716213952a50d7475"
+source = "git+https://github.com/helius-labs/privacy-program-libs?rev=eecd83af918f0935875612d716213952a50d7475#eecd83af918f0935875612d716213952a50d7475"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2626,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "light-merkle-tree-reference"
 version = "4.0.0"
-source = "git+https://github.com/helius-labs/privacy-program-libs?branch=main#eecd83af918f0935875612d716213952a50d7475"
+source = "git+https://github.com/helius-labs/privacy-program-libs?rev=eecd83af918f0935875612d716213952a50d7475#eecd83af918f0935875612d716213952a50d7475"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -2691,6 +2697,7 @@ dependencies = [
  "pinocchio 0.11.1",
  "serial_test",
  "shielded-pool-program",
+ "solana-compute-budget-interface",
  "solana-instruction",
  "solana-keypair",
  "solana-message 3.1.0",
@@ -2755,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "light-verifier"
 version = "10.0.0"
-source = "git+https://github.com/helius-labs/privacy-program-libs?branch=main#eecd83af918f0935875612d716213952a50d7475"
+source = "git+https://github.com/helius-labs/privacy-program-libs?rev=eecd83af918f0935875612d716213952a50d7475#eecd83af918f0935875612d716213952a50d7475"
 dependencies = [
  "groth16-solana 0.2.0 (git+https://github.com/Lightprotocol/groth16-solana?rev=4e6cacff2f4ff53744fda0509f5e62545fd99aa6)",
  "light-compressed-account",
@@ -2787,7 +2794,7 @@ dependencies = [
 [[package]]
 name = "light-zero-copy-vec"
 version = "0.1.0"
-source = "git+https://github.com/helius-labs/privacy-program-libs?branch=main#eecd83af918f0935875612d716213952a50d7475"
+source = "git+https://github.com/helius-labs/privacy-program-libs?rev=eecd83af918f0935875612d716213952a50d7475#eecd83af918f0935875612d716213952a50d7475"
 dependencies = [
  "solana-program-error",
  "wincode",
@@ -4124,8 +4131,26 @@ dependencies = [
 name = "shielded-pool-tests"
 version = "0.1.0"
 dependencies = [
- "pinocchio 0.10.2",
+ "groth16-solana 0.2.0 (git+https://github.com/Lightprotocol/groth16-solana?rev=b374683cd0139b9e8cd8c148b08cc1e22e8ace02)",
+ "hex",
+ "light-batched-merkle-tree",
+ "light-hasher",
+ "light-program-test",
+ "light-prover-client",
+ "light-sparse-merkle-tree",
+ "light-verifier",
+ "pinocchio 0.11.1",
+ "serde",
+ "serde_json",
  "shielded-pool-program",
+ "solana-account 3.4.0",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-program-pack",
+ "solana-pubkey 4.2.0",
+ "solana-signer",
+ "solana-system-interface 3.2.0",
+ "spl-token",
  "zolana-interface",
 ]
 
@@ -6333,6 +6358,34 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-zero-copy",
  "solana-zk-sdk",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "spl-token"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878b0183d51fcd8a53e1604f4c13321894cf53227e6773c529b0d03d499a8dfd"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-account-info",
+ "solana-cpi",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-rent 3.1.0",
+ "solana-sdk-ids",
+ "solana-sysvar 3.1.1",
+ "spl-token-interface",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,17 +36,17 @@ light-registry = { path = "programs/registry", version = "2.1.0", features = ["c
 # Published Light Protocol crates.
 aligned-sized = "1.1.0"
 light-array-map = "0.2.0"
-light-account-checks = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main", version = "0.8.0", default-features = false }
-light-batched-merkle-tree = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main", version = "0.11.0", default-features = false }
-light-bloom-filter = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main", version = "0.6.0" }
-light-hasher = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main", version = "5.0.0", default-features = false }
-light-indexed-array = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main", version = "0.3.0" }
-light-macros = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main", version = "2.2.0" }
-light-merkle-tree-metadata = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main", version = "0.11.0" }
-light-merkle-tree-reference = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main", version = "4.0.0" }
+light-account-checks = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475", version = "0.8.0", default-features = false }
+light-batched-merkle-tree = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475", version = "0.11.0", default-features = false }
+light-bloom-filter = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475", version = "0.6.0" }
+light-hasher = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475", version = "5.0.0", default-features = false }
+light-indexed-array = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475", version = "0.3.0" }
+light-macros = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475", version = "2.2.0" }
+light-merkle-tree-metadata = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475", version = "0.11.0" }
+light-merkle-tree-reference = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475", version = "4.0.0" }
 light-poseidon = "0.4.0"
 light-program-profiler = "0.1.1"
-light-verifier = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main", version = "10.0.0" }
+light-verifier = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475", version = "10.0.0" }
 light-sparse-merkle-tree = "0.3.0"
 groth16-solana = { version = "0.2.0" }
 groth16-solana-bsb22 = { package = "groth16-solana", git = "https://github.com/Lightprotocol/groth16-solana", rev = "b374683cd0139b9e8cd8c148b08cc1e22e8ace02", features = ["bsb22"] }
@@ -150,15 +150,15 @@ ark-std = "0.5"
 
 [patch.crates-io]
 groth16-solana = { git = "https://github.com/Lightprotocol/groth16-solana", rev = "4e6cacff2f4ff53744fda0509f5e62545fd99aa6" }
-light-account-checks = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main" }
-light-batched-merkle-tree = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main" }
-light-bloom-filter = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main" }
-light-hasher = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main" }
-light-indexed-array = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main" }
-light-macros = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main" }
-light-merkle-tree-metadata = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main" }
-light-verifier = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main" }
-light-merkle-tree-reference = { git = "https://github.com/helius-labs/privacy-program-libs", branch = "main" }
+light-account-checks = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475" }
+light-batched-merkle-tree = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475" }
+light-bloom-filter = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475" }
+light-hasher = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475" }
+light-indexed-array = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475" }
+light-macros = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475" }
+light-merkle-tree-metadata = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475" }
+light-verifier = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475" }
+light-merkle-tree-reference = { git = "https://github.com/helius-labs/privacy-program-libs", rev = "eecd83af918f0935875612d716213952a50d7475" }
 light-registry = { path = "programs/registry" }
 
 [profile.dev]

--- a/justfile
+++ b/justfile
@@ -53,12 +53,16 @@ test-scaffold:
     cargo test -p shielded-pool-program --lib --tests
     cargo test -p shielded-pool-tests
 
-# End-to-end litesvm tests for shielded-pool + registry. Requires the SBF
-# `.so`s under `target/deploy/`; run `just build-programs` first.
+# End-to-end LiteSVM tests for shielded-pool plus stable program-test coverage.
+# Requires the SBF `.so`s under `target/deploy`; run `just build-programs` first.
 test-litesvm:
     cargo build-sbf --tools-version {{sbf-tools-version}} --manifest-path programs/shielded-pool/Cargo.toml -- --features bpf-entrypoint
-    cargo build-sbf --tools-version {{sbf-tools-version}} --manifest-path programs/registry/Cargo.toml
-    cargo test -p light-program-test
+    cargo build-sbf --tools-version {{sbf-tools-version}} --manifest-path programs/registry/Cargo.toml --features no-idl,no-log-ix-name
+    cargo test -p shielded-pool-tests --test transact_e2e
+    # Registry lifecycle/CPI tests currently trap inside light_registry's
+    # initialize_protocol_config under LiteSVM before reaching shielded-pool.
+    cargo test -p light-program-test --lib
+    cargo test -p light-program-test --test end_to_end
 
 # Aggregate of all CI-runnable rust tests.
 test-all: test-scaffold test-litesvm
@@ -179,7 +183,7 @@ build-light-programs: fetch-fixtures
     #!/usr/bin/env bash
     set -euo pipefail
     cargo build-sbf --tools-version {{sbf-tools-version}} --manifest-path programs/shielded-pool/Cargo.toml
-    cargo build-sbf --tools-version {{sbf-tools-version}} --manifest-path programs/registry/Cargo.toml
+    cargo build-sbf --tools-version {{sbf-tools-version}} --manifest-path programs/registry/Cargo.toml --features no-idl,no-log-ix-name
     mkdir -p target/deploy
     tag=$(tr -d '[:space:]' < .fixtures-version)
     fixtures="${ZOLANA_CACHE_DIR:-$HOME/.cache/zolana}/fixtures/${tag}"

--- a/program-tests/shielded-pool/Cargo.toml
+++ b/program-tests/shielded-pool/Cargo.toml
@@ -5,6 +5,26 @@ edition.workspace = true
 publish = false
 
 [dependencies]
-pinocchio = "0.10"
+pinocchio = { workspace = true }
 shielded-pool-program = { workspace = true }
 zolana-interface = { workspace = true }
+
+[dev-dependencies]
+light-batched-merkle-tree = { workspace = true, features = ["pinocchio"] }
+light-hasher = { workspace = true, features = ["poseidon"] }
+light-program-test = { path = "../../sdk-libs/program-test" }
+light-prover-client = { workspace = true }
+light-sparse-merkle-tree = { workspace = true }
+light-verifier = { workspace = true }
+groth16-solana-bsb22 = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+solana-account = { workspace = true }
+solana-instruction = { workspace = true }
+solana-keypair = { workspace = true }
+solana-program-pack = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-signer = { workspace = true }
+solana-system-interface = { workspace = true }
+spl-token = { workspace = true }

--- a/program-tests/shielded-pool/src/lib.rs
+++ b/program-tests/shielded-pool/src/lib.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod tests {
     use shielded_pool_program::process_instruction;
-    use zolana_interface::instruction::{encode_instruction, tag, BatchUpdateAddressTreeData};
+    use zolana_interface::instruction::{
+        encode_instruction, tag, BatchUpdateAddressTreeData, BatchUpdateNullifierTreeData,
+    };
 
     #[test]
     fn batch_update_without_accounts_does_not_succeed() {
@@ -12,6 +14,26 @@ mod tests {
                 compressed_proof_a: [1u8; 32],
                 compressed_proof_b: [2u8; 64],
                 compressed_proof_c: [3u8; 32],
+            },
+        );
+        let program_id = pinocchio::Address::new_from_array([0u8; 32]);
+
+        assert!(process_instruction(&program_id, &mut [], &data).is_err());
+    }
+
+    #[test]
+    fn nullifier_batch_update_without_accounts_does_not_succeed() {
+        let data = encode_instruction(
+            tag::BATCH_UPDATE_NULLIFIER_TREE,
+            &BatchUpdateNullifierTreeData {
+                address_new_root: [7u8; 32],
+                address_compressed_proof_a: [1u8; 32],
+                address_compressed_proof_b: [2u8; 64],
+                address_compressed_proof_c: [3u8; 32],
+                nullifier_new_root: [8u8; 32],
+                nullifier_compressed_proof_a: [4u8; 32],
+                nullifier_compressed_proof_b: [5u8; 64],
+                nullifier_compressed_proof_c: [6u8; 32],
             },
         );
         let program_id = pinocchio::Address::new_from_array([0u8; 32]);

--- a/program-tests/shielded-pool/tests/fixtures/spp_e2e.json
+++ b/program-tests/shielded-pool/tests/fixtures/spp_e2e.json
@@ -1,0 +1,666 @@
+{
+  "shape": {
+    "NInputs": 1,
+    "NOutputs": 2
+  },
+  "solana_signer_pubkey": "2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12",
+  "fixtures": [
+    {
+      "name": "shield",
+      "expiry_unix_ts": 1000000000,
+      "sender_view_tag": "00000000000000000000000000000000000000000000000000000000000003e9",
+      "proof": {
+        "ar": [
+          "0x1f9a250886d8d9873310c47b9cfbabbb8a92212ffef7e88bb603e995d4df5703",
+          "0x13f3d584fbb84aa835eebdc0bd67fc4fa483d7540a68a1300df21efe2382a67a"
+        ],
+        "bs": [
+          [
+            "0x254d3e29a0646cd3e7e6be97854e0ef349998aa6b31c31d5d4ffa44dc97ec6d2",
+            "0x090dbb809a362e1566c85b66ea0185cb7a123356a0f73c8b517c7b020ee51fd0"
+          ],
+          [
+            "0x0909d54c468d13b310f4ece1a53dc6a9071a6e01bae6e2291e30a652e83ee6d0",
+            "0x039c8233519ab5816032957f89792803225f495c3b563ecd50ebabc1ecf5787c"
+          ]
+        ],
+        "krs": [
+          "0x2b8b9337fdfc7e690027290460be1ff8a785a56bb2cac50d2a683373575761f0",
+          "0x004a413f48dd08b10ad33d5a8b09fc8f9980c5cc5956e9e079116ffff02ef73c"
+        ],
+        "proof_commitment": [
+          "0x2e73bdb6321262641a8bf2bda9920602be94984a9cf3fae8f5f2b5e6b06d107c",
+          "0x060db6e946113d1695db728795ae5c5cea5101f0e7def8849fed4f98eb1d5ffa"
+        ],
+        "proof_commitment_pok": [
+          "0x20a5861ce05b64aba0a9bbfd0dd2f896448ec9f7fcefe838f5ecd15b1312325f",
+          "0x0433d242ad998e2d68cbb3ac45955112d863ae0fdc336be58b6cad7f21dd3f5d"
+        ]
+      },
+      "relayer_fee": 0,
+      "nullifiers": [],
+      "output_utxo_hashes": [
+        "1df6a49e4651dd4669182679faeea992ae8138e73d87cb9ce531b795cc151e82"
+      ],
+      "utxo_tree_root_index": [],
+      "nullifier_tree_root_index": [],
+      "private_tx_hash": "2f3caf4a241c8af55c7208a5f070135b63a8d07a225552ed94b62a0c473b2366",
+      "public_amount_mode": 1,
+      "public_sol_amount": null,
+      "public_spl_amount": 100,
+      "public_spl_asset_pubkey": "58936604abda112bc94933569c82f8d0cc0ddf92a3f8329f2f448f7f484a594c",
+      "encrypted_utxos": "01000a0b",
+      "expected_state_next_index": 1,
+      "expected_queue_next_index": 1,
+      "expected_state_root": "290b0a8613bf04bdd54a0cb5ff92b32d4ef17eec625778d2e0c0adf920b17de5",
+      "public_input_hash": "06aadaae570962c012863e7cd7b7880993f61e223acccec71808d3234a319ca7",
+      "external_data_hash": "0039a691cb5cf669ee24f5635d80a553a1e0dc4dc8f9bb0943490dd9f81b23db",
+      "user_sol_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "user_spl_token_account": "a09aa5f47a6759802ff955f8dc2d2a14a5c99d23be97f864127ff9383455a4f0",
+      "spl_token_interface": "c5eb0fa5bf9f602e6b7336a388d438c4d6107de40ea83f72bc69639f97dc84c4",
+      "solana_owner_input_indices": [],
+      "debug_input_utxo_hashes": [
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "debug_output_utxo_hashes": [
+        "1df6a49e4651dd4669182679faeea992ae8138e73d87cb9ce531b795cc151e82",
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "debug_utxo_tree_roots": [
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "debug_nullifier_tree_roots": [
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ]
+    },
+    {
+      "name": "transfer",
+      "expiry_unix_ts": 1000000000,
+      "sender_view_tag": "00000000000000000000000000000000000000000000000000000000000003ea",
+      "proof": {
+        "ar": [
+          "0x2fb2638855dbc23304f80a61626e9995c979af3f1d3609140c48e0e4a118af64",
+          "0x18780147270bdd5399cfb87397100b7869c701be98864488150632074b281d63"
+        ],
+        "bs": [
+          [
+            "0x242a0451cde0e5707941893bebf2ab5405396a9b63fa8a42097e8e1f73c86362",
+            "0x03d7963765dd1c3d768981d80db215253ff5577490abca46f66e683b1117fc7b"
+          ],
+          [
+            "0x05fc3c86c14591abbd84d6cb5734cf557dfd057fa3d9d818998af4b0131993bf",
+            "0x11465f4d31520d04023d3027f21e4b00a9a72fc0ae03b172ff64e5e6899baa62"
+          ]
+        ],
+        "krs": [
+          "0x1ff90cc6a33be99a877eaac84d75f9b87799cee32bd7a8b4359914af7541750c",
+          "0x142872ca684b75787d47aca4da51037490ae0c06630559cfe635918c9106b3a6"
+        ],
+        "proof_commitment": [
+          "0x24c245ba63e523d75281635d5d8f1da50f8b129d500d14473605118acfbaa5a9",
+          "0x24983510aaba79d997582118133b196b246bbeca6ad17dd98a6b5c99612e34a5"
+        ],
+        "proof_commitment_pok": [
+          "0x2a3d1df66ec18a95453b537d0c13731c6c49531509828d72a1f24adf02a47a87",
+          "0x0bc6156fff76d3546f41d005bee8c47bf08eee7b0e2736f9cacfb4883f0d3e74"
+        ]
+      },
+      "relayer_fee": 0,
+      "nullifiers": [
+        "10e40da681b0a13898a2d1de33d72a734bd096951863d5ff20ae4e712c65bd45"
+      ],
+      "output_utxo_hashes": [
+        "0f6501f5e1e6b26230e5ef7232d28fdfbed62215668b2afbc822a7ed7cb90fca",
+        "1ec4e931eb80288c3177ba481477859814ee8610d82e2d279b5b18d031cb85f8"
+      ],
+      "utxo_tree_root_index": [
+        1
+      ],
+      "nullifier_tree_root_index": [
+        0
+      ],
+      "private_tx_hash": "2208e9a426ef96c0ba2c18541e8ad7b1cc27e3974f6082afca1b21f7ff3890c6",
+      "public_amount_mode": 0,
+      "public_sol_amount": null,
+      "public_spl_amount": null,
+      "public_spl_asset_pubkey": "",
+      "encrypted_utxos": "0200141516",
+      "expected_state_next_index": 3,
+      "expected_queue_next_index": 3,
+      "expected_state_root": "2e11c6dfc3f825ae473aaa89b4e59bb495bf983d1652c81559eea1d8ec88825e",
+      "public_input_hash": "2f69255756de3ba7095d2cae82a093039fb2e690ba02b90ad158c197032d8718",
+      "external_data_hash": "00b33fa0d913908997d97ff3868e8aee6515991bee62f9ce13887fe3d99d2b26",
+      "user_sol_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "user_spl_token_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "spl_token_interface": "0000000000000000000000000000000000000000000000000000000000000000",
+      "solana_owner_input_indices": [
+        0
+      ],
+      "debug_input_utxo_hashes": [
+        "1df6a49e4651dd4669182679faeea992ae8138e73d87cb9ce531b795cc151e82"
+      ],
+      "debug_output_utxo_hashes": [
+        "0f6501f5e1e6b26230e5ef7232d28fdfbed62215668b2afbc822a7ed7cb90fca",
+        "1ec4e931eb80288c3177ba481477859814ee8610d82e2d279b5b18d031cb85f8"
+      ],
+      "debug_utxo_tree_roots": [
+        "290b0a8613bf04bdd54a0cb5ff92b32d4ef17eec625778d2e0c0adf920b17de5"
+      ],
+      "debug_nullifier_tree_roots": [
+        "1d8e71a601b3e8debbba9b557b8369c7f404ae57bebf0852236b072820954277"
+      ]
+    },
+    {
+      "name": "unshield",
+      "expiry_unix_ts": 1000000000,
+      "sender_view_tag": "00000000000000000000000000000000000000000000000000000000000003eb",
+      "proof": {
+        "ar": [
+          "0x0cf3cf3da52d07cedb76d2c846fbffc0037c204e96fd13e41038857ab7d8a512",
+          "0x2665f1e98ac32c103c79973cea6eb4eac1836c9051e86b0cf3d43d8545de0e5d"
+        ],
+        "bs": [
+          [
+            "0x13fc8c4b3975084ee91eedc26de724921b91db5added9f23bd63cab556e3c2ce",
+            "0x00e9b094b978a8e42532376b8bfe577bd12fb451ce65c3ae6069b085f3df089e"
+          ],
+          [
+            "0x218a8dd7fd6e7efb4b5bbd932a955763a8bf959495e385548c1c76a56868976c",
+            "0x117e6f607a741d5683ac03692b523873df84e5c50c701b281efbc0fe846d741d"
+          ]
+        ],
+        "krs": [
+          "0x1881374effe4d1d8b9c2f4387e2bca727ddd502d86edf171216e04eb6efb1e6f",
+          "0x17f6992ed4cefbfb81b5b5385ccf28d3c66f139e0cc4c22c688ff0b29e6020bd"
+        ],
+        "proof_commitment": [
+          "0x23f3b410587860b3e1521bc93e7499b8c753672e027c1fea0dec544ae5e20166",
+          "0x105170122719c95a569b7f02faa2a36ad51b0d98f3669f3b24244fba164a910f"
+        ],
+        "proof_commitment_pok": [
+          "0x027472e8b003e70c210e096a44ec68ad22006ce709f1f98de8e1668b2bef7ea8",
+          "0x15443d651f635eb16fb065d8def38e4794c9b53e6f533af41668e2435696927c"
+        ]
+      },
+      "relayer_fee": 0,
+      "nullifiers": [
+        "0978a44a6e1277492d9aa77c09474405ff837f272d59773c9d47e5abf04340a6"
+      ],
+      "output_utxo_hashes": [],
+      "utxo_tree_root_index": [
+        2
+      ],
+      "nullifier_tree_root_index": [
+        0
+      ],
+      "private_tx_hash": "1ac9431cce1cfadc633a846484dc15bd3b50e4c563b8ac9efce00a000fcf96cb",
+      "public_amount_mode": 2,
+      "public_sol_amount": null,
+      "public_spl_amount": 40,
+      "public_spl_asset_pubkey": "58936604abda112bc94933569c82f8d0cc0ddf92a3f8329f2f448f7f484a594c",
+      "encrypted_utxos": "03001e",
+      "expected_state_next_index": 3,
+      "expected_queue_next_index": 5,
+      "expected_state_root": "2e11c6dfc3f825ae473aaa89b4e59bb495bf983d1652c81559eea1d8ec88825e",
+      "public_input_hash": "143471979a30b630c8b40cdc9e29764d874d2d28cd392b62c3517e832d07c674",
+      "external_data_hash": "00d7d59635f87258032e42c53f320c439dbbf91d84d757f570e5be5e8c17a155",
+      "user_sol_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "user_spl_token_account": "a09aa5f47a6759802ff955f8dc2d2a14a5c99d23be97f864127ff9383455a4f0",
+      "spl_token_interface": "c5eb0fa5bf9f602e6b7336a388d438c4d6107de40ea83f72bc69639f97dc84c4",
+      "solana_owner_input_indices": [
+        0
+      ],
+      "debug_input_utxo_hashes": [
+        "1ec4e931eb80288c3177ba481477859814ee8610d82e2d279b5b18d031cb85f8"
+      ],
+      "debug_output_utxo_hashes": [
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "debug_utxo_tree_roots": [
+        "2e11c6dfc3f825ae473aaa89b4e59bb495bf983d1652c81559eea1d8ec88825e"
+      ],
+      "debug_nullifier_tree_roots": [
+        "1d8e71a601b3e8debbba9b557b8369c7f404ae57bebf0852236b072820954277"
+      ]
+    },
+    {
+      "name": "double_spend",
+      "expiry_unix_ts": 1000000000,
+      "sender_view_tag": "00000000000000000000000000000000000000000000000000000000000003ec",
+      "proof": {
+        "ar": [
+          "0x1457771ccd01ae970f233890fff607929c395e82a2d305d1c45ef9565810fcbd",
+          "0x10858c24f672da54f847a2a0344518315216bd8d621cc59302c8e2cdc83f73ff"
+        ],
+        "bs": [
+          [
+            "0x01d3c5786173fe01b4259fbc876ff2d6eed34621e1b70e37af2ca14eed8452ac",
+            "0x0a0f72048dae053595f20dd56f3d5dd91bfab74a132c9ad0d376dde1956f72ec"
+          ],
+          [
+            "0x24bbc45762ce44ac2905b52ca294387d46f2e5b7069e7c8f794cfd2ba7f99a6c",
+            "0x2de76a10436cbe9e37a8e9d24ac17adf54dcc598e0a640cc386a8f9600bab9b9"
+          ]
+        ],
+        "krs": [
+          "0x173c02d74d474827ebb25f46594ccce0bc6b2e838076a553a2956ad583a3cee9",
+          "0x16ccf6437567babf6db11a0bf4e33449c43f43e45a2aa59650de286214912899"
+        ],
+        "proof_commitment": [
+          "0x21dfeea8812bb42ed053ae42f80203b1daece852f8b5ad79eb1c3f6810492b8e",
+          "0x0e1267cf75720265baf6cc8f492d0b87065da1bdcea5701230af0afdda984f84"
+        ],
+        "proof_commitment_pok": [
+          "0x0bd84b584483a551ebd6c2748be0b01071240a67a50b2405e6bd735c297b37e6",
+          "0x01b8a5deb9aab53867784d30cc452fd4b4fd9c2d813a99c06f29b328f422029e"
+        ]
+      },
+      "relayer_fee": 0,
+      "nullifiers": [
+        "10e40da681b0a13898a2d1de33d72a734bd096951863d5ff20ae4e712c65bd45"
+      ],
+      "output_utxo_hashes": [
+        "0f6501f5e1e6b26230e5ef7232d28fdfbed62215668b2afbc822a7ed7cb90fca",
+        "1ec4e931eb80288c3177ba481477859814ee8610d82e2d279b5b18d031cb85f8"
+      ],
+      "utxo_tree_root_index": [
+        2
+      ],
+      "nullifier_tree_root_index": [
+        0
+      ],
+      "private_tx_hash": "1e51d925ffe298241eeb8cff7ecd16c56a81e762af94aa6e0ee1697b5a03ce33",
+      "public_amount_mode": 0,
+      "public_sol_amount": null,
+      "public_spl_amount": null,
+      "public_spl_asset_pubkey": "",
+      "encrypted_utxos": "040028292a",
+      "expected_state_next_index": 3,
+      "expected_queue_next_index": 3,
+      "expected_state_root": "2e11c6dfc3f825ae473aaa89b4e59bb495bf983d1652c81559eea1d8ec88825e",
+      "public_input_hash": "22540daab247ce459d1aa0998558db50218610759a6e4f0cce3340e0a4a6b25d",
+      "external_data_hash": "00765f87a8aed3016971b1d81b9f86f658525e89c85f7c5b734c3db542585a3f",
+      "user_sol_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "user_spl_token_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "spl_token_interface": "0000000000000000000000000000000000000000000000000000000000000000",
+      "solana_owner_input_indices": [
+        0
+      ],
+      "debug_input_utxo_hashes": [
+        "1df6a49e4651dd4669182679faeea992ae8138e73d87cb9ce531b795cc151e82"
+      ],
+      "debug_output_utxo_hashes": [
+        "0f6501f5e1e6b26230e5ef7232d28fdfbed62215668b2afbc822a7ed7cb90fca",
+        "1ec4e931eb80288c3177ba481477859814ee8610d82e2d279b5b18d031cb85f8"
+      ],
+      "debug_utxo_tree_roots": [
+        "2e11c6dfc3f825ae473aaa89b4e59bb495bf983d1652c81559eea1d8ec88825e"
+      ],
+      "debug_nullifier_tree_roots": [
+        "1d8e71a601b3e8debbba9b557b8369c7f404ae57bebf0852236b072820954277"
+      ]
+    },
+    {
+      "name": "sol_shield",
+      "expiry_unix_ts": 1000000000,
+      "sender_view_tag": "00000000000000000000000000000000000000000000000000000000000007d1",
+      "proof": {
+        "ar": [
+          "0x25d8897477a9e3e7d3dbc22e4bda6c632168c16eeff636d0cc7fb08e04b82049",
+          "0x1259b6595b85b0f62c522d0ccd24bf9f2c4eb3f235c6d91196d415681414185d"
+        ],
+        "bs": [
+          [
+            "0x01448093f08bd3f4a2815021aa31bdd67960b57cffee8b6b556341dae5dfaa4b",
+            "0x2a3ac15d31baef2c5203f88817e18382acdf443d0994ced36e992afc667a1018"
+          ],
+          [
+            "0x25f698adf279cac48b702540b1f0ad2b77d64fdb31b718e00bc9882aeeaaaa9c",
+            "0x271fb43dfc4c7acfd2e787b824e5cbaa8aee8298b6d31525dab47aef796d5681"
+          ]
+        ],
+        "krs": [
+          "0x09cb1e0422d3821b9a2643f192429a00152cc77b844efb17fba5a784c1618e09",
+          "0x2697ecae3d134cdb4838bb5784806c15d475382a4d7d96474a118c31a1c6b669"
+        ],
+        "proof_commitment": [
+          "0x2fed57f70ec6b2d939e15f16d96c24979d4b813b290336d47f2aa41291ef9678",
+          "0x207dfdd7438ba93d4edf1e170f0ef3550a6f26ae44fa08619ac9bd30600248b9"
+        ],
+        "proof_commitment_pok": [
+          "0x0c0a65333facd1cf23bad3aab8027d9dd32a259f0bcf7ee937270093ebcf141b",
+          "0x20b923c656c6d1417c0866189c5763422ef1d4b3ab2306dab701a860881cf9f8"
+        ]
+      },
+      "relayer_fee": 0,
+      "nullifiers": [],
+      "output_utxo_hashes": [
+        "1037795baea0f220d8aad42c637bf837852d369314fca99e8333cc739908fcd7"
+      ],
+      "utxo_tree_root_index": [],
+      "nullifier_tree_root_index": [],
+      "private_tx_hash": "08e5df3837d157839ce9ff9e8fd39037a1f7754aa0f1442e2093c082f0ec3aa3",
+      "public_amount_mode": 1,
+      "public_sol_amount": 80,
+      "public_spl_amount": null,
+      "public_spl_asset_pubkey": "",
+      "encrypted_utxos": "06003c3d",
+      "expected_state_next_index": 1,
+      "expected_queue_next_index": 1,
+      "expected_state_root": "1a5bc0c31aa01eee3b5d31654b755dc097057de58702a4900467a0b1d535b117",
+      "public_input_hash": "02cf7653f83a776f72715ddf3e993d23f2081d2950c8e936e53a5970bc5ac21a",
+      "external_data_hash": "004e30fe3e83c2aed30555076f81692b68036872923a8d2af82f6047e8d16074",
+      "user_sol_account": "2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12",
+      "user_spl_token_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "spl_token_interface": "0000000000000000000000000000000000000000000000000000000000000000",
+      "solana_owner_input_indices": [],
+      "debug_input_utxo_hashes": [
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "debug_output_utxo_hashes": [
+        "1037795baea0f220d8aad42c637bf837852d369314fca99e8333cc739908fcd7",
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "debug_utxo_tree_roots": [
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "debug_nullifier_tree_roots": [
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ]
+    },
+    {
+      "name": "sol_unshield",
+      "expiry_unix_ts": 1000000000,
+      "sender_view_tag": "00000000000000000000000000000000000000000000000000000000000007d2",
+      "proof": {
+        "ar": [
+          "0x1fc30cf8659390cc65c044cd35fbb064245f3b4e5274db97cb92edbab811ba6a",
+          "0x2ceb03f23acabddb05b236f383abf646b7eb37609321e510252c87a04baa3142"
+        ],
+        "bs": [
+          [
+            "0x12db192376e81b58d4089e7ea246a7f6f38d8f56064c653f88c75db5f6105aa2",
+            "0x072e0c26c792fd89340942d58e4212174ef1f8daf3a2bfd3ab55dfb134397e72"
+          ],
+          [
+            "0x08118299dc85e840e57715a3f9ac2e6203e955b024ed7ae6fc21b686ae044719",
+            "0x196bdc60a5a4871e5153c4c774d3f54f77a7dfa1d5d57fa2d6871e5250090e5d"
+          ]
+        ],
+        "krs": [
+          "0x0c8f949c64b872a2208ed5e22bb57168087c14c454f8f37939512af8ac2ddf8c",
+          "0x08519f63e1e81bcb1fc4d883457a2a73483eafccd6b685a2dbb6c5786ee320b2"
+        ],
+        "proof_commitment": [
+          "0x1b2cd2b3b323ed5c43dadc5df0318dc45cc8504c834a80331cb58ae683079db6",
+          "0x20569ab6408383f258e50574bd98c0b62f21cb3de65b016fc54a04aacd65967b"
+        ],
+        "proof_commitment_pok": [
+          "0x0fe23ece20ca716dd841f4ac57d04ee049c89836bae2b27726741c18c2fb5e66",
+          "0x02230d73b7f1afb78776ea30038d3d71c7410a7acbd1317bbe83a1da30bdd6eb"
+        ]
+      },
+      "relayer_fee": 0,
+      "nullifiers": [
+        "2329788c70d9732a8d453cac06b0e0929ad3592ec7f83bf678d4191d785cacff"
+      ],
+      "output_utxo_hashes": [],
+      "utxo_tree_root_index": [
+        1
+      ],
+      "nullifier_tree_root_index": [
+        0
+      ],
+      "private_tx_hash": "300bfee7a976e83325bc46894b5e1d87ff73fcbdeea2762361753299ab820c16",
+      "public_amount_mode": 2,
+      "public_sol_amount": 80,
+      "public_spl_amount": null,
+      "public_spl_asset_pubkey": "",
+      "encrypted_utxos": "070046",
+      "expected_state_next_index": 1,
+      "expected_queue_next_index": 3,
+      "expected_state_root": "1a5bc0c31aa01eee3b5d31654b755dc097057de58702a4900467a0b1d535b117",
+      "public_input_hash": "0d6d6512278ebc30e776acfb939f8ef541abb03ed3d0447c66e2fbcae5f5e9b8",
+      "external_data_hash": "00667755f7d3f44a9a7ba036dba2cae22b6a6fb982781004642bfe6c7ed005f2",
+      "user_sol_account": "2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12",
+      "user_spl_token_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "spl_token_interface": "0000000000000000000000000000000000000000000000000000000000000000",
+      "solana_owner_input_indices": [
+        0
+      ],
+      "debug_input_utxo_hashes": [
+        "1037795baea0f220d8aad42c637bf837852d369314fca99e8333cc739908fcd7"
+      ],
+      "debug_output_utxo_hashes": [
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "debug_utxo_tree_roots": [
+        "1a5bc0c31aa01eee3b5d31654b755dc097057de58702a4900467a0b1d535b117"
+      ],
+      "debug_nullifier_tree_roots": [
+        "1d8e71a601b3e8debbba9b557b8369c7f404ae57bebf0852236b072820954277"
+      ]
+    },
+    {
+      "name": "wrong_discriminator",
+      "expiry_unix_ts": 1000000000,
+      "sender_view_tag": "00000000000000000000000000000000000000000000000000000000000003ed",
+      "proof": {
+        "ar": [
+          "0x22e40c08c9fb79d81c595b1623c3375857afffb658ce1c87e5236b0b1b127c9f",
+          "0x086685cd6cdcdd59f5483710b4fe5f2c7fca34e8ee3111d1c30241b916fea7f1"
+        ],
+        "bs": [
+          [
+            "0x2739240149159dfc0402749eab3c5fbdea951e3b6c5cb97633516323d11da895",
+            "0x262ce79a88613ba274dc61064fe398c5a77d2c69b4dfd79b7414f87f4e9dcc78"
+          ],
+          [
+            "0x13e53a7fc606884844e11607a87f13a5763682b21013e0ff44de6b74b9a807c6",
+            "0x08ba812b6b2714c679ca812344ce7c2ad1506b7cdc22f8ec0b227410fe28b718"
+          ]
+        ],
+        "krs": [
+          "0x1bc0df6e4e6344d473343aaeaa09442e81e88b04c9faf371005b1c46ae78eec0",
+          "0x0b0c409aaf647da61ef18039540d95a92547f9c3d9bc8f46976dd291bfa735bb"
+        ],
+        "proof_commitment": [
+          "0x2a3b75c94d4d7fe471df76293863352135ae0c34c7073fdbc6c4086937fb578e",
+          "0x205f9126a63662f6edccd1d5507c773c582eb23907b78f01eb0dd8147488a0b7"
+        ],
+        "proof_commitment_pok": [
+          "0x161bce27de860b308b916fb09675bd313d80dd1add1af4df070436737ec015b4",
+          "0x2eb9988810c60cbf28e78313c3208574a08d350c003c1646cd497180e150f1a8"
+        ]
+      },
+      "relayer_fee": 0,
+      "nullifiers": [
+        "10e40da681b0a13898a2d1de33d72a734bd096951863d5ff20ae4e712c65bd45"
+      ],
+      "output_utxo_hashes": [
+        "0f6501f5e1e6b26230e5ef7232d28fdfbed62215668b2afbc822a7ed7cb90fca",
+        "1ec4e931eb80288c3177ba481477859814ee8610d82e2d279b5b18d031cb85f8"
+      ],
+      "utxo_tree_root_index": [
+        1
+      ],
+      "nullifier_tree_root_index": [
+        0
+      ],
+      "private_tx_hash": "1a6bb8289543422ace2d5773b9c5e7508825821bb3a59dec447eb893ce5cd7cb",
+      "public_amount_mode": 0,
+      "public_sol_amount": null,
+      "public_spl_amount": null,
+      "public_spl_asset_pubkey": "",
+      "encrypted_utxos": "0500323334",
+      "expected_state_next_index": 3,
+      "expected_queue_next_index": 3,
+      "expected_state_root": "2e11c6dfc3f825ae473aaa89b4e59bb495bf983d1652c81559eea1d8ec88825e",
+      "public_input_hash": "0c02c29be4f0ef73fd4a9ba5e291762b51e9fa619e6de2c3b4f55cb9f0613bee",
+      "external_data_hash": "007c157d51d2eb3c400e4fde46546e8b35cb2600e8691ef926f13150f99631b0",
+      "user_sol_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "user_spl_token_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "spl_token_interface": "0000000000000000000000000000000000000000000000000000000000000000",
+      "solana_owner_input_indices": [
+        0
+      ],
+      "debug_input_utxo_hashes": [
+        "1df6a49e4651dd4669182679faeea992ae8138e73d87cb9ce531b795cc151e82"
+      ],
+      "debug_output_utxo_hashes": [
+        "0f6501f5e1e6b26230e5ef7232d28fdfbed62215668b2afbc822a7ed7cb90fca",
+        "1ec4e931eb80288c3177ba481477859814ee8610d82e2d279b5b18d031cb85f8"
+      ],
+      "debug_utxo_tree_roots": [
+        "290b0a8613bf04bdd54a0cb5ff92b32d4ef17eec625778d2e0c0adf920b17de5"
+      ],
+      "debug_nullifier_tree_roots": [
+        "1d8e71a601b3e8debbba9b557b8369c7f404ae57bebf0852236b072820954277"
+      ]
+    },
+    {
+      "name": "p256_shield",
+      "expiry_unix_ts": 1000000000,
+      "sender_view_tag": "0000000000000000000000000000000000000000000000000000000000000bb9",
+      "proof": {
+        "ar": [
+          "0x16405a7e072b0b32a797d7e76b3af2b4730b0a7c106d495aee66176726b830ff",
+          "0x137c10f6a39f5cc36978dd3191a3e016a7992b7f51d73d3f00316020a338ba82"
+        ],
+        "bs": [
+          [
+            "0x114d1212e7734a3cf6495fbf77ae9fc063ff060134390c9c6f69871fdb04f604",
+            "0x0d0a7f79820cffa17438e7fec65be8ca16401e869a93f8976f20b7a04b092794"
+          ],
+          [
+            "0x0018bbc8c4ba74a8424cce8882ce7bfc71223933f99cbf52694f8a5448b0b8ae",
+            "0x01e7564b87d08a5b73cc61d961c6387be48cbe3a16ea3a2057eb54f5e7ca6ddc"
+          ]
+        ],
+        "krs": [
+          "0x113fef7392002199ceb17d7e6162177b21e660c53add47c8184651b7cbd8c1c2",
+          "0x0b62dce4f4862564dc1539ced56d27713ff435c6a9a8dc67cf4b4eba9d88fc6f"
+        ],
+        "proof_commitment": [
+          "0x2b45882fe80a7e0e1a1b13221e87e5f5b01821655e7a4b15140f91369561b2d7",
+          "0x1b43b5e6ff593f1797b941b12ad7f96388cb0802aabb6e42b1f733a6fb654e33"
+        ],
+        "proof_commitment_pok": [
+          "0x250c4c05066f1ace32dc702a100cb81210091a205f35481620c910f740a504b1",
+          "0x24edc2cbc62fff5a9cbada044bfa510c0d96a5c48583fab2309e84dcab5b420d"
+        ]
+      },
+      "relayer_fee": 0,
+      "nullifiers": [],
+      "output_utxo_hashes": [
+        "2ef4815ae5ba0299dc38455f96283d092d4c8a65623f4ba028c6c1d19ba3cc66"
+      ],
+      "utxo_tree_root_index": [],
+      "nullifier_tree_root_index": [],
+      "private_tx_hash": "28c9a1e1a690ff98111983213a22b27754b8c2913802dd9afd128eb5907cf917",
+      "public_amount_mode": 1,
+      "public_sol_amount": null,
+      "public_spl_amount": 25,
+      "public_spl_asset_pubkey": "58936604abda112bc94933569c82f8d0cc0ddf92a3f8329f2f448f7f484a594c",
+      "encrypted_utxos": "08005051",
+      "expected_state_next_index": 1,
+      "expected_queue_next_index": 1,
+      "expected_state_root": "0a7ef1ae16885a9cf868623a29cb8ab683cc0adb016e6018d7c6b572430276d7",
+      "public_input_hash": "0e21f13217414b3618e0f4be22b68c92345b9bf217e3746cfb59c9bbb517d787",
+      "external_data_hash": "00491c146f8666c97e66797d9bf9d3e22e62e6fcc7c35d56344ebd19df76406f",
+      "user_sol_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "user_spl_token_account": "a09aa5f47a6759802ff955f8dc2d2a14a5c99d23be97f864127ff9383455a4f0",
+      "spl_token_interface": "c5eb0fa5bf9f602e6b7336a388d438c4d6107de40ea83f72bc69639f97dc84c4",
+      "solana_owner_input_indices": [],
+      "debug_input_utxo_hashes": [
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "debug_output_utxo_hashes": [
+        "2ef4815ae5ba0299dc38455f96283d092d4c8a65623f4ba028c6c1d19ba3cc66",
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "debug_utxo_tree_roots": [
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "debug_nullifier_tree_roots": [
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ]
+    },
+    {
+      "name": "p256_transfer",
+      "expiry_unix_ts": 1000000000,
+      "sender_view_tag": "0000000000000000000000000000000000000000000000000000000000000bba",
+      "proof": {
+        "ar": [
+          "0x024a3999baee9d3ffd3e16addd71c811149183c417a7b63baeec1ad803b678ac",
+          "0x28987d16a06675cc856c154ee7d55f971d3a22c60a1bb876d982c368bb2ceb44"
+        ],
+        "bs": [
+          [
+            "0x2d7d5584af974cece8747beff57300907665b1d96b6af35fff0afe6470566c7c",
+            "0x1a00a956decfce30c93dd6a1186794cafab4325d1351c0806e5daf2e1927750d"
+          ],
+          [
+            "0x0b6f08b0b62654f37bf819661a2ef9f462a9af869e845e093f2c4d07adcc2da0",
+            "0x1b36813e19e235fe3f408c35edda0b05b2ff2a763bf010a4dcf2d5b0807eede9"
+          ]
+        ],
+        "krs": [
+          "0x0925721ace9c8023a4121bf3ba4b464c1c7511f0db554476135c23ef2cc47c21",
+          "0x06ce2c408814900e472fcb23862da8cc47922af529dfe19f8f0e5558b586d128"
+        ],
+        "proof_commitment": [
+          "0x16df16edb826bc0a4e6b034a44ce7e28549b20b5b4f5f79f282f8c3d0f376f4f",
+          "0x08e956a495407b71eb4564b57d790f072f17333c8b1711b05109715cbb3bc8b3"
+        ],
+        "proof_commitment_pok": [
+          "0x1fb14bc447029885a106d4c948f52b23b8c23c1eeeb374d49baa05ac26fe66fe",
+          "0x1e9918f0db3018811a6682c13989702330ab00c004132cf3cc107854c74d0cc9"
+        ]
+      },
+      "relayer_fee": 0,
+      "nullifiers": [
+        "2f9d156fc25716a6fd2c1839f9d2dd91e1529a635f24551b86ca223580170416"
+      ],
+      "output_utxo_hashes": [
+        "1a61ae28b53ef16212370d83a9e0ee4fa36dce6ac83f7f6859c23af0c737133a"
+      ],
+      "utxo_tree_root_index": [
+        1
+      ],
+      "nullifier_tree_root_index": [
+        0
+      ],
+      "private_tx_hash": "28ec54d9a11e3326fa4690f8db56546b4d5569fd60ad29e514f565d59deb75da",
+      "public_amount_mode": 0,
+      "public_sol_amount": null,
+      "public_spl_amount": null,
+      "public_spl_asset_pubkey": "",
+      "encrypted_utxos": "09005a5b",
+      "expected_state_next_index": 2,
+      "expected_queue_next_index": 3,
+      "expected_state_root": "24301395922bc31dd19d71d07ad58bb47d7a8aa7132868036f5f438eb92f63e1",
+      "public_input_hash": "103dd9e3e6a4752d6c8e570843a159780c396faca8f0769b1e6b0bff4c81203d",
+      "external_data_hash": "00ab00b21f3503d2adc9c4cb2af09bd2a0a3132f2325f40f34494c63808cdd94",
+      "user_sol_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "user_spl_token_account": "0000000000000000000000000000000000000000000000000000000000000000",
+      "spl_token_interface": "0000000000000000000000000000000000000000000000000000000000000000",
+      "solana_owner_input_indices": [],
+      "debug_input_utxo_hashes": [
+        "2ef4815ae5ba0299dc38455f96283d092d4c8a65623f4ba028c6c1d19ba3cc66"
+      ],
+      "debug_output_utxo_hashes": [
+        "1a61ae28b53ef16212370d83a9e0ee4fa36dce6ac83f7f6859c23af0c737133a",
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "debug_utxo_tree_roots": [
+        "0a7ef1ae16885a9cf868623a29cb8ab683cc0adb016e6018d7c6b572430276d7"
+      ],
+      "debug_nullifier_tree_roots": [
+        "1d8e71a601b3e8debbba9b557b8369c7f404ae57bebf0852236b072820954277"
+      ]
+    }
+  ]
+}

--- a/program-tests/shielded-pool/tests/transact_e2e.rs
+++ b/program-tests/shielded-pool/tests/transact_e2e.rs
@@ -1,0 +1,1269 @@
+use groth16_solana_bsb22::{decompression, groth16::Groth16Verifier};
+use light_batched_merkle_tree::merkle_tree::BatchedMerkleTreeAccount;
+use light_program_test::{PoolTestRig, RigError};
+use light_prover_client::proof::{bsb22_proof_bytes_from_json_struct, GnarkProofJson};
+use light_sparse_merkle_tree::SparseMerkleTree;
+use serde::Deserialize;
+use shielded_pool_program::instructions::create_pool_tree::init::{
+    address_sub_tree_slice_mut, current_state_root_index, pool_tree_account_size,
+    state_next_index_offset, state_root_by_index, state_root_offset, STATE_HEIGHT,
+};
+use shielded_pool_program::instructions::transact::verifying_keys;
+use solana_account::Account as SolanaAccount;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_program_pack::Pack;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use solana_system_interface::instruction as system_instruction;
+use spl_token::state::{Account as TokenAccount, Mint};
+use zolana_interface::{
+    instruction::{
+        encode_instruction, tag, CreateProtocolConfigData, CreateSplInterfaceData,
+        InputUtxoSignerIndex, PauseTreeData, TransactData, UpdateProtocolConfigData,
+    },
+    SHIELDED_POOL_CPI_AUTHORITY, SHIELDED_POOL_PROGRAM_ID, SPL_ASSET_COUNTER_PDA_SEED,
+    SPL_ASSET_REGISTRY_ACCOUNT_LEN, SPL_ASSET_REGISTRY_PDA_SEED, SPL_ASSET_VAULT_PDA_SEED,
+};
+
+fn rig() -> Option<PoolTestRig> {
+    let payer = fixture_payer();
+    assert_eq!(
+        fixtures().solana_signer_pubkey,
+        hex::encode(payer.pubkey().to_bytes())
+    );
+    match PoolTestRig::new_with_payer(payer) {
+        Ok(r) => Some(r),
+        Err(RigError::MissingProgram(_)) => {
+            eprintln!("skipping shielded-pool transact e2e test: shielded_pool_program.so missing");
+            None
+        }
+        Err(e) => panic!("rig boot failed: {e}"),
+    }
+}
+
+fn fixture_payer() -> Keypair {
+    Keypair::new_from_array([0x42; 32])
+}
+
+fn tree_account_size() -> u64 {
+    pool_tree_account_size() as u64
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, Deserialize)]
+struct FixtureSet {
+    shape: serde_json::Value,
+    solana_signer_pubkey: String,
+    fixtures: Vec<Fixture>,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, Deserialize)]
+struct Fixture {
+    name: String,
+    expiry_unix_ts: u64,
+    sender_view_tag: String,
+    proof: serde_json::Value,
+    relayer_fee: u16,
+    nullifiers: Vec<String>,
+    output_utxo_hashes: Vec<String>,
+    utxo_tree_root_index: Vec<u16>,
+    nullifier_tree_root_index: Vec<u16>,
+    private_tx_hash: String,
+    public_amount_mode: u8,
+    public_sol_amount: Option<u64>,
+    public_spl_amount: Option<u64>,
+    public_spl_asset_pubkey: String,
+    encrypted_utxos: String,
+    expected_state_next_index: u64,
+    expected_queue_next_index: u64,
+    expected_state_root: String,
+    public_input_hash: String,
+    external_data_hash: String,
+    user_sol_account: String,
+    user_spl_token_account: String,
+    spl_token_interface: String,
+    #[serde(default)]
+    solana_owner_input_indices: Vec<u8>,
+    debug_input_utxo_hashes: Vec<String>,
+    debug_output_utxo_hashes: Vec<String>,
+    debug_utxo_tree_roots: Vec<String>,
+    debug_nullifier_tree_roots: Vec<String>,
+}
+
+fn fixtures() -> FixtureSet {
+    serde_json::from_str(include_str!("fixtures/spp_e2e.json")).expect("valid SPP fixture JSON")
+}
+
+fn fixture(name: &str) -> Fixture {
+    fixtures()
+        .fixtures
+        .into_iter()
+        .find(|fixture| fixture.name == name)
+        .unwrap_or_else(|| panic!("fixture {name} not found"))
+}
+
+fn field_from_hex(value: &str) -> [u8; 32] {
+    let bytes = hex::decode(value.trim_start_matches("0x")).expect("valid field hex");
+    assert_eq!(bytes.len(), 32);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes);
+    out
+}
+
+fn bytes_from_hex(value: &str) -> Vec<u8> {
+    hex::decode(value.trim_start_matches("0x")).expect("valid bytes hex")
+}
+
+fn proof_bytes(value: &serde_json::Value) -> [u8; 192] {
+    let proof: GnarkProofJson =
+        serde_json::from_value(value.clone()).expect("valid gnark proof fixture");
+    bsb22_proof_bytes_from_json_struct(proof).expect("valid BSB22 proof fixture")
+}
+
+fn transact_data(fixture: &Fixture) -> TransactData {
+    TransactData {
+        expiry_unix_ts: fixture.expiry_unix_ts,
+        sender_view_tag: field_from_hex(&fixture.sender_view_tag),
+        proof: proof_bytes(&fixture.proof),
+        relayer_fee: fixture.relayer_fee,
+        public_amount_mode: fixture.public_amount_mode,
+        nullifiers: fixture
+            .nullifiers
+            .iter()
+            .map(|value| field_from_hex(value))
+            .collect(),
+        output_utxo_hashes: fixture
+            .output_utxo_hashes
+            .iter()
+            .map(|value| field_from_hex(value))
+            .collect(),
+        utxo_tree_root_index: fixture.utxo_tree_root_index.clone(),
+        nullifier_tree_root_index: fixture.nullifier_tree_root_index.clone(),
+        private_tx_hash: field_from_hex(&fixture.private_tx_hash),
+        public_sol_amount: fixture.public_sol_amount,
+        public_spl_amount: fixture.public_spl_amount,
+        cpi_signer: None,
+        in_utxo_signer_indices: input_signer_indices(&fixture.solana_owner_input_indices),
+        encrypted_utxos: bytes_from_hex(&fixture.encrypted_utxos),
+    }
+}
+
+fn input_signer_indices(input_indices: &[u8]) -> Option<Vec<InputUtxoSignerIndex>> {
+    if input_indices.is_empty() {
+        return None;
+    }
+    Some(
+        input_indices
+            .iter()
+            .map(|input_index| InputUtxoSignerIndex {
+                account_index: 1,
+                input_index: *input_index,
+            })
+            .collect(),
+    )
+}
+
+fn read_u64(data: &[u8], offset: usize) -> u64 {
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&data[offset..offset + 8]);
+    u64::from_le_bytes(bytes)
+}
+
+fn read_state_root(data: &[u8]) -> [u8; 32] {
+    let offset = state_root_offset();
+    let mut root = [0u8; 32];
+    root.copy_from_slice(&data[offset..offset + 32]);
+    root
+}
+
+fn address_queue_next_index(mut data: Vec<u8>, tree_pubkey: Pubkey) -> u64 {
+    let tree_address = pinocchio::Address::new_from_array(tree_pubkey.to_bytes());
+    let address_slice = address_sub_tree_slice_mut(&mut data).expect("address sub-tree slice");
+    let tree = BatchedMerkleTreeAccount::address_from_bytes(address_slice, &tree_address).unwrap();
+    tree.get_metadata().queue_batches.next_index
+}
+
+fn assert_pool_state(
+    rig: &PoolTestRig,
+    tree_pubkey: Pubkey,
+    reference: &SparseMerkleTree<light_hasher::Poseidon, STATE_HEIGHT>,
+    fixture: &Fixture,
+) {
+    let data = rig.account_data(&tree_pubkey).expect("account data");
+    assert_eq!(
+        read_u64(&data, state_next_index_offset()),
+        fixture.expected_state_next_index
+    );
+    assert_eq!(read_state_root(&data), reference.root());
+    assert_eq!(
+        reference.root(),
+        field_from_hex(&fixture.expected_state_root)
+    );
+    let current_index = current_state_root_index(&data).expect("state root history index");
+    assert_eq!(
+        state_root_by_index(&data, current_index).expect("state root by index"),
+        reference.root()
+    );
+    assert_eq!(
+        address_queue_next_index(data, tree_pubkey),
+        fixture.expected_queue_next_index
+    );
+}
+
+fn append_reference(
+    reference: &mut SparseMerkleTree<light_hasher::Poseidon, STATE_HEIGHT>,
+    leaves: &[[u8; 32]],
+) {
+    for leaf in leaves {
+        reference.append(*leaf);
+    }
+}
+
+fn fixture_output_hashes(fixture: &Fixture) -> Vec<[u8; 32]> {
+    fixture
+        .output_utxo_hashes
+        .iter()
+        .map(|value| field_from_hex(value))
+        .collect()
+}
+
+fn assert_error_contains(err: RigError, expected: &str) {
+    let msg = format!("{err}");
+    assert!(
+        msg.contains(expected),
+        "expected error containing {expected}, got: {msg}"
+    );
+}
+
+#[derive(Clone, Copy)]
+struct SplSettlement {
+    cpi_authority: Pubkey,
+    protocol_config: Pubkey,
+    asset_counter: Pubkey,
+    mint: Pubkey,
+    user_token: Pubkey,
+    vault: Pubkey,
+    registry: Pubkey,
+}
+
+impl SplSettlement {
+    fn metas(&self) -> Vec<AccountMeta> {
+        vec![
+            AccountMeta::new_readonly(self.cpi_authority, false),
+            AccountMeta::new(self.user_token, false),
+            AccountMeta::new(self.vault, false),
+            AccountMeta::new_readonly(self.registry, false),
+            AccountMeta::new_readonly(spl_token::id(), false),
+        ]
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SolSettlement {
+    cpi_authority: Pubkey,
+    user_sol: Pubkey,
+}
+
+impl SolSettlement {
+    fn metas(&self) -> Vec<AccountMeta> {
+        vec![
+            AccountMeta::new_readonly(Pubkey::default(), false),
+            AccountMeta::new(self.cpi_authority, false),
+            AccountMeta::new(self.user_sol, false),
+        ]
+    }
+}
+
+fn set_cpi_authority_account(rig: &mut PoolTestRig) -> Pubkey {
+    let cpi_authority = Pubkey::new_from_array(SHIELDED_POOL_CPI_AUTHORITY);
+    rig.svm
+        .set_account(
+            cpi_authority,
+            SolanaAccount {
+                lamports: 1_000_000,
+                data: Vec::new(),
+                owner: Pubkey::default(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .expect("set cpi authority account");
+    cpi_authority
+}
+
+fn setup_sol_settlement(rig: &mut PoolTestRig, user_sol: Pubkey) -> SolSettlement {
+    let cpi_authority = set_cpi_authority_account(rig);
+    if rig.svm.get_account(&user_sol).is_none() {
+        rig.airdrop(&user_sol, 1_000_000)
+            .expect("fund SOL recipient account");
+    }
+    SolSettlement {
+        cpi_authority,
+        user_sol,
+    }
+}
+
+fn setup_spl_settlement(rig: &mut PoolTestRig) -> SplSettlement {
+    let cpi_authority = set_cpi_authority_account(rig);
+
+    let payer = rig.payer.insecure_clone();
+    let mint = Keypair::new_from_array([0x24; 32]);
+    let user_token = Keypair::new_from_array([0x22; 32]);
+    let token_program = spl_token::id();
+    let mint_len = Mint::LEN;
+    let token_len = TokenAccount::LEN;
+    let payer_pubkey = payer.pubkey();
+    let program_id = Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID);
+    let (asset_counter, _) =
+        Pubkey::find_program_address(&[SPL_ASSET_COUNTER_PDA_SEED], &program_id);
+    let (registry, _) = Pubkey::find_program_address(
+        &[SPL_ASSET_REGISTRY_PDA_SEED, mint.pubkey().as_ref()],
+        &program_id,
+    );
+    let (vault, _) = Pubkey::find_program_address(
+        &[SPL_ASSET_VAULT_PDA_SEED, mint.pubkey().as_ref()],
+        &program_id,
+    );
+    let shield_fixture = fixture("shield");
+    assert_eq!(
+        shield_fixture.public_spl_asset_pubkey,
+        hex::encode(mint.pubkey().to_bytes())
+    );
+    assert_eq!(
+        shield_fixture.user_spl_token_account,
+        hex::encode(user_token.pubkey().to_bytes())
+    );
+    assert_eq!(
+        shield_fixture.spl_token_interface,
+        hex::encode(vault.to_bytes())
+    );
+
+    let ixs: Vec<Instruction> = vec![
+        system_instruction::create_account(
+            &payer_pubkey,
+            &mint.pubkey(),
+            rig.svm.minimum_balance_for_rent_exemption(mint_len),
+            mint_len as u64,
+            &token_program,
+        ),
+        spl_token::instruction::initialize_mint2(
+            &token_program,
+            &mint.pubkey(),
+            &payer_pubkey,
+            None,
+            0,
+        )
+        .expect("initialize mint"),
+        system_instruction::create_account(
+            &payer_pubkey,
+            &user_token.pubkey(),
+            rig.svm.minimum_balance_for_rent_exemption(token_len),
+            token_len as u64,
+            &token_program,
+        ),
+        spl_token::instruction::initialize_account3(
+            &token_program,
+            &user_token.pubkey(),
+            &mint.pubkey(),
+            &payer_pubkey,
+        )
+        .expect("initialize user token"),
+        spl_token::instruction::mint_to(
+            &token_program,
+            &mint.pubkey(),
+            &user_token.pubkey(),
+            &payer_pubkey,
+            &[],
+            1_000_000,
+        )
+        .expect("mint user tokens"),
+    ];
+    rig.send_instructions(&ixs, &[&payer, &mint, &user_token])
+        .expect("create token settlement accounts");
+
+    let protocol_config = rig
+        .create_protocol_config_account()
+        .expect("create protocol config account");
+    rig.create_shielded_pool_protocol_config(
+        &protocol_config,
+        &payer,
+        CreateProtocolConfigData {
+            authority: payer_pubkey.to_bytes(),
+        },
+    )
+    .expect("create protocol config");
+    let create_registry_ix = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(payer_pubkey, true),
+            AccountMeta::new_readonly(protocol_config.pubkey(), false),
+            AccountMeta::new(asset_counter, false),
+            AccountMeta::new(registry, false),
+            AccountMeta::new_readonly(mint.pubkey(), false),
+            AccountMeta::new(vault, false),
+            AccountMeta::new_readonly(cpi_authority, false),
+            AccountMeta::new_readonly(Pubkey::default(), false),
+            AccountMeta::new_readonly(token_program, false),
+        ],
+        data: encode_instruction(tag::CREATE_SPL_INTERFACE, &CreateSplInterfaceData),
+    };
+    rig.send_instructions(&[create_registry_ix], &[&payer])
+        .expect("initialize asset registry");
+
+    SplSettlement {
+        cpi_authority,
+        protocol_config: protocol_config.pubkey(),
+        asset_counter,
+        mint: mint.pubkey(),
+        user_token: user_token.pubkey(),
+        vault,
+        registry,
+    }
+}
+
+fn token_amount(rig: &PoolTestRig, token_account: &Pubkey) -> u64 {
+    let account = rig.svm.get_account(token_account).expect("token account");
+    TokenAccount::unpack(&account.data)
+        .expect("valid token account")
+        .amount
+}
+
+fn lamports(rig: &PoolTestRig, account: &Pubkey) -> u64 {
+    rig.svm
+        .get_account(account)
+        .map(|account| account.lamports)
+        .unwrap_or(0)
+}
+
+fn submit_data(
+    rig: &mut PoolTestRig,
+    tree: &Keypair,
+    data: TransactData,
+    settlement: Option<&SplSettlement>,
+) -> Result<(), RigError> {
+    if data.public_spl_amount.unwrap_or(0) != 0 {
+        rig.transact_with_extra_accounts(tree, data, settlement.expect("SPL settlement").metas())
+    } else {
+        rig.transact(tree, data)
+    }
+}
+
+fn submit_sol_fixture(
+    rig: &mut PoolTestRig,
+    tree: &Keypair,
+    fixture: &Fixture,
+    settlement: &SolSettlement,
+) -> Result<(), RigError> {
+    rig.transact_with_extra_accounts(tree, transact_data(fixture), settlement.metas())
+}
+
+fn submit_fixture(
+    rig: &mut PoolTestRig,
+    tree: &Keypair,
+    fixture: &Fixture,
+    settlement: Option<&SplSettlement>,
+) -> Result<(), RigError> {
+    submit_data(rig, tree, transact_data(fixture), settlement)
+}
+
+fn compact_u16_len(value: usize) -> usize {
+    match value {
+        0..=0x7f => 1,
+        0x80..=0x3fff => 2,
+        _ => 3,
+    }
+}
+
+fn legacy_tx_size(
+    instruction_data_len: usize,
+    account_count: usize,
+    ix_account_count: usize,
+) -> usize {
+    let signature_count = 1usize;
+    let signatures = compact_u16_len(signature_count) + signature_count * 64;
+    let account_keys = compact_u16_len(account_count) + account_count * 32;
+    let instruction = 1
+        + compact_u16_len(ix_account_count)
+        + ix_account_count
+        + compact_u16_len(instruction_data_len)
+        + instruction_data_len;
+    signatures + 3 + account_keys + 32 + compact_u16_len(1) + instruction
+}
+
+fn transact_wire_size(data: &TransactData, account_count: usize, ix_account_count: usize) -> usize {
+    let instruction_data = encode_instruction(tag::TRANSACT, data);
+    legacy_tx_size(instruction_data.len(), account_count, ix_account_count)
+}
+
+#[test]
+fn transact_fixture_wire_sizes_are_golden() {
+    let transfer_accounts = 3; // tree, payer, program id
+    let transfer_ix_accounts = 2; // tree, payer
+    let spl_accounts = 8; // tree, payer, cpi authority, token accounts, registry, token program, program id
+    let spl_ix_accounts = 7;
+    let sol_accounts = 6; // tree, payer, system program, cpi authority, user SOL, program id
+    let sol_ix_accounts = 5;
+
+    let cases = [
+        (
+            "spl_shield",
+            transact_wire_size(
+                &transact_data(&fixture("shield")),
+                spl_accounts,
+                spl_ix_accounts,
+            ),
+            705,
+        ),
+        (
+            "transfer",
+            transact_wire_size(
+                &transact_data(&fixture("transfer")),
+                transfer_accounts,
+                transfer_ix_accounts,
+            ),
+            607,
+        ),
+        (
+            "spl_unshield",
+            transact_wire_size(
+                &transact_data(&fixture("unshield")),
+                spl_accounts,
+                spl_ix_accounts,
+            ),
+            714,
+        ),
+        (
+            "sol_shield",
+            transact_wire_size(
+                &transact_data(&fixture("sol_shield")),
+                sol_accounts,
+                sol_ix_accounts,
+            ),
+            639,
+        ),
+        (
+            "sol_unshield",
+            transact_wire_size(
+                &transact_data(&fixture("sol_unshield")),
+                sol_accounts,
+                sol_ix_accounts,
+            ),
+            648,
+        ),
+    ];
+
+    for (name, size, expected) in cases {
+        assert_eq!(size, expected, "{name} canonical wire size changed");
+        assert!(size <= 1232, "{name} wire size {size} exceeds packet limit");
+    }
+}
+
+#[test]
+fn create_spl_interface_rejects_initialized_registry() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let settlement = setup_spl_settlement(&mut rig);
+    let payer = rig.payer.insecure_clone();
+    let create_registry_ix = Instruction {
+        program_id: Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID),
+        accounts: vec![
+            AccountMeta::new_readonly(payer.pubkey(), true),
+            AccountMeta::new_readonly(settlement.protocol_config, false),
+            AccountMeta::new(settlement.asset_counter, false),
+            AccountMeta::new(settlement.registry, false),
+            AccountMeta::new_readonly(settlement.mint, false),
+            AccountMeta::new(settlement.vault, false),
+            AccountMeta::new_readonly(settlement.cpi_authority, false),
+            AccountMeta::new_readonly(Pubkey::default(), false),
+            AccountMeta::new_readonly(spl_token::id(), false),
+        ],
+        data: encode_instruction(tag::CREATE_SPL_INTERFACE, &CreateSplInterfaceData),
+    };
+
+    rig.svm.expire_blockhash();
+    let err = rig
+        .send_instructions(&[create_registry_ix], &[&payer])
+        .expect_err("initialized SPL registry must reject reinitialization");
+    assert_error_contains(err, "Custom(15)");
+}
+
+#[test]
+fn protocol_config_can_pause_and_unpause_tree() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let config = rig
+        .create_protocol_config_account()
+        .expect("create protocol config account");
+    let authority = Keypair::new_from_array([0x31; 32]);
+    rig.create_shielded_pool_protocol_config(
+        &config,
+        &authority,
+        CreateProtocolConfigData {
+            authority: authority.pubkey().to_bytes(),
+        },
+    )
+    .expect("create protocol config");
+
+    rig.pause_tree(&config, &tree, &authority, PauseTreeData { paused: true })
+        .expect("pause tree");
+    let before = rig.account_data(&tree.pubkey()).expect("tree account data");
+    let settlement = setup_spl_settlement(&mut rig);
+    let err = submit_fixture(&mut rig, &tree, &fixture("shield"), Some(&settlement))
+        .expect_err("paused tree must reject transact");
+    assert_error_contains(err, "Custom(17)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("tree account data"),
+        before
+    );
+    assert_eq!(token_amount(&rig, &settlement.user_token), 1_000_000);
+    assert_eq!(token_amount(&rig, &settlement.vault), 0);
+
+    rig.svm.expire_blockhash();
+    rig.pause_tree(&config, &tree, &authority, PauseTreeData { paused: false })
+        .expect("unpause tree");
+    submit_fixture(&mut rig, &tree, &fixture("shield"), Some(&settlement))
+        .expect("unpaused tree accepts transact");
+}
+
+#[test]
+fn protocol_config_authority_can_rotate() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let config = rig
+        .create_protocol_config_account()
+        .expect("create protocol config account");
+    let old_authority = Keypair::new_from_array([0x32; 32]);
+    let new_authority = Keypair::new_from_array([0x33; 32]);
+
+    rig.create_shielded_pool_protocol_config(
+        &config,
+        &old_authority,
+        CreateProtocolConfigData {
+            authority: old_authority.pubkey().to_bytes(),
+        },
+    )
+    .expect("create protocol config");
+    rig.update_shielded_pool_protocol_config(
+        &config,
+        &old_authority,
+        UpdateProtocolConfigData {
+            new_authority: new_authority.pubkey().to_bytes(),
+        },
+    )
+    .expect("rotate protocol config authority");
+
+    let err = rig
+        .pause_tree(
+            &config,
+            &tree,
+            &old_authority,
+            PauseTreeData { paused: true },
+        )
+        .expect_err("old authority must not pause after rotation");
+    assert_error_contains(err, "Custom(5)");
+    rig.pause_tree(
+        &config,
+        &tree,
+        &new_authority,
+        PauseTreeData { paused: true },
+    )
+    .expect("new authority pauses");
+}
+
+#[test]
+fn fixture_proofs_verify_against_committed_verifying_key() {
+    for fixture in fixtures().fixtures {
+        let data = transact_data(&fixture);
+        let public_input_hash = field_from_hex(&fixture.public_input_hash);
+        let proof_a: [u8; 32] = data.proof[..32].try_into().unwrap();
+        let proof_b: [u8; 64] = data.proof[32..96].try_into().unwrap();
+        let proof_c: [u8; 32] = data.proof[96..128].try_into().unwrap();
+        let commitment: [u8; 32] = data.proof[128..160].try_into().unwrap();
+        let commitment_pok: [u8; 32] = data.proof[160..192].try_into().unwrap();
+        let proof_a = decompression::decompress_g1(&proof_a).unwrap();
+        let proof_b = decompression::decompress_g2(&proof_b).unwrap();
+        let proof_c = decompression::decompress_g1(&proof_c).unwrap();
+        let commitment = decompression::decompress_g1(&commitment).unwrap();
+        let commitment_pok = decompression::decompress_g1(&commitment_pok).unwrap();
+        let public_inputs = [public_input_hash];
+        let mut verifier = Groth16Verifier::new_with_commitment(
+            &proof_a,
+            &proof_b,
+            &proof_c,
+            &commitment,
+            &commitment_pok,
+            &public_inputs,
+            &verifying_keys::spp_1_2::VERIFYINGKEY,
+        )
+        .unwrap_or_else(|err| {
+            panic!(
+                "fixture {} BSB22 verifier init failed: {err:?}",
+                fixture.name
+            )
+        });
+        verifier.verify().unwrap_or_else(|err| {
+            panic!("fixture {} proof does not verify: {err:?}", fixture.name)
+        });
+    }
+}
+
+#[test]
+fn transact_shield_transfer_unshield_updates_state_and_nullifier_queue() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let mut reference = SparseMerkleTree::<light_hasher::Poseidon, STATE_HEIGHT>::new_empty();
+    let settlement = setup_spl_settlement(&mut rig);
+
+    for name in ["shield", "transfer", "unshield"] {
+        let fixture = fixture(name);
+        submit_fixture(&mut rig, &tree, &fixture, Some(&settlement))
+            .unwrap_or_else(|err| panic!("{name} transact failed: {err}"));
+        append_reference(&mut reference, &fixture_output_hashes(&fixture));
+        assert_pool_state(&rig, tree.pubkey(), &reference, &fixture);
+    }
+    assert_eq!(token_amount(&rig, &settlement.user_token), 999_940);
+    assert_eq!(token_amount(&rig, &settlement.vault), 60);
+}
+
+#[test]
+fn transact_supports_two_output_transfer() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let mut reference = SparseMerkleTree::<light_hasher::Poseidon, STATE_HEIGHT>::new_empty();
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("shield");
+    submit_fixture(&mut rig, &tree, &shield, Some(&settlement)).expect("shield transact");
+    append_reference(&mut reference, &fixture_output_hashes(&shield));
+
+    let transfer = fixture("transfer");
+    assert_eq!(transfer.output_utxo_hashes.len(), 2);
+    submit_fixture(&mut rig, &tree, &transfer, Some(&settlement)).expect("two-output transfer");
+    append_reference(&mut reference, &fixture_output_hashes(&transfer));
+    assert_pool_state(&rig, tree.pubkey(), &reference, &transfer);
+}
+
+#[test]
+fn transact_accepts_p256_owned_input_without_solana_owner_signer() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let mut reference = SparseMerkleTree::<light_hasher::Poseidon, STATE_HEIGHT>::new_empty();
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("p256_shield");
+    submit_fixture(&mut rig, &tree, &shield, Some(&settlement)).expect("P256 shield transact");
+    append_reference(&mut reference, &fixture_output_hashes(&shield));
+
+    let transfer = fixture("p256_transfer");
+    assert!(transact_data(&transfer).in_utxo_signer_indices.is_none());
+    submit_fixture(&mut rig, &tree, &transfer, Some(&settlement)).expect("P256 transfer transact");
+    append_reference(&mut reference, &fixture_output_hashes(&transfer));
+    assert_pool_state(&rig, tree.pubkey(), &reference, &transfer);
+}
+
+#[test]
+fn transact_supports_full_unshield_without_change_output() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let mut reference = SparseMerkleTree::<light_hasher::Poseidon, STATE_HEIGHT>::new_empty();
+    let settlement = setup_spl_settlement(&mut rig);
+
+    for name in ["shield", "transfer"] {
+        let fixture = fixture(name);
+        submit_fixture(&mut rig, &tree, &fixture, Some(&settlement))
+            .unwrap_or_else(|err| panic!("{name} transact failed: {err}"));
+        append_reference(&mut reference, &fixture_output_hashes(&fixture));
+    }
+    let before_unshield_root = reference.root();
+
+    let unshield = fixture("unshield");
+    assert!(unshield.output_utxo_hashes.is_empty());
+    submit_fixture(&mut rig, &tree, &unshield, Some(&settlement)).expect("full unshield transact");
+    assert_eq!(reference.root(), before_unshield_root);
+    assert_pool_state(&rig, tree.pubkey(), &reference, &unshield);
+}
+
+#[test]
+fn transact_rejects_tampered_output_hash_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("shield");
+    let mut data = transact_data(&shield);
+    data.output_utxo_hashes[0][31] ^= 1;
+
+    let err = rig
+        .transact_with_extra_accounts(&tree, data, settlement.metas())
+        .expect_err("tampered output hash must fail");
+    assert_error_contains(err, "Custom(12)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+}
+
+#[test]
+fn transact_rejects_tampered_encrypted_utxos_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("shield");
+    let mut data = transact_data(&shield);
+    data.encrypted_utxos[0] ^= 1;
+
+    let err = rig
+        .transact_with_extra_accounts(&tree, data, settlement.metas())
+        .expect_err("tampered encrypted UTXO blob must fail");
+    assert_error_contains(err, "Custom(12)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+}
+
+#[test]
+fn transact_rejects_tampered_proof_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("shield");
+    let mut data = transact_data(&shield);
+    data.proof[0] ^= 1;
+
+    let err = rig
+        .transact_with_extra_accounts(&tree, data, settlement.metas())
+        .expect_err("tampered proof must fail");
+    assert_error_contains(err, "Custom(12)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+}
+
+#[test]
+fn transact_rejects_missing_bsb22_commitment_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("shield");
+    let mut data = transact_data(&shield);
+    data.proof[128..160].fill(0);
+
+    let err = rig
+        .transact_with_extra_accounts(&tree, data, settlement.metas())
+        .expect_err("missing BSB22 commitment must fail");
+    assert_error_contains(err, "Custom(11)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+}
+
+#[test]
+fn transact_rejects_tampered_bsb22_commitment_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("shield");
+    let mut data = transact_data(&shield);
+    data.proof[128] ^= 1;
+
+    let err = rig
+        .transact_with_extra_accounts(&tree, data, settlement.metas())
+        .expect_err("tampered BSB22 commitment must fail");
+    assert_error_contains(err, "Custom(11)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+}
+
+#[test]
+fn transact_rejects_duplicate_sender_view_tag_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("shield");
+    submit_fixture(&mut rig, &tree, &shield, Some(&settlement)).expect("initial shield");
+    let after_initial = rig.account_data(&tree.pubkey()).expect("account data");
+    let user_after_initial = token_amount(&rig, &settlement.user_token);
+    let vault_after_initial = token_amount(&rig, &settlement.vault);
+    rig.svm.expire_blockhash();
+
+    let err = rig
+        .transact_with_extra_accounts(&tree, transact_data(&shield), settlement.metas())
+        .expect_err("duplicate sender view tag must fail");
+    assert_error_contains(err, "Custom(7)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        after_initial
+    );
+    assert_eq!(
+        token_amount(&rig, &settlement.user_token),
+        user_after_initial
+    );
+    assert_eq!(token_amount(&rig, &settlement.vault), vault_after_initial);
+}
+
+#[test]
+fn transact_rejects_mismatched_root_indices_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("shield");
+    submit_fixture(&mut rig, &tree, &shield, Some(&settlement)).expect("shield transact");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+
+    let transfer = fixture("transfer");
+    let mut data = transact_data(&transfer);
+    data.utxo_tree_root_index.clear();
+
+    let err = rig.transact(&tree, data).expect_err("shape must fail");
+    assert_error_contains(err, "Custom(10)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+}
+
+#[test]
+fn transact_rejects_stale_root_index_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("shield");
+    submit_fixture(&mut rig, &tree, &shield, Some(&settlement)).expect("shield transact");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+
+    let transfer = fixture("transfer");
+    let mut data = transact_data(&transfer);
+    data.utxo_tree_root_index[0] = 199;
+
+    let err = submit_data(&mut rig, &tree, data, None)
+        .expect_err("unknown root index must fail before proof/state mutation");
+    assert_error_contains(err, "Custom(10)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+}
+
+#[test]
+fn transact_rejects_stale_nullifier_root_index_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("shield");
+    submit_fixture(&mut rig, &tree, &shield, Some(&settlement)).expect("shield transact");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+
+    let transfer = fixture("transfer");
+    let mut data = transact_data(&transfer);
+    data.nullifier_tree_root_index[0] = 199;
+
+    let err = submit_data(&mut rig, &tree, data, None)
+        .expect_err("unknown nullifier root index must fail before proof/state mutation");
+    assert_error_contains(err, "Custom(10)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+}
+
+#[test]
+fn transact_rejects_invalid_input_signer_indices_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("shield");
+    submit_fixture(&mut rig, &tree, &shield, Some(&settlement)).expect("shield transact");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+
+    let transfer = fixture("transfer");
+    let mut data = transact_data(&transfer);
+    data.in_utxo_signer_indices = Some(vec![InputUtxoSignerIndex {
+        account_index: 250,
+        input_index: 0,
+    }]);
+
+    let err = submit_data(&mut rig, &tree, data, None).expect_err("bad signer index must fail");
+    assert_error_contains(err, "Custom(10)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+}
+
+#[test]
+fn transact_rejects_sol_withdraw_recipient_substitution_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let payer = rig.payer.pubkey();
+    let settlement = setup_sol_settlement(&mut rig, payer);
+
+    let sol_shield = fixture("sol_shield");
+    assert_eq!(sol_shield.public_sol_amount, Some(80));
+    assert_eq!(sol_shield.user_sol_account, hex::encode(payer.to_bytes()));
+    submit_sol_fixture(&mut rig, &tree, &sol_shield, &settlement).expect("SOL shield transact");
+
+    let substitute = Keypair::new();
+    rig.airdrop(&substitute.pubkey(), 1_000_000)
+        .expect("fund substituted recipient");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+    let cpi_before = lamports(&rig, &settlement.cpi_authority);
+    let substitute_before = lamports(&rig, &substitute.pubkey());
+    let substituted = SolSettlement {
+        user_sol: substitute.pubkey(),
+        ..settlement
+    };
+
+    let err = submit_sol_fixture(&mut rig, &tree, &fixture("sol_unshield"), &substituted)
+        .expect_err("substituted SOL withdrawal recipient must fail");
+    assert_error_contains(err, "Custom(12)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+    assert_eq!(lamports(&rig, &settlement.cpi_authority), cpi_before);
+    assert_eq!(lamports(&rig, &substitute.pubkey()), substitute_before);
+}
+
+#[test]
+fn transact_rejects_public_spl_mint_substitution_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let settlement = setup_spl_settlement(&mut rig);
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+
+    let fake_registry = Pubkey::new_unique();
+    let fake_mint = Pubkey::new_unique();
+    let mut registry_data = vec![0u8; SPL_ASSET_REGISTRY_ACCOUNT_LEN];
+    registry_data[0..8].copy_from_slice(&zolana_interface::SPL_ASSET_REGISTRY_MAGIC);
+    registry_data[8..40].copy_from_slice(fake_mint.as_ref());
+    rig.svm
+        .set_account(
+            fake_registry,
+            SolanaAccount {
+                lamports: 1_000_000,
+                data: registry_data,
+                owner: Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID),
+                executable: false,
+                rent_epoch: 0,
+            },
+        )
+        .expect("set fake asset registry");
+
+    let substituted = SplSettlement {
+        registry: fake_registry,
+        ..settlement
+    };
+    let err = submit_fixture(&mut rig, &tree, &fixture("shield"), Some(&substituted))
+        .expect_err("SPL mint substitution must fail");
+    assert_error_contains(err, "Custom(12)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+    assert_eq!(token_amount(&rig, &settlement.user_token), 1_000_000);
+    assert_eq!(token_amount(&rig, &settlement.vault), 0);
+}
+
+#[test]
+fn transact_rejects_instruction_discriminator_mismatch_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    let shield = fixture("shield");
+    submit_fixture(&mut rig, &tree, &shield, Some(&settlement)).expect("shield transact");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+
+    let wrong = fixture("wrong_discriminator");
+    let err = submit_fixture(&mut rig, &tree, &wrong, None)
+        .expect_err("proof for another discriminator must fail");
+    assert_error_contains(err, "Custom(12)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+}
+
+#[test]
+fn transact_rejects_spl_withdraw_recipient_substitution_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    for name in ["shield", "transfer"] {
+        let fixture = fixture(name);
+        submit_fixture(&mut rig, &tree, &fixture, Some(&settlement))
+            .unwrap_or_else(|err| panic!("{name} transact failed: {err}"));
+    }
+
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+    let user_before = token_amount(&rig, &settlement.user_token);
+    let vault_before = token_amount(&rig, &settlement.vault);
+    let mut substituted = settlement;
+    substituted.user_token = settlement.vault;
+
+    let err = submit_fixture(&mut rig, &tree, &fixture("unshield"), Some(&substituted))
+        .expect_err("substituted SPL withdrawal recipient must fail");
+    assert_error_contains(err, "Custom(12)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+    assert_eq!(token_amount(&rig, &settlement.user_token), user_before);
+    assert_eq!(token_amount(&rig, &settlement.vault), vault_before);
+}
+
+#[test]
+fn transact_rejects_replayed_nullifier_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let settlement = setup_spl_settlement(&mut rig);
+
+    submit_fixture(&mut rig, &tree, &fixture("shield"), Some(&settlement))
+        .expect("shield transact");
+    let transfer = fixture("transfer");
+    submit_fixture(&mut rig, &tree, &transfer, Some(&settlement)).expect("transfer transact");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+    rig.svm.expire_blockhash();
+
+    let err = submit_fixture(&mut rig, &tree, &fixture("double_spend"), Some(&settlement))
+        .expect_err("replayed nullifier must fail");
+    assert_error_contains(err, "Custom(7)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+}
+
+#[test]
+fn transact_rejects_invalid_shape_without_mutating() {
+    let Some(mut rig) = rig() else {
+        return;
+    };
+    let tree = rig
+        .create_pool_tree(tree_account_size())
+        .expect("create_pool_tree");
+    let before = rig.account_data(&tree.pubkey()).expect("account data");
+    let settlement = setup_spl_settlement(&mut rig);
+    let mut data = transact_data(&fixture("shield"));
+    while data.output_utxo_hashes.len() <= 8 {
+        data.output_utxo_hashes
+            .push([data.output_utxo_hashes.len() as u8; 32]);
+    }
+
+    let err = submit_data(&mut rig, &tree, data, Some(&settlement))
+        .expect_err("oversized output shape must fail");
+    assert_error_contains(err, "Custom(10)");
+    assert_eq!(
+        rig.account_data(&tree.pubkey()).expect("account data"),
+        before
+    );
+    assert_eq!(token_amount(&rig, &settlement.user_token), 1_000_000);
+    assert_eq!(token_amount(&rig, &settlement.vault), 0);
+}

--- a/prover/server/prover/spp/fixtures.go
+++ b/prover/server/prover/spp/fixtures.go
@@ -1,0 +1,897 @@
+//go:build spp_e2e_fixtures
+
+package spp
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+
+	"light/light-prover/prover/common"
+
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/math/emulated"
+	gnarkecdsa "github.com/consensys/gnark/std/signature/ecdsa"
+)
+
+var (
+	fixtureZeroSolAccount     [32]byte
+	fixtureZeroSplToken       [32]byte
+	fixtureZeroTokenInterface [32]byte
+)
+
+const fixtureTransactDiscriminator = 0
+
+const (
+	PublicAmountNone uint8 = iota
+	PublicAmountDeposit
+	PublicAmountWithdraw
+)
+
+type E2EFixtureSet struct {
+	Shape                 Shape        `json:"shape"`
+	SolanaSignerPubkeyHex string       `json:"solana_signer_pubkey"`
+	Fixtures              []E2EFixture `json:"fixtures"`
+}
+
+type E2EFixtureOptions struct {
+	SolanaSignerPubkey   [32]byte
+	PublicSplAssetPubkey [32]byte
+	UserSolAccount       [32]byte
+	UserSplToken         [32]byte
+	SplTokenInterface    [32]byte
+}
+
+type E2EFixture struct {
+	Name                    string        `json:"name"`
+	ExpiryUnixTs            uint64        `json:"expiry_unix_ts"`
+	SenderViewTag           string        `json:"sender_view_tag"`
+	Proof                   *common.Proof `json:"proof"`
+	RelayerFee              uint16        `json:"relayer_fee"`
+	Nullifiers              []string      `json:"nullifiers"`
+	OutputUtxoHashes        []string      `json:"output_utxo_hashes"`
+	UtxoTreeRootIndex       []uint16      `json:"utxo_tree_root_index"`
+	NullifierTreeRootIndex  []uint16      `json:"nullifier_tree_root_index"`
+	PrivateTxHash           string        `json:"private_tx_hash"`
+	PublicAmountMode        uint8         `json:"public_amount_mode"`
+	PublicSolAmount         *uint64       `json:"public_sol_amount"`
+	PublicSplAmount         *uint64       `json:"public_spl_amount"`
+	PublicSplAssetPubkey    string        `json:"public_spl_asset_pubkey"`
+	EncryptedUtxos          string        `json:"encrypted_utxos"`
+	ExpectedStateNextIndex  uint64        `json:"expected_state_next_index"`
+	ExpectedQueueNextIndex  uint64        `json:"expected_queue_next_index"`
+	ExpectedStateRoot       string        `json:"expected_state_root"`
+	PublicInputHash         string        `json:"public_input_hash"`
+	ExternalDataHash        string        `json:"external_data_hash"`
+	UserSolAccount          string        `json:"user_sol_account"`
+	UserSplTokenAccount     string        `json:"user_spl_token_account"`
+	SplTokenInterface       string        `json:"spl_token_interface"`
+	SolanaOwnerInputIndices []int         `json:"solana_owner_input_indices"`
+	DebugInputUtxoHashes    []string      `json:"debug_input_utxo_hashes"`
+	DebugOutputUtxoHashes   []string      `json:"debug_output_utxo_hashes"`
+	DebugUtxoTreeRoots      []string      `json:"debug_utxo_tree_roots"`
+	DebugNullifierTreeRoots []string      `json:"debug_nullifier_tree_roots"`
+}
+
+type fixtureTx struct {
+	name                     string
+	instructionDiscriminator uint8
+	senderTag                *big.Int
+	inputs                   []fixtureInput
+	outputs                  []Utxo
+	amountMode               uint8
+	publicSolDelta           int64
+	publicSplDelta           int64
+	encryptedUtxos           []byte
+	stateEntries             map[uint64]*big.Int
+	utxoRootIndex            uint16
+	ownerKeyHash             *big.Int
+	nullifierSecret          *big.Int
+	isP256Owner              bool
+	p256PrivateKey           *ecdsa.PrivateKey
+}
+
+type fixtureInput struct {
+	utxo      Utxo
+	leafIndex uint64
+}
+
+func WriteE2EFixtures(ps *ProofSystem, path string, options E2EFixtureOptions) error {
+	fixtures, err := BuildE2EFixtures(ps, options)
+	if err != nil {
+		return err
+	}
+	bytes, err := json.MarshalIndent(fixtures, "", "  ")
+	if err != nil {
+		return err
+	}
+	bytes = append(bytes, '\n')
+	return os.WriteFile(path, bytes, 0644)
+}
+
+func BuildE2EFixtures(ps *ProofSystem, options E2EFixtureOptions) (*E2EFixtureSet, error) {
+	shape := ps.Shape
+	if options.SolanaSignerPubkey == [32]byte{} {
+		return nil, fmt.Errorf("spp: e2e fixtures require a Solana signer pubkey")
+	}
+	if options.PublicSplAssetPubkey == [32]byte{} {
+		return nil, fmt.Errorf("spp: e2e fixtures require a non-zero public SPL asset pubkey")
+	}
+	if options.UserSplToken == [32]byte{} {
+		return nil, fmt.Errorf("spp: e2e fixtures require a user SPL token account pubkey")
+	}
+	if options.SplTokenInterface == [32]byte{} {
+		return nil, fmt.Errorf("spp: e2e fixtures require an SPL vault/interface pubkey")
+	}
+
+	assetID, err := SolanaPkHash(options.PublicSplAssetPubkey)
+	if err != nil {
+		return nil, err
+	}
+	nullifierPk, err := NullifierPk(big.NewInt(99))
+	if err != nil {
+		return nil, err
+	}
+	ownerKeyHash, err := SolanaPkHash(options.SolanaSignerPubkey)
+	if err != nil {
+		return nil, err
+	}
+	ownerHash, err := OwnerHash(ownerKeyHash, nullifierPk)
+	if err != nil {
+		return nil, err
+	}
+	signerHash := HashToFieldSize(options.SolanaSignerPubkey[:])
+	utxoA := sampleFixtureUtxo(10, ownerHash, assetID, big.NewInt(100))
+	utxoB := sampleFixtureUtxo(30, ownerHash, assetID, big.NewInt(60))
+	utxoC := sampleFixtureUtxo(50, ownerHash, assetID, big.NewInt(40))
+	solUtxo := sampleFixtureUtxo(70, ownerHash, SolAsset(), big.NewInt(80))
+	p256Priv, err := fixedP256PrivateKey(big.NewInt(11))
+	if err != nil {
+		return nil, err
+	}
+	p256Compressed := elliptic.MarshalCompressed(elliptic.P256(), p256Priv.PublicKey.X, p256Priv.PublicKey.Y)
+	p256OwnerKeyHash, err := P256OwnerKeyHash(p256Compressed)
+	if err != nil {
+		return nil, err
+	}
+	p256NullifierSecret := big.NewInt(199)
+	p256NullifierPk, err := NullifierPk(p256NullifierSecret)
+	if err != nil {
+		return nil, err
+	}
+	p256OwnerHash, err := OwnerHash(p256OwnerKeyHash, p256NullifierPk)
+	if err != nil {
+		return nil, err
+	}
+	p256UtxoA := sampleFixtureUtxo(90, p256OwnerHash, assetID, big.NewInt(25))
+	p256UtxoB := sampleFixtureUtxo(110, p256OwnerHash, assetID, big.NewInt(25))
+
+	hashA, err := UtxoHash(utxoA)
+	if err != nil {
+		return nil, err
+	}
+	hashB, err := UtxoHash(utxoB)
+	if err != nil {
+		return nil, err
+	}
+	hashC, err := UtxoHash(utxoC)
+	if err != nil {
+		return nil, err
+	}
+	solHash, err := UtxoHash(solUtxo)
+	if err != nil {
+		return nil, err
+	}
+	p256HashA, err := UtxoHash(p256UtxoA)
+	if err != nil {
+		return nil, err
+	}
+	p256HashB, err := UtxoHash(p256UtxoB)
+	if err != nil {
+		return nil, err
+	}
+
+	stateAfterShield := map[uint64]*big.Int{0: hashA}
+	stateAfterTransfer := map[uint64]*big.Int{0: hashA, 1: hashB, 2: hashC}
+	solStateAfterShield := map[uint64]*big.Int{0: solHash}
+	p256StateAfterShield := map[uint64]*big.Int{0: p256HashA}
+	p256StateAfterTransfer := map[uint64]*big.Int{0: p256HashA, 1: p256HashB}
+
+	txs := []fixtureTx{
+		{
+			name:           "shield",
+			senderTag:      big.NewInt(1001),
+			outputs:        []Utxo{utxoA},
+			amountMode:     PublicAmountDeposit,
+			publicSplDelta: 100,
+			encryptedUtxos: []byte{1, 0, 10, 11},
+			stateEntries:   map[uint64]*big.Int{},
+		},
+		{
+			name:      "transfer",
+			senderTag: big.NewInt(1002),
+			inputs: []fixtureInput{
+				{utxo: utxoA, leafIndex: 0},
+			},
+			outputs:        []Utxo{utxoB, utxoC},
+			amountMode:     PublicAmountNone,
+			publicSplDelta: 0,
+			encryptedUtxos: []byte{2, 0, 20, 21, 22},
+			stateEntries:   stateAfterShield,
+			utxoRootIndex:  1,
+		},
+		{
+			name:      "unshield",
+			senderTag: big.NewInt(1003),
+			inputs: []fixtureInput{
+				{utxo: utxoC, leafIndex: 2},
+			},
+			outputs:        nil,
+			amountMode:     PublicAmountWithdraw,
+			publicSplDelta: -40,
+			encryptedUtxos: []byte{3, 0, 30},
+			stateEntries:   stateAfterTransfer,
+			utxoRootIndex:  2,
+		},
+	}
+
+	out := &E2EFixtureSet{
+		Shape:                 shape,
+		SolanaSignerPubkeyHex: bytesHex(options.SolanaSignerPubkey[:]),
+	}
+	stateNextIndex := uint64(0)
+	queueNextIndex := uint64(0)
+	for _, tx := range txs {
+		fixture, err := buildE2EFixture(ps, shape, tx, assetID, signerHash, options)
+		if err != nil {
+			return nil, err
+		}
+		stateNextIndex += uint64(len(tx.outputs))
+		queueNextIndex += uint64(len(tx.inputs)) + 1
+		root, _ := BuildSparseStateTree(nextStateEntries(tx.name, hashA, hashB, hashC))
+		fixture.ExpectedStateNextIndex = stateNextIndex
+		fixture.ExpectedQueueNextIndex = queueNextIndex
+		fixture.ExpectedStateRoot = fieldHex(root)
+		out.Fixtures = append(out.Fixtures, fixture)
+	}
+
+	doubleSpend := fixtureTx{
+		name:      "double_spend",
+		senderTag: big.NewInt(1004),
+		inputs: []fixtureInput{
+			{utxo: utxoA, leafIndex: 0},
+		},
+		outputs:        []Utxo{utxoB, utxoC},
+		amountMode:     PublicAmountNone,
+		publicSplDelta: 0,
+		encryptedUtxos: []byte{4, 0, 40, 41, 42},
+		stateEntries:   stateAfterTransfer,
+		utxoRootIndex:  2,
+	}
+	fixture, err := buildE2EFixture(ps, shape, doubleSpend, assetID, signerHash, options)
+	if err != nil {
+		return nil, err
+	}
+	root, _ := BuildSparseStateTree(stateAfterTransfer)
+	fixture.ExpectedStateNextIndex = 3
+	fixture.ExpectedQueueNextIndex = 3
+	fixture.ExpectedStateRoot = fieldHex(root)
+	out.Fixtures = append(out.Fixtures, fixture)
+
+	solShield := fixtureTx{
+		name:           "sol_shield",
+		senderTag:      big.NewInt(2001),
+		outputs:        []Utxo{solUtxo},
+		amountMode:     PublicAmountDeposit,
+		publicSolDelta: 80,
+		encryptedUtxos: []byte{6, 0, 60, 61},
+		stateEntries:   map[uint64]*big.Int{},
+	}
+	fixture, err = buildE2EFixture(ps, shape, solShield, assetID, signerHash, options)
+	if err != nil {
+		return nil, err
+	}
+	solRoot, _ := BuildSparseStateTree(solStateAfterShield)
+	fixture.ExpectedStateNextIndex = 1
+	fixture.ExpectedQueueNextIndex = 1
+	fixture.ExpectedStateRoot = fieldHex(solRoot)
+	out.Fixtures = append(out.Fixtures, fixture)
+
+	solUnshield := fixtureTx{
+		name:      "sol_unshield",
+		senderTag: big.NewInt(2002),
+		inputs: []fixtureInput{
+			{utxo: solUtxo, leafIndex: 0},
+		},
+		outputs:        nil,
+		amountMode:     PublicAmountWithdraw,
+		publicSolDelta: -80,
+		encryptedUtxos: []byte{7, 0, 70},
+		stateEntries:   solStateAfterShield,
+		utxoRootIndex:  1,
+	}
+	fixture, err = buildE2EFixture(ps, shape, solUnshield, assetID, signerHash, options)
+	if err != nil {
+		return nil, err
+	}
+	fixture.ExpectedStateNextIndex = 1
+	fixture.ExpectedQueueNextIndex = 3
+	fixture.ExpectedStateRoot = fieldHex(solRoot)
+	out.Fixtures = append(out.Fixtures, fixture)
+
+	wrongDiscriminator := fixtureTx{
+		name:                     "wrong_discriminator",
+		instructionDiscriminator: 4,
+		senderTag:                big.NewInt(1005),
+		inputs: []fixtureInput{
+			{utxo: utxoA, leafIndex: 0},
+		},
+		outputs:        []Utxo{utxoB, utxoC},
+		amountMode:     PublicAmountNone,
+		publicSplDelta: 0,
+		encryptedUtxos: []byte{5, 0, 50, 51, 52},
+		stateEntries:   stateAfterShield,
+		utxoRootIndex:  1,
+	}
+	fixture, err = buildE2EFixture(ps, shape, wrongDiscriminator, assetID, signerHash, options)
+	if err != nil {
+		return nil, err
+	}
+	root, _ = BuildSparseStateTree(stateAfterTransfer)
+	fixture.ExpectedStateNextIndex = 3
+	fixture.ExpectedQueueNextIndex = 3
+	fixture.ExpectedStateRoot = fieldHex(root)
+	out.Fixtures = append(out.Fixtures, fixture)
+
+	p256Shield := fixtureTx{
+		name:           "p256_shield",
+		senderTag:      big.NewInt(3001),
+		outputs:        []Utxo{p256UtxoA},
+		amountMode:     PublicAmountDeposit,
+		publicSplDelta: 25,
+		encryptedUtxos: []byte{8, 0, 80, 81},
+		stateEntries:   map[uint64]*big.Int{},
+	}
+	fixture, err = buildE2EFixture(ps, shape, p256Shield, assetID, signerHash, options)
+	if err != nil {
+		return nil, err
+	}
+	p256RootAfterShield, _ := BuildSparseStateTree(p256StateAfterShield)
+	fixture.ExpectedStateNextIndex = 1
+	fixture.ExpectedQueueNextIndex = 1
+	fixture.ExpectedStateRoot = fieldHex(p256RootAfterShield)
+	out.Fixtures = append(out.Fixtures, fixture)
+
+	p256Transfer := fixtureTx{
+		name:      "p256_transfer",
+		senderTag: big.NewInt(3002),
+		inputs: []fixtureInput{
+			{utxo: p256UtxoA, leafIndex: 0},
+		},
+		outputs:         []Utxo{p256UtxoB},
+		amountMode:      PublicAmountNone,
+		encryptedUtxos:  []byte{9, 0, 90, 91},
+		stateEntries:    p256StateAfterShield,
+		utxoRootIndex:   1,
+		ownerKeyHash:    p256OwnerKeyHash,
+		nullifierSecret: p256NullifierSecret,
+		isP256Owner:     true,
+		p256PrivateKey:  p256Priv,
+	}
+	fixture, err = buildE2EFixture(ps, shape, p256Transfer, assetID, signerHash, options)
+	if err != nil {
+		return nil, err
+	}
+	p256RootAfterTransfer, _ := BuildSparseStateTree(p256StateAfterTransfer)
+	fixture.ExpectedStateNextIndex = 2
+	fixture.ExpectedQueueNextIndex = 3
+	fixture.ExpectedStateRoot = fieldHex(p256RootAfterTransfer)
+	out.Fixtures = append(out.Fixtures, fixture)
+	return out, nil
+}
+
+func buildE2EFixture(ps *ProofSystem, shape Shape, tx fixtureTx, assetID, signerHash *big.Int, options E2EFixtureOptions) (E2EFixture, error) {
+	assignment, publicInputs, debug, err := buildFixtureAssignment(shape, tx, assetID, signerHash, options)
+	if err != nil {
+		return E2EFixture{}, err
+	}
+	proof, err := Prove(ps, assignment)
+	if err != nil {
+		return E2EFixture{}, err
+	}
+	if err := Verify(ps, assignment, proof); err != nil {
+		return E2EFixture{}, err
+	}
+
+	publicInputHash, err := PublicInputHash(publicInputs)
+	if err != nil {
+		return E2EFixture{}, err
+	}
+
+	publicSolAmount := uint64(abs64(tx.publicSolDelta))
+	publicSplAmount := uint64(abs64(tx.publicSplDelta))
+	userSolAccount, userSplTokenAccount, splTokenInterface := fixtureSettlementAccounts(tx, options)
+	utxoRootIndices := make([]uint16, len(tx.inputs))
+	nullifierRootIndices := make([]uint16, len(tx.inputs))
+	for i := range utxoRootIndices {
+		utxoRootIndices[i] = tx.utxoRootIndex
+	}
+	outputHashes := trimTrailingZeroHexes(debug.outputHashes)
+	fixture := E2EFixture{
+		Name:                    tx.name,
+		ExpiryUnixTs:            1_000_000_000,
+		SenderViewTag:           fieldHex(tx.senderTag),
+		Proof:                   &common.Proof{Proof: proof},
+		RelayerFee:              0,
+		Nullifiers:              trimTrailingZeroHexes(debug.nullifiers),
+		OutputUtxoHashes:        outputHashes,
+		UtxoTreeRootIndex:       utxoRootIndices,
+		NullifierTreeRootIndex:  nullifierRootIndices,
+		PrivateTxHash:           fieldHex(publicInputs.PrivateTxHash),
+		PublicAmountMode:        tx.amountMode,
+		PublicSolAmount:         &publicSolAmount,
+		PublicSplAmount:         &publicSplAmount,
+		PublicSplAssetPubkey:    bytesHex(options.PublicSplAssetPubkey[:]),
+		EncryptedUtxos:          bytesHex(tx.encryptedUtxos),
+		PublicInputHash:         fieldHex(publicInputHash),
+		ExternalDataHash:        fieldHex(publicInputs.ExternalDataHash),
+		UserSolAccount:          bytesHex(userSolAccount[:]),
+		UserSplTokenAccount:     bytesHex(userSplTokenAccount[:]),
+		SplTokenInterface:       bytesHex(splTokenInterface[:]),
+		SolanaOwnerInputIndices: tx.solanaOwnerInputIndices(),
+		DebugInputUtxoHashes:    bigIntHexes(debug.inputHashes),
+		DebugOutputUtxoHashes:   bigIntHexes(debug.outputHashes),
+		DebugUtxoTreeRoots:      bigIntHexes(publicInputs.UtxoTreeRoots),
+		DebugNullifierTreeRoots: bigIntHexes(publicInputs.NullifierRoots),
+	}
+	if tx.publicSolDelta == 0 {
+		fixture.PublicSolAmount = nil
+	}
+	if tx.publicSplDelta == 0 {
+		fixture.PublicSplAmount = nil
+		fixture.PublicSplAssetPubkey = ""
+	}
+	return fixture, nil
+}
+
+type fixtureDebug struct {
+	inputHashes  []*big.Int
+	outputHashes []*big.Int
+	nullifiers   []*big.Int
+}
+
+func buildFixtureAssignment(shape Shape, tx fixtureTx, assetID, signerHash *big.Int, options E2EFixtureOptions) (*Circuit, PublicInputs, fixtureDebug, error) {
+	inputUtxos := make([]UtxoCircuitFields, shape.NInputs)
+	solanaPkHashes := make([]frontend.Variable, shape.NInputs)
+	isDummyInput := make([]frontend.Variable, shape.NInputs)
+	statePath := make([][]frontend.Variable, shape.NInputs)
+	stateDirs := make([][]frontend.Variable, shape.NInputs)
+	nfLowValue := make([]frontend.Variable, shape.NInputs)
+	nfNextValue := make([]frontend.Variable, shape.NInputs)
+	nfLowPath := make([][]frontend.Variable, shape.NInputs)
+	nfLowDirs := make([][]frontend.Variable, shape.NInputs)
+	nullifiers := make([]frontend.Variable, shape.NInputs)
+	inputHashes := make([]*big.Int, shape.NInputs)
+	utxoRoots := make([]*big.Int, shape.NInputs)
+	nullifierRoots := make([]*big.Int, shape.NInputs)
+
+	stateRoot, stateProofs := BuildSparseStateTree(tx.stateEntries)
+	nullifierTree := NewIndexedTree()
+	nullifierSecret := tx.nullifierSecret
+	if nullifierSecret == nil {
+		nullifierSecret = big.NewInt(99)
+	}
+	var err error
+	ownerKeyHash := tx.ownerKeyHash
+	if ownerKeyHash == nil {
+		if tx.isP256Owner {
+			if tx.p256PrivateKey == nil {
+				return nil, PublicInputs{}, fixtureDebug{}, fmt.Errorf("spp: P256 fixture %s missing private key", tx.name)
+			}
+			compressed := elliptic.MarshalCompressed(elliptic.P256(), tx.p256PrivateKey.PublicKey.X, tx.p256PrivateKey.PublicKey.Y)
+			ownerKeyHash, err = P256OwnerKeyHash(compressed)
+			if err != nil {
+				return nil, PublicInputs{}, fixtureDebug{}, err
+			}
+		} else {
+			ownerKeyHash, err = SolanaPkHash(options.SolanaSignerPubkey)
+			if err != nil {
+				return nil, PublicInputs{}, fixtureDebug{}, err
+			}
+		}
+	}
+	for i := 0; i < shape.NInputs; i++ {
+		statePath[i] = zeroVariableSlice(StateTreeHeight)
+		stateDirs[i] = zeroVariableSlice(StateTreeHeight)
+		nfLowPath[i] = zeroVariableSlice(NullifierTreeHeight)
+		nfLowDirs[i] = zeroVariableSlice(NullifierTreeHeight)
+		nfLowValue[i] = big.NewInt(0)
+		nfNextValue[i] = big.NewInt(0)
+		utxoRoots[i] = big.NewInt(0)
+		nullifierRoots[i] = big.NewInt(0)
+
+		if i >= len(tx.inputs) {
+			inputUtxos[i] = toFixtureCircuitFields(zeroUtxo())
+			solanaPkHashes[i] = big.NewInt(0)
+			isDummyInput[i] = frontend.Variable(1)
+			nullifiers[i] = big.NewInt(0)
+			inputHashes[i] = big.NewInt(0)
+			continue
+		}
+
+		input := tx.inputs[i]
+		inputUtxos[i] = toFixtureCircuitFields(input.utxo)
+		inputHash, err := UtxoHash(input.utxo)
+		if err != nil {
+			return nil, PublicInputs{}, fixtureDebug{}, err
+		}
+		nullifier, err := NullifierHash(inputHash, input.utxo.Blinding, nullifierSecret)
+		if err != nil {
+			return nil, PublicInputs{}, fixtureDebug{}, err
+		}
+		inputHashes[i] = inputHash
+		if tx.isP256Owner {
+			solanaPkHashes[i] = big.NewInt(0)
+		} else {
+			solanaPkHashes[i] = ownerKeyHash
+		}
+		isDummyInput[i] = frontend.Variable(0)
+		nullifiers[i] = nullifier
+		utxoRoots[i] = stateRoot
+		nullifierRoots[i] = nullifierTree.Root
+
+		proof, ok := stateProofs[input.leafIndex]
+		if !ok {
+			return nil, PublicInputs{}, fixtureDebug{}, fmt.Errorf("spp: missing state proof for leaf %d", input.leafIndex)
+		}
+		fillFixturePath(statePath[i], stateDirs[i], proof.Siblings, proof.Directions)
+
+		nfWitness := nullifierTree.NonInclusion(nullifier)
+		nfLowValue[i] = nfWitness.LowValue
+		nfNextValue[i] = nfWitness.NextValue
+		fillFixturePath(nfLowPath[i], nfLowDirs[i], nfWitness.Siblings, nfWitness.Directions)
+	}
+
+	outputUtxos := make([]UtxoCircuitFields, shape.NOutputs)
+	isDummyOutput := make([]frontend.Variable, shape.NOutputs)
+	outputHashes := make([]*big.Int, shape.NOutputs)
+	outputHashVars := make([]frontend.Variable, shape.NOutputs)
+	for i := 0; i < shape.NOutputs; i++ {
+		if i >= len(tx.outputs) {
+			outputUtxos[i] = toFixtureCircuitFields(zeroUtxo())
+			isDummyOutput[i] = frontend.Variable(1)
+			outputHashes[i] = big.NewInt(0)
+			outputHashVars[i] = big.NewInt(0)
+			continue
+		}
+		outputUtxos[i] = toFixtureCircuitFields(tx.outputs[i])
+		outputHash, err := UtxoHash(tx.outputs[i])
+		if err != nil {
+			return nil, PublicInputs{}, fixtureDebug{}, err
+		}
+		isDummyOutput[i] = frontend.Variable(0)
+		outputHashes[i] = outputHash
+		outputHashVars[i] = outputHash
+	}
+
+	userSolAccount, userSplTokenAccount, splTokenInterface := fixtureSettlementAccounts(tx, options)
+	externalDataHash := ExternalDataFieldHash(ExternalData{
+		InstructionDiscriminator: tx.discriminator(),
+		SenderViewTag:            fieldBytes(tx.senderTag),
+		RelayerFee:               0,
+		PublicSolAmount:          uint64(abs64(tx.publicSolDelta)),
+		PublicSplAmount:          uint64(abs64(tx.publicSplDelta)),
+		UserSolAccount:           userSolAccount,
+		UserSplToken:             userSplTokenAccount,
+		SplTokenInterface:        splTokenInterface,
+		EncryptedUtxos:           tx.encryptedUtxos,
+	})
+	privateTxHash, err := PrivateTxHash(inputHashes, outputHashes, externalDataHash)
+	if err != nil {
+		return nil, PublicInputs{}, fixtureDebug{}, err
+	}
+	privateTxHashBytes := proofFieldBytes(privateTxHash)
+	p256Pub, p256Sig, err := tx.p256Witness(privateTxHashBytes[:])
+	if err != nil {
+		return nil, PublicInputs{}, fixtureDebug{}, err
+	}
+	publicSolAmount := SignedToFe(big.NewInt(tx.publicSolDelta))
+	publicSplAmount := SignedToFe(big.NewInt(tx.publicSplDelta))
+	publicSplAsset := big.NewInt(0)
+	if tx.publicSplDelta != 0 {
+		publicSplAsset = new(big.Int).Set(assetID)
+	}
+	publicInputs := PublicInputs{
+		Nullifiers:           toFixtureBigInts(nullifiers),
+		OutputUtxoHashes:     outputHashes,
+		UtxoTreeRoots:        utxoRoots,
+		NullifierRoots:       nullifierRoots,
+		PrivateTxHash:        privateTxHash,
+		ExternalDataHash:     externalDataHash,
+		PublicSolAmount:      publicSolAmount,
+		PublicSplAmount:      publicSplAmount,
+		PublicSplAssetPubkey: publicSplAsset,
+		ProgramIDHashChain:   big.NewInt(0),
+		SolanaPubkeyHash:     new(big.Int).Set(signerHash),
+		SolanaPkHashes:       toFixtureBigInts(solanaPkHashes),
+	}
+	publicInputHash, err := PublicInputHash(publicInputs)
+	if err != nil {
+		return nil, PublicInputs{}, fixtureDebug{}, err
+	}
+
+	utxoRootVars := toFixtureVariables(utxoRoots)
+	nullifierRootVars := toFixtureVariables(nullifierRoots)
+	inputs := make([]Input, shape.NInputs)
+	for i := range inputs {
+		inputs[i] = Input{
+			Utxo:          inputUtxos[i],
+			IsDummy:       isDummyInput[i],
+			SolanaPkHash:  solanaPkHashes[i],
+			Nullifier:     nullifiers[i],
+			UtxoTreeRoot:  utxoRootVars[i],
+			NullifierRoot: nullifierRootVars[i],
+			State:         MerkleProof{Siblings: statePath[i], Directions: stateDirs[i]},
+			NfLowValue:    nfLowValue[i],
+			NfNextValue:   nfNextValue[i],
+			NfLow:         MerkleProof{Siblings: nfLowPath[i], Directions: nfLowDirs[i]},
+		}
+	}
+	outputs := make([]Output, shape.NOutputs)
+	for i := range outputs {
+		outputs[i] = Output{
+			Utxo:    outputUtxos[i],
+			IsDummy: isDummyOutput[i],
+			Hash:    outputHashVars[i],
+		}
+	}
+
+	assignment := &Circuit{
+		Shape:                shape,
+		Inputs:               inputs,
+		Outputs:              outputs,
+		ExternalDataHash:     externalDataHash,
+		NullifierSecret:      nullifierSecret,
+		P256Pub:              p256Pub,
+		P256Sig:              p256Sig,
+		PrivateTxHash:        privateTxHash,
+		PublicSolAmount:      publicInputs.PublicSolAmount,
+		PublicSplAmount:      publicInputs.PublicSplAmount,
+		PublicSplAssetPubkey: publicInputs.PublicSplAssetPubkey,
+		ProgramIDHashChain:   publicInputs.ProgramIDHashChain,
+		SolanaPubkeyHash:     publicInputs.SolanaPubkeyHash,
+		PublicInputHash:      publicInputHash,
+	}
+	return assignment, publicInputs, fixtureDebug{
+		inputHashes:  inputHashes,
+		outputHashes: outputHashes,
+		nullifiers:   toFixtureBigInts(nullifiers),
+	}, nil
+}
+
+func (tx fixtureTx) discriminator() uint8 {
+	if tx.instructionDiscriminator != 0 {
+		return tx.instructionDiscriminator
+	}
+	return fixtureTransactDiscriminator
+}
+
+func (tx fixtureTx) solanaOwnerInputIndices() []int {
+	if len(tx.inputs) == 0 || tx.isP256Owner {
+		return []int{}
+	}
+	out := make([]int, len(tx.inputs))
+	for i := range out {
+		out[i] = i
+	}
+	return out
+}
+
+func (tx fixtureTx) p256Witness(msg []byte) (gnarkecdsa.PublicKey[emulated.P256Fp, emulated.P256Fr], gnarkecdsa.Signature[emulated.P256Fr], error) {
+	if !tx.isP256Owner || len(tx.inputs) == 0 {
+		return dummyP256Witness(msg)
+	}
+	if tx.p256PrivateKey == nil {
+		return gnarkecdsa.PublicKey[emulated.P256Fp, emulated.P256Fr]{}, gnarkecdsa.Signature[emulated.P256Fr]{}, fmt.Errorf("spp: P256 fixture %s missing private key", tx.name)
+	}
+	r, s, err := ecdsa.Sign(rand.Reader, tx.p256PrivateKey, msg)
+	if err != nil {
+		return gnarkecdsa.PublicKey[emulated.P256Fp, emulated.P256Fr]{}, gnarkecdsa.Signature[emulated.P256Fr]{}, err
+	}
+	return gnarkecdsa.PublicKey[emulated.P256Fp, emulated.P256Fr]{
+			X: emulated.ValueOf[emulated.P256Fp](tx.p256PrivateKey.PublicKey.X),
+			Y: emulated.ValueOf[emulated.P256Fp](tx.p256PrivateKey.PublicKey.Y),
+		}, gnarkecdsa.Signature[emulated.P256Fr]{
+			R: emulated.ValueOf[emulated.P256Fr](r),
+			S: emulated.ValueOf[emulated.P256Fr](s),
+		}, nil
+}
+
+type ExternalData struct {
+	InstructionDiscriminator uint8
+	SenderViewTag            [32]byte
+	RelayerFee               uint16
+	PublicSolAmount          uint64
+	PublicSplAmount          uint64
+	UserSolAccount           [32]byte
+	UserSplToken             [32]byte
+	SplTokenInterface        [32]byte
+	EncryptedUtxos           []byte
+}
+
+func ExternalDataFieldHash(data ExternalData) *big.Int {
+	// TODO(v2): strengthen this encoding with explicit direction and
+	// length-delimited encrypted outputs before adding richer transaction
+	// variants. v1 keeps the spec's flat field order.
+	hasher := sha256.New()
+	hasher.Write([]byte{data.InstructionDiscriminator})
+	hasher.Write(data.SenderViewTag[:])
+	var fee [2]byte
+	binary.BigEndian.PutUint16(fee[:], data.RelayerFee)
+	hasher.Write(fee[:])
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], data.PublicSolAmount)
+	hasher.Write(buf[:])
+	binary.BigEndian.PutUint64(buf[:], data.PublicSplAmount)
+	hasher.Write(buf[:])
+	hasher.Write(data.UserSolAccount[:])
+	hasher.Write(data.UserSplToken[:])
+	hasher.Write(data.SplTokenInterface[:])
+	hasher.Write(data.EncryptedUtxos)
+	sum := hasher.Sum(nil)
+	sum[0] = 0
+	return new(big.Int).SetBytes(sum)
+}
+
+func fixtureSettlementAccounts(tx fixtureTx, options E2EFixtureOptions) ([32]byte, [32]byte, [32]byte) {
+	if tx.publicSolDelta != 0 {
+		userSolAccount := options.UserSolAccount
+		if userSolAccount == [32]byte{} {
+			userSolAccount = options.SolanaSignerPubkey
+		}
+		return userSolAccount, fixtureZeroSplToken, fixtureZeroTokenInterface
+	}
+	if tx.publicSplDelta != 0 {
+		return fixtureZeroSolAccount, options.UserSplToken, options.SplTokenInterface
+	}
+	return fixtureZeroSolAccount, fixtureZeroSplToken, fixtureZeroTokenInterface
+}
+
+func nextStateEntries(name string, hashA, hashB, hashC *big.Int) map[uint64]*big.Int {
+	switch name {
+	case "shield":
+		return map[uint64]*big.Int{0: hashA}
+	case "transfer", "unshield":
+		return map[uint64]*big.Int{0: hashA, 1: hashB, 2: hashC}
+	default:
+		return map[uint64]*big.Int{}
+	}
+}
+
+func sampleFixtureUtxo(base int64, ownerHash, assetID, amount *big.Int) Utxo {
+	return Utxo{
+		Domain:        big.NewInt(UtxoDomain),
+		Owner:         new(big.Int).Set(ownerHash),
+		Asset:         new(big.Int).Set(assetID),
+		AssetAmount:   new(big.Int).Set(amount),
+		Blinding:      big.NewInt(base + 5),
+		DataHash:      big.NewInt(base + 6),
+		ZoneDataHash:  big.NewInt(base + 7),
+		ZoneProgramID: big.NewInt(0),
+	}
+}
+
+func zeroUtxo() Utxo {
+	return Utxo{
+		Domain:        big.NewInt(0),
+		Owner:         big.NewInt(0),
+		Asset:         big.NewInt(0),
+		AssetAmount:   big.NewInt(0),
+		Blinding:      big.NewInt(0),
+		DataHash:      big.NewInt(0),
+		ZoneDataHash:  big.NewInt(0),
+		ZoneProgramID: big.NewInt(0),
+	}
+}
+
+func toFixtureCircuitFields(utxo Utxo) UtxoCircuitFields {
+	return UtxoCircuitFields{
+		Domain:        utxo.Domain,
+		Owner:         utxo.Owner,
+		Asset:         utxo.Asset,
+		AssetAmount:   utxo.AssetAmount,
+		Blinding:      utxo.Blinding,
+		DataHash:      utxo.DataHash,
+		ZoneDataHash:  utxo.ZoneDataHash,
+		ZoneProgramID: utxo.ZoneProgramID,
+	}
+}
+
+func zeroVariableSlice(n int) []frontend.Variable {
+	out := make([]frontend.Variable, n)
+	for i := range out {
+		out[i] = big.NewInt(0)
+	}
+	return out
+}
+
+func fillFixturePath(path []frontend.Variable, dirs []frontend.Variable, siblings []*big.Int, directions []int) {
+	for i := range siblings {
+		path[i] = siblings[i]
+		dirs[i] = big.NewInt(int64(directions[i]))
+	}
+}
+
+func toFixtureVariables(values []*big.Int) []frontend.Variable {
+	out := make([]frontend.Variable, len(values))
+	for i, value := range values {
+		out[i] = value
+	}
+	return out
+}
+
+func toFixtureBigInts(values []frontend.Variable) []*big.Int {
+	out := make([]*big.Int, len(values))
+	for i, value := range values {
+		switch v := value.(type) {
+		case *big.Int:
+			out[i] = new(big.Int).Set(v)
+		case int:
+			out[i] = big.NewInt(int64(v))
+		case int64:
+			out[i] = big.NewInt(v)
+		default:
+			out[i] = new(big.Int).SetInt64(0)
+			fmt.Sscan(fmt.Sprint(v), out[i])
+		}
+	}
+	return out
+}
+
+func trimTrailingZeroHexes(values []*big.Int) []string {
+	end := len(values)
+	for end > 0 && values[end-1].Sign() == 0 {
+		end--
+	}
+	out := make([]string, end)
+	for i := 0; i < end; i++ {
+		out[i] = fieldHex(values[i])
+	}
+	return out
+}
+
+func bigIntHexes(values []*big.Int) []string {
+	out := make([]string, len(values))
+	for i, value := range values {
+		out[i] = fieldHex(value)
+	}
+	return out
+}
+
+func fieldHex(value *big.Int) string {
+	return fmt.Sprintf("%064x", value)
+}
+
+func bytesHex(value []byte) string {
+	return fmt.Sprintf("%x", value)
+}
+
+func fieldBytes(value *big.Int) [32]byte {
+	var out [32]byte
+	bytes := value.Bytes()
+	copy(out[32-len(bytes):], bytes)
+	return out
+}
+
+func abs64(value int64) int64 {
+	if value < 0 {
+		return -value
+	}
+	return value
+}

--- a/prover/server/spp_cli_fixtures.go
+++ b/prover/server/spp_cli_fixtures.go
@@ -1,0 +1,107 @@
+//go:build spp_e2e_fixtures
+
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"fmt"
+	"light/light-prover/prover/spp"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+)
+
+func sppFixtureCommands() []*cli.Command {
+	return []*cli.Command{
+		{
+			Name:  "e2e-proof-bundle",
+			Usage: "generate an SPP E2E proof bundle for program tests",
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "keys-file", Usage: "SPP proving system file", Required: true},
+				&cli.StringFlag{Name: "output", Usage: "proof-bundle JSON output", Required: true},
+				&cli.StringFlag{Name: "solana-signer-seed-hex", Usage: "32-byte ed25519 seed for the real Solana signer used by the test transaction", Required: true},
+				&cli.StringFlag{Name: "public-spl-asset-pubkey", Usage: "32-byte public SPL mint pubkey", Required: true},
+				&cli.StringFlag{Name: "user-sol-account-hex", Usage: "32-byte SOL recipient/account pubkey for public SOL settlement"},
+				&cli.StringFlag{Name: "user-spl-token-account-hex", Usage: "32-byte SPL token account pubkey created by the test", Required: true},
+				&cli.StringFlag{Name: "spl-token-interface-hex", Usage: "32-byte SPL vault/interface pubkey created by the test", Required: true},
+			},
+			Action: func(context *cli.Context) error {
+				system, err := spp.ReadProofSystem(context.String("keys-file"))
+				if err != nil {
+					return err
+				}
+				seed, err := hex.DecodeString(context.String("solana-signer-seed-hex"))
+				if err != nil {
+					return fmt.Errorf("decode Solana signer seed: %w", err)
+				}
+				if len(seed) != ed25519.SeedSize {
+					return fmt.Errorf("Solana signer seed must be %d bytes", ed25519.SeedSize)
+				}
+				privateKey := ed25519.NewKeyFromSeed(seed)
+				var pubkey [32]byte
+				copy(pubkey[:], privateKey[32:])
+				userSolAccount, err := optionalHex32(context.String("user-sol-account-hex"))
+				if err != nil {
+					return fmt.Errorf("decode user SOL account: %w", err)
+				}
+				userSplToken, err := requiredHex32(context.String("user-spl-token-account-hex"), "user SPL token account")
+				if err != nil {
+					return err
+				}
+				splTokenInterface, err := requiredHex32(context.String("spl-token-interface-hex"), "SPL token interface")
+				if err != nil {
+					return err
+				}
+				publicSplAssetPubkey, err := requiredHex32(context.String("public-spl-asset-pubkey"), "public SPL asset pubkey")
+				if err != nil {
+					return err
+				}
+
+				if err := os.MkdirAll(filepath.Dir(context.String("output")), 0755); err != nil {
+					return err
+				}
+				options := spp.E2EFixtureOptions{
+					SolanaSignerPubkey:   pubkey,
+					PublicSplAssetPubkey: publicSplAssetPubkey,
+					UserSolAccount:       userSolAccount,
+					UserSplToken:         userSplToken,
+					SplTokenInterface:    splTokenInterface,
+				}
+				if err := spp.WriteE2EFixtures(system, context.String("output"), options); err != nil {
+					return err
+				}
+				fmt.Printf("wrote %s\n", context.String("output"))
+				return nil
+			},
+		},
+	}
+}
+
+func requiredHex32(value string, name string) ([32]byte, error) {
+	out, err := optionalHex32(value)
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("decode %s: %w", name, err)
+	}
+	if out == [32]byte{} {
+		return [32]byte{}, fmt.Errorf("%s must be non-zero", name)
+	}
+	return out, nil
+}
+
+func optionalHex32(value string) ([32]byte, error) {
+	var out [32]byte
+	if value == "" {
+		return out, nil
+	}
+	bytes, err := hex.DecodeString(value)
+	if err != nil {
+		return out, err
+	}
+	if len(bytes) != len(out) {
+		return out, fmt.Errorf("expected %d bytes, got %d", len(out), len(bytes))
+	}
+	copy(out[:], bytes)
+	return out, nil
+}

--- a/sdk-libs/program-test/Cargo.toml
+++ b/sdk-libs/program-test/Cargo.toml
@@ -15,6 +15,7 @@ default = []
 borsh = { workspace = true }
 litesvm = { workspace = true }
 solana-instruction = { workspace = true }
+solana-compute-budget-interface = { workspace = true }
 solana-keypair = { workspace = true }
 solana-message = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/sdk-libs/program-test/src/lib.rs
+++ b/sdk-libs/program-test/src/lib.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 
 use borsh::BorshSerialize;
 use litesvm::LiteSVM;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_message::Message;
@@ -28,8 +29,10 @@ use thiserror::Error;
 use zolana_interface::{
     instruction::{
         tag, AppendStateLeavesData, BatchUpdateAddressTreeData, CreatePoolTreeData,
-        InsertAddressesData,
+        CreateProtocolConfigData, InsertAddressesData, PauseTreeData, TransactData,
+        UpdateProtocolConfigData,
     },
+    state::PROTOCOL_CONFIG_ACCOUNT_LEN,
     LIGHT_REGISTRY_PROGRAM_ID, SHIELDED_POOL_PROGRAM_ID,
 };
 
@@ -78,6 +81,15 @@ impl PoolTestRig {
     }
 
     pub fn with_program_path(path: &Path) -> Result<Self, RigError> {
+        Self::with_program_path_and_payer(path, Keypair::new())
+    }
+
+    pub fn new_with_payer(payer: Keypair) -> Result<Self, RigError> {
+        let program_path = default_program_path();
+        Self::with_program_path_and_payer(&program_path, payer)
+    }
+
+    pub fn with_program_path_and_payer(path: &Path, payer: Keypair) -> Result<Self, RigError> {
         if !path.exists() {
             return Err(RigError::MissingProgram(path.to_path_buf()));
         }
@@ -88,7 +100,6 @@ impl PoolTestRig {
         svm.add_program(program_id, &program_bytes)
             .map_err(|e| RigError::Litesvm(format!("add_program: {e:?}")))?;
 
-        let payer = Keypair::new();
         // ~20 SOL — the combined pool-tree account is ~1.16 MB which costs
         // ~8 SOL rent-exempt, so a 1 SOL airdrop is too small.
         svm.airdrop(&payer.pubkey(), 20_000_000_000)
@@ -141,6 +152,10 @@ impl PoolTestRig {
     pub fn create_program_owned_account(&mut self, account_size: u64) -> Result<Keypair, RigError> {
         let program_id = self.program_id;
         self.create_account_with_owner(account_size, program_id)
+    }
+
+    pub fn create_protocol_config_account(&mut self) -> Result<Keypair, RigError> {
+        self.create_program_owned_account(PROTOCOL_CONFIG_ACCOUNT_LEN as u64)
     }
 
     pub fn create_account_with_owner(
@@ -406,6 +421,91 @@ impl PoolTestRig {
             data: payload,
         };
         self.send(&[ix], &[&self.payer.insecure_clone()])
+    }
+
+    pub fn create_shielded_pool_protocol_config(
+        &mut self,
+        config: &Keypair,
+        authority: &Keypair,
+        data: CreateProtocolConfigData,
+    ) -> Result<(), RigError> {
+        let mut payload = vec![tag::CREATE_PROTOCOL_CONFIG];
+        data.serialize(&mut payload).expect("infallible");
+        let ix = Instruction {
+            program_id: self.program_id,
+            accounts: vec![
+                AccountMeta::new_readonly(authority.pubkey(), true),
+                AccountMeta::new(config.pubkey(), false),
+            ],
+            data: payload,
+        };
+        self.send(&[ix], &[&self.payer.insecure_clone(), authority])
+    }
+
+    pub fn update_shielded_pool_protocol_config(
+        &mut self,
+        config: &Keypair,
+        authority: &Keypair,
+        data: UpdateProtocolConfigData,
+    ) -> Result<(), RigError> {
+        let mut payload = vec![tag::UPDATE_PROTOCOL_CONFIG];
+        data.serialize(&mut payload).expect("infallible");
+        let ix = Instruction {
+            program_id: self.program_id,
+            accounts: vec![
+                AccountMeta::new_readonly(authority.pubkey(), true),
+                AccountMeta::new(config.pubkey(), false),
+            ],
+            data: payload,
+        };
+        self.send(&[ix], &[&self.payer.insecure_clone(), authority])
+    }
+
+    pub fn pause_tree(
+        &mut self,
+        config: &Keypair,
+        tree: &Keypair,
+        authority: &Keypair,
+        data: PauseTreeData,
+    ) -> Result<(), RigError> {
+        let mut payload = vec![tag::PAUSE_TREE];
+        data.serialize(&mut payload).expect("infallible");
+        let ix = Instruction {
+            program_id: self.program_id,
+            accounts: vec![
+                AccountMeta::new_readonly(authority.pubkey(), true),
+                AccountMeta::new_readonly(config.pubkey(), false),
+                AccountMeta::new(tree.pubkey(), false),
+            ],
+            data: payload,
+        };
+        self.send(&[ix], &[&self.payer.insecure_clone(), authority])
+    }
+
+    pub fn transact(&mut self, tree: &Keypair, data: TransactData) -> Result<(), RigError> {
+        self.transact_with_extra_accounts(tree, data, Vec::new())
+    }
+
+    pub fn transact_with_extra_accounts(
+        &mut self,
+        tree: &Keypair,
+        data: TransactData,
+        extra_accounts: Vec<AccountMeta>,
+    ) -> Result<(), RigError> {
+        let mut payload = vec![tag::TRANSACT];
+        data.serialize(&mut payload).expect("infallible");
+        let mut accounts = vec![
+            AccountMeta::new(tree.pubkey(), false),
+            AccountMeta::new_readonly(self.payer.pubkey(), true),
+        ];
+        accounts.extend(extra_accounts);
+        let ix = Instruction {
+            program_id: self.program_id,
+            accounts,
+            data: payload,
+        };
+        let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
+        self.send(&[compute_budget_ix, ix], &[&self.payer.insecure_clone()])
     }
 
     /// Read the raw bytes of any account in the rig.


### PR DESCRIPTION
Restacked from the old #25. Adds program/prover SPP e2e fixtures and LiteSVM transaction coverage. CLI e2e coverage was moved to #24 so this PR can sit before the CLI layer.

Verification run on the final stack:
- cargo test --offline -p zolana-interface
- cargo check --offline -p shielded-pool-program --lib --tests
- cargo test --offline -p shielded-pool-program --lib --tests
- cargo check --offline -p zolana-cli --tests
- go test -count=1 ./... in prover/server