### PR TITLE
Add SPP interface wire format

### DIFF
--- a/program-libs/interface/src/instruction/builders/batch_update_nullifier_tree.rs
+++ b/program-libs/interface/src/instruction/builders/batch_update_nullifier_tree.rs
@@ -1,0 +1,27 @@
+use borsh::BorshSerialize;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_pubkey::Pubkey;
+
+use crate::{
+    instruction::{tag, BatchUpdateNullifierTreeData},
+    SHIELDED_POOL_PROGRAM_ID,
+};
+
+pub fn batch_update_nullifier_tree(
+    authority: Pubkey,
+    tree: Pubkey,
+    data: BatchUpdateNullifierTreeData,
+) -> Instruction {
+    let mut instruction_data = vec![tag::BATCH_UPDATE_NULLIFIER_TREE];
+    data.serialize(&mut instruction_data)
+        .expect("shielded-pool instruction serialization is infallible");
+
+    Instruction {
+        program_id: Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID),
+        accounts: vec![
+            AccountMeta::new_readonly(authority, true),
+            AccountMeta::new(tree, false),
+        ],
+        data: instruction_data,
+    }
+}

--- a/program-libs/interface/src/instruction/builders/create_spl_interface.rs
+++ b/program-libs/interface/src/instruction/builders/create_spl_interface.rs
@@ -1,0 +1,45 @@
+use borsh::BorshSerialize;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_pubkey::Pubkey;
+
+use crate::{
+    instruction::{tag, CreateSplInterfaceData},
+    SHIELDED_POOL_PROGRAM_ID,
+};
+
+pub struct CreateSplInterfaceAccounts {
+    pub authority: Pubkey,
+    pub protocol_config: Pubkey,
+    pub asset_counter: Pubkey,
+    pub registry: Pubkey,
+    pub mint: Pubkey,
+    pub vault: Pubkey,
+    pub cpi_authority: Pubkey,
+    pub system_program: Pubkey,
+    pub token_program: Pubkey,
+}
+
+pub fn create_spl_interface(
+    accounts: CreateSplInterfaceAccounts,
+    data: CreateSplInterfaceData,
+) -> Instruction {
+    let mut instruction_data = vec![tag::CREATE_SPL_INTERFACE];
+    data.serialize(&mut instruction_data)
+        .expect("shielded-pool instruction serialization is infallible");
+
+    Instruction {
+        program_id: Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID),
+        accounts: vec![
+            AccountMeta::new_readonly(accounts.authority, true),
+            AccountMeta::new_readonly(accounts.protocol_config, false),
+            AccountMeta::new(accounts.asset_counter, false),
+            AccountMeta::new(accounts.registry, false),
+            AccountMeta::new_readonly(accounts.mint, false),
+            AccountMeta::new(accounts.vault, false),
+            AccountMeta::new_readonly(accounts.cpi_authority, false),
+            AccountMeta::new_readonly(accounts.system_program, false),
+            AccountMeta::new_readonly(accounts.token_program, false),
+        ],
+        data: instruction_data,
+    }
+}

--- a/program-libs/interface/src/instruction/builders/mod.rs
+++ b/program-libs/interface/src/instruction/builders/mod.rs
@@ -1,9 +1,19 @@
 mod append_state_leaves;
 mod batch_update_address_tree;
+mod batch_update_nullifier_tree;
 mod create_pool_tree;
+mod create_spl_interface;
 mod insert_addresses;
+mod pocket_config;
+mod protocol_config;
+mod transact;
 
 pub use append_state_leaves::append_state_leaves;
 pub use batch_update_address_tree::batch_update_address_tree;
+pub use batch_update_nullifier_tree::batch_update_nullifier_tree;
 pub use create_pool_tree::create_pool_tree;
+pub use create_spl_interface::create_spl_interface;
 pub use insert_addresses::insert_addresses;
+pub use pocket_config::{create_pocket_config, update_pocket_config, update_pocket_config_owner};
+pub use protocol_config::{create_protocol_config, pause_tree, update_protocol_config};
+pub use transact::transact;

--- a/program-libs/interface/src/instruction/builders/pocket_config/mod.rs
+++ b/program-libs/interface/src/instruction/builders/pocket_config/mod.rs
@@ -1,0 +1,72 @@
+use borsh::BorshSerialize;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_pubkey::Pubkey;
+
+use crate::{
+    instruction::{
+        tag, CreatePocketConfigData, UpdatePocketConfigData, UpdatePocketConfigOwnerData,
+    },
+    SHIELDED_POOL_PROGRAM_ID,
+};
+
+pub fn create_pocket_config(
+    payer: Pubkey,
+    pocket_config: Pubkey,
+    pocket_auth: Pubkey,
+    data: CreatePocketConfigData,
+) -> Instruction {
+    let mut instruction_data = vec![tag::CREATE_POCKET_CONFIG];
+    data.serialize(&mut instruction_data)
+        .expect("shielded-pool instruction serialization is infallible");
+
+    Instruction {
+        program_id: Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID),
+        accounts: vec![
+            AccountMeta::new_readonly(payer, true),
+            AccountMeta::new(pocket_config, false),
+            AccountMeta::new_readonly(pocket_auth, true),
+        ],
+        data: instruction_data,
+    }
+}
+
+pub fn update_pocket_config_owner(
+    authority: Pubkey,
+    pocket_config: Pubkey,
+    data: UpdatePocketConfigOwnerData,
+) -> Instruction {
+    build_update_ix(
+        tag::UPDATE_POCKET_CONFIG_OWNER,
+        authority,
+        pocket_config,
+        data,
+    )
+}
+
+pub fn update_pocket_config(
+    authority: Pubkey,
+    pocket_config: Pubkey,
+    data: UpdatePocketConfigData,
+) -> Instruction {
+    build_update_ix(tag::UPDATE_POCKET_CONFIG, authority, pocket_config, data)
+}
+
+fn build_update_ix<T: BorshSerialize>(
+    tag: u8,
+    authority: Pubkey,
+    pocket_config: Pubkey,
+    data: T,
+) -> Instruction {
+    let mut instruction_data = vec![tag];
+    data.serialize(&mut instruction_data)
+        .expect("shielded-pool instruction serialization is infallible");
+
+    Instruction {
+        program_id: Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID),
+        accounts: vec![
+            AccountMeta::new_readonly(authority, true),
+            AccountMeta::new(pocket_config, false),
+        ],
+        data: instruction_data,
+    }
+}

--- a/program-libs/interface/src/instruction/builders/protocol_config/mod.rs
+++ b/program-libs/interface/src/instruction/builders/protocol_config/mod.rs
@@ -1,0 +1,77 @@
+use borsh::BorshSerialize;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_pubkey::Pubkey;
+
+use crate::{
+    instruction::{tag, CreateProtocolConfigData, PauseTreeData, UpdateProtocolConfigData},
+    SHIELDED_POOL_PROGRAM_ID,
+};
+
+pub fn create_protocol_config(
+    authority: Pubkey,
+    protocol_config: Pubkey,
+    data: CreateProtocolConfigData,
+) -> Instruction {
+    build_config_ix(
+        tag::CREATE_PROTOCOL_CONFIG,
+        authority,
+        protocol_config,
+        None,
+        data,
+    )
+}
+
+pub fn update_protocol_config(
+    authority: Pubkey,
+    protocol_config: Pubkey,
+    data: UpdateProtocolConfigData,
+) -> Instruction {
+    build_config_ix(
+        tag::UPDATE_PROTOCOL_CONFIG,
+        authority,
+        protocol_config,
+        None,
+        data,
+    )
+}
+
+pub fn pause_tree(
+    authority: Pubkey,
+    protocol_config: Pubkey,
+    tree: Pubkey,
+    data: PauseTreeData,
+) -> Instruction {
+    build_config_ix(
+        tag::PAUSE_TREE,
+        authority,
+        protocol_config,
+        Some(tree),
+        data,
+    )
+}
+
+fn build_config_ix<T: BorshSerialize>(
+    tag: u8,
+    authority: Pubkey,
+    protocol_config: Pubkey,
+    tree: Option<Pubkey>,
+    data: T,
+) -> Instruction {
+    let mut instruction_data = vec![tag];
+    data.serialize(&mut instruction_data)
+        .expect("shielded-pool instruction serialization is infallible");
+
+    let mut accounts = vec![
+        AccountMeta::new_readonly(authority, true),
+        AccountMeta::new(protocol_config, false),
+    ];
+    if let Some(tree) = tree {
+        accounts.push(AccountMeta::new(tree, false));
+    }
+
+    Instruction {
+        program_id: Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID),
+        accounts,
+        data: instruction_data,
+    }
+}

--- a/program-libs/interface/src/instruction/builders/transact.rs
+++ b/program-libs/interface/src/instruction/builders/transact.rs
@@ -1,0 +1,23 @@
+use borsh::BorshSerialize;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_pubkey::Pubkey;
+
+use crate::{
+    instruction::{tag, TransactData},
+    SHIELDED_POOL_PROGRAM_ID,
+};
+
+pub fn transact(authority: Pubkey, tree: Pubkey, data: TransactData) -> Instruction {
+    let mut instruction_data = vec![tag::TRANSACT];
+    data.serialize(&mut instruction_data)
+        .expect("shielded-pool instruction serialization is infallible");
+
+    Instruction {
+        program_id: Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID),
+        accounts: vec![
+            AccountMeta::new_readonly(authority, true),
+            AccountMeta::new(tree, false),
+        ],
+        data: instruction_data,
+    }
+}

--- a/program-libs/interface/src/instruction/instruction_data/batch_update_nullifier_tree.rs
+++ b/program-libs/interface/src/instruction/instruction_data/batch_update_nullifier_tree.rs
@@ -1,0 +1,19 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+/// Inputs for `batch_update_nullifier_tree`.
+///
+/// The address-tree proof is verified by the embedded Light address queue and
+/// consumes the pending queue batch. The SPP nullifier proof is verified
+/// against the same queued-value hashchain and advances SPP's full-field
+/// indexed nullifier root cache.
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct BatchUpdateNullifierTreeData {
+    pub address_new_root: [u8; 32],
+    pub address_compressed_proof_a: [u8; 32],
+    pub address_compressed_proof_b: [u8; 64],
+    pub address_compressed_proof_c: [u8; 32],
+    pub nullifier_new_root: [u8; 32],
+    pub nullifier_compressed_proof_a: [u8; 32],
+    pub nullifier_compressed_proof_b: [u8; 64],
+    pub nullifier_compressed_proof_c: [u8; 32],
+}

--- a/program-libs/interface/src/instruction/instruction_data/create_spl_interface.rs
+++ b/program-libs/interface/src/instruction/instruction_data/create_spl_interface.rs
@@ -1,0 +1,4 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct CreateSplInterfaceData;

--- a/program-libs/interface/src/instruction/instruction_data/mod.rs
+++ b/program-libs/interface/src/instruction/instruction_data/mod.rs
@@ -1,9 +1,24 @@
 pub mod append_state_leaves;
 pub mod batch_update_address_tree;
+pub mod batch_update_nullifier_tree;
 pub mod create_pool_tree;
+pub mod create_spl_interface;
 pub mod insert_addresses;
+pub mod pocket_config;
+pub mod protocol_config;
+pub mod transact;
 
 pub use append_state_leaves::AppendStateLeavesData;
 pub use batch_update_address_tree::BatchUpdateAddressTreeData;
+pub use batch_update_nullifier_tree::BatchUpdateNullifierTreeData;
 pub use create_pool_tree::CreatePoolTreeData;
+pub use create_spl_interface::CreateSplInterfaceData;
 pub use insert_addresses::InsertAddressesData;
+pub use pocket_config::{
+    CreatePocketConfigData, UpdatePocketConfigData, UpdatePocketConfigOwnerData,
+};
+pub use protocol_config::{CreateProtocolConfigData, PauseTreeData, UpdateProtocolConfigData};
+pub use transact::{
+    CpiSignerData, InputUtxoSignerIndex, TransactData, PUBLIC_AMOUNT_DEPOSIT, PUBLIC_AMOUNT_NONE,
+    PUBLIC_AMOUNT_WITHDRAW,
+};

--- a/program-libs/interface/src/instruction/instruction_data/pocket_config.rs
+++ b/program-libs/interface/src/instruction/instruction_data/pocket_config.rs
@@ -1,0 +1,20 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct CreatePocketConfigData {
+    pub policy_program_id: [u8; 32],
+    pub pocket_auth_bump: u8,
+    pub authority: [u8; 32],
+    pub pocket_authority_transact_is_enabled: bool,
+    pub pocket_config_bump: u8,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct UpdatePocketConfigOwnerData {
+    pub new_authority: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct UpdatePocketConfigData {
+    pub pocket_authority_transact_is_enabled: bool,
+}

--- a/program-libs/interface/src/instruction/instruction_data/protocol_config.rs
+++ b/program-libs/interface/src/instruction/instruction_data/protocol_config.rs
@@ -1,0 +1,16 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct CreateProtocolConfigData {
+    pub authority: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct UpdateProtocolConfigData {
+    pub new_authority: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct PauseTreeData {
+    pub paused: bool,
+}

--- a/program-libs/interface/src/instruction/instruction_data/transact.rs
+++ b/program-libs/interface/src/instruction/instruction_data/transact.rs
@@ -1,0 +1,36 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct TransactData {
+    pub expiry_unix_ts: u64,
+    pub sender_view_tag: [u8; 32],
+    pub proof: [u8; 192],
+    pub relayer_fee: u16,
+    pub public_amount_mode: u8,
+    pub nullifiers: Vec<[u8; 32]>,
+    pub output_utxo_hashes: Vec<[u8; 32]>,
+    pub utxo_tree_root_index: Vec<u16>,
+    pub nullifier_tree_root_index: Vec<u16>,
+    pub private_tx_hash: [u8; 32],
+    pub public_sol_amount: Option<u64>,
+    pub public_spl_amount: Option<u64>,
+    pub cpi_signer: Option<CpiSignerData>,
+    pub in_utxo_signer_indices: Option<Vec<InputUtxoSignerIndex>>,
+    pub encrypted_utxos: Vec<u8>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct CpiSignerData {
+    pub program_id: [u8; 32],
+    pub bump: u8,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct InputUtxoSignerIndex {
+    pub account_index: u8,
+    pub input_index: u8,
+}
+
+pub const PUBLIC_AMOUNT_NONE: u8 = 0;
+pub const PUBLIC_AMOUNT_DEPOSIT: u8 = 1;
+pub const PUBLIC_AMOUNT_WITHDRAW: u8 = 2;

--- a/program-libs/interface/src/instruction/mod.rs
+++ b/program-libs/interface/src/instruction/mod.rs
@@ -6,7 +6,11 @@ pub mod tag;
 use borsh::BorshSerialize;
 
 pub use instruction_data::{
-    AppendStateLeavesData, BatchUpdateAddressTreeData, CreatePoolTreeData, InsertAddressesData,
+    AppendStateLeavesData, BatchUpdateAddressTreeData, BatchUpdateNullifierTreeData, CpiSignerData,
+    CreatePocketConfigData, CreatePoolTreeData, CreateProtocolConfigData, CreateSplInterfaceData,
+    InputUtxoSignerIndex, InsertAddressesData, PauseTreeData, TransactData, UpdatePocketConfigData,
+    UpdatePocketConfigOwnerData, UpdateProtocolConfigData, PUBLIC_AMOUNT_DEPOSIT,
+    PUBLIC_AMOUNT_NONE, PUBLIC_AMOUNT_WITHDRAW,
 };
 pub use tag::InstructionTag;
 

--- a/program-libs/interface/src/instruction/tag.rs
+++ b/program-libs/interface/src/instruction/tag.rs
@@ -1,8 +1,28 @@
 /// First-byte instruction dispatch tags for the shielded-pool program.
-pub const CREATE_POOL_TREE: u8 = 0;
-pub const INSERT_ADDRESSES: u8 = 1;
-pub const BATCH_UPDATE_ADDRESS_TREE: u8 = 2;
-pub const APPEND_STATE_LEAVES: u8 = 3;
+pub const TRANSACT: u8 = 0;
+pub const PROOFLESS_SHIELD: u8 = 1;
+pub const POCKET_TRANSACT: u8 = 2;
+pub const POCKET_AUTHORITY_TRANSACT: u8 = 3;
+pub const CREATE_SPL_INTERFACE: u8 = 6;
+pub const CREATE_POOL_TREE: u8 = 7;
+pub const CREATE_PROTOCOL_CONFIG: u8 = 9;
+pub const UPDATE_PROTOCOL_CONFIG: u8 = 10;
+pub const PAUSE_TREE: u8 = 11;
+pub const CREATE_POCKET_CONFIG: u8 = 12;
+pub const UPDATE_POCKET_CONFIG_OWNER: u8 = 13;
+pub const UPDATE_POCKET_CONFIG: u8 = 14;
+pub const MERGE_TRANSACT: u8 = 15;
+pub const ENABLE_MERGE_AUTHORITY: u8 = 16;
+pub const DISABLE_MERGE_AUTHORITY: u8 = 17;
+pub const CREATE_MERGE_AUTHORITY_TREE: u8 = 18;
+pub const MERGE_POCKET: u8 = 19;
+
+// Legacy/internal tree maintenance instructions. They are outside the SPP spec
+// dispatch table and intentionally avoid the reserved proof/pocket tags.
+pub const INSERT_ADDRESSES: u8 = 50;
+pub const BATCH_UPDATE_ADDRESS_TREE: u8 = 51;
+pub const APPEND_STATE_LEAVES: u8 = 52;
+pub const BATCH_UPDATE_NULLIFIER_TREE: u8 = 53;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
@@ -10,7 +30,24 @@ pub enum InstructionTag {
     CreatePoolTree = CREATE_POOL_TREE,
     InsertAddresses = INSERT_ADDRESSES,
     BatchUpdateAddressTree = BATCH_UPDATE_ADDRESS_TREE,
+    BatchUpdateNullifierTree = BATCH_UPDATE_NULLIFIER_TREE,
     AppendStateLeaves = APPEND_STATE_LEAVES,
+    Transact = TRANSACT,
+    ProoflessShield = PROOFLESS_SHIELD,
+    PocketTransact = POCKET_TRANSACT,
+    PocketAuthorityTransact = POCKET_AUTHORITY_TRANSACT,
+    CreateSplInterface = CREATE_SPL_INTERFACE,
+    CreateProtocolConfig = CREATE_PROTOCOL_CONFIG,
+    UpdateProtocolConfig = UPDATE_PROTOCOL_CONFIG,
+    PauseTree = PAUSE_TREE,
+    CreatePocketConfig = CREATE_POCKET_CONFIG,
+    UpdatePocketConfigOwner = UPDATE_POCKET_CONFIG_OWNER,
+    UpdatePocketConfig = UPDATE_POCKET_CONFIG,
+    MergeTransact = MERGE_TRANSACT,
+    EnableMergeAuthority = ENABLE_MERGE_AUTHORITY,
+    DisableMergeAuthority = DISABLE_MERGE_AUTHORITY,
+    CreateMergeAuthorityTree = CREATE_MERGE_AUTHORITY_TREE,
+    MergePocket = MERGE_POCKET,
 }
 
 impl TryFrom<u8> for InstructionTag {
@@ -21,7 +58,24 @@ impl TryFrom<u8> for InstructionTag {
             CREATE_POOL_TREE => Ok(Self::CreatePoolTree),
             INSERT_ADDRESSES => Ok(Self::InsertAddresses),
             BATCH_UPDATE_ADDRESS_TREE => Ok(Self::BatchUpdateAddressTree),
+            BATCH_UPDATE_NULLIFIER_TREE => Ok(Self::BatchUpdateNullifierTree),
             APPEND_STATE_LEAVES => Ok(Self::AppendStateLeaves),
+            TRANSACT => Ok(Self::Transact),
+            PROOFLESS_SHIELD => Ok(Self::ProoflessShield),
+            POCKET_TRANSACT => Ok(Self::PocketTransact),
+            POCKET_AUTHORITY_TRANSACT => Ok(Self::PocketAuthorityTransact),
+            CREATE_SPL_INTERFACE => Ok(Self::CreateSplInterface),
+            CREATE_PROTOCOL_CONFIG => Ok(Self::CreateProtocolConfig),
+            UPDATE_PROTOCOL_CONFIG => Ok(Self::UpdateProtocolConfig),
+            PAUSE_TREE => Ok(Self::PauseTree),
+            CREATE_POCKET_CONFIG => Ok(Self::CreatePocketConfig),
+            UPDATE_POCKET_CONFIG_OWNER => Ok(Self::UpdatePocketConfigOwner),
+            UPDATE_POCKET_CONFIG => Ok(Self::UpdatePocketConfig),
+            MERGE_TRANSACT => Ok(Self::MergeTransact),
+            ENABLE_MERGE_AUTHORITY => Ok(Self::EnableMergeAuthority),
+            DISABLE_MERGE_AUTHORITY => Ok(Self::DisableMergeAuthority),
+            CREATE_MERGE_AUTHORITY_TREE => Ok(Self::CreateMergeAuthorityTree),
+            MERGE_POCKET => Ok(Self::MergePocket),
             _ => Err(()),
         }
     }

--- a/program-libs/interface/src/lib.rs
+++ b/program-libs/interface/src/lib.rs
@@ -22,6 +22,45 @@ pub const LIGHT_REGISTRY_PROGRAM_ID: [u8; 32] = [
 /// `Pubkey::find_program_address(&[CPI_AUTHORITY_PDA_SEED], &LIGHT_REGISTRY_PROGRAM_ID)`.
 pub const CPI_AUTHORITY_PDA_SEED: &[u8] = b"cpi_authority";
 
+/// Seed for the shielded-pool program's own CPI authority PDA, used as the
+/// SOL vault and SPL vault authority for public settlement.
+pub const SHIELDED_POOL_CPI_AUTHORITY_PDA_SEED: &[u8] = b"cpi_authority";
+pub const SPP_POCKET_CONFIG_PDA_SEED: &[u8] = b"spp_pocket_config";
+pub const POCKET_AUTH_PDA_SEED: &[u8] = b"pocket_auth";
+pub const SPL_ASSET_COUNTER_PDA_SEED: &[u8] = b"spl_asset_counter";
+pub const SPL_ASSET_REGISTRY_PDA_SEED: &[u8] = b"spl_asset_registry";
+pub const SPL_ASSET_VAULT_PDA_SEED: &[u8] = b"spl_asset_vault";
+
+/// Canonical shielded-pool CPI authority PDA:
+/// `find_program_address(&[b"cpi_authority"], SHIELDED_POOL_PROGRAM_ID)`.
+/// Kept as a constant so the SBF program validates settlement accounts with a
+/// direct equality check.
+pub const SHIELDED_POOL_CPI_AUTHORITY: [u8; 32] = [
+    85, 90, 130, 119, 99, 189, 124, 34, 25, 77, 186, 49, 37, 53, 39, 49, 7, 137, 62, 163, 187, 111,
+    36, 84, 136, 126, 165, 236, 8, 174, 36, 5,
+];
+
+/// Bump for `SHIELDED_POOL_CPI_AUTHORITY`.
+pub const SHIELDED_POOL_CPI_AUTHORITY_BUMP: u8 = 255;
+
+/// SPL Token v3 program id: `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA`.
+pub const SPL_TOKEN_PROGRAM_ID: [u8; 32] = [
+    6, 221, 246, 225, 215, 101, 161, 147, 217, 203, 225, 70, 206, 235, 121, 172, 28, 180, 133, 237,
+    95, 91, 55, 145, 58, 140, 245, 133, 126, 255, 0, 169,
+];
+
+/// Canonical layout for a shielded-pool SPL asset registry record:
+/// magic (8), mint pubkey (32), reserved (8). SPL asset identity is the
+/// Poseidon hash of the mint pubkey, not the reserved bytes.
+pub const SPL_ASSET_REGISTRY_MAGIC: [u8; 8] = *b"SPASSET1";
+pub const SPL_ASSET_REGISTRY_ACCOUNT_LEN: usize = 48;
+/// Deprecated compatibility PDA. SPL identity is mint-derived.
+pub const SPL_ASSET_COUNTER_MAGIC: [u8; 8] = *b"SPCOUNT1";
+pub const SPL_ASSET_COUNTER_ACCOUNT_LEN: usize = 16;
+/// Deprecated compatibility value. Native SOL remains asset id 1; SPL assets
+/// are mint-derived field elements.
+pub const FIRST_SPL_ASSET_ID: u64 = 2;
+
 /// Canonical registry CPI authority PDA — `find_program_address(&[b"cpi_authority"], LIGHT_REGISTRY_PROGRAM_ID)`.
 /// Hardcoded so shielded-pool can do a single equality check on the signer
 /// without re-deriving on every call. A pin test against

--- a/program-libs/interface/src/state/config.rs
+++ b/program-libs/interface/src/state/config.rs
@@ -1,0 +1,16 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+pub const PROTOCOL_CONFIG_ACCOUNT_LEN: usize = 40;
+pub const POCKET_CONFIG_ACCOUNT_LEN: usize = 42;
+
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct ProtocolConfig {
+    pub authority: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+pub struct SppPocketConfig {
+    pub authority: [u8; 32],
+    pub pocket_authority_transact_is_enabled: bool,
+    pub bump: u8,
+}

--- a/program-libs/interface/src/state/discriminator.rs
+++ b/program-libs/interface/src/state/discriminator.rs
@@ -1,2 +1,4 @@
 pub const POOL_TREE_HEADER: u8 = 1;
 pub const SHIELDED_POOL_CONFIG: u8 = 2;
+pub const PROTOCOL_CONFIG: u8 = 3;
+pub const POCKET_CONFIG: u8 = 4;

--- a/program-libs/interface/src/state/mod.rs
+++ b/program-libs/interface/src/state/mod.rs
@@ -1,6 +1,11 @@
+pub mod config;
 pub mod discriminator;
 pub mod pool;
 pub mod pool_tree;
+
+pub use config::{
+    ProtocolConfig, SppPocketConfig, POCKET_CONFIG_ACCOUNT_LEN, PROTOCOL_CONFIG_ACCOUNT_LEN,
+};
 
 pub use pool::ShieldedPoolConfig;
 pub use pool_tree::PoolTreeHeader;

--- a/program-libs/interface/tests/instruction_roundtrip.rs
+++ b/program-libs/interface/tests/instruction_roundtrip.rs
@@ -1,7 +1,10 @@
 use borsh::BorshDeserialize;
 use zolana_interface::instruction::{
-    encode_instruction, tag, AppendStateLeavesData, BatchUpdateAddressTreeData, CreatePoolTreeData,
-    InsertAddressesData, InstructionTag,
+    encode_instruction, tag, AppendStateLeavesData, BatchUpdateAddressTreeData,
+    BatchUpdateNullifierTreeData, CreatePocketConfigData, CreatePoolTreeData,
+    CreateProtocolConfigData, CreateSplInterfaceData, InputUtxoSignerIndex, InsertAddressesData,
+    InstructionTag, PauseTreeData, TransactData, UpdatePocketConfigData,
+    UpdatePocketConfigOwnerData, UpdateProtocolConfigData, PUBLIC_AMOUNT_DEPOSIT,
 };
 
 #[test]
@@ -67,4 +70,190 @@ fn batch_update_address_tree_roundtrip() {
         Ok(InstructionTag::BatchUpdateAddressTree)
     );
     assert_eq!(decoded, payload);
+}
+
+#[test]
+fn batch_update_nullifier_tree_roundtrip() {
+    let payload = BatchUpdateNullifierTreeData {
+        address_new_root: [3u8; 32],
+        address_compressed_proof_a: [4u8; 32],
+        address_compressed_proof_b: [5u8; 64],
+        address_compressed_proof_c: [6u8; 32],
+        nullifier_new_root: [7u8; 32],
+        nullifier_compressed_proof_a: [8u8; 32],
+        nullifier_compressed_proof_b: [9u8; 64],
+        nullifier_compressed_proof_c: [10u8; 32],
+    };
+    let bytes = encode_instruction(tag::BATCH_UPDATE_NULLIFIER_TREE, &payload);
+    let decoded = BatchUpdateNullifierTreeData::try_from_slice(&bytes[1..]).unwrap();
+
+    assert_eq!(bytes[0], tag::BATCH_UPDATE_NULLIFIER_TREE);
+    assert_eq!(
+        InstructionTag::try_from(bytes[0]),
+        Ok(InstructionTag::BatchUpdateNullifierTree)
+    );
+    assert_eq!(decoded, payload);
+}
+
+#[test]
+fn transact_roundtrip() {
+    let payload = TransactData {
+        expiry_unix_ts: 123,
+        sender_view_tag: [1u8; 32],
+        proof: [2u8; 192],
+        relayer_fee: 3,
+        public_amount_mode: PUBLIC_AMOUNT_DEPOSIT,
+        nullifiers: vec![[4u8; 32]],
+        output_utxo_hashes: vec![[5u8; 32], [6u8; 32]],
+        utxo_tree_root_index: vec![7],
+        nullifier_tree_root_index: vec![8],
+        private_tx_hash: [9u8; 32],
+        public_sol_amount: None,
+        public_spl_amount: Some(10),
+        cpi_signer: None,
+        in_utxo_signer_indices: Some(vec![InputUtxoSignerIndex {
+            account_index: 1,
+            input_index: 0,
+        }]),
+        encrypted_utxos: vec![12, 13],
+    };
+    let bytes = encode_instruction(tag::TRANSACT, &payload);
+    let decoded = TransactData::try_from_slice(&bytes[1..]).unwrap();
+
+    assert_eq!(bytes[0], tag::TRANSACT);
+    assert_eq!(
+        InstructionTag::try_from(bytes[0]),
+        Ok(InstructionTag::Transact)
+    );
+    assert_eq!(decoded, payload);
+}
+
+#[test]
+fn create_spl_interface_roundtrip() {
+    let payload = CreateSplInterfaceData;
+    let bytes = encode_instruction(tag::CREATE_SPL_INTERFACE, &payload);
+    let decoded = CreateSplInterfaceData::try_from_slice(&bytes[1..]).unwrap();
+
+    assert_eq!(bytes[0], tag::CREATE_SPL_INTERFACE);
+    assert_eq!(
+        InstructionTag::try_from(bytes[0]),
+        Ok(InstructionTag::CreateSplInterface)
+    );
+    assert_eq!(decoded, payload);
+}
+
+#[test]
+fn protocol_config_roundtrips() {
+    let create = CreateProtocolConfigData {
+        authority: [1u8; 32],
+    };
+    let bytes = encode_instruction(tag::CREATE_PROTOCOL_CONFIG, &create);
+    assert_eq!(bytes[0], tag::CREATE_PROTOCOL_CONFIG);
+    assert_eq!(
+        CreateProtocolConfigData::try_from_slice(&bytes[1..]).unwrap(),
+        create
+    );
+
+    let update = UpdateProtocolConfigData {
+        new_authority: [2u8; 32],
+    };
+    let bytes = encode_instruction(tag::UPDATE_PROTOCOL_CONFIG, &update);
+    assert_eq!(bytes[0], tag::UPDATE_PROTOCOL_CONFIG);
+    assert_eq!(
+        UpdateProtocolConfigData::try_from_slice(&bytes[1..]).unwrap(),
+        update
+    );
+
+    let pause = PauseTreeData { paused: true };
+    let bytes = encode_instruction(tag::PAUSE_TREE, &pause);
+    assert_eq!(bytes[0], tag::PAUSE_TREE);
+    assert_eq!(PauseTreeData::try_from_slice(&bytes[1..]).unwrap(), pause);
+}
+
+#[test]
+fn pocket_config_update_roundtrips() {
+    let create = CreatePocketConfigData {
+        policy_program_id: [9u8; 32],
+        pocket_auth_bump: 255,
+        authority: [4u8; 32],
+        pocket_authority_transact_is_enabled: true,
+        pocket_config_bump: 254,
+    };
+    let bytes = encode_instruction(tag::CREATE_POCKET_CONFIG, &create);
+    assert_eq!(bytes[0], tag::CREATE_POCKET_CONFIG);
+    assert_eq!(
+        CreatePocketConfigData::try_from_slice(&bytes[1..]).unwrap(),
+        create
+    );
+
+    let owner = UpdatePocketConfigOwnerData {
+        new_authority: [3u8; 32],
+    };
+    let bytes = encode_instruction(tag::UPDATE_POCKET_CONFIG_OWNER, &owner);
+    assert_eq!(bytes[0], tag::UPDATE_POCKET_CONFIG_OWNER);
+    assert_eq!(
+        UpdatePocketConfigOwnerData::try_from_slice(&bytes[1..]).unwrap(),
+        owner
+    );
+
+    let update = UpdatePocketConfigData {
+        pocket_authority_transact_is_enabled: true,
+    };
+    let bytes = encode_instruction(tag::UPDATE_POCKET_CONFIG, &update);
+    assert_eq!(bytes[0], tag::UPDATE_POCKET_CONFIG);
+    assert_eq!(
+        UpdatePocketConfigData::try_from_slice(&bytes[1..]).unwrap(),
+        update
+    );
+}
+
+#[test]
+fn spec_reserved_tags_are_recognized() {
+    let tags = [
+        (tag::PROOFLESS_SHIELD, InstructionTag::ProoflessShield),
+        (tag::POCKET_TRANSACT, InstructionTag::PocketTransact),
+        (
+            tag::POCKET_AUTHORITY_TRANSACT,
+            InstructionTag::PocketAuthorityTransact,
+        ),
+        (
+            tag::CREATE_PROTOCOL_CONFIG,
+            InstructionTag::CreateProtocolConfig,
+        ),
+        (
+            tag::UPDATE_PROTOCOL_CONFIG,
+            InstructionTag::UpdateProtocolConfig,
+        ),
+        (tag::PAUSE_TREE, InstructionTag::PauseTree),
+        (
+            tag::CREATE_POCKET_CONFIG,
+            InstructionTag::CreatePocketConfig,
+        ),
+        (
+            tag::UPDATE_POCKET_CONFIG_OWNER,
+            InstructionTag::UpdatePocketConfigOwner,
+        ),
+        (
+            tag::UPDATE_POCKET_CONFIG,
+            InstructionTag::UpdatePocketConfig,
+        ),
+        (tag::MERGE_TRANSACT, InstructionTag::MergeTransact),
+        (
+            tag::ENABLE_MERGE_AUTHORITY,
+            InstructionTag::EnableMergeAuthority,
+        ),
+        (
+            tag::DISABLE_MERGE_AUTHORITY,
+            InstructionTag::DisableMergeAuthority,
+        ),
+        (
+            tag::CREATE_MERGE_AUTHORITY_TREE,
+            InstructionTag::CreateMergeAuthorityTree,
+        ),
+        (tag::MERGE_POCKET, InstructionTag::MergePocket),
+    ];
+
+    for (tag, expected) in tags {
+        assert_eq!(InstructionTag::try_from(tag), Ok(expected));
+    }
 }


### PR DESCRIPTION
Replacement for #26 after restacking. Adds SPP instruction/config wire data and roundtrip tests; base is the program-test harness PR.