### PR TITLE
Add SPP prover tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7570,6 +7570,8 @@ dependencies = [
 name = "xtask"
 version = "0.1.0"
 dependencies = [
+ "groth16-solana 0.2.0 (git+https://github.com/Lightprotocol/groth16-solana?rev=4e6cacff2f4ff53744fda0509f5e62545fd99aa6)",
+ "groth16-solana 0.2.0 (git+https://github.com/Lightprotocol/groth16-solana?rev=b374683cd0139b9e8cd8c148b08cc1e22e8ace02)",
  "sha2 0.10.9",
 ]
 

--- a/justfile
+++ b/justfile
@@ -187,8 +187,52 @@ build-light-programs: fetch-fixtures
     cp "${fixtures}/bin/light_system_program_pinocchio.so" target/deploy/light_system_program_pinocchio.so
 
 build-prover-server:
+    #!/usr/bin/env bash
+    set -euo pipefail
     mkdir -p target
-    cd prover/server && go build -o ../../target/prover-server .
+    go_bin="${GO_BIN:-}"
+    if [[ -z "$go_bin" ]] && command -v go >/dev/null 2>&1; then
+        go_bin=go
+    fi
+    if [[ -z "$go_bin" ]]; then
+        if [[ -x target/prover-server ]]; then
+            echo "go not found; reusing existing target/prover-server"
+            exit 0
+        fi
+        echo "go not found; install Go or set GO_BIN" >&2
+        exit 127
+    fi
+    cd prover/server && "$go_bin" build -o ../../target/prover-server .
+
+build-spp-keys: build-prover-server
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p target/spp
+    if [[ ! -f target/spp/spp_1_2.key ]]; then
+        target/prover-server spp setup --inputs 1 --outputs 2 --output target/spp/spp_1_2.key --output-vkey target/spp/spp_1_2.vkey
+    fi
+
+build-spp-spec-keys: build-prover-server
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p target/spp
+    for shape in 2:2 1:2 3:3 5:3 1:8; do
+        inputs="${shape%%:*}"
+        outputs="${shape##*:}"
+        stem="target/spp/spp_${inputs}_${outputs}"
+        if [[ ! -f "${stem}.key" ]]; then
+            target/prover-server spp setup --inputs "$inputs" --outputs "$outputs" --output "${stem}.key" --output-vkey "${stem}.vkey"
+        fi
+    done
+
+build-spp-nullifier-keys: build-prover-server
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p target/spp
+    stem="target/spp/spp-nullifier-update_40_10"
+    if [[ ! -f "${stem}.key" ]]; then
+        target/prover-server spp setup-nullifier-update --tree-height 40 --batch-size 10 --output "${stem}.key" --output-vkey "${stem}.vkey"
+    fi
 
 # === Formatting and linting ===
 

--- a/prover/client/src/proof.rs
+++ b/prover/client/src/proof.rs
@@ -59,6 +59,8 @@ pub struct GnarkProofJson {
     pub ar: Vec<String>,
     pub bs: Vec<Vec<String>>,
     pub krs: Vec<String>,
+    pub proof_commitment: Option<Vec<String>>,
+    pub proof_commitment_pok: Option<Vec<String>>,
 }
 
 pub fn deserialize_gnark_proof_json(json_data: &str) -> serde_json::Result<GnarkProofJson> {
@@ -108,6 +110,46 @@ pub fn proof_from_json_struct(json: GnarkProofJson) -> ([u8; 64], [u8; 128], [u8
     let proof_c_y = deserialize_hex_string_to_be_bytes(&json.krs[1]);
     let proof_c: [u8; 64] = [proof_c_x, proof_c_y].concat().try_into().unwrap();
     (proof_a, proof_b, proof_c)
+}
+
+pub fn bsb22_proof_bytes_from_json_struct(
+    json: GnarkProofJson,
+) -> Result<[u8; 192], ProverClientError> {
+    let commitment = parse_g1_pair(json.proof_commitment.as_deref(), "proof_commitment")?;
+    let commitment_pok =
+        parse_g1_pair(json.proof_commitment_pok.as_deref(), "proof_commitment_pok")?;
+    let (proof_a, proof_b, proof_c) = proof_from_json_struct(json);
+    let (proof_a, proof_b, proof_c) = compress_proof(&proof_a, &proof_b, &proof_c);
+    let proof_commitment = alt_bn128_g1_compress_be(&commitment)?;
+    let proof_commitment_pok = alt_bn128_g1_compress_be(&commitment_pok)?;
+
+    if proof_commitment == [0u8; 32] || proof_commitment_pok == [0u8; 32] {
+        return Err(ProverClientError::InvalidProofData(
+            "BSB22 commitment fields must be non-zero".to_string(),
+        ));
+    }
+
+    let mut out = [0u8; 192];
+    out[..32].copy_from_slice(&proof_a);
+    out[32..96].copy_from_slice(&proof_b);
+    out[96..128].copy_from_slice(&proof_c);
+    out[128..160].copy_from_slice(&proof_commitment);
+    out[160..192].copy_from_slice(&proof_commitment_pok);
+    Ok(out)
+}
+
+fn parse_g1_pair(value: Option<&[String]>, name: &str) -> Result<[u8; 64], ProverClientError> {
+    let value = value.ok_or_else(|| {
+        ProverClientError::InvalidProofData(format!("{name} is required for BSB22 proof"))
+    })?;
+    if value.len() != 2 {
+        return Err(ProverClientError::InvalidProofData(format!(
+            "{name} must contain exactly two coordinates"
+        )));
+    }
+    let x = deserialize_hex_string_to_be_bytes(&value[0]);
+    let y = deserialize_hex_string_to_be_bytes(&value[1]);
+    Ok([x, y].concat().try_into().unwrap())
 }
 
 pub fn negate_g1(g1_be: &[u8; 64]) -> [u8; 64] {

--- a/prover/server/main.go
+++ b/prover/server/main.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/consensys/gnark/constraint"
+	gnarkio "github.com/consensys/gnark/io"
 	gnarkLogger "github.com/consensys/gnark/logger"
 	"github.com/urfave/cli/v2"
 )
@@ -33,6 +34,7 @@ func runCli() {
 	app := cli.App{
 		EnableBashCompletion: true,
 		Commands: []*cli.Command{
+			sppCommand(),
 			{
 				Name: "setup",
 				Flags: []cli.Flag{
@@ -425,7 +427,7 @@ func runCli() {
 					}
 
 					var buf bytes.Buffer
-					_, err = vk.(io.WriterTo).WriteTo(&buf)
+					_, err = vk.(gnarkio.WriterRawTo).WriteRawTo(&buf)
 					if err != nil {
 						return fmt.Errorf("failed to serialize verification key: %v", err)
 					}
@@ -435,16 +437,31 @@ func runCli() {
 						return fmt.Errorf("failed to create output directory: %v", err)
 					}
 
-					var dataToWrite = buf.Bytes()
-
-					err = os.WriteFile(outputFile, dataToWrite, 0644)
+					file, err := os.Create(outputFile)
 					if err != nil {
-						return fmt.Errorf("failed to write verification key to file: %v", err)
+						return fmt.Errorf("failed to create verification key file: %v", err)
+					}
+					defer file.Close()
+					if _, err := file.WriteString("["); err != nil {
+						return fmt.Errorf("failed to write verification key file: %v", err)
+					}
+					for i, b := range buf.Bytes() {
+						if i > 0 {
+							if _, err := file.WriteString(" "); err != nil {
+								return fmt.Errorf("failed to write verification key file: %v", err)
+							}
+						}
+						if _, err := fmt.Fprintf(file, "%d", b); err != nil {
+							return fmt.Errorf("failed to write verification key file: %v", err)
+						}
+					}
+					if _, err := file.WriteString("]"); err != nil {
+						return fmt.Errorf("failed to write verification key file: %v", err)
 					}
 
 					logging.Logger().Info().
 						Str("file", outputFile).
-						Int("bytes", len(dataToWrite)).
+						Int("bytes", buf.Len()).
 						Msg("Verification key exported successfully")
 
 					return nil

--- a/prover/server/spp_cli.go
+++ b/prover/server/spp_cli.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"fmt"
+	"light/light-prover/prover/common"
+	"light/light-prover/prover/spp/model"
+	nullifierbatchupdate "light/light-prover/prover/spp/prover/nullifier_batch_update"
+	txprover "light/light-prover/prover/spp/prover/transaction"
+	"os"
+	"path/filepath"
+
+	"github.com/urfave/cli/v2"
+)
+
+func sppCommand() *cli.Command {
+	subcommands := []*cli.Command{
+		{
+			Name: "setup",
+			Flags: []cli.Flag{
+				&cli.IntFlag{Name: "inputs", Usage: "fixed input slots", Required: true},
+				&cli.IntFlag{Name: "outputs", Usage: "fixed output slots", Required: true},
+				&cli.StringFlag{Name: "output", Usage: "proving system output", Required: true},
+				&cli.StringFlag{Name: "output-vkey", Usage: "text verifying key output", Required: false},
+			},
+			Action: func(context *cli.Context) error {
+				shape, err := model.NewShape(context.Int("inputs"), context.Int("outputs"))
+				if err != nil {
+					return err
+				}
+				system, err := txprover.Setup(shape)
+				if err != nil {
+					return err
+				}
+				if err := os.MkdirAll(filepath.Dir(context.String("output")), 0755); err != nil {
+					return err
+				}
+				if vkey := context.String("output-vkey"); vkey != "" {
+					if err := os.MkdirAll(filepath.Dir(vkey), 0755); err != nil {
+						return err
+					}
+				}
+				return txprover.WriteProofSystem(system, context.String("output"), context.String("output-vkey"))
+			},
+		},
+		{
+			Name: "export-vk",
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "keys-file", Usage: "SPP proving system file", Required: true},
+				&cli.StringFlag{Name: "output", Usage: "text verifying key output", Required: true},
+			},
+			Action: func(context *cli.Context) error {
+				system, err := txprover.ReadProofSystem(context.String("keys-file"))
+				if err != nil {
+					return err
+				}
+				if err := os.MkdirAll(filepath.Dir(context.String("output")), 0755); err != nil {
+					return err
+				}
+				return txprover.WriteVerifyingKeyText(system.VerifyingKey, context.String("output"))
+			},
+		},
+		{
+			Name: "export-nullifier-update-vk",
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "keys-file", Usage: "SPP nullifier update proving system file", Required: true},
+				&cli.StringFlag{Name: "output", Usage: "text verifying key output", Required: true},
+			},
+			Action: func(context *cli.Context) error {
+				system, err := common.ReadSystemFromFile(context.String("keys-file"))
+				if err != nil {
+					return err
+				}
+				batchSystem, ok := system.(*common.BatchProofSystem)
+				if !ok || batchSystem.CircuitType != common.SppNullifierUpdateCircuitType {
+					return fmt.Errorf("expected %s proving system", common.SppNullifierUpdateCircuitType)
+				}
+				if err := os.MkdirAll(filepath.Dir(context.String("output")), 0755); err != nil {
+					return err
+				}
+				return txprover.WriteVerifyingKeyText(batchSystem.VerifyingKey, context.String("output"))
+			},
+		},
+		{
+			Name: "setup-nullifier-update",
+			Flags: []cli.Flag{
+				&cli.UintFlag{Name: "tree-height", Usage: "SPP nullifier indexed-tree height", Value: 40, Required: false},
+				&cli.UintFlag{Name: "batch-size", Usage: "queued nullifiers per proof", Value: 10, Required: false},
+				&cli.StringFlag{Name: "output", Usage: "proving system output", Required: true},
+				&cli.StringFlag{Name: "output-vkey", Usage: "text verifying key output", Required: false},
+			},
+			Action: func(context *cli.Context) error {
+				system, err := nullifierbatchupdate.SetupNullifierBatchUpdate(
+					uint32(context.Uint("tree-height")),
+					uint32(context.Uint("batch-size")),
+				)
+				if err != nil {
+					return err
+				}
+				if err := os.MkdirAll(filepath.Dir(context.String("output")), 0755); err != nil {
+					return err
+				}
+				if vkey := context.String("output-vkey"); vkey != "" {
+					if err := os.MkdirAll(filepath.Dir(vkey), 0755); err != nil {
+						return err
+					}
+				}
+				return common.WriteProvingSystem(system, context.String("output"), context.String("output-vkey"))
+			},
+		},
+		{
+			Name:  "prove-nullifier-update",
+			Usage: "prove an SPP nullifier indexed-tree batch update from explicit witness JSON",
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "keys-file", Usage: "SPP nullifier update proving system file", Required: true},
+				&cli.StringFlag{Name: "input", Usage: "nullifier update request JSON input", Required: true},
+				&cli.StringFlag{Name: "output", Usage: "nullifier update proof bundle JSON output", Required: true},
+			},
+			Action: func(context *cli.Context) error {
+				system, err := common.ReadSystemFromFile(context.String("keys-file"))
+				if err != nil {
+					return err
+				}
+				batchSystem, ok := system.(*common.BatchProofSystem)
+				if !ok || batchSystem.CircuitType != common.SppNullifierUpdateCircuitType {
+					return fmt.Errorf("expected %s proving system", common.SppNullifierUpdateCircuitType)
+				}
+				if err := os.MkdirAll(filepath.Dir(context.String("output")), 0755); err != nil {
+					return err
+				}
+				return nullifierbatchupdate.WriteNullifierBatchUpdateBundle(
+					batchSystem,
+					context.String("input"),
+					context.String("output"),
+				)
+			},
+		},
+		{
+			Name:  "prove-bundle",
+			Usage: "prove an SPP transaction bundle from explicit witness JSON",
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "keys-file", Usage: "SPP proving system file", Required: true},
+				&cli.StringFlag{Name: "input", Usage: "proof request JSON input", Required: true},
+				&cli.StringFlag{Name: "output", Usage: "proof bundle JSON output", Required: true},
+			},
+			Action: func(context *cli.Context) error {
+				system, err := txprover.ReadProofSystem(context.String("keys-file"))
+				if err != nil {
+					return err
+				}
+				if err := os.MkdirAll(filepath.Dir(context.String("output")), 0755); err != nil {
+					return err
+				}
+				return txprover.WriteProofBundle(system, context.String("input"), context.String("output"))
+			},
+		},
+		{
+			Name:  "signing-payload",
+			Usage: "compute SPP private transaction hashes needed for external owner signatures",
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "keys-file", Usage: "SPP proving system file", Required: true},
+				&cli.StringFlag{Name: "input", Usage: "proof request JSON input", Required: true},
+				&cli.StringFlag{Name: "output", Usage: "signing payload JSON output", Required: true},
+			},
+			Action: func(context *cli.Context) error {
+				system, err := txprover.ReadProofSystem(context.String("keys-file"))
+				if err != nil {
+					return err
+				}
+				if err := os.MkdirAll(filepath.Dir(context.String("output")), 0755); err != nil {
+					return err
+				}
+				return txprover.WriteProofSigningPayload(system, context.String("input"), context.String("output"))
+			},
+		},
+	}
+	subcommands = append(subcommands, sppFixtureCommands()...)
+	return &cli.Command{
+		Name:        "spp",
+		Usage:       "SPP circuit setup and verifying-key export",
+		Subcommands: subcommands,
+	}
+}

--- a/prover/server/spp_cli_fixtures_stub.go
+++ b/prover/server/spp_cli_fixtures_stub.go
@@ -1,0 +1,9 @@
+//go:build !spp_e2e_fixtures
+
+package main
+
+import "github.com/urfave/cli/v2"
+
+func sppFixtureCommands() []*cli.Command {
+	return nil
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,4 +5,6 @@ edition.workspace = true
 publish = false
 
 [dependencies]
+groth16-solana = { workspace = true }
+groth16-solana-bsb22 = { workspace = true }
 sha2 = { workspace = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,10 +1,11 @@
 use std::{
     env, fs,
-    io::Read,
+    io::{Read, Write},
     path::{Path, PathBuf},
     process::Command,
 };
 
+use groth16_solana_bsb22::gnark_vk_parser::{bsb22_vk_to_rust_const, parse_gnark_vk_bytes};
 use sha2::{Digest, Sha256};
 
 fn main() {
@@ -14,11 +15,58 @@ fn main() {
             let options = CreateVerifyingKeysOptions::parse(args.collect());
             create_verifying_keys(options);
         }
+        Some("generate-vkey-rs") => {
+            let options = GenerateVkeyRsOptions::parse(args.collect());
+            generate_vkey_rs(options);
+        }
         Some("--help") | Some("-h") | None => print_help(),
         Some(command) => {
             eprintln!("unknown xtask command: {command}");
             print_help();
             std::process::exit(2);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct GenerateVkeyRsOptions {
+    input_path: PathBuf,
+    output_path: PathBuf,
+}
+
+impl GenerateVkeyRsOptions {
+    fn parse(args: Vec<String>) -> Self {
+        let mut input_path = None;
+        let mut output_path = None;
+
+        let mut args = args.into_iter();
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--input-path" => {
+                    input_path = Some(
+                        args.next()
+                            .map(PathBuf::from)
+                            .unwrap_or_else(|| usage_and_exit("--input-path missing value")),
+                    );
+                }
+                "--output-path" => {
+                    output_path = Some(
+                        args.next()
+                            .map(PathBuf::from)
+                            .unwrap_or_else(|| usage_and_exit("--output-path missing value")),
+                    );
+                }
+                "--help" | "-h" => {
+                    print_generate_vkey_rs_help();
+                    std::process::exit(0);
+                }
+                other => usage_and_exit(&format!("unexpected arg {other:?}")),
+            }
+        }
+
+        Self {
+            input_path: input_path.unwrap_or_else(|| usage_and_exit("--input-path is required")),
+            output_path: output_path.unwrap_or_else(|| usage_and_exit("--output-path is required")),
         }
     }
 }
@@ -167,7 +215,8 @@ fn read_proving_keys(keys_dir: &Path) -> Vec<PathBuf> {
 }
 
 fn export_verifying_key(prover_server_dir: &Path, key_path: &Path, output_path: &Path) {
-    let status = Command::new("go")
+    let go = env::var("GO").unwrap_or_else(|_| "go".to_string());
+    let status = Command::new(go)
         .current_dir(prover_server_dir)
         .args(["run", ".", "export-vk", "--keys-file"])
         .arg(key_path)
@@ -178,6 +227,51 @@ fn export_verifying_key(prover_server_dir: &Path, key_path: &Path, output_path: 
 
     if !status.success() {
         panic!("go export-vk failed with status {status}");
+    }
+}
+
+fn generate_vkey_rs(options: GenerateVkeyRsOptions) {
+    let input_path = options.input_path;
+    let output_path = options.output_path;
+    let bytes = read_vkey_bytes(&input_path);
+    let vk = parse_gnark_vk_bytes(&bytes).expect("failed to parse gnark verifying key");
+    let code = bsb22_vk_to_rust_const(&vk, "VERIFYINGKEY").replace(
+        "use groth16_solana::groth16::Groth16Verifyingkey;",
+        "use groth16_solana_bsb22::groth16::Groth16Verifyingkey;",
+    );
+
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent).expect("failed to create vkey output directory");
+    }
+    let mut file = fs::File::create(&output_path).expect("failed to create vkey rs file");
+    file.write_all(code.as_bytes())
+        .expect("failed to write vkey rs");
+    run_rustfmt(&output_path);
+}
+
+fn read_vkey_bytes(path: &Path) -> Vec<u8> {
+    let bytes = fs::read(path)
+        .unwrap_or_else(|error| panic!("failed to read verifying key {}: {error}", path.display()));
+    if bytes.first() != Some(&b'[') {
+        return bytes;
+    }
+    let text = String::from_utf8(bytes).expect("text vkey is not UTF-8");
+    text.trim_matches(|p| p == '[' || p == ']')
+        .split_whitespace()
+        .map(|s| {
+            s.parse::<u8>()
+                .unwrap_or_else(|_| panic!("invalid vkey byte {s:?}"))
+        })
+        .collect()
+}
+
+fn run_rustfmt(path: &Path) {
+    let status = Command::new("rustfmt")
+        .arg(path)
+        .status()
+        .unwrap_or_else(|error| panic!("failed to run rustfmt: {error}"));
+    if !status.success() {
+        panic!("rustfmt failed with status {status}");
     }
 }
 
@@ -225,6 +319,7 @@ fn print_help() {
     println!();
     println!("Commands:");
     println!("  create-verifying-keys    Export prover-server verifying key artifacts");
+    println!("  generate-vkey-rs         Convert a gnark verifying key into Rust constants");
 }
 
 fn print_create_verifying_keys_help() {
@@ -233,4 +328,8 @@ fn print_create_verifying_keys_help() {
     println!("Defaults:");
     println!("  --keys-dir prover/server/proving-keys");
     println!("  --out-dir  $ZOLANA_VERIFYING_KEYS_DIR or target/verifying-keys");
+}
+
+fn print_generate_vkey_rs_help() {
+    println!("xtask generate-vkey-rs --input-path <path> --output-path <path>");
 }


### PR DESCRIPTION
Split from #14.

Adds SPP prover-server CLI commands, BSB22 proof encoding support, xtask verifying-key generation, and justfile SPP key-generation targets.

Verification:
- cargo check --offline -p xtask
- go test ./... in prover/server