### PR TITLE
photon e2e

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -154,6 +154,40 @@ jobs:
           key: proving-keys-transfer-keys-v2
       - run: just test-programs
 
+  test-localnet-photon:
+    name: tests / localnet photon
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    env:
+      AGAVE_VERSION: v4.0.2
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PHOTON_ZOLANA_RELEASE_TAG: photon-zolana-ae5234d0c9e8
+      PHOTON_ZOLANA_SHA256: be260fd8b7f6fae86e8da258b07882698b4d6abbc0a22eba3ada5fb9d4a8ccee
+      ZOLANA_PHOTON_BIN: target/bin/photon
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: prover/server/go.mod
+          cache-dependency-path: prover/server/go.sum
+      - uses: ./.github/actions/setup-rust
+        with:
+          shared-key: localnet-photon
+          private-libs-token: ${{ secrets.PRIVATE_LIBS_TOKEN }}
+      - name: Install Anza CLI
+        run: |
+          sh -c "$(curl -sSfL https://release.anza.xyz/${AGAVE_VERSION}/install)"
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+      - run: cargo build-sbf --version
+      - name: Cache transfer proving keys
+        uses: actions/cache@v4
+        with:
+          path: prover/server/proving-keys
+          key: proving-keys-transfer-keys-v2
+      - name: Install pinned Photon
+        run: ./tools/install-photon.sh
+      - run: just test-localnet-e2e-photon
+
   test-user-registry-litesvm:
     name: tests / user-registry litesvm
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,12 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -838,6 +844,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +956,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1015,22 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -1390,6 +1431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "eager"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +1660,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "forester"
@@ -1927,7 +1980,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2329,6 +2393,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine 4.6.7",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -2948,6 +3061,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openapiv3"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3255,6 +3385,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "progenitor"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc8cf6196a0139ab7b833b500f7f1acd005c91be0fe27a9e20112bf83dc9535"
+dependencies = [
+ "progenitor-client",
+ "progenitor-impl",
+ "progenitor-macro",
+]
+
+[[package]]
+name = "progenitor-client"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffab7b358944dba033a7b324e7558e66e6bcb1fb4705cf57f26fd5092bcae630"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+]
+
+[[package]]
+name = "progenitor-impl"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea21f106f8345d4417f3a39c90e4ff826ea777cb51579d72165d380a4d6f685d"
+dependencies = [
+ "heck",
+ "http",
+ "indexmap",
+ "openapiv3",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "schemars",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+ "typify",
+ "unicode-ident",
+]
+
+[[package]]
+name = "progenitor-macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c16f9cab95e07c5e6995db8d69d86e7472688b3deedb23e52631e398fddc2470"
+dependencies = [
+ "openapiv3",
+ "proc-macro2",
+ "progenitor-impl",
+ "quote",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "serde_yaml",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3572,6 +3768,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "regress"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3612,6 +3818,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "reqwest-middleware"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,7 +3867,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -3699,6 +3946,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,6 +3966,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3753,6 +4039,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3784,10 +4105,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -3839,6 +4187,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3849,6 +4208,18 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_tokenstream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c49585c52c01f13c5c2ebb333f14f6885d76daa768d8a037d28017ec538c69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3883,6 +4254,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4013,6 +4397,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -5029,7 +5429,7 @@ dependencies = [
  "futures",
  "indicatif",
  "log",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-middleware",
  "semver",
  "serde",
@@ -5064,7 +5464,7 @@ checksum = "b8a3c68bbeae45d991900fa7020ddd4a974cf2c428b28b18be0300e8526c204b"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-middleware",
  "serde",
  "serde_json",
@@ -5117,7 +5517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15b079e08471a9dbfe1e48b2c7439c85aa2a055cbd54eddd8bd257b0a7dbb29"
 dependencies = [
  "byteorder",
- "combine",
+ "combine 3.8.1",
  "hash32",
  "libc",
  "log",
@@ -5134,7 +5534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "733b3657a0fab205102b799dbe17f85d3972cf984232c1b0b108fa6ba438e382"
 dependencies = [
  "byteorder",
- "combine",
+ "combine 3.8.1",
  "hash32",
  "log",
  "rustc-demangle",
@@ -6489,6 +6889,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "typify"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0b89f47309feaeb23c4509c15c9a04234f7deccef6f96c3bfe95319819a304"
+dependencies = [
+ "typify-impl",
+ "typify-macro",
+]
+
+[[package]]
+name = "typify-impl"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7b026f540b148b81043c720889dbb942b08659aa8a43f624ac4f04dbfc1861"
+dependencies = [
+ "heck",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regress",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typify-macro"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ed96c57f06ae0839416b986921a98f18b220da63bbb243a8570a00c8492183"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn 2.0.117",
+ "typify-impl",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6550,6 +6997,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6605,6 +7058,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 
 [[package]]
 name = "valuable"
@@ -6760,6 +7219,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6789,6 +7261,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -7271,6 +7752,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
+name = "zolana-api"
+version = "0.1.0"
+dependencies = [
+ "openapiv3",
+ "prettyplease",
+ "progenitor",
+ "progenitor-client",
+ "reqwest 0.13.4",
+ "rustls",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "zolana-cli"
 version = "0.1.0"
 dependencies = [
@@ -7283,6 +7780,7 @@ dependencies = [
 name = "zolana-client"
 version = "0.1.0"
 dependencies = [
+ "base64 0.13.1",
  "bs58",
  "cucumber",
  "futures",
@@ -7293,7 +7791,7 @@ dependencies = [
  "num-traits",
  "p256",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "solana-account",
@@ -7313,6 +7811,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-status-client-types",
  "thiserror 2.0.18",
+ "zolana-api",
  "zolana-interface",
  "zolana-keypair",
  "zolana-transaction",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "cli",
     "sdk-libs/client",
     "sdk-libs/keypair",
+    "sdk-libs/zolana-api",
     "sdk-libs/program-test",
     "sdk-libs/transaction",
     "xtask",
@@ -37,6 +38,7 @@ zolana-event = { path = "program-libs/event", version = "0.1.0" }
 zolana-interface = { path = "program-libs/interface", version = "0.1.0" }
 zolana-tree = { path = "program-libs/tree", version = "0.1.0" }
 zolana-keypair = { path = "sdk-libs/keypair", version = "0.1.0" }
+zolana-api = { path = "sdk-libs/zolana-api", version = "0.1.0" }
 zolana-program-test = { path = "sdk-libs/program-test", version = "0.23.0" }
 zolana-transaction = { path = "sdk-libs/transaction", version = "0.1.0" }
 zolana-client = { path = "sdk-libs/client", version = "0.1.0" }

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -1,8 +1,8 @@
 use clap::{Args, Parser, Subcommand};
 
 use crate::config::{
-    DEFAULT_GOSSIP_HOST, DEFAULT_LIMIT_LEDGER_SIZE, DEFAULT_LOG_DIR, DEFAULT_PROVER_PORT,
-    DEFAULT_RPC_PORT,
+    DEFAULT_GOSSIP_HOST, DEFAULT_LIMIT_LEDGER_SIZE, DEFAULT_LOG_DIR, DEFAULT_PHOTON_PORT,
+    DEFAULT_PROVER_PORT, DEFAULT_RPC_PORT,
 };
 
 #[derive(Debug, Parser)]
@@ -42,6 +42,9 @@ pub(crate) struct TestValidatorOptions {
     #[arg(long, help = "Do not start the prover server")]
     pub(crate) skip_prover: bool,
 
+    #[arg(long, help = "Start a local Photon indexer in Zolana mode")]
+    pub(crate) with_photon: bool,
+
     #[arg(long, help = "Stop the local validator environment")]
     pub(crate) stop: bool,
 
@@ -78,6 +81,26 @@ pub(crate) struct TestValidatorOptions {
         help = "Prover server port"
     )]
     pub(crate) prover_port: u16,
+
+    #[arg(
+        long,
+        default_value_t = DEFAULT_PHOTON_PORT,
+        help = "Photon indexer API port"
+    )]
+    pub(crate) photon_port: u16,
+
+    #[arg(
+        long,
+        help = "Photon database URL; omit for Photon's temporary SQLite database"
+    )]
+    pub(crate) photon_db_url: Option<String>,
+
+    #[arg(
+        long,
+        default_value = "latest",
+        help = "Photon start slot, such as `latest` or an explicit slot"
+    )]
+    pub(crate) photon_start_slot: String,
 
     #[arg(
         long,
@@ -239,6 +262,7 @@ mod tests {
             "--faucet-port <PORT>",
             "--ledger <PATH>",
             "--log-dir <LOG_DIR>",
+            "--photon-port <PHOTON_PORT>",
             "--sbf-program <ADDRESS> <PATH>",
         ] {
             assert!(help.contains(flag), "missing help entry for {flag}");
@@ -266,6 +290,13 @@ mod tests {
             "8901",
             "--faucet-port",
             "9901",
+            "--with-photon",
+            "--photon-port",
+            "8785",
+            "--photon-db-url",
+            "sqlite:///tmp/zolana-photon-test.db",
+            "--photon-start-slot",
+            "latest",
             "--ledger",
             "target/localnet/ledger",
             "--log-dir",
@@ -280,8 +311,15 @@ mod tests {
 
         assert!(!opts.use_surfpool_backend());
         assert!(opts.skip_prover);
+        assert!(opts.with_photon);
         assert_eq!(opts.rpc_port, 8901);
         assert_eq!(opts.faucet_port, Some(9901));
+        assert_eq!(opts.photon_port, 8785);
+        assert_eq!(
+            opts.photon_db_url.as_deref(),
+            Some("sqlite:///tmp/zolana-photon-test.db")
+        );
+        assert_eq!(opts.photon_start_slot, "latest");
         assert_eq!(opts.ledger.as_deref(), Some("target/localnet/ledger"));
         assert_eq!(opts.log_dir, "target/localnet/logs");
         let programs = opts.sbf_program_specs();

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 pub(crate) const DEFAULT_RPC_PORT: u16 = 8899;
 pub(crate) const DEFAULT_PROVER_PORT: u16 = 3001;
+pub(crate) const DEFAULT_PHOTON_PORT: u16 = 8784;
 pub(crate) const DEFAULT_LIMIT_LEDGER_SIZE: u64 = 10_000;
 pub(crate) const DEFAULT_GOSSIP_HOST: &str = "127.0.0.1";
 pub(crate) const DEFAULT_LOG_DIR: &str = "test-ledger";

--- a/cli/src/http.rs
+++ b/cli/src/http.rs
@@ -32,6 +32,15 @@ pub(crate) fn wait_for_http_get_with_child(
     })
 }
 
+pub(crate) fn wait_for_tcp_with_child(
+    port: u16,
+    timeout: Duration,
+    child: &mut Child,
+    label: &str,
+) -> Result<()> {
+    wait_until_with_child(timeout, child, label, || tcp_connect(port).is_ok())
+}
+
 fn wait_until_with_child<F>(
     timeout: Duration,
     child: &mut Child,
@@ -61,6 +70,13 @@ fn rpc_health(port: u16) -> bool {
         .and_then(|value| value.as_str().map(str::to_string))
         .as_deref()
         == Some("ok")
+}
+
+fn tcp_connect(port: u16) -> Result<()> {
+    let address = SocketAddr::from(([127, 0, 0, 1], port));
+    TcpStream::connect_timeout(&address, Duration::from_secs(1))
+        .map(|_| ())
+        .map_err(Into::into)
 }
 
 fn rpc_request(port: u16, method: &str) -> Result<Value> {

--- a/cli/src/localnet.rs
+++ b/cli/src/localnet.rs
@@ -5,7 +5,7 @@ use anyhow::{bail, Context, Result};
 use crate::{
     args::TestValidatorOptions,
     config::READINESS_TIMEOUT,
-    http::wait_for_rpc_with_child,
+    http::{wait_for_rpc_with_child, wait_for_tcp_with_child},
     process::{find_binary, remove_launchd_validators, spawn_service, stop_name, stop_port},
     prover::start_prover_service,
 };
@@ -57,6 +57,10 @@ pub(crate) fn run_test_validator(opts: TestValidatorOptions) -> Result<()> {
 
     if !opts.skip_prover {
         start_prover_service(opts.prover_port, None, &opts.log_dir)?;
+    }
+
+    if opts.with_photon {
+        start_photon_service(&opts)?;
     }
 
     println!("Local validator environment is ready");
@@ -144,6 +148,10 @@ fn stop_test_env(opts: &TestValidatorOptions) {
         stop_name("prover-server");
         stop_port(opts.prover_port);
     }
+    if opts.with_photon {
+        stop_name("photon");
+        stop_port(opts.photon_port);
+    }
     stop_test_validator(opts.rpc_port);
 }
 
@@ -152,6 +160,46 @@ fn stop_test_validator(rpc_port: u16) {
     stop_name("solana-test-validator");
     stop_name("surfpool");
     stop_port(rpc_port);
+}
+
+fn start_photon_service(opts: &TestValidatorOptions) -> Result<()> {
+    stop_name("photon");
+    stop_port(opts.photon_port);
+
+    let photon = find_binary(
+        &["PHOTON_BIN", "ZOLANA_PHOTON_BIN"],
+        &[
+            "../photon/target/debug/photon",
+            "../photon/target/release/photon",
+        ],
+        &["photon"],
+    )?;
+    let rpc_url = format!("http://127.0.0.1:{}", opts.rpc_port);
+    let mut args = vec![
+        "--mode".to_string(),
+        "zolana".to_string(),
+        "--rpc-url".to_string(),
+        rpc_url,
+        "--port".to_string(),
+        opts.photon_port.to_string(),
+        "--start-slot".to_string(),
+        opts.photon_start_slot.clone(),
+    ];
+    if let Some(db_url) = &opts.photon_db_url {
+        args.push("--db-url".to_string());
+        args.push(db_url.clone());
+    }
+
+    println!("Starting Photon: {} {}", photon.display(), args.join(" "));
+    let mut child = spawn_service(&photon, &args, "photon", &opts.log_dir)?;
+    wait_for_tcp_with_child(opts.photon_port, READINESS_TIMEOUT, &mut child, "photon")
+        .with_context(|| format!("Photon on port {} did not become ready", opts.photon_port))?;
+    println!(
+        "Photon indexer is ready at http://127.0.0.1:{}",
+        opts.photon_port
+    );
+    std::mem::forget(child);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -200,6 +248,14 @@ mod tests {
         ]);
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn finds_photon_binary_from_env_or_sibling_checkout() {
+        let opts = parse_validator(&["--with-photon", "--photon-port", "8785"]);
+        assert!(opts.with_photon);
+        assert_eq!(opts.photon_port, 8785);
+        assert_eq!(opts.photon_start_slot, "latest");
     }
 
     #[test]

--- a/justfile
+++ b/justfile
@@ -7,6 +7,8 @@ surfpool-release-tag := env_var_or_default("SURFPOOL_RELEASE_TAG", "v1.1.1-light
 surfpool-version := env_var_or_default("SURFPOOL_VERSION", "1.1.1")
 localnet-rpc-port := env_var_or_default("ZOLANA_LOCALNET_RPC_PORT", "8899")
 localnet-rpc-url := env_var_or_default("ZOLANA_LOCALNET_URL", "http://127.0.0.1:8899")
+localnet-photon-port := env_var_or_default("ZOLANA_LOCALNET_PHOTON_PORT", "8784")
+localnet-photon-url := env_var_or_default("ZOLANA_LOCALNET_PHOTON_URL", "http://127.0.0.1:8784")
 
 mod forester 'forester'
 mod prover 'prover/server'
@@ -99,6 +101,14 @@ test-localnet-e2e: build-programs build-prover-server build-cli
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" cargo test -p shielded-pool-tests --features localnet --test localnet_e2e -- --nocapture
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" cargo test -p shielded-pool-tests --features localnet --test localnet_deposit -- --nocapture
 
+# Local-validator SOL cycle backed by a real Photon Zolana indexer.
+test-localnet-e2e-photon: build-programs build-prover-server build-cli build-photon
+    #!/usr/bin/env bash
+    set -euo pipefail
+    eval "$(cargo run -q -p xtask -- program-ids)"
+    cargo run -p zolana-cli -- test-validator --skip-prover --with-photon --no-use-surfpool --rpc-port {{localnet-rpc-port}} --photon-port {{localnet-photon-port}} --sbf-program "$SHIELDED_POOL_PROGRAM_ID" target/deploy/shielded_pool_program.so --sbf-program "$ZONE_TEST_PROGRAM_ID" target/deploy/zone_test_program.so
+    env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" cargo test -p shielded-pool-tests --features localnet --test localnet_photon_e2e -- --nocapture
+
 install-surfpool:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -134,6 +144,9 @@ build-programs:
 build-prover-server:
     mkdir -p target
     cd prover/server && go build -o ../../target/prover-server .
+
+build-photon:
+    cd ../photon && cargo build --bin photon
 
 # === Formatting and linting ===
 

--- a/justfile
+++ b/justfile
@@ -9,6 +9,7 @@ localnet-rpc-port := env_var_or_default("ZOLANA_LOCALNET_RPC_PORT", "8899")
 localnet-rpc-url := env_var_or_default("ZOLANA_LOCALNET_URL", "http://127.0.0.1:8899")
 localnet-photon-port := env_var_or_default("ZOLANA_LOCALNET_PHOTON_PORT", "8784")
 localnet-photon-url := env_var_or_default("ZOLANA_LOCALNET_PHOTON_URL", "http://127.0.0.1:8784")
+photon-bin := env_var_or_default("ZOLANA_PHOTON_BIN", "target/bin/photon")
 
 mod forester 'forester'
 mod prover 'prover/server'
@@ -102,11 +103,11 @@ test-localnet-e2e: build-programs build-prover-server build-cli
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" cargo test -p shielded-pool-tests --features localnet --test localnet_deposit -- --nocapture
 
 # Local-validator SOL cycle backed by a real Photon Zolana indexer.
-test-localnet-e2e-photon: build-programs build-prover-server build-cli build-photon
+test-localnet-e2e-photon: build-programs build-prover-server build-cli ensure-photon
     #!/usr/bin/env bash
     set -euo pipefail
     eval "$(cargo run -q -p xtask -- program-ids)"
-    cargo run -p zolana-cli -- test-validator --skip-prover --with-photon --no-use-surfpool --rpc-port {{localnet-rpc-port}} --photon-port {{localnet-photon-port}} --sbf-program "$SHIELDED_POOL_PROGRAM_ID" target/deploy/shielded_pool_program.so --sbf-program "$ZONE_TEST_PROGRAM_ID" target/deploy/zone_test_program.so
+    env ZOLANA_PHOTON_BIN="{{photon-bin}}" cargo run -p zolana-cli -- test-validator --skip-prover --with-photon --no-use-surfpool --rpc-port {{localnet-rpc-port}} --photon-port {{localnet-photon-port}} --sbf-program "$SHIELDED_POOL_PROGRAM_ID" target/deploy/shielded_pool_program.so --sbf-program "$ZONE_TEST_PROGRAM_ID" target/deploy/zone_test_program.so
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" cargo test -p shielded-pool-tests --features localnet --test localnet_photon_e2e -- --nocapture
 
 install-surfpool:
@@ -146,7 +147,27 @@ build-prover-server:
     cd prover/server && go build -o ../../target/prover-server .
 
 build-photon:
-    cd ../photon && cargo build --bin photon
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cargo build --manifest-path ../photon/Cargo.toml --target-dir target/photon-build --bin photon
+    mkdir -p "$(dirname "{{photon-bin}}")"
+    cp target/photon-build/debug/photon "{{photon-bin}}"
+
+install-photon:
+    ./tools/install-photon.sh
+
+ensure-photon:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ -x "{{photon-bin}}" ]]; then
+      echo "Using Photon binary at {{photon-bin}}"
+      exit 0
+    fi
+    if [[ -n "${ZOLANA_PHOTON_BIN:-}" ]]; then
+      echo "ZOLANA_PHOTON_BIN is set to ${ZOLANA_PHOTON_BIN}, but it is not executable" >&2
+      exit 1
+    fi
+    just build-photon
 
 # === Formatting and linting ===
 

--- a/program-tests/shielded-pool/Cargo.toml
+++ b/program-tests/shielded-pool/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [features]
 default = []
-localnet = ["zolana-client/solana-rpc"]
+localnet = ["zolana-client/indexer-api", "zolana-client/solana-rpc"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -47,6 +47,11 @@ required-features = ["localnet"]
 [[test]]
 name = "localnet_deposit"
 path = "tests/localnet_deposit.rs"
+required-features = ["localnet"]
+
+[[test]]
+name = "localnet_photon_e2e"
+path = "tests/localnet_photon_e2e.rs"
 required-features = ["localnet"]
 
 [[test]]

--- a/program-tests/shielded-pool/tests/localnet_photon_e2e.rs
+++ b/program-tests/shielded-pool/tests/localnet_photon_e2e.rs
@@ -1,0 +1,569 @@
+//! Local-validator SOL cycle backed by a real Photon Zolana indexer.
+//!
+//! Run with `just test-localnet-e2e-photon`.
+
+#[path = "common/transact.rs"]
+#[allow(dead_code)]
+mod transact_common;
+
+use std::{
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
+use anyhow::anyhow;
+use light_hasher::{sha256::Sha256BE, Hasher};
+use solana_address::Address;
+use solana_keypair::Keypair;
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_signature::Signature;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+use zolana_client::private_transaction::field::{be, right_align_slice};
+use zolana_client::{
+    EncryptedUtxoMatch, MerkleProof as IndexedMerkleProof,
+    NonInclusionProof as IndexedNonInclusionProof, Rpc, ShieldedTransaction, SolanaRpc,
+    TransferInput, TransferOutput, UtxoInputs, ZolanaIndexer,
+};
+use zolana_interface::{
+    instruction::{
+        CreateProtocolConfig, Deposit, Transact, TransactSolWithdrawal, TransactWithdrawal,
+    },
+    pda,
+    state::tree_account_size,
+    SHIELDED_POOL_PROGRAM_ID,
+};
+use zolana_keypair::hash::owner_hash;
+use zolana_keypair::pubkey::PublicKey;
+use zolana_keypair::NullifierKey;
+use zolana_program_test::{create_tree_instructions, rpc_state_root, ZolanaProgramTest};
+use zolana_transaction::transaction::private_tx_hash;
+use zolana_transaction::{Data, OutputUtxo, Utxo, SOL_MINT};
+use zolana_tree::TreeAccount;
+
+use crate::transact_common::{
+    build_transfer_prover_inputs, dummy_input, dummy_ix_output, eddsa_input_utxo,
+    external_data_hash, fe, ix_output, new_transact_ix_data, prove_and_verify_transfer,
+    public_input_hash, public_sol_field, start_prover, transfer_output, TransferProverInputsArgs,
+};
+
+const RPC_URL_ENV: &str = "ZOLANA_LOCALNET_URL";
+const INDEXER_URL_ENV: &str = "ZOLANA_INDEXER_URL";
+const DEFAULT_RPC_URL: &str = "http://127.0.0.1:8899";
+const DEFAULT_INDEXER_URL: &str = "http://127.0.0.1:8784";
+const INDEXER_TIMEOUT: Duration = Duration::from_secs(120);
+const AMOUNT: u64 = 1_000_000_000;
+const TRANSFER_AMOUNT: u64 = 400_000_000;
+const CHANGE_AMOUNT: u64 = AMOUNT - TRANSFER_AMOUNT;
+
+type TestResult<T = ()> = anyhow::Result<T>;
+
+#[test]
+fn shield_transfer_unshield_sol_with_photon_indexer() -> TestResult {
+    start_prover()?;
+
+    let rpc_url = std::env::var(RPC_URL_ENV).unwrap_or_else(|_| DEFAULT_RPC_URL.to_owned());
+    let indexer_url =
+        std::env::var(INDEXER_URL_ENV).unwrap_or_else(|_| DEFAULT_INDEXER_URL.to_owned());
+
+    let program_id = Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID);
+    let mut rpc = SolanaRpc::new(rpc_url.clone());
+    let indexer = ZolanaIndexer::new(indexer_url.clone()).with_http_trace();
+    rpc.assert_executable(&program_id)?;
+
+    let payer = Keypair::new();
+    let authority = Keypair::new();
+    print_signature(
+        "airdrop payer",
+        &rpc.airdrop(&payer.pubkey(), 20_000_000_000)?,
+    );
+    print_signature(
+        "airdrop authority",
+        &rpc.airdrop(&authority.pubkey(), 1_000_000_000)?,
+    );
+    let recipient_owner = Keypair::new();
+    print_signature(
+        "airdrop recipient owner",
+        &rpc.airdrop(&recipient_owner.pubkey(), 1_000_000)?,
+    );
+
+    let authority_bytes = authority.pubkey().to_bytes();
+    let create_config = CreateProtocolConfig {
+        authority: authority.pubkey(),
+        protocol_authority: authority_bytes.into(),
+        tree_creation_authority: authority_bytes.into(),
+        tree_creation_is_permissionless: false,
+        forester_authority: authority_bytes.into(),
+        zone_creation_authority: authority_bytes.into(),
+        zone_creation_is_permissionless: false,
+        merge_authority: authority_bytes.into(),
+    }
+    .instruction();
+    let create_config_sig = send_transaction(
+        &mut rpc,
+        &[create_config],
+        &authority.pubkey(),
+        &[&authority],
+    )?;
+    print_signature("create_protocol_config", &create_config_sig);
+
+    let tree = Keypair::new();
+    let create_tree = create_tree_instructions(
+        &rpc,
+        &payer.pubkey(),
+        &authority.pubkey(),
+        &tree.pubkey(),
+        tree_account_size() as u64,
+    )?;
+    let create_tree_sig = send_transaction(
+        &mut rpc,
+        &create_tree,
+        &payer.pubkey(),
+        &[&payer, &tree, &authority],
+    )?;
+    print_signature("create_tree", &create_tree_sig);
+    let tree_pubkey = tree.pubkey();
+    let tree_address = Address::new_from_array(tree_pubkey.to_bytes());
+    let zero = [0u8; 32];
+
+    let payer_bytes = payer.pubkey().to_bytes();
+    let payer_blinding: [u8; 31] = [7u8; 31];
+    let payer_nullifier_key = NullifierKey::from_secret([9u8; 31]);
+    let payer_nullifier_pk = payer_nullifier_key.pubkey()?;
+    let payer_utxo = Utxo {
+        owner: PublicKey::from_ed25519(&payer_bytes),
+        asset: SOL_MINT,
+        amount: AMOUNT,
+        blinding: payer_blinding,
+        zone_program_id: None,
+        data: Data::default(),
+    };
+    let payer_owner_pk_hash = payer_utxo.owner.hash()?;
+    let payer_owner_field = owner_hash(&payer_utxo.owner, &payer_nullifier_pk)?;
+    let owner_utxo_hash = payer_utxo.owner_utxo_hash(&payer_nullifier_pk)?;
+
+    let shield_data = ZolanaProgramTest::sol_shield_data(AMOUNT, owner_utxo_hash);
+    let shield_ix = Deposit {
+        tree: tree_pubkey,
+        depositor: payer.pubkey(),
+        spl: None,
+        view_tag: shield_data.view_tag,
+        owner_utxo_hash: shield_data.owner_utxo_hash,
+        salt: shield_data.salt,
+        public_amount: shield_data.public_amount,
+        program_data_hash: shield_data.program_data_hash,
+        program_data: shield_data.program_data,
+        cpi_signer: shield_data.cpi_signer,
+    }
+    .instruction();
+    let shield_sig = send_transaction(&mut rpc, &[shield_ix], &payer.pubkey(), &[&payer])?;
+    print_signature("deposit", &shield_sig);
+
+    let payer_utxo_hash = payer_utxo.hash(&payer_nullifier_pk, &zero, &zero)?;
+    let indexed_deposit = wait_for_indexed_utxo(&indexer, shield_data.view_tag, shield_sig)?;
+    assert_eq!(indexed_deposit.view_tag, shield_data.view_tag);
+    assert_eq!(indexed_deposit.tx_signature, shield_sig);
+    assert!(indexed_deposit.tx_viewing_pk.is_none());
+
+    let payer_nullifier = payer_nullifier_key.nullifier(&payer_utxo_hash, &payer_blinding)?;
+    let payer_state_proof = wait_for_merkle_proof(&indexer, tree_address, payer_utxo_hash)?;
+    let payer_nullifier_proof =
+        wait_for_non_inclusion_proof(&indexer, tree_address, payer_nullifier)?;
+    let (shield_utxo_root, nullifier_root) = on_chain_roots(&rpc, &tree_pubkey, 1)?;
+    assert_eq!(payer_state_proof.root, shield_utxo_root, "shield root gate");
+    assert_eq!(
+        payer_nullifier_proof.root, nullifier_root,
+        "nullifier root gate"
+    );
+    assert_eq!(rpc_state_root(&rpc, &tree_pubkey)?, payer_state_proof.root);
+    let payer_spend_input = indexed_spend_input(IndexedSpendInputArgs {
+        utxo: &payer_utxo,
+        owner_field: &payer_owner_field,
+        state_proof: &payer_state_proof,
+        nullifier_proof: &payer_nullifier_proof,
+        nullifier: &payer_nullifier,
+        owner_pk_hash: &payer_owner_pk_hash,
+        nullifier_key: &payer_nullifier_key,
+    })?;
+
+    let recipient_bytes = recipient_owner.pubkey().to_bytes();
+    let recipient_nullifier_key = NullifierKey::from_secret([11u8; 31]);
+    let recipient_nullifier_pk = recipient_nullifier_key.pubkey()?;
+    let recipient_public_key = PublicKey::from_ed25519(&recipient_bytes);
+    let recipient_owner_field = owner_hash(&recipient_public_key, &recipient_nullifier_pk)?;
+
+    let change_output = OutputUtxo {
+        owner_hash: payer_owner_field,
+        asset: SOL_MINT,
+        amount: CHANGE_AMOUNT,
+        blinding: [13u8; 31],
+        ..Default::default()
+    };
+    let recipient_output = OutputUtxo {
+        owner_hash: recipient_owner_field,
+        asset: SOL_MINT,
+        amount: TRANSFER_AMOUNT,
+        blinding: [17u8; 31],
+        ..Default::default()
+    };
+    let change_hash = change_output.hash()?;
+    let recipient_hash = recipient_output.hash()?;
+    let transfer_dummy_nullifier = fe(20);
+    let transfer_roots = (payer_state_proof.root, payer_nullifier_proof.root);
+
+    let mut transfer_ix_data = new_transact_ix_data(
+        vec![
+            eddsa_input_utxo(payer_nullifier, payer_state_proof.root_index),
+            eddsa_input_utxo(transfer_dummy_nullifier, payer_state_proof.root_index),
+        ],
+        None,
+        ix_output([1u8; 32], change_hash),
+        vec![ix_output([2u8; 32], recipient_hash), dummy_ix_output()],
+    );
+    let transfer_external_hash = external_data_hash(&transfer_ix_data, &zero)?;
+    let transfer_private_tx = private_tx_hash(
+        &[payer_utxo_hash, zero],
+        &[change_hash, recipient_hash, zero],
+        &transfer_external_hash,
+    )?;
+    let payer_pubkey_hash = Sha256BE::hash(&payer_bytes)?;
+    let transfer_public_input_hash = public_input_hash(
+        &[payer_nullifier, transfer_dummy_nullifier],
+        &[change_hash, recipient_hash, zero],
+        &[transfer_roots.0, transfer_roots.0],
+        &[transfer_roots.1, transfer_roots.1],
+        &transfer_private_tx,
+        &transfer_external_hash,
+        &zero,
+        &payer_pubkey_hash,
+        &[payer_owner_pk_hash, payer_owner_pk_hash],
+    );
+    let transfer_prover_inputs = build_transfer_prover_inputs(TransferProverInputsArgs {
+        inputs: vec![
+            payer_spend_input,
+            dummy_input(
+                &transfer_dummy_nullifier,
+                transfer_roots,
+                &payer_owner_pk_hash,
+            ),
+        ],
+        outputs: vec![
+            transfer_output(&change_output)?,
+            transfer_output(&recipient_output)?,
+            TransferOutput::new_dummy(),
+        ],
+        external_data_hash: transfer_external_hash,
+        private_tx_hash: transfer_private_tx,
+        public_sol_amount: zero,
+        payer_pubkey_hash,
+        public_input_hash: transfer_public_input_hash,
+    });
+    transfer_ix_data.proof = prove_and_verify_transfer(
+        &transfer_prover_inputs,
+        transfer_public_input_hash,
+        "transfer",
+    )?;
+    transfer_ix_data.private_tx_hash = transfer_private_tx;
+
+    let transfer_ix = Transact {
+        payer: payer.pubkey(),
+        tree: tree_pubkey,
+        cpi_signer: None,
+        withdrawal: None,
+        data: transfer_ix_data,
+    }
+    .instruction();
+    let transfer_sig = send_transaction(&mut rpc, &[transfer_ix], &payer.pubkey(), &[&payer])?;
+    print_signature("shielded_transfer", &transfer_sig);
+
+    let indexed_transfer = wait_for_indexed_transaction(&indexer, [2u8; 32], transfer_sig)?;
+    assert_eq!(indexed_transfer.nullifiers.len(), 2);
+    assert_eq!(indexed_transfer.output_slots.len(), 3);
+    assert!(!indexed_transfer.proofless);
+
+    let recipient_utxo = Utxo {
+        owner: recipient_public_key,
+        asset: SOL_MINT,
+        amount: TRANSFER_AMOUNT,
+        blinding: recipient_output.blinding,
+        zone_program_id: None,
+        data: Data::default(),
+    };
+    assert_eq!(
+        recipient_hash,
+        recipient_utxo.hash(&recipient_nullifier_pk, &zero, &zero)?
+    );
+    let recipient_owner_pk_hash = recipient_utxo.owner.hash()?;
+    let recipient_nullifier =
+        recipient_nullifier_key.nullifier(&recipient_hash, &recipient_utxo.blinding)?;
+    let recipient_state_proof = wait_for_merkle_proof(&indexer, tree_address, recipient_hash)?;
+    let recipient_nullifier_proof =
+        wait_for_non_inclusion_proof(&indexer, tree_address, recipient_nullifier)?;
+    let (transfer_utxo_root, transfer_nullifier_root) =
+        on_chain_roots(&rpc, &tree_pubkey, recipient_state_proof.root_index)?;
+    assert_eq!(
+        recipient_state_proof.root, transfer_utxo_root,
+        "transfer root gate"
+    );
+    assert_eq!(recipient_nullifier_proof.root, transfer_nullifier_root);
+    let recipient_spend_input = indexed_spend_input(IndexedSpendInputArgs {
+        utxo: &recipient_utxo,
+        owner_field: &recipient_owner_field,
+        state_proof: &recipient_state_proof,
+        nullifier_proof: &recipient_nullifier_proof,
+        nullifier: &recipient_nullifier,
+        owner_pk_hash: &recipient_owner_pk_hash,
+        nullifier_key: &recipient_nullifier_key,
+    })?;
+
+    let public_recipient = Keypair::new().pubkey();
+    print_signature(
+        "airdrop public recipient",
+        &rpc.airdrop(&public_recipient, 1_000_000)?,
+    );
+    let public_recipient_before = account_lamports(&rpc, &public_recipient)?;
+    let vault = pda::sol_interface();
+    let vault_before = account_lamports(&rpc, &vault)?;
+    let withdraw_dummy_nullifier = fe(21);
+    let withdraw_roots = (recipient_state_proof.root, recipient_nullifier_proof.root);
+
+    let mut withdraw_ix_data = new_transact_ix_data(
+        vec![
+            eddsa_input_utxo(recipient_nullifier, recipient_state_proof.root_index),
+            eddsa_input_utxo(withdraw_dummy_nullifier, recipient_state_proof.root_index),
+        ],
+        Some(-(TRANSFER_AMOUNT as i64)),
+        dummy_ix_output(),
+        vec![dummy_ix_output(); 2],
+    );
+    let withdraw_external_hash =
+        external_data_hash(&withdraw_ix_data, &public_recipient.to_bytes())?;
+    let withdraw_private_tx = private_tx_hash(
+        &[recipient_hash, zero],
+        &[zero, zero, zero],
+        &withdraw_external_hash,
+    )?;
+    let public_sol_field = public_sol_field(withdraw_ix_data.public_sol_amount);
+    let recipient_pubkey_hash = Sha256BE::hash(&recipient_bytes)?;
+    let withdraw_public_input_hash = public_input_hash(
+        &[recipient_nullifier, withdraw_dummy_nullifier],
+        &[zero, zero, zero],
+        &[withdraw_roots.0, withdraw_roots.0],
+        &[withdraw_roots.1, withdraw_roots.1],
+        &withdraw_private_tx,
+        &withdraw_external_hash,
+        &public_sol_field,
+        &recipient_pubkey_hash,
+        &[recipient_owner_pk_hash, recipient_owner_pk_hash],
+    );
+    let withdraw_prover_inputs = build_transfer_prover_inputs(TransferProverInputsArgs {
+        inputs: vec![
+            recipient_spend_input,
+            dummy_input(
+                &withdraw_dummy_nullifier,
+                withdraw_roots,
+                &recipient_owner_pk_hash,
+            ),
+        ],
+        outputs: vec![TransferOutput::new_dummy(); 3],
+        external_data_hash: withdraw_external_hash,
+        private_tx_hash: withdraw_private_tx,
+        public_sol_amount: public_sol_field,
+        payer_pubkey_hash: recipient_pubkey_hash,
+        public_input_hash: withdraw_public_input_hash,
+    });
+    withdraw_ix_data.proof = prove_and_verify_transfer(
+        &withdraw_prover_inputs,
+        withdraw_public_input_hash,
+        "withdraw",
+    )?;
+    withdraw_ix_data.private_tx_hash = withdraw_private_tx;
+
+    let withdraw_ix = Transact {
+        payer: recipient_owner.pubkey(),
+        tree: tree_pubkey,
+        cpi_signer: None,
+        withdrawal: Some(TransactWithdrawal::Sol(TransactSolWithdrawal {
+            recipient: public_recipient,
+        })),
+        data: withdraw_ix_data,
+    }
+    .instruction();
+    let withdraw_sig = send_transaction(
+        &mut rpc,
+        &[withdraw_ix],
+        &payer.pubkey(),
+        &[&payer, &recipient_owner],
+    )?;
+    print_signature("unshield", &withdraw_sig);
+    let indexed_withdraw = wait_for_indexed_transaction(&indexer, [0u8; 32], withdraw_sig)?;
+    assert_eq!(indexed_withdraw.nullifiers.len(), 2);
+
+    let public_recipient_after = account_lamports(&rpc, &public_recipient)?;
+    let vault_after = account_lamports(&rpc, &vault)?;
+    assert_eq!(
+        public_recipient_after,
+        public_recipient_before + TRANSFER_AMOUNT,
+        "public recipient credited"
+    );
+    assert_eq!(
+        vault_after,
+        vault_before - TRANSFER_AMOUNT,
+        "vault debited by transferred amount"
+    );
+
+    println!(
+        "localnet Photon-backed shield-transfer-unshield SOL test passed via rpc={rpc_url} indexer={indexer_url}"
+    );
+    Ok(())
+}
+
+struct IndexedSpendInputArgs<'a> {
+    utxo: &'a Utxo,
+    owner_field: &'a [u8; 32],
+    state_proof: &'a IndexedMerkleProof,
+    nullifier_proof: &'a IndexedNonInclusionProof,
+    nullifier: &'a [u8; 32],
+    owner_pk_hash: &'a [u8; 32],
+    nullifier_key: &'a NullifierKey,
+}
+
+fn indexed_spend_input(args: IndexedSpendInputArgs<'_>) -> TestResult<TransferInput> {
+    Ok(TransferInput {
+        utxo: UtxoInputs::new(
+            args.owner_field,
+            &args.utxo.asset,
+            args.utxo.amount,
+            &args.utxo.blinding,
+        )?,
+        is_dummy: be(&fe(0)),
+        state_path_elements: args.state_proof.path.iter().map(be).collect(),
+        state_path_index: be(&fe(args.state_proof.leaf_index)),
+        nullifier_low_value: be(&args.nullifier_proof.low_element),
+        nullifier_next_value: be(&args.nullifier_proof.high_element),
+        nullifier_low_path_elements: args.nullifier_proof.path.iter().map(be).collect(),
+        nullifier_low_path_index: be(&fe(args.nullifier_proof.low_element_index)),
+        utxo_tree_root: be(&args.state_proof.root),
+        nullifier_tree_root: be(&args.nullifier_proof.root),
+        nullifier: be(args.nullifier),
+        solana_owner_pk_hash: be(args.owner_pk_hash),
+        nullifier_secret: be(&right_align_slice(args.nullifier_key.secret())?),
+    })
+}
+
+fn on_chain_roots(
+    rpc: &SolanaRpc,
+    tree: &Pubkey,
+    utxo_index: u16,
+) -> TestResult<([u8; 32], [u8; 32])> {
+    let address = Address::new_from_array(tree.to_bytes());
+    let mut data = rpc
+        .get_account(address)?
+        .ok_or_else(|| anyhow!("tree account not found: {tree}"))?
+        .data;
+    let account = TreeAccount::from_bytes(&mut data, tree.to_bytes())
+        .map_err(|err| anyhow!("load tree account: {err:?}"))?;
+    Ok((
+        account
+            .get_utxo_tree_root(utxo_index)
+            .map_err(|err| anyhow!("get utxo root {utxo_index}: {err:?}"))?,
+        account
+            .get_nullifier_tree_root(0)
+            .map_err(|err| anyhow!("get nullifier root: {err:?}"))?,
+    ))
+}
+
+fn account_lamports(rpc: &SolanaRpc, pubkey: &Pubkey) -> TestResult<u64> {
+    let address = Address::new_from_array(pubkey.to_bytes());
+    Ok(rpc
+        .get_account(address)?
+        .map(|account| account.lamports)
+        .unwrap_or(0))
+}
+
+fn send_transaction(
+    rpc: &mut SolanaRpc,
+    ixs: &[solana_instruction::Instruction],
+    payer: &Pubkey,
+    signers: &[&Keypair],
+) -> TestResult<Signature> {
+    let (blockhash, _) = rpc.get_latest_blockhash()?;
+    let message = Message::new(ixs, Some(payer));
+    let transaction = Transaction::new(signers, message, blockhash);
+    Ok(rpc.send_transaction(&transaction)?)
+}
+
+fn wait_for_indexed_utxo(
+    indexer: &ZolanaIndexer,
+    tag: [u8; 32],
+    signature: Signature,
+) -> TestResult<EncryptedUtxoMatch> {
+    wait_for("indexed UTXO", || {
+        let response = indexer.get_encrypted_utxos_by_tags(vec![tag], None, Some(50))?;
+        Ok(response
+            .matches
+            .into_iter()
+            .find(|item| item.tx_signature == signature))
+    })
+}
+
+fn wait_for_indexed_transaction(
+    indexer: &ZolanaIndexer,
+    tag: [u8; 32],
+    signature: Signature,
+) -> TestResult<ShieldedTransaction> {
+    wait_for("indexed transaction", || {
+        let response = indexer.get_shielded_transactions_by_tags(vec![tag], None, Some(100))?;
+        Ok(response
+            .transactions
+            .into_iter()
+            .find(|item| item.tx_signature == signature))
+    })
+}
+
+fn wait_for_merkle_proof(
+    indexer: &ZolanaIndexer,
+    tree: Address,
+    leaf: [u8; 32],
+) -> TestResult<IndexedMerkleProof> {
+    wait_for("indexed merkle proof", || {
+        let response = indexer.get_merkle_proofs(tree, vec![leaf])?;
+        Ok(response.proofs.into_iter().next())
+    })
+}
+
+fn wait_for_non_inclusion_proof(
+    indexer: &ZolanaIndexer,
+    tree: Address,
+    leaf: [u8; 32],
+) -> TestResult<IndexedNonInclusionProof> {
+    wait_for("indexed non-inclusion proof", || {
+        let response = indexer.get_non_inclusion_proofs(tree, vec![leaf])?;
+        Ok(response.proofs.into_iter().next())
+    })
+}
+
+fn wait_for<T>(
+    label: &'static str,
+    mut poll: impl FnMut() -> Result<Option<T>, zolana_client::ClientError>,
+) -> TestResult<T> {
+    let started = Instant::now();
+    let mut last_error = None;
+    while started.elapsed() < INDEXER_TIMEOUT {
+        match poll() {
+            Ok(Some(value)) => return Ok(value),
+            Ok(None) => {}
+            Err(error) => last_error = Some(error.to_string()),
+        }
+        sleep(Duration::from_millis(500));
+    }
+    Err(anyhow!(
+        "timed out waiting for {label}; last indexer error: {}",
+        last_error.unwrap_or_else(|| "none".to_string())
+    ))
+}
+
+fn print_signature(label: &str, signature: &Signature) {
+    println!("{label}: {signature}");
+}

--- a/prover/server/server/server.go
+++ b/prover/server/server/server.go
@@ -11,7 +11,7 @@ import (
 	"time"
 	"zolana/prover/logging"
 	"zolana/prover/prover/common"
-	"zolana/prover/prover/nullifier_tree"
+	nullifiertree "zolana/prover/prover/nullifier_tree"
 	"zolana/prover/prover/transfer"
 	transfereddsaonly "zolana/prover/prover/transfer_eddsa_only"
 

--- a/sdk-libs/client/Cargo.toml
+++ b/sdk-libs/client/Cargo.toml
@@ -7,12 +7,15 @@ edition.workspace = true
 
 [features]
 default = []
+indexer-api = ["dep:base64", "dep:bs58", "dep:zolana-api"]
 solana-rpc = ["dep:bs58", "dep:solana-rpc-client", "dep:solana-commitment-config"]
 
 [dependencies]
 zolana-interface = { workspace = true, features = ["solana"] }
 zolana-keypair = { workspace = true }
 zolana-transaction = { workspace = true }
+zolana-api = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
 solana-address = { workspace = true }

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -1,0 +1,408 @@
+//! Blocking RPC adapter for the Zolana indexer API.
+
+use solana_address::Address;
+use solana_signature::Signature;
+use zolana_api::types::{
+    Base64String, Hash as ApiHash, SerializablePubkey, ZolanaOutputSlot as ApiOutputSlot,
+};
+use zolana_api::BlockingZolanaApi;
+use zolana_keypair::{constants::P256_PUBKEY_LEN, P256Pubkey};
+
+use crate::{
+    error::ClientError,
+    rpc::{
+        Context, EncryptedUtxoMatch, GetEncryptedUtxosByTagsResponse, GetMerkleProofsResponse,
+        GetNonInclusionProofsResponse, GetShieldedTransactionsByTagsResponse, MerkleContext,
+        MerkleProof, NonInclusionProof, OutputSlot, Rpc, ShieldedTransaction,
+    },
+};
+
+#[derive(Clone, Debug)]
+pub struct ZolanaIndexer {
+    api: BlockingZolanaApi,
+}
+
+impl ZolanaIndexer {
+    pub fn new(url: impl AsRef<str>) -> Self {
+        Self {
+            api: BlockingZolanaApi::new(url),
+        }
+    }
+
+    pub fn with_api(api: BlockingZolanaApi) -> Self {
+        Self { api }
+    }
+
+    pub fn with_http_trace(mut self) -> Self {
+        self.api = self.api.with_http_trace();
+        self
+    }
+
+    pub fn api(&self) -> &BlockingZolanaApi {
+        &self.api
+    }
+}
+
+impl Rpc for ZolanaIndexer {
+    fn get_encrypted_utxos_by_tags(
+        &self,
+        tags: Vec<[u8; 32]>,
+        cursor: Option<Vec<u8>>,
+        limit: Option<u32>,
+    ) -> Result<GetEncryptedUtxosByTagsResponse, ClientError> {
+        let response = self
+            .api
+            .get_encrypted_utxos_by_tags(
+                tags.into_iter().map(encode_hash).collect(),
+                encode_cursor(cursor),
+                limit.map(u64::from),
+            )
+            .map_err(indexer_error)?;
+
+        Ok(GetEncryptedUtxosByTagsResponse {
+            context: convert_context(response.context),
+            matches: response
+                .matches
+                .into_iter()
+                .enumerate()
+                .map(|(index, item)| convert_encrypted_utxo_match(index, item))
+                .collect::<Result<Vec<_>, _>>()?,
+            next_cursor: decode_optional_cursor(response.next_cursor)?,
+        })
+    }
+
+    fn get_shielded_transactions_by_tags(
+        &self,
+        tags: Vec<[u8; 32]>,
+        cursor: Option<Vec<u8>>,
+        limit: Option<u32>,
+    ) -> Result<GetShieldedTransactionsByTagsResponse, ClientError> {
+        let response = self
+            .api
+            .get_shielded_transactions_by_tags(
+                tags.into_iter().map(encode_hash).collect(),
+                encode_cursor(cursor),
+                limit.map(u64::from),
+            )
+            .map_err(indexer_error)?;
+
+        Ok(GetShieldedTransactionsByTagsResponse {
+            context: convert_context(response.context),
+            transactions: response
+                .transactions
+                .into_iter()
+                .enumerate()
+                .map(|(index, item)| convert_shielded_transaction(index, item))
+                .collect::<Result<Vec<_>, _>>()?,
+            next_cursor: decode_optional_cursor(response.next_cursor)?,
+        })
+    }
+
+    fn get_merkle_proofs(
+        &self,
+        tree_account: Address,
+        leaves: Vec<[u8; 32]>,
+    ) -> Result<GetMerkleProofsResponse, ClientError> {
+        let response = self
+            .api
+            .get_merkle_proofs(
+                encode_pubkey(tree_account),
+                leaves.into_iter().map(encode_hash).collect(),
+            )
+            .map_err(indexer_error)?;
+
+        Ok(GetMerkleProofsResponse {
+            context: convert_context(response.context),
+            proofs: response
+                .proofs
+                .into_iter()
+                .enumerate()
+                .map(|(index, proof)| convert_merkle_proof(index, proof))
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+
+    fn get_non_inclusion_proofs(
+        &self,
+        tree_account: Address,
+        leaves: Vec<[u8; 32]>,
+    ) -> Result<GetNonInclusionProofsResponse, ClientError> {
+        let response = self
+            .api
+            .get_non_inclusion_proofs(
+                encode_pubkey(tree_account),
+                leaves.into_iter().map(encode_hash).collect(),
+            )
+            .map_err(indexer_error)?;
+
+        Ok(GetNonInclusionProofsResponse {
+            context: convert_context(response.context),
+            proofs: response
+                .proofs
+                .into_iter()
+                .enumerate()
+                .map(|(index, proof)| convert_non_inclusion_proof(index, proof))
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+}
+
+fn indexer_error(error: zolana_api::ApiError) -> ClientError {
+    ClientError::Rpc(format!("indexer API: {error}"))
+}
+
+fn convert_context(context: zolana_api::Context) -> Context {
+    Context { slot: context.slot }
+}
+
+fn convert_encrypted_utxo_match(
+    index: usize,
+    item: zolana_api::EncryptedUtxoMatch,
+) -> Result<EncryptedUtxoMatch, ClientError> {
+    Ok(EncryptedUtxoMatch {
+        slot: item.slot,
+        tx_signature: decode_signature(
+            &item.tx_signature,
+            &format!("matches[{index}].tx_signature"),
+        )?,
+        view_tag: decode_hash(&item.view_tag, &format!("matches[{index}].view_tag"))?,
+        tx_viewing_pk: decode_optional_p256(
+            item.tx_viewing_pk,
+            &format!("matches[{index}].tx_viewing_pk"),
+        )?,
+        ciphertext: decode_base64(&item.ciphertext, &format!("matches[{index}].ciphertext"))?,
+    })
+}
+
+fn convert_shielded_transaction(
+    index: usize,
+    item: zolana_api::ShieldedTransaction,
+) -> Result<ShieldedTransaction, ClientError> {
+    Ok(ShieldedTransaction {
+        slot: item.slot,
+        tx_signature: decode_signature(
+            &item.tx_signature,
+            &format!("transactions[{index}].tx_signature"),
+        )?,
+        tx_viewing_pk: decode_optional_p256(
+            item.tx_viewing_pk,
+            &format!("transactions[{index}].tx_viewing_pk"),
+        )?,
+        output_slots: item
+            .output_slots
+            .into_iter()
+            .enumerate()
+            .map(|(slot_index, slot)| {
+                convert_output_slot(
+                    slot,
+                    &format!("transactions[{index}].output_slots[{slot_index}]"),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        nullifiers: item
+            .nullifiers
+            .iter()
+            .enumerate()
+            .map(|(nullifier_index, nullifier)| {
+                decode_hash(
+                    nullifier,
+                    &format!("transactions[{index}].nullifiers[{nullifier_index}]"),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        proofless: item.proofless,
+    })
+}
+
+fn convert_output_slot(slot: ApiOutputSlot, field: &str) -> Result<OutputSlot, ClientError> {
+    Ok(OutputSlot {
+        view_tag: decode_hash(&slot.view_tag, &format!("{field}.view_tag"))?,
+        payload: decode_base64(&slot.payload, &format!("{field}.payload"))?,
+    })
+}
+
+fn convert_merkle_proof(
+    index: usize,
+    proof: zolana_api::MerkleProof,
+) -> Result<MerkleProof, ClientError> {
+    Ok(MerkleProof {
+        leaf: decode_hash(&proof.leaf, &format!("proofs[{index}].leaf"))?,
+        merkle_context: convert_merkle_context(
+            proof.merkle_context,
+            &format!("proofs[{index}].merkle_context"),
+        )?,
+        path: proof
+            .path
+            .iter()
+            .enumerate()
+            .map(|(path_index, hash)| {
+                decode_hash(hash, &format!("proofs[{index}].path[{path_index}]"))
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        leaf_index: proof.leaf_index,
+        root: decode_hash(&proof.root, &format!("proofs[{index}].root"))?,
+        root_seq: proof.root_seq,
+        root_index: proof.root_index,
+    })
+}
+
+fn convert_non_inclusion_proof(
+    index: usize,
+    proof: zolana_api::NonInclusionProof,
+) -> Result<NonInclusionProof, ClientError> {
+    Ok(NonInclusionProof {
+        leaf: decode_hash(&proof.leaf, &format!("proofs[{index}].leaf"))?,
+        merkle_context: convert_merkle_context(
+            proof.merkle_context,
+            &format!("proofs[{index}].merkle_context"),
+        )?,
+        path: proof
+            .path
+            .iter()
+            .enumerate()
+            .map(|(path_index, hash)| {
+                decode_hash(hash, &format!("proofs[{index}].path[{path_index}]"))
+            })
+            .collect::<Result<Vec<_>, _>>()?,
+        low_element: decode_hash(&proof.low_element, &format!("proofs[{index}].low_element"))?,
+        low_element_index: proof.low_element_index,
+        high_element: decode_hash(
+            &proof.high_element,
+            &format!("proofs[{index}].high_element"),
+        )?,
+        high_element_index: proof.high_element_index,
+        root: decode_hash(&proof.root, &format!("proofs[{index}].root"))?,
+        root_seq: proof.root_seq,
+        root_index: proof.root_index,
+    })
+}
+
+fn convert_merkle_context(
+    context: zolana_api::MerkleContext,
+    field: &str,
+) -> Result<MerkleContext, ClientError> {
+    Ok(MerkleContext {
+        tree_type: context.tree_type,
+        tree: decode_pubkey(&context.tree, &format!("{field}.tree"))?,
+    })
+}
+
+fn encode_hash(hash: [u8; 32]) -> ApiHash {
+    ApiHash(bs58::encode(hash).into_string())
+}
+
+fn encode_pubkey(address: Address) -> SerializablePubkey {
+    SerializablePubkey(bs58::encode(address.to_bytes()).into_string())
+}
+
+fn encode_cursor(cursor: Option<Vec<u8>>) -> Option<Base64String> {
+    cursor.map(|cursor| Base64String(base64::encode(cursor)))
+}
+
+fn decode_optional_cursor(cursor: Option<Base64String>) -> Result<Option<Vec<u8>>, ClientError> {
+    cursor
+        .map(|cursor| decode_base64(&cursor, "next_cursor"))
+        .transpose()
+}
+
+fn decode_signature(
+    signature: &zolana_api::SerializableSignature,
+    field: &str,
+) -> Result<Signature, ClientError> {
+    signature
+        .0
+        .parse::<Signature>()
+        .map_err(|error| decode_error(field, error))
+}
+
+fn decode_pubkey(
+    pubkey: &zolana_api::SerializablePubkey,
+    field: &str,
+) -> Result<Address, ClientError> {
+    Ok(Address::new_from_array(decode_base58_32(&pubkey.0, field)?))
+}
+
+fn decode_hash(hash: &ApiHash, field: &str) -> Result<[u8; 32], ClientError> {
+    decode_base58_32(&hash.0, field)
+}
+
+fn decode_base58_32(value: &str, field: &str) -> Result<[u8; 32], ClientError> {
+    let bytes = bs58::decode(value)
+        .into_vec()
+        .map_err(|error| decode_error(field, error))?;
+    fixed_bytes(bytes, 32, field)
+}
+
+fn decode_base64(value: &Base64String, field: &str) -> Result<Vec<u8>, ClientError> {
+    base64::decode(&value.0).map_err(|error| decode_error(field, error))
+}
+
+fn decode_optional_p256(
+    value: Option<Base64String>,
+    field: &str,
+) -> Result<Option<P256Pubkey>, ClientError> {
+    value
+        .map(|value| {
+            let bytes = fixed_bytes(decode_base64(&value, field)?, P256_PUBKEY_LEN, field)?;
+            P256Pubkey::from_bytes(bytes).map_err(|error| decode_error(field, error))
+        })
+        .transpose()
+}
+
+fn fixed_bytes<const N: usize>(
+    bytes: Vec<u8>,
+    expected_len: usize,
+    field: &str,
+) -> Result<[u8; N], ClientError> {
+    let actual_len = bytes.len();
+    bytes.try_into().map_err(|_| {
+        ClientError::Rpc(format!(
+            "invalid indexer field {field}: expected {expected_len} bytes, got {actual_len}"
+        ))
+    })
+}
+
+fn decode_error(field: &str, error: impl std::fmt::Display) -> ClientError {
+    ClientError::Rpc(format!("invalid indexer field {field}: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use p256::elliptic_curve::sec1::ToEncodedPoint;
+    use p256::SecretKey;
+
+    use super::*;
+
+    #[test]
+    fn round_trips_hashes_and_cursors() {
+        let hash = [7u8; 32];
+        let encoded = encode_hash(hash);
+        assert_eq!(decode_hash(&encoded, "hash").unwrap(), hash);
+
+        let cursor = Some(vec![1, 2, 3, 4]);
+        let encoded = encode_cursor(cursor.clone());
+        assert_eq!(decode_optional_cursor(encoded).unwrap(), cursor);
+    }
+
+    #[test]
+    fn decodes_compressed_p256_pubkey() {
+        let secret = SecretKey::from_slice(&[1u8; 32]).unwrap();
+        let public = secret.public_key();
+        let point = public.to_encoded_point(true);
+        let key = decode_optional_p256(
+            Some(Base64String(base64::encode(point.as_bytes()))),
+            "tx_viewing_pk",
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(key.as_bytes(), point.as_bytes());
+    }
+
+    #[test]
+    fn rejects_bad_hash_length() {
+        let err = decode_hash(&ApiHash(bs58::encode([1u8; 31]).into_string()), "root")
+            .expect_err("short hash must fail");
+        assert!(err.to_string().contains("expected 32 bytes"));
+    }
+}

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod actions;
 pub mod error;
+#[cfg(feature = "indexer-api")]
+pub mod indexer;
 pub mod private_transaction;
 pub mod prover;
 pub mod rpc;
@@ -7,6 +9,8 @@ pub mod rpc;
 pub mod solana_rpc;
 
 pub use error::ClientError;
+#[cfg(feature = "indexer-api")]
+pub use indexer::ZolanaIndexer;
 pub use private_transaction::{
     CircuitType, InputCommitment, SignedTransaction, SpendProof, SpendUtxo, Transaction,
     WithdrawalTarget,

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -176,13 +176,7 @@ fn health_check(retries: usize, timeout_secs: u64) -> bool {
             .get(format!("{}{}", SERVER_ADDRESS, HEALTH_CHECK))
             .timeout(timeout)
             .send()
-            .ok()
-            .filter(|response| response.status().is_success())
-            .and_then(|response| response.json::<HealthResponse>().ok())
-            .is_some_and(|health| {
-                health.status.as_deref() == Some("ok")
-                    && health.service.as_deref() == Some(HEALTH_SERVICE)
-            });
+            .is_ok();
         if ok {
             return true;
         }

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -7,6 +7,8 @@ use std::{
     time::Duration,
 };
 
+use serde::Deserialize;
+
 use crate::error::ClientError;
 use crate::prover::inputs::{TransferInputs, TransferP256Inputs};
 use crate::prover::json::{to_json, to_json_p256};
@@ -17,7 +19,14 @@ pub const HEALTH_CHECK: &str = "/health";
 pub const PROVE_PATH: &str = "/prove";
 
 const STARTUP_HEALTH_CHECK_RETRIES: usize = 300;
+const HEALTH_SERVICE: &str = "zolana-prover";
 static IS_LOADING: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Deserialize)]
+struct HealthResponse {
+    service: Option<String>,
+    status: Option<String>,
+}
 
 fn build_http_client() -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()
@@ -167,7 +176,13 @@ fn health_check(retries: usize, timeout_secs: u64) -> bool {
             .get(format!("{}{}", SERVER_ADDRESS, HEALTH_CHECK))
             .timeout(timeout)
             .send()
-            .is_ok();
+            .ok()
+            .filter(|response| response.status().is_success())
+            .and_then(|response| response.json::<HealthResponse>().ok())
+            .is_some_and(|health| {
+                health.status.as_deref() == Some("ok")
+                    && health.service.as_deref() == Some(HEALTH_SERVICE)
+            });
         if ok {
             return true;
         }

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -7,8 +7,6 @@ use std::{
     time::Duration,
 };
 
-use serde::Deserialize;
-
 use crate::error::ClientError;
 use crate::prover::inputs::{TransferInputs, TransferP256Inputs};
 use crate::prover::json::{to_json, to_json_p256};
@@ -19,14 +17,7 @@ pub const HEALTH_CHECK: &str = "/health";
 pub const PROVE_PATH: &str = "/prove";
 
 const STARTUP_HEALTH_CHECK_RETRIES: usize = 300;
-const HEALTH_SERVICE: &str = "zolana-prover";
 static IS_LOADING: AtomicBool = AtomicBool::new(false);
-
-#[derive(Debug, Deserialize)]
-struct HealthResponse {
-    service: Option<String>,
-    status: Option<String>,
-}
 
 fn build_http_client() -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()

--- a/sdk-libs/zolana-api/Cargo.toml
+++ b/sdk-libs/zolana-api/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "zolana-api"
+version = "0.1.0"
+description = "Typed client for the Zolana indexer API."
+license = "Apache-2.0"
+edition.workspace = true
+
+[features]
+default = []
+# Regenerate src/codegen.rs from Photon's Zolana-only OpenAPI spec.
+# Usage:
+#   ZOLANA_OPENAPI_SPEC=/path/to/zolana.yaml cargo build -p zolana-api --features generate
+generate = [
+    "dep:progenitor",
+    "dep:openapiv3",
+    "dep:serde_yaml",
+    "dep:syn",
+    "dep:prettyplease",
+]
+
+[dependencies]
+progenitor-client = "0.12"
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "stream", "rustls-no-provider"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[build-dependencies]
+progenitor = { version = "0.12", optional = true }
+openapiv3 = { version = "2.0", optional = true }
+serde_yaml = { version = "0.9", optional = true }
+syn = { workspace = true, optional = true }
+prettyplease = { version = "0.2", optional = true }

--- a/sdk-libs/zolana-api/build.rs
+++ b/sdk-libs/zolana-api/build.rs
@@ -1,0 +1,98 @@
+fn main() {
+    #[cfg(feature = "generate")]
+    generate();
+}
+
+#[cfg(feature = "generate")]
+fn generate() {
+    use std::{env, fs, path::PathBuf};
+
+    let manifest_dir =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"));
+    let spec_path = env::var("ZOLANA_OPENAPI_SPEC")
+        .or_else(|_| env::var("PHOTON_ZOLANA_OPENAPI_SPEC"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| manifest_dir.join("../../../photon/src/openapi/specs/zolana.yaml"));
+
+    println!("cargo::rerun-if-changed={}", spec_path.display());
+
+    let spec_content = fs::read_to_string(&spec_path).expect("Failed to read OpenAPI spec");
+    let mut spec: serde_yaml::Value =
+        serde_yaml::from_str(&spec_content).expect("Failed to parse OpenAPI spec");
+
+    if let Some(info) = spec.get_mut("info").and_then(|info| info.as_mapping_mut()) {
+        info.insert(
+            serde_yaml::Value::String("title".to_string()),
+            serde_yaml::Value::String("zolana-indexer-api".to_string()),
+        );
+        info.insert(
+            serde_yaml::Value::String("description".to_string()),
+            serde_yaml::Value::String("Zolana indexer API".to_string()),
+        );
+    }
+
+    if let Some(paths) = spec.get_mut("paths").and_then(|p| p.as_mapping_mut()) {
+        for (path, methods) in paths.iter_mut() {
+            let path_str = path.as_str().unwrap_or("");
+            let base_id = path_str.trim_start_matches('/');
+
+            if let Some(methods_map) = methods.as_mapping_mut() {
+                for (method, operation) in methods_map.iter_mut() {
+                    if method.as_str() == Some("summary") {
+                        continue;
+                    }
+
+                    if let Some(op_map) = operation.as_mapping_mut() {
+                        let method_str = method.as_str().unwrap_or("get");
+                        let operation_id = format!("{}_{}", method_str, to_snake_case(base_id));
+
+                        op_map.insert(
+                            serde_yaml::Value::String("operationId".to_string()),
+                            serde_yaml::Value::String(operation_id),
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    let modified_spec = serde_yaml::to_string(&spec).expect("Failed to serialize modified spec");
+    let spec: openapiv3::OpenAPI =
+        serde_yaml::from_str(&modified_spec).expect("Failed to parse modified OpenAPI spec");
+
+    let mut settings = progenitor::GenerationSettings::default();
+    settings.with_interface(progenitor::InterfaceStyle::Builder);
+
+    let mut generator = progenitor::Generator::new(&settings);
+    let tokens = generator
+        .generate_tokens(&spec)
+        .expect("Failed to generate client code");
+
+    let ast: syn::File = syn::parse2(tokens).expect("Failed to parse generated code");
+    let content = prettyplease::unparse(&ast);
+    fs::write(manifest_dir.join("src/codegen.rs"), content)
+        .expect("Failed to write generated code");
+
+    eprintln!("zolana-api: regenerated src/codegen.rs from OpenAPI spec");
+}
+
+#[cfg(feature = "generate")]
+fn to_snake_case(s: &str) -> String {
+    let mut result = String::new();
+    let mut prev_is_lower = false;
+
+    for c in s.chars() {
+        if c.is_uppercase() {
+            if prev_is_lower {
+                result.push('_');
+            }
+            result.extend(c.to_lowercase());
+            prev_is_lower = false;
+        } else {
+            result.push(c);
+            prev_is_lower = c.is_lowercase();
+        }
+    }
+
+    result
+}

--- a/sdk-libs/zolana-api/src/codegen.rs
+++ b/sdk-libs/zolana-api/src/codegen.rs
@@ -1,0 +1,6367 @@
+#[allow(unused_imports)]
+pub use progenitor_client::{ByteStream, ClientInfo, Error, ResponseValue};
+#[allow(unused_imports)]
+use progenitor_client::{encode_path, ClientHooks, OperationInfo, RequestBuilderExt};
+/// Types used as operation parameters and responses.
+#[allow(clippy::all)]
+pub mod types {
+    /// Error types.
+    pub mod error {
+        /// Error from a `TryFrom` or `FromStr` implementation.
+        pub struct ConversionError(::std::borrow::Cow<'static, str>);
+        impl ::std::error::Error for ConversionError {}
+        impl ::std::fmt::Display for ConversionError {
+            fn fmt(
+                &self,
+                f: &mut ::std::fmt::Formatter<'_>,
+            ) -> Result<(), ::std::fmt::Error> {
+                ::std::fmt::Display::fmt(&self.0, f)
+            }
+        }
+        impl ::std::fmt::Debug for ConversionError {
+            fn fmt(
+                &self,
+                f: &mut ::std::fmt::Formatter<'_>,
+            ) -> Result<(), ::std::fmt::Error> {
+                ::std::fmt::Debug::fmt(&self.0, f)
+            }
+        }
+        impl From<&'static str> for ConversionError {
+            fn from(value: &'static str) -> Self {
+                Self(value.into())
+            }
+        }
+        impl From<String> for ConversionError {
+            fn from(value: String) -> Self {
+                Self(value.into())
+            }
+        }
+    }
+    ///A base 64 encoded string.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "A base 64 encoded string.",
+    ///  "default": "SGVsbG8sIFdvcmxkIQ==",
+    ///  "examples": [
+    ///    "SGVsbG8sIFdvcmxkIQ=="
+    ///  ],
+    ///  "type": "string"
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    #[serde(transparent)]
+    pub struct Base64String(pub ::std::string::String);
+    impl ::std::ops::Deref for Base64String {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<Base64String> for ::std::string::String {
+        fn from(value: Base64String) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<::std::string::String> for Base64String {
+        fn from(value: ::std::string::String) -> Self {
+            Self(value)
+        }
+    }
+    impl ::std::str::FromStr for Base64String {
+        type Err = ::std::convert::Infallible;
+        fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::fmt::Display for Base64String {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+    ///`Context`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "slot"
+    ///  ],
+    ///  "properties": {
+    ///    "slot": {
+    ///      "default": 100,
+    ///      "examples": [
+    ///        100
+    ///      ],
+    ///      "type": "integer",
+    ///      "format": "uint64"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct Context {
+        pub slot: u64,
+    }
+    impl Context {
+        pub fn builder() -> builder::Context {
+            Default::default()
+        }
+    }
+    ///`EncryptedUtxoMatch`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "ciphertext",
+    ///    "slot",
+    ///    "tx_signature",
+    ///    "view_tag"
+    ///  ],
+    ///  "properties": {
+    ///    "ciphertext": {
+    ///      "$ref": "#/components/schemas/Base64String"
+    ///    },
+    ///    "slot": {
+    ///      "type": "integer",
+    ///      "format": "uint64",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "tx_signature": {
+    ///      "$ref": "#/components/schemas/SerializableSignature"
+    ///    },
+    ///    "tx_viewing_pk": {
+    ///      "$ref": "#/components/schemas/Base64String"
+    ///    },
+    ///    "view_tag": {
+    ///      "$ref": "#/components/schemas/Hash"
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct EncryptedUtxoMatch {
+        pub ciphertext: Base64String,
+        pub slot: u64,
+        pub tx_signature: SerializableSignature,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub tx_viewing_pk: ::std::option::Option<Base64String>,
+        pub view_tag: Hash,
+    }
+    impl EncryptedUtxoMatch {
+        pub fn builder() -> builder::EncryptedUtxoMatch {
+            Default::default()
+        }
+    }
+    ///A 32-byte hash represented as a base58 string.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "A 32-byte hash represented as a base58 string.",
+    ///  "examples": [
+    ///    "11111112cMQwSC9qirWGjZM6gLGwW69X22mqwLLGP"
+    ///  ],
+    ///  "type": "string"
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    #[serde(transparent)]
+    pub struct Hash(pub ::std::string::String);
+    impl ::std::ops::Deref for Hash {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<Hash> for ::std::string::String {
+        fn from(value: Hash) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<::std::string::String> for Hash {
+        fn from(value: ::std::string::String) -> Self {
+            Self(value)
+        }
+    }
+    impl ::std::str::FromStr for Hash {
+        type Err = ::std::convert::Infallible;
+        fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::fmt::Display for Hash {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+    ///`Limit`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "integer",
+    ///  "format": "uint64",
+    ///  "minimum": 0.0
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(transparent)]
+    pub struct Limit(pub u64);
+    impl ::std::ops::Deref for Limit {
+        type Target = u64;
+        fn deref(&self) -> &u64 {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<Limit> for u64 {
+        fn from(value: Limit) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<u64> for Limit {
+        fn from(value: u64) -> Self {
+            Self(value)
+        }
+    }
+    impl ::std::str::FromStr for Limit {
+        type Err = <u64 as ::std::str::FromStr>::Err;
+        fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
+            Ok(Self(value.parse()?))
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for Limit {
+        type Error = <u64 as ::std::str::FromStr>::Err;
+        fn try_from(value: &str) -> ::std::result::Result<Self, Self::Error> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<String> for Limit {
+        type Error = <u64 as ::std::str::FromStr>::Err;
+        fn try_from(value: String) -> ::std::result::Result<Self, Self::Error> {
+            value.parse()
+        }
+    }
+    impl ::std::fmt::Display for Limit {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+    ///`MerkleContext`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "tree",
+    ///    "tree_type"
+    ///  ],
+    ///  "properties": {
+    ///    "tree": {
+    ///      "$ref": "#/components/schemas/SerializablePubkey"
+    ///    },
+    ///    "tree_type": {
+    ///      "type": "integer",
+    ///      "format": "uint16",
+    ///      "minimum": 0.0
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct MerkleContext {
+        pub tree: SerializablePubkey,
+        pub tree_type: u16,
+    }
+    impl MerkleContext {
+        pub fn builder() -> builder::MerkleContext {
+            Default::default()
+        }
+    }
+    ///`MerkleProof`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "leaf",
+    ///    "leaf_index",
+    ///    "merkle_context",
+    ///    "path",
+    ///    "root",
+    ///    "root_index",
+    ///    "root_seq"
+    ///  ],
+    ///  "properties": {
+    ///    "leaf": {
+    ///      "$ref": "#/components/schemas/Hash"
+    ///    },
+    ///    "leaf_index": {
+    ///      "type": "integer",
+    ///      "format": "uint64",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "merkle_context": {
+    ///      "$ref": "#/components/schemas/MerkleContext"
+    ///    },
+    ///    "path": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/Hash"
+    ///      }
+    ///    },
+    ///    "root": {
+    ///      "$ref": "#/components/schemas/Hash"
+    ///    },
+    ///    "root_index": {
+    ///      "type": "integer",
+    ///      "format": "uint16",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "root_seq": {
+    ///      "type": "integer",
+    ///      "format": "uint64",
+    ///      "minimum": 0.0
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct MerkleProof {
+        pub leaf: Hash,
+        pub leaf_index: u64,
+        pub merkle_context: MerkleContext,
+        pub path: ::std::vec::Vec<Hash>,
+        pub root: Hash,
+        pub root_index: u16,
+        pub root_seq: u64,
+    }
+    impl MerkleProof {
+        pub fn builder() -> builder::MerkleProof {
+            Default::default()
+        }
+    }
+    ///`NonInclusionProof`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "high_element",
+    ///    "high_element_index",
+    ///    "leaf",
+    ///    "low_element",
+    ///    "low_element_index",
+    ///    "merkle_context",
+    ///    "path",
+    ///    "root",
+    ///    "root_index",
+    ///    "root_seq"
+    ///  ],
+    ///  "properties": {
+    ///    "high_element": {
+    ///      "$ref": "#/components/schemas/Hash"
+    ///    },
+    ///    "high_element_index": {
+    ///      "type": "integer",
+    ///      "format": "uint64",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "leaf": {
+    ///      "$ref": "#/components/schemas/Hash"
+    ///    },
+    ///    "low_element": {
+    ///      "$ref": "#/components/schemas/Hash"
+    ///    },
+    ///    "low_element_index": {
+    ///      "type": "integer",
+    ///      "format": "uint64",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "merkle_context": {
+    ///      "$ref": "#/components/schemas/MerkleContext"
+    ///    },
+    ///    "path": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/Hash"
+    ///      }
+    ///    },
+    ///    "root": {
+    ///      "$ref": "#/components/schemas/Hash"
+    ///    },
+    ///    "root_index": {
+    ///      "type": "integer",
+    ///      "format": "uint16",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "root_seq": {
+    ///      "type": "integer",
+    ///      "format": "uint64",
+    ///      "minimum": 0.0
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct NonInclusionProof {
+        pub high_element: Hash,
+        pub high_element_index: u64,
+        pub leaf: Hash,
+        pub low_element: Hash,
+        pub low_element_index: u64,
+        pub merkle_context: MerkleContext,
+        pub path: ::std::vec::Vec<Hash>,
+        pub root: Hash,
+        pub root_index: u16,
+        pub root_seq: u64,
+    }
+    impl NonInclusionProof {
+        pub fn builder() -> builder::NonInclusionProof {
+            Default::default()
+        }
+    }
+    ///`PostGetEncryptedUtxosByTagsBody`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "id",
+    ///    "jsonrpc",
+    ///    "method",
+    ///    "params"
+    ///  ],
+    ///  "properties": {
+    ///    "id": {
+    ///      "description": "An ID to identify the request.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "test-account"
+    ///      ]
+    ///    },
+    ///    "jsonrpc": {
+    ///      "description": "The version of the JSON-RPC protocol.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "2.0"
+    ///      ]
+    ///    },
+    ///    "method": {
+    ///      "description": "The name of the method to invoke.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "get_encrypted_utxos_by_tags"
+    ///      ]
+    ///    },
+    ///    "params": {
+    ///      "type": "object",
+    ///      "required": [
+    ///        "tags"
+    ///      ],
+    ///      "properties": {
+    ///        "cursor": {
+    ///          "oneOf": [
+    ///            {
+    ///              "type": "null"
+    ///            },
+    ///            {
+    ///              "allOf": [
+    ///                {
+    ///                  "$ref": "#/components/schemas/Base64String"
+    ///                }
+    ///              ]
+    ///            }
+    ///          ]
+    ///        },
+    ///        "limit": {
+    ///          "oneOf": [
+    ///            {
+    ///              "type": "null"
+    ///            },
+    ///            {
+    ///              "allOf": [
+    ///                {
+    ///                  "$ref": "#/components/schemas/Limit"
+    ///                }
+    ///              ]
+    ///            }
+    ///          ]
+    ///        },
+    ///        "tags": {
+    ///          "type": "array",
+    ///          "items": {
+    ///            "$ref": "#/components/schemas/Hash"
+    ///          }
+    ///        }
+    ///      },
+    ///      "additionalProperties": false
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PostGetEncryptedUtxosByTagsBody {
+        ///An ID to identify the request.
+        pub id: PostGetEncryptedUtxosByTagsBodyId,
+        ///The version of the JSON-RPC protocol.
+        pub jsonrpc: PostGetEncryptedUtxosByTagsBodyJsonrpc,
+        ///The name of the method to invoke.
+        pub method: PostGetEncryptedUtxosByTagsBodyMethod,
+        pub params: PostGetEncryptedUtxosByTagsBodyParams,
+    }
+    impl PostGetEncryptedUtxosByTagsBody {
+        pub fn builder() -> builder::PostGetEncryptedUtxosByTagsBody {
+            Default::default()
+        }
+    }
+    ///An ID to identify the request.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "An ID to identify the request.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "test-account"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetEncryptedUtxosByTagsBodyId {
+        #[serde(rename = "test-account")]
+        TestAccount,
+    }
+    impl ::std::fmt::Display for PostGetEncryptedUtxosByTagsBodyId {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::TestAccount => f.write_str("test-account"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetEncryptedUtxosByTagsBodyId {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "test-account" => Ok(Self::TestAccount),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetEncryptedUtxosByTagsBodyId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetEncryptedUtxosByTagsBodyId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetEncryptedUtxosByTagsBodyId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///The version of the JSON-RPC protocol.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "The version of the JSON-RPC protocol.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "2.0"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetEncryptedUtxosByTagsBodyJsonrpc {
+        #[serde(rename = "2.0")]
+        X20,
+    }
+    impl ::std::fmt::Display for PostGetEncryptedUtxosByTagsBodyJsonrpc {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::X20 => f.write_str("2.0"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetEncryptedUtxosByTagsBodyJsonrpc {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "2.0" => Ok(Self::X20),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetEncryptedUtxosByTagsBodyJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetEncryptedUtxosByTagsBodyJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetEncryptedUtxosByTagsBodyJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///The name of the method to invoke.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "The name of the method to invoke.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "get_encrypted_utxos_by_tags"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetEncryptedUtxosByTagsBodyMethod {
+        #[serde(rename = "get_encrypted_utxos_by_tags")]
+        GetEncryptedUtxosByTags,
+    }
+    impl ::std::fmt::Display for PostGetEncryptedUtxosByTagsBodyMethod {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::GetEncryptedUtxosByTags => {
+                    f.write_str("get_encrypted_utxos_by_tags")
+                }
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetEncryptedUtxosByTagsBodyMethod {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "get_encrypted_utxos_by_tags" => Ok(Self::GetEncryptedUtxosByTags),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetEncryptedUtxosByTagsBodyMethod {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetEncryptedUtxosByTagsBodyMethod {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetEncryptedUtxosByTagsBodyMethod {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///`PostGetEncryptedUtxosByTagsBodyParams`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "tags"
+    ///  ],
+    ///  "properties": {
+    ///    "cursor": {
+    ///      "oneOf": [
+    ///        {
+    ///          "type": "null"
+    ///        },
+    ///        {
+    ///          "allOf": [
+    ///            {
+    ///              "$ref": "#/components/schemas/Base64String"
+    ///            }
+    ///          ]
+    ///        }
+    ///      ]
+    ///    },
+    ///    "limit": {
+    ///      "oneOf": [
+    ///        {
+    ///          "type": "null"
+    ///        },
+    ///        {
+    ///          "allOf": [
+    ///            {
+    ///              "$ref": "#/components/schemas/Limit"
+    ///            }
+    ///          ]
+    ///        }
+    ///      ]
+    ///    },
+    ///    "tags": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/Hash"
+    ///      }
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct PostGetEncryptedUtxosByTagsBodyParams {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub cursor: ::std::option::Option<Base64String>,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub limit: ::std::option::Option<Limit>,
+        pub tags: ::std::vec::Vec<Hash>,
+    }
+    impl PostGetEncryptedUtxosByTagsBodyParams {
+        pub fn builder() -> builder::PostGetEncryptedUtxosByTagsBodyParams {
+            Default::default()
+        }
+    }
+    ///`PostGetEncryptedUtxosByTagsResponse`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "id",
+    ///    "jsonrpc"
+    ///  ],
+    ///  "properties": {
+    ///    "error": {
+    ///      "type": "object",
+    ///      "properties": {
+    ///        "code": {
+    ///          "type": "integer"
+    ///        },
+    ///        "message": {
+    ///          "type": "string"
+    ///        }
+    ///      }
+    ///    },
+    ///    "id": {
+    ///      "description": "An ID to identify the response.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "test-account"
+    ///      ]
+    ///    },
+    ///    "jsonrpc": {
+    ///      "description": "The version of the JSON-RPC protocol.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "2.0"
+    ///      ]
+    ///    },
+    ///    "result": {
+    ///      "type": "object",
+    ///      "required": [
+    ///        "context",
+    ///        "matches"
+    ///      ],
+    ///      "properties": {
+    ///        "context": {
+    ///          "$ref": "#/components/schemas/Context"
+    ///        },
+    ///        "matches": {
+    ///          "type": "array",
+    ///          "items": {
+    ///            "$ref": "#/components/schemas/EncryptedUtxoMatch"
+    ///          }
+    ///        },
+    ///        "next_cursor": {
+    ///          "$ref": "#/components/schemas/Base64String"
+    ///        }
+    ///      },
+    ///      "additionalProperties": false
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PostGetEncryptedUtxosByTagsResponse {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub error: ::std::option::Option<PostGetEncryptedUtxosByTagsResponseError>,
+        ///An ID to identify the response.
+        pub id: PostGetEncryptedUtxosByTagsResponseId,
+        ///The version of the JSON-RPC protocol.
+        pub jsonrpc: PostGetEncryptedUtxosByTagsResponseJsonrpc,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub result: ::std::option::Option<PostGetEncryptedUtxosByTagsResponseResult>,
+    }
+    impl PostGetEncryptedUtxosByTagsResponse {
+        pub fn builder() -> builder::PostGetEncryptedUtxosByTagsResponse {
+            Default::default()
+        }
+    }
+    ///`PostGetEncryptedUtxosByTagsResponseError`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "properties": {
+    ///    "code": {
+    ///      "type": "integer"
+    ///    },
+    ///    "message": {
+    ///      "type": "string"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PostGetEncryptedUtxosByTagsResponseError {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub code: ::std::option::Option<i64>,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub message: ::std::option::Option<::std::string::String>,
+    }
+    impl ::std::default::Default for PostGetEncryptedUtxosByTagsResponseError {
+        fn default() -> Self {
+            Self {
+                code: Default::default(),
+                message: Default::default(),
+            }
+        }
+    }
+    impl PostGetEncryptedUtxosByTagsResponseError {
+        pub fn builder() -> builder::PostGetEncryptedUtxosByTagsResponseError {
+            Default::default()
+        }
+    }
+    ///An ID to identify the response.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "An ID to identify the response.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "test-account"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetEncryptedUtxosByTagsResponseId {
+        #[serde(rename = "test-account")]
+        TestAccount,
+    }
+    impl ::std::fmt::Display for PostGetEncryptedUtxosByTagsResponseId {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::TestAccount => f.write_str("test-account"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetEncryptedUtxosByTagsResponseId {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "test-account" => Ok(Self::TestAccount),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetEncryptedUtxosByTagsResponseId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetEncryptedUtxosByTagsResponseId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetEncryptedUtxosByTagsResponseId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///The version of the JSON-RPC protocol.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "The version of the JSON-RPC protocol.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "2.0"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetEncryptedUtxosByTagsResponseJsonrpc {
+        #[serde(rename = "2.0")]
+        X20,
+    }
+    impl ::std::fmt::Display for PostGetEncryptedUtxosByTagsResponseJsonrpc {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::X20 => f.write_str("2.0"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetEncryptedUtxosByTagsResponseJsonrpc {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "2.0" => Ok(Self::X20),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetEncryptedUtxosByTagsResponseJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetEncryptedUtxosByTagsResponseJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetEncryptedUtxosByTagsResponseJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///`PostGetEncryptedUtxosByTagsResponseResult`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "context",
+    ///    "matches"
+    ///  ],
+    ///  "properties": {
+    ///    "context": {
+    ///      "$ref": "#/components/schemas/Context"
+    ///    },
+    ///    "matches": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/EncryptedUtxoMatch"
+    ///      }
+    ///    },
+    ///    "next_cursor": {
+    ///      "$ref": "#/components/schemas/Base64String"
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct PostGetEncryptedUtxosByTagsResponseResult {
+        pub context: Context,
+        pub matches: ::std::vec::Vec<EncryptedUtxoMatch>,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub next_cursor: ::std::option::Option<Base64String>,
+    }
+    impl PostGetEncryptedUtxosByTagsResponseResult {
+        pub fn builder() -> builder::PostGetEncryptedUtxosByTagsResponseResult {
+            Default::default()
+        }
+    }
+    ///`PostGetMerkleProofsBody`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "id",
+    ///    "jsonrpc",
+    ///    "method",
+    ///    "params"
+    ///  ],
+    ///  "properties": {
+    ///    "id": {
+    ///      "description": "An ID to identify the request.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "test-account"
+    ///      ]
+    ///    },
+    ///    "jsonrpc": {
+    ///      "description": "The version of the JSON-RPC protocol.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "2.0"
+    ///      ]
+    ///    },
+    ///    "method": {
+    ///      "description": "The name of the method to invoke.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "get_merkle_proofs"
+    ///      ]
+    ///    },
+    ///    "params": {
+    ///      "type": "object",
+    ///      "required": [
+    ///        "leaves",
+    ///        "tree_account"
+    ///      ],
+    ///      "properties": {
+    ///        "leaves": {
+    ///          "type": "array",
+    ///          "items": {
+    ///            "$ref": "#/components/schemas/Hash"
+    ///          }
+    ///        },
+    ///        "tree_account": {
+    ///          "$ref": "#/components/schemas/SerializablePubkey"
+    ///        }
+    ///      },
+    ///      "additionalProperties": false
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PostGetMerkleProofsBody {
+        ///An ID to identify the request.
+        pub id: PostGetMerkleProofsBodyId,
+        ///The version of the JSON-RPC protocol.
+        pub jsonrpc: PostGetMerkleProofsBodyJsonrpc,
+        ///The name of the method to invoke.
+        pub method: PostGetMerkleProofsBodyMethod,
+        pub params: PostGetMerkleProofsBodyParams,
+    }
+    impl PostGetMerkleProofsBody {
+        pub fn builder() -> builder::PostGetMerkleProofsBody {
+            Default::default()
+        }
+    }
+    ///An ID to identify the request.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "An ID to identify the request.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "test-account"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetMerkleProofsBodyId {
+        #[serde(rename = "test-account")]
+        TestAccount,
+    }
+    impl ::std::fmt::Display for PostGetMerkleProofsBodyId {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::TestAccount => f.write_str("test-account"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetMerkleProofsBodyId {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "test-account" => Ok(Self::TestAccount),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetMerkleProofsBodyId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String> for PostGetMerkleProofsBodyId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String> for PostGetMerkleProofsBodyId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///The version of the JSON-RPC protocol.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "The version of the JSON-RPC protocol.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "2.0"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetMerkleProofsBodyJsonrpc {
+        #[serde(rename = "2.0")]
+        X20,
+    }
+    impl ::std::fmt::Display for PostGetMerkleProofsBodyJsonrpc {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::X20 => f.write_str("2.0"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetMerkleProofsBodyJsonrpc {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "2.0" => Ok(Self::X20),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetMerkleProofsBodyJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetMerkleProofsBodyJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetMerkleProofsBodyJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///The name of the method to invoke.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "The name of the method to invoke.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "get_merkle_proofs"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetMerkleProofsBodyMethod {
+        #[serde(rename = "get_merkle_proofs")]
+        GetMerkleProofs,
+    }
+    impl ::std::fmt::Display for PostGetMerkleProofsBodyMethod {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::GetMerkleProofs => f.write_str("get_merkle_proofs"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetMerkleProofsBodyMethod {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "get_merkle_proofs" => Ok(Self::GetMerkleProofs),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetMerkleProofsBodyMethod {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetMerkleProofsBodyMethod {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetMerkleProofsBodyMethod {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///`PostGetMerkleProofsBodyParams`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "leaves",
+    ///    "tree_account"
+    ///  ],
+    ///  "properties": {
+    ///    "leaves": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/Hash"
+    ///      }
+    ///    },
+    ///    "tree_account": {
+    ///      "$ref": "#/components/schemas/SerializablePubkey"
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct PostGetMerkleProofsBodyParams {
+        pub leaves: ::std::vec::Vec<Hash>,
+        pub tree_account: SerializablePubkey,
+    }
+    impl PostGetMerkleProofsBodyParams {
+        pub fn builder() -> builder::PostGetMerkleProofsBodyParams {
+            Default::default()
+        }
+    }
+    ///`PostGetMerkleProofsResponse`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "id",
+    ///    "jsonrpc"
+    ///  ],
+    ///  "properties": {
+    ///    "error": {
+    ///      "type": "object",
+    ///      "properties": {
+    ///        "code": {
+    ///          "type": "integer"
+    ///        },
+    ///        "message": {
+    ///          "type": "string"
+    ///        }
+    ///      }
+    ///    },
+    ///    "id": {
+    ///      "description": "An ID to identify the response.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "test-account"
+    ///      ]
+    ///    },
+    ///    "jsonrpc": {
+    ///      "description": "The version of the JSON-RPC protocol.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "2.0"
+    ///      ]
+    ///    },
+    ///    "result": {
+    ///      "type": "object",
+    ///      "required": [
+    ///        "context",
+    ///        "proofs"
+    ///      ],
+    ///      "properties": {
+    ///        "context": {
+    ///          "$ref": "#/components/schemas/Context"
+    ///        },
+    ///        "proofs": {
+    ///          "type": "array",
+    ///          "items": {
+    ///            "$ref": "#/components/schemas/MerkleProof"
+    ///          }
+    ///        }
+    ///      },
+    ///      "additionalProperties": false
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PostGetMerkleProofsResponse {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub error: ::std::option::Option<PostGetMerkleProofsResponseError>,
+        ///An ID to identify the response.
+        pub id: PostGetMerkleProofsResponseId,
+        ///The version of the JSON-RPC protocol.
+        pub jsonrpc: PostGetMerkleProofsResponseJsonrpc,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub result: ::std::option::Option<PostGetMerkleProofsResponseResult>,
+    }
+    impl PostGetMerkleProofsResponse {
+        pub fn builder() -> builder::PostGetMerkleProofsResponse {
+            Default::default()
+        }
+    }
+    ///`PostGetMerkleProofsResponseError`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "properties": {
+    ///    "code": {
+    ///      "type": "integer"
+    ///    },
+    ///    "message": {
+    ///      "type": "string"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PostGetMerkleProofsResponseError {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub code: ::std::option::Option<i64>,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub message: ::std::option::Option<::std::string::String>,
+    }
+    impl ::std::default::Default for PostGetMerkleProofsResponseError {
+        fn default() -> Self {
+            Self {
+                code: Default::default(),
+                message: Default::default(),
+            }
+        }
+    }
+    impl PostGetMerkleProofsResponseError {
+        pub fn builder() -> builder::PostGetMerkleProofsResponseError {
+            Default::default()
+        }
+    }
+    ///An ID to identify the response.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "An ID to identify the response.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "test-account"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetMerkleProofsResponseId {
+        #[serde(rename = "test-account")]
+        TestAccount,
+    }
+    impl ::std::fmt::Display for PostGetMerkleProofsResponseId {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::TestAccount => f.write_str("test-account"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetMerkleProofsResponseId {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "test-account" => Ok(Self::TestAccount),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetMerkleProofsResponseId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetMerkleProofsResponseId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetMerkleProofsResponseId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///The version of the JSON-RPC protocol.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "The version of the JSON-RPC protocol.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "2.0"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetMerkleProofsResponseJsonrpc {
+        #[serde(rename = "2.0")]
+        X20,
+    }
+    impl ::std::fmt::Display for PostGetMerkleProofsResponseJsonrpc {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::X20 => f.write_str("2.0"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetMerkleProofsResponseJsonrpc {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "2.0" => Ok(Self::X20),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetMerkleProofsResponseJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetMerkleProofsResponseJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetMerkleProofsResponseJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///`PostGetMerkleProofsResponseResult`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "context",
+    ///    "proofs"
+    ///  ],
+    ///  "properties": {
+    ///    "context": {
+    ///      "$ref": "#/components/schemas/Context"
+    ///    },
+    ///    "proofs": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/MerkleProof"
+    ///      }
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct PostGetMerkleProofsResponseResult {
+        pub context: Context,
+        pub proofs: ::std::vec::Vec<MerkleProof>,
+    }
+    impl PostGetMerkleProofsResponseResult {
+        pub fn builder() -> builder::PostGetMerkleProofsResponseResult {
+            Default::default()
+        }
+    }
+    ///`PostGetNonInclusionProofsBody`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "id",
+    ///    "jsonrpc",
+    ///    "method",
+    ///    "params"
+    ///  ],
+    ///  "properties": {
+    ///    "id": {
+    ///      "description": "An ID to identify the request.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "test-account"
+    ///      ]
+    ///    },
+    ///    "jsonrpc": {
+    ///      "description": "The version of the JSON-RPC protocol.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "2.0"
+    ///      ]
+    ///    },
+    ///    "method": {
+    ///      "description": "The name of the method to invoke.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "get_non_inclusion_proofs"
+    ///      ]
+    ///    },
+    ///    "params": {
+    ///      "type": "object",
+    ///      "required": [
+    ///        "leaves",
+    ///        "tree_account"
+    ///      ],
+    ///      "properties": {
+    ///        "leaves": {
+    ///          "type": "array",
+    ///          "items": {
+    ///            "$ref": "#/components/schemas/Hash"
+    ///          }
+    ///        },
+    ///        "tree_account": {
+    ///          "$ref": "#/components/schemas/SerializablePubkey"
+    ///        }
+    ///      },
+    ///      "additionalProperties": false
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PostGetNonInclusionProofsBody {
+        ///An ID to identify the request.
+        pub id: PostGetNonInclusionProofsBodyId,
+        ///The version of the JSON-RPC protocol.
+        pub jsonrpc: PostGetNonInclusionProofsBodyJsonrpc,
+        ///The name of the method to invoke.
+        pub method: PostGetNonInclusionProofsBodyMethod,
+        pub params: PostGetNonInclusionProofsBodyParams,
+    }
+    impl PostGetNonInclusionProofsBody {
+        pub fn builder() -> builder::PostGetNonInclusionProofsBody {
+            Default::default()
+        }
+    }
+    ///An ID to identify the request.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "An ID to identify the request.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "test-account"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetNonInclusionProofsBodyId {
+        #[serde(rename = "test-account")]
+        TestAccount,
+    }
+    impl ::std::fmt::Display for PostGetNonInclusionProofsBodyId {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::TestAccount => f.write_str("test-account"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetNonInclusionProofsBodyId {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "test-account" => Ok(Self::TestAccount),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetNonInclusionProofsBodyId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetNonInclusionProofsBodyId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetNonInclusionProofsBodyId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///The version of the JSON-RPC protocol.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "The version of the JSON-RPC protocol.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "2.0"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetNonInclusionProofsBodyJsonrpc {
+        #[serde(rename = "2.0")]
+        X20,
+    }
+    impl ::std::fmt::Display for PostGetNonInclusionProofsBodyJsonrpc {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::X20 => f.write_str("2.0"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetNonInclusionProofsBodyJsonrpc {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "2.0" => Ok(Self::X20),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetNonInclusionProofsBodyJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetNonInclusionProofsBodyJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetNonInclusionProofsBodyJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///The name of the method to invoke.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "The name of the method to invoke.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "get_non_inclusion_proofs"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetNonInclusionProofsBodyMethod {
+        #[serde(rename = "get_non_inclusion_proofs")]
+        GetNonInclusionProofs,
+    }
+    impl ::std::fmt::Display for PostGetNonInclusionProofsBodyMethod {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::GetNonInclusionProofs => f.write_str("get_non_inclusion_proofs"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetNonInclusionProofsBodyMethod {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "get_non_inclusion_proofs" => Ok(Self::GetNonInclusionProofs),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetNonInclusionProofsBodyMethod {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetNonInclusionProofsBodyMethod {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetNonInclusionProofsBodyMethod {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///`PostGetNonInclusionProofsBodyParams`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "leaves",
+    ///    "tree_account"
+    ///  ],
+    ///  "properties": {
+    ///    "leaves": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/Hash"
+    ///      }
+    ///    },
+    ///    "tree_account": {
+    ///      "$ref": "#/components/schemas/SerializablePubkey"
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct PostGetNonInclusionProofsBodyParams {
+        pub leaves: ::std::vec::Vec<Hash>,
+        pub tree_account: SerializablePubkey,
+    }
+    impl PostGetNonInclusionProofsBodyParams {
+        pub fn builder() -> builder::PostGetNonInclusionProofsBodyParams {
+            Default::default()
+        }
+    }
+    ///`PostGetNonInclusionProofsResponse`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "id",
+    ///    "jsonrpc"
+    ///  ],
+    ///  "properties": {
+    ///    "error": {
+    ///      "type": "object",
+    ///      "properties": {
+    ///        "code": {
+    ///          "type": "integer"
+    ///        },
+    ///        "message": {
+    ///          "type": "string"
+    ///        }
+    ///      }
+    ///    },
+    ///    "id": {
+    ///      "description": "An ID to identify the response.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "test-account"
+    ///      ]
+    ///    },
+    ///    "jsonrpc": {
+    ///      "description": "The version of the JSON-RPC protocol.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "2.0"
+    ///      ]
+    ///    },
+    ///    "result": {
+    ///      "type": "object",
+    ///      "required": [
+    ///        "context",
+    ///        "proofs"
+    ///      ],
+    ///      "properties": {
+    ///        "context": {
+    ///          "$ref": "#/components/schemas/Context"
+    ///        },
+    ///        "proofs": {
+    ///          "type": "array",
+    ///          "items": {
+    ///            "$ref": "#/components/schemas/NonInclusionProof"
+    ///          }
+    ///        }
+    ///      },
+    ///      "additionalProperties": false
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PostGetNonInclusionProofsResponse {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub error: ::std::option::Option<PostGetNonInclusionProofsResponseError>,
+        ///An ID to identify the response.
+        pub id: PostGetNonInclusionProofsResponseId,
+        ///The version of the JSON-RPC protocol.
+        pub jsonrpc: PostGetNonInclusionProofsResponseJsonrpc,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub result: ::std::option::Option<PostGetNonInclusionProofsResponseResult>,
+    }
+    impl PostGetNonInclusionProofsResponse {
+        pub fn builder() -> builder::PostGetNonInclusionProofsResponse {
+            Default::default()
+        }
+    }
+    ///`PostGetNonInclusionProofsResponseError`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "properties": {
+    ///    "code": {
+    ///      "type": "integer"
+    ///    },
+    ///    "message": {
+    ///      "type": "string"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PostGetNonInclusionProofsResponseError {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub code: ::std::option::Option<i64>,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub message: ::std::option::Option<::std::string::String>,
+    }
+    impl ::std::default::Default for PostGetNonInclusionProofsResponseError {
+        fn default() -> Self {
+            Self {
+                code: Default::default(),
+                message: Default::default(),
+            }
+        }
+    }
+    impl PostGetNonInclusionProofsResponseError {
+        pub fn builder() -> builder::PostGetNonInclusionProofsResponseError {
+            Default::default()
+        }
+    }
+    ///An ID to identify the response.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "An ID to identify the response.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "test-account"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetNonInclusionProofsResponseId {
+        #[serde(rename = "test-account")]
+        TestAccount,
+    }
+    impl ::std::fmt::Display for PostGetNonInclusionProofsResponseId {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::TestAccount => f.write_str("test-account"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetNonInclusionProofsResponseId {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "test-account" => Ok(Self::TestAccount),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetNonInclusionProofsResponseId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetNonInclusionProofsResponseId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetNonInclusionProofsResponseId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///The version of the JSON-RPC protocol.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "The version of the JSON-RPC protocol.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "2.0"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetNonInclusionProofsResponseJsonrpc {
+        #[serde(rename = "2.0")]
+        X20,
+    }
+    impl ::std::fmt::Display for PostGetNonInclusionProofsResponseJsonrpc {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::X20 => f.write_str("2.0"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetNonInclusionProofsResponseJsonrpc {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "2.0" => Ok(Self::X20),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetNonInclusionProofsResponseJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetNonInclusionProofsResponseJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetNonInclusionProofsResponseJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///`PostGetNonInclusionProofsResponseResult`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "context",
+    ///    "proofs"
+    ///  ],
+    ///  "properties": {
+    ///    "context": {
+    ///      "$ref": "#/components/schemas/Context"
+    ///    },
+    ///    "proofs": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/NonInclusionProof"
+    ///      }
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct PostGetNonInclusionProofsResponseResult {
+        pub context: Context,
+        pub proofs: ::std::vec::Vec<NonInclusionProof>,
+    }
+    impl PostGetNonInclusionProofsResponseResult {
+        pub fn builder() -> builder::PostGetNonInclusionProofsResponseResult {
+            Default::default()
+        }
+    }
+    ///`PostGetShieldedTransactionsByTagsBody`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "id",
+    ///    "jsonrpc",
+    ///    "method",
+    ///    "params"
+    ///  ],
+    ///  "properties": {
+    ///    "id": {
+    ///      "description": "An ID to identify the request.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "test-account"
+    ///      ]
+    ///    },
+    ///    "jsonrpc": {
+    ///      "description": "The version of the JSON-RPC protocol.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "2.0"
+    ///      ]
+    ///    },
+    ///    "method": {
+    ///      "description": "The name of the method to invoke.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "get_shielded_transactions_by_tags"
+    ///      ]
+    ///    },
+    ///    "params": {
+    ///      "type": "object",
+    ///      "required": [
+    ///        "tags"
+    ///      ],
+    ///      "properties": {
+    ///        "cursor": {
+    ///          "oneOf": [
+    ///            {
+    ///              "type": "null"
+    ///            },
+    ///            {
+    ///              "allOf": [
+    ///                {
+    ///                  "$ref": "#/components/schemas/Base64String"
+    ///                }
+    ///              ]
+    ///            }
+    ///          ]
+    ///        },
+    ///        "limit": {
+    ///          "oneOf": [
+    ///            {
+    ///              "type": "null"
+    ///            },
+    ///            {
+    ///              "allOf": [
+    ///                {
+    ///                  "$ref": "#/components/schemas/Limit"
+    ///                }
+    ///              ]
+    ///            }
+    ///          ]
+    ///        },
+    ///        "tags": {
+    ///          "type": "array",
+    ///          "items": {
+    ///            "$ref": "#/components/schemas/Hash"
+    ///          }
+    ///        }
+    ///      },
+    ///      "additionalProperties": false
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PostGetShieldedTransactionsByTagsBody {
+        ///An ID to identify the request.
+        pub id: PostGetShieldedTransactionsByTagsBodyId,
+        ///The version of the JSON-RPC protocol.
+        pub jsonrpc: PostGetShieldedTransactionsByTagsBodyJsonrpc,
+        ///The name of the method to invoke.
+        pub method: PostGetShieldedTransactionsByTagsBodyMethod,
+        pub params: PostGetShieldedTransactionsByTagsBodyParams,
+    }
+    impl PostGetShieldedTransactionsByTagsBody {
+        pub fn builder() -> builder::PostGetShieldedTransactionsByTagsBody {
+            Default::default()
+        }
+    }
+    ///An ID to identify the request.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "An ID to identify the request.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "test-account"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetShieldedTransactionsByTagsBodyId {
+        #[serde(rename = "test-account")]
+        TestAccount,
+    }
+    impl ::std::fmt::Display for PostGetShieldedTransactionsByTagsBodyId {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::TestAccount => f.write_str("test-account"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetShieldedTransactionsByTagsBodyId {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "test-account" => Ok(Self::TestAccount),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetShieldedTransactionsByTagsBodyId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetShieldedTransactionsByTagsBodyId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetShieldedTransactionsByTagsBodyId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///The version of the JSON-RPC protocol.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "The version of the JSON-RPC protocol.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "2.0"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetShieldedTransactionsByTagsBodyJsonrpc {
+        #[serde(rename = "2.0")]
+        X20,
+    }
+    impl ::std::fmt::Display for PostGetShieldedTransactionsByTagsBodyJsonrpc {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::X20 => f.write_str("2.0"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetShieldedTransactionsByTagsBodyJsonrpc {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "2.0" => Ok(Self::X20),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetShieldedTransactionsByTagsBodyJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetShieldedTransactionsByTagsBodyJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetShieldedTransactionsByTagsBodyJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///The name of the method to invoke.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "The name of the method to invoke.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "get_shielded_transactions_by_tags"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetShieldedTransactionsByTagsBodyMethod {
+        #[serde(rename = "get_shielded_transactions_by_tags")]
+        GetShieldedTransactionsByTags,
+    }
+    impl ::std::fmt::Display for PostGetShieldedTransactionsByTagsBodyMethod {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::GetShieldedTransactionsByTags => {
+                    f.write_str("get_shielded_transactions_by_tags")
+                }
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetShieldedTransactionsByTagsBodyMethod {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "get_shielded_transactions_by_tags" => {
+                    Ok(Self::GetShieldedTransactionsByTags)
+                }
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetShieldedTransactionsByTagsBodyMethod {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetShieldedTransactionsByTagsBodyMethod {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetShieldedTransactionsByTagsBodyMethod {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///`PostGetShieldedTransactionsByTagsBodyParams`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "tags"
+    ///  ],
+    ///  "properties": {
+    ///    "cursor": {
+    ///      "oneOf": [
+    ///        {
+    ///          "type": "null"
+    ///        },
+    ///        {
+    ///          "allOf": [
+    ///            {
+    ///              "$ref": "#/components/schemas/Base64String"
+    ///            }
+    ///          ]
+    ///        }
+    ///      ]
+    ///    },
+    ///    "limit": {
+    ///      "oneOf": [
+    ///        {
+    ///          "type": "null"
+    ///        },
+    ///        {
+    ///          "allOf": [
+    ///            {
+    ///              "$ref": "#/components/schemas/Limit"
+    ///            }
+    ///          ]
+    ///        }
+    ///      ]
+    ///    },
+    ///    "tags": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/Hash"
+    ///      }
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct PostGetShieldedTransactionsByTagsBodyParams {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub cursor: ::std::option::Option<Base64String>,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub limit: ::std::option::Option<Limit>,
+        pub tags: ::std::vec::Vec<Hash>,
+    }
+    impl PostGetShieldedTransactionsByTagsBodyParams {
+        pub fn builder() -> builder::PostGetShieldedTransactionsByTagsBodyParams {
+            Default::default()
+        }
+    }
+    ///`PostGetShieldedTransactionsByTagsResponse`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "id",
+    ///    "jsonrpc"
+    ///  ],
+    ///  "properties": {
+    ///    "error": {
+    ///      "type": "object",
+    ///      "properties": {
+    ///        "code": {
+    ///          "type": "integer"
+    ///        },
+    ///        "message": {
+    ///          "type": "string"
+    ///        }
+    ///      }
+    ///    },
+    ///    "id": {
+    ///      "description": "An ID to identify the response.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "test-account"
+    ///      ]
+    ///    },
+    ///    "jsonrpc": {
+    ///      "description": "The version of the JSON-RPC protocol.",
+    ///      "type": "string",
+    ///      "enum": [
+    ///        "2.0"
+    ///      ]
+    ///    },
+    ///    "result": {
+    ///      "type": "object",
+    ///      "required": [
+    ///        "context",
+    ///        "transactions"
+    ///      ],
+    ///      "properties": {
+    ///        "context": {
+    ///          "$ref": "#/components/schemas/Context"
+    ///        },
+    ///        "next_cursor": {
+    ///          "$ref": "#/components/schemas/Base64String"
+    ///        },
+    ///        "transactions": {
+    ///          "type": "array",
+    ///          "items": {
+    ///            "$ref": "#/components/schemas/ShieldedTransaction"
+    ///          }
+    ///        }
+    ///      },
+    ///      "additionalProperties": false
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PostGetShieldedTransactionsByTagsResponse {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub error: ::std::option::Option<PostGetShieldedTransactionsByTagsResponseError>,
+        ///An ID to identify the response.
+        pub id: PostGetShieldedTransactionsByTagsResponseId,
+        ///The version of the JSON-RPC protocol.
+        pub jsonrpc: PostGetShieldedTransactionsByTagsResponseJsonrpc,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub result: ::std::option::Option<
+            PostGetShieldedTransactionsByTagsResponseResult,
+        >,
+    }
+    impl PostGetShieldedTransactionsByTagsResponse {
+        pub fn builder() -> builder::PostGetShieldedTransactionsByTagsResponse {
+            Default::default()
+        }
+    }
+    ///`PostGetShieldedTransactionsByTagsResponseError`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "properties": {
+    ///    "code": {
+    ///      "type": "integer"
+    ///    },
+    ///    "message": {
+    ///      "type": "string"
+    ///    }
+    ///  }
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    pub struct PostGetShieldedTransactionsByTagsResponseError {
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub code: ::std::option::Option<i64>,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub message: ::std::option::Option<::std::string::String>,
+    }
+    impl ::std::default::Default for PostGetShieldedTransactionsByTagsResponseError {
+        fn default() -> Self {
+            Self {
+                code: Default::default(),
+                message: Default::default(),
+            }
+        }
+    }
+    impl PostGetShieldedTransactionsByTagsResponseError {
+        pub fn builder() -> builder::PostGetShieldedTransactionsByTagsResponseError {
+            Default::default()
+        }
+    }
+    ///An ID to identify the response.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "An ID to identify the response.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "test-account"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetShieldedTransactionsByTagsResponseId {
+        #[serde(rename = "test-account")]
+        TestAccount,
+    }
+    impl ::std::fmt::Display for PostGetShieldedTransactionsByTagsResponseId {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::TestAccount => f.write_str("test-account"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetShieldedTransactionsByTagsResponseId {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "test-account" => Ok(Self::TestAccount),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PostGetShieldedTransactionsByTagsResponseId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetShieldedTransactionsByTagsResponseId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetShieldedTransactionsByTagsResponseId {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///The version of the JSON-RPC protocol.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "The version of the JSON-RPC protocol.",
+    ///  "type": "string",
+    ///  "enum": [
+    ///    "2.0"
+    ///  ]
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Copy,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    pub enum PostGetShieldedTransactionsByTagsResponseJsonrpc {
+        #[serde(rename = "2.0")]
+        X20,
+    }
+    impl ::std::fmt::Display for PostGetShieldedTransactionsByTagsResponseJsonrpc {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            match *self {
+                Self::X20 => f.write_str("2.0"),
+            }
+        }
+    }
+    impl ::std::str::FromStr for PostGetShieldedTransactionsByTagsResponseJsonrpc {
+        type Err = self::error::ConversionError;
+        fn from_str(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            match value {
+                "2.0" => Ok(Self::X20),
+                _ => Err("invalid value".into()),
+            }
+        }
+    }
+    impl ::std::convert::TryFrom<&str>
+    for PostGetShieldedTransactionsByTagsResponseJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &str,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String>
+    for PostGetShieldedTransactionsByTagsResponseJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String>
+    for PostGetShieldedTransactionsByTagsResponseJsonrpc {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    ///`PostGetShieldedTransactionsByTagsResponseResult`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "context",
+    ///    "transactions"
+    ///  ],
+    ///  "properties": {
+    ///    "context": {
+    ///      "$ref": "#/components/schemas/Context"
+    ///    },
+    ///    "next_cursor": {
+    ///      "$ref": "#/components/schemas/Base64String"
+    ///    },
+    ///    "transactions": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/ShieldedTransaction"
+    ///      }
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct PostGetShieldedTransactionsByTagsResponseResult {
+        pub context: Context,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub next_cursor: ::std::option::Option<Base64String>,
+        pub transactions: ::std::vec::Vec<ShieldedTransaction>,
+    }
+    impl PostGetShieldedTransactionsByTagsResponseResult {
+        pub fn builder() -> builder::PostGetShieldedTransactionsByTagsResponseResult {
+            Default::default()
+        }
+    }
+    ///A Solana public key represented as a base58 string.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "A Solana public key represented as a base58 string.",
+    ///  "default": "111JV6iBiRLoJUtNieRJ9QmcpE2KPE3gLpDzAUkbNW",
+    ///  "examples": [
+    ///    "111JV6iBiRLoJUtNieRJ9QmcpE2KPE3gLpDzAUkbNW"
+    ///  ],
+    ///  "type": "string"
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    #[serde(transparent)]
+    pub struct SerializablePubkey(pub ::std::string::String);
+    impl ::std::ops::Deref for SerializablePubkey {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<SerializablePubkey> for ::std::string::String {
+        fn from(value: SerializablePubkey) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<::std::string::String> for SerializablePubkey {
+        fn from(value: ::std::string::String) -> Self {
+            Self(value)
+        }
+    }
+    impl ::std::str::FromStr for SerializablePubkey {
+        type Err = ::std::convert::Infallible;
+        fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::fmt::Display for SerializablePubkey {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+    ///A Solana transaction signature.
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "description": "A Solana transaction signature.",
+    ///  "default": "5J8H5sTvEhnGcB4R8K1n7mfoiWUD9RzPVGES7e3WxC7c",
+    ///  "examples": [
+    ///    "5J8H5sTvEhnGcB4R8K1n7mfoiWUD9RzPVGES7e3WxC7c"
+    ///  ],
+    ///  "type": "string"
+    ///}
+    /// ```
+    /// </details>
+    #[derive(
+        ::serde::Deserialize,
+        ::serde::Serialize,
+        Clone,
+        Debug,
+        Eq,
+        Hash,
+        Ord,
+        PartialEq,
+        PartialOrd
+    )]
+    #[serde(transparent)]
+    pub struct SerializableSignature(pub ::std::string::String);
+    impl ::std::ops::Deref for SerializableSignature {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<SerializableSignature> for ::std::string::String {
+        fn from(value: SerializableSignature) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<::std::string::String> for SerializableSignature {
+        fn from(value: ::std::string::String) -> Self {
+            Self(value)
+        }
+    }
+    impl ::std::str::FromStr for SerializableSignature {
+        type Err = ::std::convert::Infallible;
+        fn from_str(value: &str) -> ::std::result::Result<Self, Self::Err> {
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::fmt::Display for SerializableSignature {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+    ///`ShieldedTransaction`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "nullifiers",
+    ///    "output_slots",
+    ///    "proofless",
+    ///    "slot",
+    ///    "tx_signature"
+    ///  ],
+    ///  "properties": {
+    ///    "nullifiers": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/Hash"
+    ///      }
+    ///    },
+    ///    "output_slots": {
+    ///      "type": "array",
+    ///      "items": {
+    ///        "$ref": "#/components/schemas/ZolanaOutputSlot"
+    ///      }
+    ///    },
+    ///    "proofless": {
+    ///      "type": "boolean"
+    ///    },
+    ///    "slot": {
+    ///      "type": "integer",
+    ///      "format": "uint64",
+    ///      "minimum": 0.0
+    ///    },
+    ///    "tx_signature": {
+    ///      "$ref": "#/components/schemas/SerializableSignature"
+    ///    },
+    ///    "tx_viewing_pk": {
+    ///      "$ref": "#/components/schemas/Base64String"
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct ShieldedTransaction {
+        pub nullifiers: ::std::vec::Vec<Hash>,
+        pub output_slots: ::std::vec::Vec<ZolanaOutputSlot>,
+        pub proofless: bool,
+        pub slot: u64,
+        pub tx_signature: SerializableSignature,
+        #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+        pub tx_viewing_pk: ::std::option::Option<Base64String>,
+    }
+    impl ShieldedTransaction {
+        pub fn builder() -> builder::ShieldedTransaction {
+            Default::default()
+        }
+    }
+    ///`ZolanaOutputSlot`
+    ///
+    /// <details><summary>JSON schema</summary>
+    ///
+    /// ```json
+    ///{
+    ///  "type": "object",
+    ///  "required": [
+    ///    "hash",
+    ///    "payload",
+    ///    "view_tag"
+    ///  ],
+    ///  "properties": {
+    ///    "hash": {
+    ///      "$ref": "#/components/schemas/Hash"
+    ///    },
+    ///    "payload": {
+    ///      "$ref": "#/components/schemas/Base64String"
+    ///    },
+    ///    "view_tag": {
+    ///      "$ref": "#/components/schemas/Hash"
+    ///    }
+    ///  },
+    ///  "additionalProperties": false
+    ///}
+    /// ```
+    /// </details>
+    #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
+    #[serde(deny_unknown_fields)]
+    pub struct ZolanaOutputSlot {
+        pub hash: Hash,
+        pub payload: Base64String,
+        pub view_tag: Hash,
+    }
+    impl ZolanaOutputSlot {
+        pub fn builder() -> builder::ZolanaOutputSlot {
+            Default::default()
+        }
+    }
+    /// Types for composing complex structures.
+    pub mod builder {
+        #[derive(Clone, Debug)]
+        pub struct Context {
+            slot: ::std::result::Result<u64, ::std::string::String>,
+        }
+        impl ::std::default::Default for Context {
+            fn default() -> Self {
+                Self {
+                    slot: Err("no value supplied for slot".to_string()),
+                }
+            }
+        }
+        impl Context {
+            pub fn slot<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.slot = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for slot: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<Context> for super::Context {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: Context,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self { slot: value.slot? })
+            }
+        }
+        impl ::std::convert::From<super::Context> for Context {
+            fn from(value: super::Context) -> Self {
+                Self { slot: Ok(value.slot) }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct EncryptedUtxoMatch {
+            ciphertext: ::std::result::Result<
+                super::Base64String,
+                ::std::string::String,
+            >,
+            slot: ::std::result::Result<u64, ::std::string::String>,
+            tx_signature: ::std::result::Result<
+                super::SerializableSignature,
+                ::std::string::String,
+            >,
+            tx_viewing_pk: ::std::result::Result<
+                ::std::option::Option<super::Base64String>,
+                ::std::string::String,
+            >,
+            view_tag: ::std::result::Result<super::Hash, ::std::string::String>,
+        }
+        impl ::std::default::Default for EncryptedUtxoMatch {
+            fn default() -> Self {
+                Self {
+                    ciphertext: Err("no value supplied for ciphertext".to_string()),
+                    slot: Err("no value supplied for slot".to_string()),
+                    tx_signature: Err("no value supplied for tx_signature".to_string()),
+                    tx_viewing_pk: Ok(Default::default()),
+                    view_tag: Err("no value supplied for view_tag".to_string()),
+                }
+            }
+        }
+        impl EncryptedUtxoMatch {
+            pub fn ciphertext<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Base64String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.ciphertext = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for ciphertext: {e}")
+                    });
+                self
+            }
+            pub fn slot<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.slot = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for slot: {e}")
+                    });
+                self
+            }
+            pub fn tx_signature<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::SerializableSignature>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.tx_signature = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for tx_signature: {e}")
+                    });
+                self
+            }
+            pub fn tx_viewing_pk<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<super::Base64String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.tx_viewing_pk = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for tx_viewing_pk: {e}")
+                    });
+                self
+            }
+            pub fn view_tag<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Hash>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.view_tag = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for view_tag: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<EncryptedUtxoMatch> for super::EncryptedUtxoMatch {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: EncryptedUtxoMatch,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    ciphertext: value.ciphertext?,
+                    slot: value.slot?,
+                    tx_signature: value.tx_signature?,
+                    tx_viewing_pk: value.tx_viewing_pk?,
+                    view_tag: value.view_tag?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::EncryptedUtxoMatch> for EncryptedUtxoMatch {
+            fn from(value: super::EncryptedUtxoMatch) -> Self {
+                Self {
+                    ciphertext: Ok(value.ciphertext),
+                    slot: Ok(value.slot),
+                    tx_signature: Ok(value.tx_signature),
+                    tx_viewing_pk: Ok(value.tx_viewing_pk),
+                    view_tag: Ok(value.view_tag),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct MerkleContext {
+            tree: ::std::result::Result<
+                super::SerializablePubkey,
+                ::std::string::String,
+            >,
+            tree_type: ::std::result::Result<u16, ::std::string::String>,
+        }
+        impl ::std::default::Default for MerkleContext {
+            fn default() -> Self {
+                Self {
+                    tree: Err("no value supplied for tree".to_string()),
+                    tree_type: Err("no value supplied for tree_type".to_string()),
+                }
+            }
+        }
+        impl MerkleContext {
+            pub fn tree<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::SerializablePubkey>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.tree = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for tree: {e}")
+                    });
+                self
+            }
+            pub fn tree_type<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u16>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.tree_type = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for tree_type: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<MerkleContext> for super::MerkleContext {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: MerkleContext,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    tree: value.tree?,
+                    tree_type: value.tree_type?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::MerkleContext> for MerkleContext {
+            fn from(value: super::MerkleContext) -> Self {
+                Self {
+                    tree: Ok(value.tree),
+                    tree_type: Ok(value.tree_type),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct MerkleProof {
+            leaf: ::std::result::Result<super::Hash, ::std::string::String>,
+            leaf_index: ::std::result::Result<u64, ::std::string::String>,
+            merkle_context: ::std::result::Result<
+                super::MerkleContext,
+                ::std::string::String,
+            >,
+            path: ::std::result::Result<
+                ::std::vec::Vec<super::Hash>,
+                ::std::string::String,
+            >,
+            root: ::std::result::Result<super::Hash, ::std::string::String>,
+            root_index: ::std::result::Result<u16, ::std::string::String>,
+            root_seq: ::std::result::Result<u64, ::std::string::String>,
+        }
+        impl ::std::default::Default for MerkleProof {
+            fn default() -> Self {
+                Self {
+                    leaf: Err("no value supplied for leaf".to_string()),
+                    leaf_index: Err("no value supplied for leaf_index".to_string()),
+                    merkle_context: Err(
+                        "no value supplied for merkle_context".to_string(),
+                    ),
+                    path: Err("no value supplied for path".to_string()),
+                    root: Err("no value supplied for root".to_string()),
+                    root_index: Err("no value supplied for root_index".to_string()),
+                    root_seq: Err("no value supplied for root_seq".to_string()),
+                }
+            }
+        }
+        impl MerkleProof {
+            pub fn leaf<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Hash>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.leaf = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for leaf: {e}")
+                    });
+                self
+            }
+            pub fn leaf_index<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.leaf_index = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for leaf_index: {e}")
+                    });
+                self
+            }
+            pub fn merkle_context<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::MerkleContext>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.merkle_context = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!(
+                            "error converting supplied value for merkle_context: {e}"
+                        )
+                    });
+                self
+            }
+            pub fn path<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::Hash>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.path = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for path: {e}")
+                    });
+                self
+            }
+            pub fn root<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Hash>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.root = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for root: {e}")
+                    });
+                self
+            }
+            pub fn root_index<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u16>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.root_index = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for root_index: {e}")
+                    });
+                self
+            }
+            pub fn root_seq<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.root_seq = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for root_seq: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<MerkleProof> for super::MerkleProof {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: MerkleProof,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    leaf: value.leaf?,
+                    leaf_index: value.leaf_index?,
+                    merkle_context: value.merkle_context?,
+                    path: value.path?,
+                    root: value.root?,
+                    root_index: value.root_index?,
+                    root_seq: value.root_seq?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::MerkleProof> for MerkleProof {
+            fn from(value: super::MerkleProof) -> Self {
+                Self {
+                    leaf: Ok(value.leaf),
+                    leaf_index: Ok(value.leaf_index),
+                    merkle_context: Ok(value.merkle_context),
+                    path: Ok(value.path),
+                    root: Ok(value.root),
+                    root_index: Ok(value.root_index),
+                    root_seq: Ok(value.root_seq),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct NonInclusionProof {
+            high_element: ::std::result::Result<super::Hash, ::std::string::String>,
+            high_element_index: ::std::result::Result<u64, ::std::string::String>,
+            leaf: ::std::result::Result<super::Hash, ::std::string::String>,
+            low_element: ::std::result::Result<super::Hash, ::std::string::String>,
+            low_element_index: ::std::result::Result<u64, ::std::string::String>,
+            merkle_context: ::std::result::Result<
+                super::MerkleContext,
+                ::std::string::String,
+            >,
+            path: ::std::result::Result<
+                ::std::vec::Vec<super::Hash>,
+                ::std::string::String,
+            >,
+            root: ::std::result::Result<super::Hash, ::std::string::String>,
+            root_index: ::std::result::Result<u16, ::std::string::String>,
+            root_seq: ::std::result::Result<u64, ::std::string::String>,
+        }
+        impl ::std::default::Default for NonInclusionProof {
+            fn default() -> Self {
+                Self {
+                    high_element: Err("no value supplied for high_element".to_string()),
+                    high_element_index: Err(
+                        "no value supplied for high_element_index".to_string(),
+                    ),
+                    leaf: Err("no value supplied for leaf".to_string()),
+                    low_element: Err("no value supplied for low_element".to_string()),
+                    low_element_index: Err(
+                        "no value supplied for low_element_index".to_string(),
+                    ),
+                    merkle_context: Err(
+                        "no value supplied for merkle_context".to_string(),
+                    ),
+                    path: Err("no value supplied for path".to_string()),
+                    root: Err("no value supplied for root".to_string()),
+                    root_index: Err("no value supplied for root_index".to_string()),
+                    root_seq: Err("no value supplied for root_seq".to_string()),
+                }
+            }
+        }
+        impl NonInclusionProof {
+            pub fn high_element<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Hash>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.high_element = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for high_element: {e}")
+                    });
+                self
+            }
+            pub fn high_element_index<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.high_element_index = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!(
+                            "error converting supplied value for high_element_index: {e}"
+                        )
+                    });
+                self
+            }
+            pub fn leaf<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Hash>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.leaf = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for leaf: {e}")
+                    });
+                self
+            }
+            pub fn low_element<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Hash>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.low_element = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for low_element: {e}")
+                    });
+                self
+            }
+            pub fn low_element_index<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.low_element_index = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!(
+                            "error converting supplied value for low_element_index: {e}"
+                        )
+                    });
+                self
+            }
+            pub fn merkle_context<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::MerkleContext>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.merkle_context = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!(
+                            "error converting supplied value for merkle_context: {e}"
+                        )
+                    });
+                self
+            }
+            pub fn path<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::Hash>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.path = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for path: {e}")
+                    });
+                self
+            }
+            pub fn root<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Hash>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.root = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for root: {e}")
+                    });
+                self
+            }
+            pub fn root_index<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u16>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.root_index = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for root_index: {e}")
+                    });
+                self
+            }
+            pub fn root_seq<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.root_seq = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for root_seq: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<NonInclusionProof> for super::NonInclusionProof {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: NonInclusionProof,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    high_element: value.high_element?,
+                    high_element_index: value.high_element_index?,
+                    leaf: value.leaf?,
+                    low_element: value.low_element?,
+                    low_element_index: value.low_element_index?,
+                    merkle_context: value.merkle_context?,
+                    path: value.path?,
+                    root: value.root?,
+                    root_index: value.root_index?,
+                    root_seq: value.root_seq?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::NonInclusionProof> for NonInclusionProof {
+            fn from(value: super::NonInclusionProof) -> Self {
+                Self {
+                    high_element: Ok(value.high_element),
+                    high_element_index: Ok(value.high_element_index),
+                    leaf: Ok(value.leaf),
+                    low_element: Ok(value.low_element),
+                    low_element_index: Ok(value.low_element_index),
+                    merkle_context: Ok(value.merkle_context),
+                    path: Ok(value.path),
+                    root: Ok(value.root),
+                    root_index: Ok(value.root_index),
+                    root_seq: Ok(value.root_seq),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetEncryptedUtxosByTagsBody {
+            id: ::std::result::Result<
+                super::PostGetEncryptedUtxosByTagsBodyId,
+                ::std::string::String,
+            >,
+            jsonrpc: ::std::result::Result<
+                super::PostGetEncryptedUtxosByTagsBodyJsonrpc,
+                ::std::string::String,
+            >,
+            method: ::std::result::Result<
+                super::PostGetEncryptedUtxosByTagsBodyMethod,
+                ::std::string::String,
+            >,
+            params: ::std::result::Result<
+                super::PostGetEncryptedUtxosByTagsBodyParams,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetEncryptedUtxosByTagsBody {
+            fn default() -> Self {
+                Self {
+                    id: Err("no value supplied for id".to_string()),
+                    jsonrpc: Err("no value supplied for jsonrpc".to_string()),
+                    method: Err("no value supplied for method".to_string()),
+                    params: Err("no value supplied for params".to_string()),
+                }
+            }
+        }
+        impl PostGetEncryptedUtxosByTagsBody {
+            pub fn id<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetEncryptedUtxosByTagsBodyId>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
+                self
+            }
+            pub fn jsonrpc<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    super::PostGetEncryptedUtxosByTagsBodyJsonrpc,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.jsonrpc = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for jsonrpc: {e}")
+                    });
+                self
+            }
+            pub fn method<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetEncryptedUtxosByTagsBodyMethod>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.method = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for method: {e}")
+                    });
+                self
+            }
+            pub fn params<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetEncryptedUtxosByTagsBodyParams>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.params = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for params: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetEncryptedUtxosByTagsBody>
+        for super::PostGetEncryptedUtxosByTagsBody {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetEncryptedUtxosByTagsBody,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    id: value.id?,
+                    jsonrpc: value.jsonrpc?,
+                    method: value.method?,
+                    params: value.params?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetEncryptedUtxosByTagsBody>
+        for PostGetEncryptedUtxosByTagsBody {
+            fn from(value: super::PostGetEncryptedUtxosByTagsBody) -> Self {
+                Self {
+                    id: Ok(value.id),
+                    jsonrpc: Ok(value.jsonrpc),
+                    method: Ok(value.method),
+                    params: Ok(value.params),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetEncryptedUtxosByTagsBodyParams {
+            cursor: ::std::result::Result<
+                ::std::option::Option<super::Base64String>,
+                ::std::string::String,
+            >,
+            limit: ::std::result::Result<
+                ::std::option::Option<super::Limit>,
+                ::std::string::String,
+            >,
+            tags: ::std::result::Result<
+                ::std::vec::Vec<super::Hash>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetEncryptedUtxosByTagsBodyParams {
+            fn default() -> Self {
+                Self {
+                    cursor: Ok(Default::default()),
+                    limit: Ok(Default::default()),
+                    tags: Err("no value supplied for tags".to_string()),
+                }
+            }
+        }
+        impl PostGetEncryptedUtxosByTagsBodyParams {
+            pub fn cursor<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<super::Base64String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.cursor = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for cursor: {e}")
+                    });
+                self
+            }
+            pub fn limit<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<super::Limit>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.limit = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for limit: {e}")
+                    });
+                self
+            }
+            pub fn tags<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::Hash>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.tags = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for tags: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetEncryptedUtxosByTagsBodyParams>
+        for super::PostGetEncryptedUtxosByTagsBodyParams {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetEncryptedUtxosByTagsBodyParams,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    cursor: value.cursor?,
+                    limit: value.limit?,
+                    tags: value.tags?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetEncryptedUtxosByTagsBodyParams>
+        for PostGetEncryptedUtxosByTagsBodyParams {
+            fn from(value: super::PostGetEncryptedUtxosByTagsBodyParams) -> Self {
+                Self {
+                    cursor: Ok(value.cursor),
+                    limit: Ok(value.limit),
+                    tags: Ok(value.tags),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetEncryptedUtxosByTagsResponse {
+            error: ::std::result::Result<
+                ::std::option::Option<super::PostGetEncryptedUtxosByTagsResponseError>,
+                ::std::string::String,
+            >,
+            id: ::std::result::Result<
+                super::PostGetEncryptedUtxosByTagsResponseId,
+                ::std::string::String,
+            >,
+            jsonrpc: ::std::result::Result<
+                super::PostGetEncryptedUtxosByTagsResponseJsonrpc,
+                ::std::string::String,
+            >,
+            result: ::std::result::Result<
+                ::std::option::Option<super::PostGetEncryptedUtxosByTagsResponseResult>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetEncryptedUtxosByTagsResponse {
+            fn default() -> Self {
+                Self {
+                    error: Ok(Default::default()),
+                    id: Err("no value supplied for id".to_string()),
+                    jsonrpc: Err("no value supplied for jsonrpc".to_string()),
+                    result: Ok(Default::default()),
+                }
+            }
+        }
+        impl PostGetEncryptedUtxosByTagsResponse {
+            pub fn error<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    ::std::option::Option<
+                        super::PostGetEncryptedUtxosByTagsResponseError,
+                    >,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.error = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for error: {e}")
+                    });
+                self
+            }
+            pub fn id<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetEncryptedUtxosByTagsResponseId>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
+                self
+            }
+            pub fn jsonrpc<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    super::PostGetEncryptedUtxosByTagsResponseJsonrpc,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.jsonrpc = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for jsonrpc: {e}")
+                    });
+                self
+            }
+            pub fn result<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    ::std::option::Option<
+                        super::PostGetEncryptedUtxosByTagsResponseResult,
+                    >,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.result = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for result: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetEncryptedUtxosByTagsResponse>
+        for super::PostGetEncryptedUtxosByTagsResponse {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetEncryptedUtxosByTagsResponse,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    error: value.error?,
+                    id: value.id?,
+                    jsonrpc: value.jsonrpc?,
+                    result: value.result?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetEncryptedUtxosByTagsResponse>
+        for PostGetEncryptedUtxosByTagsResponse {
+            fn from(value: super::PostGetEncryptedUtxosByTagsResponse) -> Self {
+                Self {
+                    error: Ok(value.error),
+                    id: Ok(value.id),
+                    jsonrpc: Ok(value.jsonrpc),
+                    result: Ok(value.result),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetEncryptedUtxosByTagsResponseError {
+            code: ::std::result::Result<
+                ::std::option::Option<i64>,
+                ::std::string::String,
+            >,
+            message: ::std::result::Result<
+                ::std::option::Option<::std::string::String>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetEncryptedUtxosByTagsResponseError {
+            fn default() -> Self {
+                Self {
+                    code: Ok(Default::default()),
+                    message: Ok(Default::default()),
+                }
+            }
+        }
+        impl PostGetEncryptedUtxosByTagsResponseError {
+            pub fn code<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<i64>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.code = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for code: {e}")
+                    });
+                self
+            }
+            pub fn message<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.message = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for message: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetEncryptedUtxosByTagsResponseError>
+        for super::PostGetEncryptedUtxosByTagsResponseError {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetEncryptedUtxosByTagsResponseError,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    code: value.code?,
+                    message: value.message?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetEncryptedUtxosByTagsResponseError>
+        for PostGetEncryptedUtxosByTagsResponseError {
+            fn from(value: super::PostGetEncryptedUtxosByTagsResponseError) -> Self {
+                Self {
+                    code: Ok(value.code),
+                    message: Ok(value.message),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetEncryptedUtxosByTagsResponseResult {
+            context: ::std::result::Result<super::Context, ::std::string::String>,
+            matches: ::std::result::Result<
+                ::std::vec::Vec<super::EncryptedUtxoMatch>,
+                ::std::string::String,
+            >,
+            next_cursor: ::std::result::Result<
+                ::std::option::Option<super::Base64String>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetEncryptedUtxosByTagsResponseResult {
+            fn default() -> Self {
+                Self {
+                    context: Err("no value supplied for context".to_string()),
+                    matches: Err("no value supplied for matches".to_string()),
+                    next_cursor: Ok(Default::default()),
+                }
+            }
+        }
+        impl PostGetEncryptedUtxosByTagsResponseResult {
+            pub fn context<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Context>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.context = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for context: {e}")
+                    });
+                self
+            }
+            pub fn matches<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::EncryptedUtxoMatch>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.matches = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for matches: {e}")
+                    });
+                self
+            }
+            pub fn next_cursor<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<super::Base64String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.next_cursor = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for next_cursor: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetEncryptedUtxosByTagsResponseResult>
+        for super::PostGetEncryptedUtxosByTagsResponseResult {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetEncryptedUtxosByTagsResponseResult,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    context: value.context?,
+                    matches: value.matches?,
+                    next_cursor: value.next_cursor?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetEncryptedUtxosByTagsResponseResult>
+        for PostGetEncryptedUtxosByTagsResponseResult {
+            fn from(value: super::PostGetEncryptedUtxosByTagsResponseResult) -> Self {
+                Self {
+                    context: Ok(value.context),
+                    matches: Ok(value.matches),
+                    next_cursor: Ok(value.next_cursor),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetMerkleProofsBody {
+            id: ::std::result::Result<
+                super::PostGetMerkleProofsBodyId,
+                ::std::string::String,
+            >,
+            jsonrpc: ::std::result::Result<
+                super::PostGetMerkleProofsBodyJsonrpc,
+                ::std::string::String,
+            >,
+            method: ::std::result::Result<
+                super::PostGetMerkleProofsBodyMethod,
+                ::std::string::String,
+            >,
+            params: ::std::result::Result<
+                super::PostGetMerkleProofsBodyParams,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetMerkleProofsBody {
+            fn default() -> Self {
+                Self {
+                    id: Err("no value supplied for id".to_string()),
+                    jsonrpc: Err("no value supplied for jsonrpc".to_string()),
+                    method: Err("no value supplied for method".to_string()),
+                    params: Err("no value supplied for params".to_string()),
+                }
+            }
+        }
+        impl PostGetMerkleProofsBody {
+            pub fn id<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetMerkleProofsBodyId>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
+                self
+            }
+            pub fn jsonrpc<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetMerkleProofsBodyJsonrpc>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.jsonrpc = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for jsonrpc: {e}")
+                    });
+                self
+            }
+            pub fn method<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetMerkleProofsBodyMethod>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.method = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for method: {e}")
+                    });
+                self
+            }
+            pub fn params<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetMerkleProofsBodyParams>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.params = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for params: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetMerkleProofsBody>
+        for super::PostGetMerkleProofsBody {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetMerkleProofsBody,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    id: value.id?,
+                    jsonrpc: value.jsonrpc?,
+                    method: value.method?,
+                    params: value.params?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetMerkleProofsBody>
+        for PostGetMerkleProofsBody {
+            fn from(value: super::PostGetMerkleProofsBody) -> Self {
+                Self {
+                    id: Ok(value.id),
+                    jsonrpc: Ok(value.jsonrpc),
+                    method: Ok(value.method),
+                    params: Ok(value.params),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetMerkleProofsBodyParams {
+            leaves: ::std::result::Result<
+                ::std::vec::Vec<super::Hash>,
+                ::std::string::String,
+            >,
+            tree_account: ::std::result::Result<
+                super::SerializablePubkey,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetMerkleProofsBodyParams {
+            fn default() -> Self {
+                Self {
+                    leaves: Err("no value supplied for leaves".to_string()),
+                    tree_account: Err("no value supplied for tree_account".to_string()),
+                }
+            }
+        }
+        impl PostGetMerkleProofsBodyParams {
+            pub fn leaves<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::Hash>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.leaves = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for leaves: {e}")
+                    });
+                self
+            }
+            pub fn tree_account<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::SerializablePubkey>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.tree_account = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for tree_account: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetMerkleProofsBodyParams>
+        for super::PostGetMerkleProofsBodyParams {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetMerkleProofsBodyParams,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    leaves: value.leaves?,
+                    tree_account: value.tree_account?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetMerkleProofsBodyParams>
+        for PostGetMerkleProofsBodyParams {
+            fn from(value: super::PostGetMerkleProofsBodyParams) -> Self {
+                Self {
+                    leaves: Ok(value.leaves),
+                    tree_account: Ok(value.tree_account),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetMerkleProofsResponse {
+            error: ::std::result::Result<
+                ::std::option::Option<super::PostGetMerkleProofsResponseError>,
+                ::std::string::String,
+            >,
+            id: ::std::result::Result<
+                super::PostGetMerkleProofsResponseId,
+                ::std::string::String,
+            >,
+            jsonrpc: ::std::result::Result<
+                super::PostGetMerkleProofsResponseJsonrpc,
+                ::std::string::String,
+            >,
+            result: ::std::result::Result<
+                ::std::option::Option<super::PostGetMerkleProofsResponseResult>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetMerkleProofsResponse {
+            fn default() -> Self {
+                Self {
+                    error: Ok(Default::default()),
+                    id: Err("no value supplied for id".to_string()),
+                    jsonrpc: Err("no value supplied for jsonrpc".to_string()),
+                    result: Ok(Default::default()),
+                }
+            }
+        }
+        impl PostGetMerkleProofsResponse {
+            pub fn error<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    ::std::option::Option<super::PostGetMerkleProofsResponseError>,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.error = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for error: {e}")
+                    });
+                self
+            }
+            pub fn id<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetMerkleProofsResponseId>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
+                self
+            }
+            pub fn jsonrpc<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetMerkleProofsResponseJsonrpc>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.jsonrpc = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for jsonrpc: {e}")
+                    });
+                self
+            }
+            pub fn result<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    ::std::option::Option<super::PostGetMerkleProofsResponseResult>,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.result = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for result: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetMerkleProofsResponse>
+        for super::PostGetMerkleProofsResponse {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetMerkleProofsResponse,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    error: value.error?,
+                    id: value.id?,
+                    jsonrpc: value.jsonrpc?,
+                    result: value.result?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetMerkleProofsResponse>
+        for PostGetMerkleProofsResponse {
+            fn from(value: super::PostGetMerkleProofsResponse) -> Self {
+                Self {
+                    error: Ok(value.error),
+                    id: Ok(value.id),
+                    jsonrpc: Ok(value.jsonrpc),
+                    result: Ok(value.result),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetMerkleProofsResponseError {
+            code: ::std::result::Result<
+                ::std::option::Option<i64>,
+                ::std::string::String,
+            >,
+            message: ::std::result::Result<
+                ::std::option::Option<::std::string::String>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetMerkleProofsResponseError {
+            fn default() -> Self {
+                Self {
+                    code: Ok(Default::default()),
+                    message: Ok(Default::default()),
+                }
+            }
+        }
+        impl PostGetMerkleProofsResponseError {
+            pub fn code<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<i64>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.code = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for code: {e}")
+                    });
+                self
+            }
+            pub fn message<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.message = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for message: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetMerkleProofsResponseError>
+        for super::PostGetMerkleProofsResponseError {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetMerkleProofsResponseError,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    code: value.code?,
+                    message: value.message?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetMerkleProofsResponseError>
+        for PostGetMerkleProofsResponseError {
+            fn from(value: super::PostGetMerkleProofsResponseError) -> Self {
+                Self {
+                    code: Ok(value.code),
+                    message: Ok(value.message),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetMerkleProofsResponseResult {
+            context: ::std::result::Result<super::Context, ::std::string::String>,
+            proofs: ::std::result::Result<
+                ::std::vec::Vec<super::MerkleProof>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetMerkleProofsResponseResult {
+            fn default() -> Self {
+                Self {
+                    context: Err("no value supplied for context".to_string()),
+                    proofs: Err("no value supplied for proofs".to_string()),
+                }
+            }
+        }
+        impl PostGetMerkleProofsResponseResult {
+            pub fn context<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Context>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.context = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for context: {e}")
+                    });
+                self
+            }
+            pub fn proofs<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::MerkleProof>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.proofs = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for proofs: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetMerkleProofsResponseResult>
+        for super::PostGetMerkleProofsResponseResult {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetMerkleProofsResponseResult,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    context: value.context?,
+                    proofs: value.proofs?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetMerkleProofsResponseResult>
+        for PostGetMerkleProofsResponseResult {
+            fn from(value: super::PostGetMerkleProofsResponseResult) -> Self {
+                Self {
+                    context: Ok(value.context),
+                    proofs: Ok(value.proofs),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetNonInclusionProofsBody {
+            id: ::std::result::Result<
+                super::PostGetNonInclusionProofsBodyId,
+                ::std::string::String,
+            >,
+            jsonrpc: ::std::result::Result<
+                super::PostGetNonInclusionProofsBodyJsonrpc,
+                ::std::string::String,
+            >,
+            method: ::std::result::Result<
+                super::PostGetNonInclusionProofsBodyMethod,
+                ::std::string::String,
+            >,
+            params: ::std::result::Result<
+                super::PostGetNonInclusionProofsBodyParams,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetNonInclusionProofsBody {
+            fn default() -> Self {
+                Self {
+                    id: Err("no value supplied for id".to_string()),
+                    jsonrpc: Err("no value supplied for jsonrpc".to_string()),
+                    method: Err("no value supplied for method".to_string()),
+                    params: Err("no value supplied for params".to_string()),
+                }
+            }
+        }
+        impl PostGetNonInclusionProofsBody {
+            pub fn id<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetNonInclusionProofsBodyId>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
+                self
+            }
+            pub fn jsonrpc<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetNonInclusionProofsBodyJsonrpc>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.jsonrpc = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for jsonrpc: {e}")
+                    });
+                self
+            }
+            pub fn method<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetNonInclusionProofsBodyMethod>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.method = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for method: {e}")
+                    });
+                self
+            }
+            pub fn params<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetNonInclusionProofsBodyParams>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.params = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for params: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetNonInclusionProofsBody>
+        for super::PostGetNonInclusionProofsBody {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetNonInclusionProofsBody,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    id: value.id?,
+                    jsonrpc: value.jsonrpc?,
+                    method: value.method?,
+                    params: value.params?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetNonInclusionProofsBody>
+        for PostGetNonInclusionProofsBody {
+            fn from(value: super::PostGetNonInclusionProofsBody) -> Self {
+                Self {
+                    id: Ok(value.id),
+                    jsonrpc: Ok(value.jsonrpc),
+                    method: Ok(value.method),
+                    params: Ok(value.params),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetNonInclusionProofsBodyParams {
+            leaves: ::std::result::Result<
+                ::std::vec::Vec<super::Hash>,
+                ::std::string::String,
+            >,
+            tree_account: ::std::result::Result<
+                super::SerializablePubkey,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetNonInclusionProofsBodyParams {
+            fn default() -> Self {
+                Self {
+                    leaves: Err("no value supplied for leaves".to_string()),
+                    tree_account: Err("no value supplied for tree_account".to_string()),
+                }
+            }
+        }
+        impl PostGetNonInclusionProofsBodyParams {
+            pub fn leaves<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::Hash>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.leaves = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for leaves: {e}")
+                    });
+                self
+            }
+            pub fn tree_account<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::SerializablePubkey>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.tree_account = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for tree_account: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetNonInclusionProofsBodyParams>
+        for super::PostGetNonInclusionProofsBodyParams {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetNonInclusionProofsBodyParams,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    leaves: value.leaves?,
+                    tree_account: value.tree_account?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetNonInclusionProofsBodyParams>
+        for PostGetNonInclusionProofsBodyParams {
+            fn from(value: super::PostGetNonInclusionProofsBodyParams) -> Self {
+                Self {
+                    leaves: Ok(value.leaves),
+                    tree_account: Ok(value.tree_account),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetNonInclusionProofsResponse {
+            error: ::std::result::Result<
+                ::std::option::Option<super::PostGetNonInclusionProofsResponseError>,
+                ::std::string::String,
+            >,
+            id: ::std::result::Result<
+                super::PostGetNonInclusionProofsResponseId,
+                ::std::string::String,
+            >,
+            jsonrpc: ::std::result::Result<
+                super::PostGetNonInclusionProofsResponseJsonrpc,
+                ::std::string::String,
+            >,
+            result: ::std::result::Result<
+                ::std::option::Option<super::PostGetNonInclusionProofsResponseResult>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetNonInclusionProofsResponse {
+            fn default() -> Self {
+                Self {
+                    error: Ok(Default::default()),
+                    id: Err("no value supplied for id".to_string()),
+                    jsonrpc: Err("no value supplied for jsonrpc".to_string()),
+                    result: Ok(Default::default()),
+                }
+            }
+        }
+        impl PostGetNonInclusionProofsResponse {
+            pub fn error<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    ::std::option::Option<super::PostGetNonInclusionProofsResponseError>,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.error = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for error: {e}")
+                    });
+                self
+            }
+            pub fn id<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::PostGetNonInclusionProofsResponseId>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
+                self
+            }
+            pub fn jsonrpc<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    super::PostGetNonInclusionProofsResponseJsonrpc,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.jsonrpc = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for jsonrpc: {e}")
+                    });
+                self
+            }
+            pub fn result<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    ::std::option::Option<super::PostGetNonInclusionProofsResponseResult>,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.result = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for result: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetNonInclusionProofsResponse>
+        for super::PostGetNonInclusionProofsResponse {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetNonInclusionProofsResponse,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    error: value.error?,
+                    id: value.id?,
+                    jsonrpc: value.jsonrpc?,
+                    result: value.result?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetNonInclusionProofsResponse>
+        for PostGetNonInclusionProofsResponse {
+            fn from(value: super::PostGetNonInclusionProofsResponse) -> Self {
+                Self {
+                    error: Ok(value.error),
+                    id: Ok(value.id),
+                    jsonrpc: Ok(value.jsonrpc),
+                    result: Ok(value.result),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetNonInclusionProofsResponseError {
+            code: ::std::result::Result<
+                ::std::option::Option<i64>,
+                ::std::string::String,
+            >,
+            message: ::std::result::Result<
+                ::std::option::Option<::std::string::String>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetNonInclusionProofsResponseError {
+            fn default() -> Self {
+                Self {
+                    code: Ok(Default::default()),
+                    message: Ok(Default::default()),
+                }
+            }
+        }
+        impl PostGetNonInclusionProofsResponseError {
+            pub fn code<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<i64>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.code = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for code: {e}")
+                    });
+                self
+            }
+            pub fn message<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.message = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for message: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetNonInclusionProofsResponseError>
+        for super::PostGetNonInclusionProofsResponseError {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetNonInclusionProofsResponseError,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    code: value.code?,
+                    message: value.message?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetNonInclusionProofsResponseError>
+        for PostGetNonInclusionProofsResponseError {
+            fn from(value: super::PostGetNonInclusionProofsResponseError) -> Self {
+                Self {
+                    code: Ok(value.code),
+                    message: Ok(value.message),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetNonInclusionProofsResponseResult {
+            context: ::std::result::Result<super::Context, ::std::string::String>,
+            proofs: ::std::result::Result<
+                ::std::vec::Vec<super::NonInclusionProof>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetNonInclusionProofsResponseResult {
+            fn default() -> Self {
+                Self {
+                    context: Err("no value supplied for context".to_string()),
+                    proofs: Err("no value supplied for proofs".to_string()),
+                }
+            }
+        }
+        impl PostGetNonInclusionProofsResponseResult {
+            pub fn context<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Context>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.context = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for context: {e}")
+                    });
+                self
+            }
+            pub fn proofs<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::NonInclusionProof>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.proofs = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for proofs: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetNonInclusionProofsResponseResult>
+        for super::PostGetNonInclusionProofsResponseResult {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetNonInclusionProofsResponseResult,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    context: value.context?,
+                    proofs: value.proofs?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetNonInclusionProofsResponseResult>
+        for PostGetNonInclusionProofsResponseResult {
+            fn from(value: super::PostGetNonInclusionProofsResponseResult) -> Self {
+                Self {
+                    context: Ok(value.context),
+                    proofs: Ok(value.proofs),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetShieldedTransactionsByTagsBody {
+            id: ::std::result::Result<
+                super::PostGetShieldedTransactionsByTagsBodyId,
+                ::std::string::String,
+            >,
+            jsonrpc: ::std::result::Result<
+                super::PostGetShieldedTransactionsByTagsBodyJsonrpc,
+                ::std::string::String,
+            >,
+            method: ::std::result::Result<
+                super::PostGetShieldedTransactionsByTagsBodyMethod,
+                ::std::string::String,
+            >,
+            params: ::std::result::Result<
+                super::PostGetShieldedTransactionsByTagsBodyParams,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetShieldedTransactionsByTagsBody {
+            fn default() -> Self {
+                Self {
+                    id: Err("no value supplied for id".to_string()),
+                    jsonrpc: Err("no value supplied for jsonrpc".to_string()),
+                    method: Err("no value supplied for method".to_string()),
+                    params: Err("no value supplied for params".to_string()),
+                }
+            }
+        }
+        impl PostGetShieldedTransactionsByTagsBody {
+            pub fn id<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    super::PostGetShieldedTransactionsByTagsBodyId,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
+                self
+            }
+            pub fn jsonrpc<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    super::PostGetShieldedTransactionsByTagsBodyJsonrpc,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.jsonrpc = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for jsonrpc: {e}")
+                    });
+                self
+            }
+            pub fn method<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    super::PostGetShieldedTransactionsByTagsBodyMethod,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.method = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for method: {e}")
+                    });
+                self
+            }
+            pub fn params<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    super::PostGetShieldedTransactionsByTagsBodyParams,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.params = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for params: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetShieldedTransactionsByTagsBody>
+        for super::PostGetShieldedTransactionsByTagsBody {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetShieldedTransactionsByTagsBody,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    id: value.id?,
+                    jsonrpc: value.jsonrpc?,
+                    method: value.method?,
+                    params: value.params?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetShieldedTransactionsByTagsBody>
+        for PostGetShieldedTransactionsByTagsBody {
+            fn from(value: super::PostGetShieldedTransactionsByTagsBody) -> Self {
+                Self {
+                    id: Ok(value.id),
+                    jsonrpc: Ok(value.jsonrpc),
+                    method: Ok(value.method),
+                    params: Ok(value.params),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetShieldedTransactionsByTagsBodyParams {
+            cursor: ::std::result::Result<
+                ::std::option::Option<super::Base64String>,
+                ::std::string::String,
+            >,
+            limit: ::std::result::Result<
+                ::std::option::Option<super::Limit>,
+                ::std::string::String,
+            >,
+            tags: ::std::result::Result<
+                ::std::vec::Vec<super::Hash>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetShieldedTransactionsByTagsBodyParams {
+            fn default() -> Self {
+                Self {
+                    cursor: Ok(Default::default()),
+                    limit: Ok(Default::default()),
+                    tags: Err("no value supplied for tags".to_string()),
+                }
+            }
+        }
+        impl PostGetShieldedTransactionsByTagsBodyParams {
+            pub fn cursor<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<super::Base64String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.cursor = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for cursor: {e}")
+                    });
+                self
+            }
+            pub fn limit<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<super::Limit>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.limit = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for limit: {e}")
+                    });
+                self
+            }
+            pub fn tags<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::Hash>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.tags = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for tags: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetShieldedTransactionsByTagsBodyParams>
+        for super::PostGetShieldedTransactionsByTagsBodyParams {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetShieldedTransactionsByTagsBodyParams,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    cursor: value.cursor?,
+                    limit: value.limit?,
+                    tags: value.tags?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetShieldedTransactionsByTagsBodyParams>
+        for PostGetShieldedTransactionsByTagsBodyParams {
+            fn from(value: super::PostGetShieldedTransactionsByTagsBodyParams) -> Self {
+                Self {
+                    cursor: Ok(value.cursor),
+                    limit: Ok(value.limit),
+                    tags: Ok(value.tags),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetShieldedTransactionsByTagsResponse {
+            error: ::std::result::Result<
+                ::std::option::Option<
+                    super::PostGetShieldedTransactionsByTagsResponseError,
+                >,
+                ::std::string::String,
+            >,
+            id: ::std::result::Result<
+                super::PostGetShieldedTransactionsByTagsResponseId,
+                ::std::string::String,
+            >,
+            jsonrpc: ::std::result::Result<
+                super::PostGetShieldedTransactionsByTagsResponseJsonrpc,
+                ::std::string::String,
+            >,
+            result: ::std::result::Result<
+                ::std::option::Option<
+                    super::PostGetShieldedTransactionsByTagsResponseResult,
+                >,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetShieldedTransactionsByTagsResponse {
+            fn default() -> Self {
+                Self {
+                    error: Ok(Default::default()),
+                    id: Err("no value supplied for id".to_string()),
+                    jsonrpc: Err("no value supplied for jsonrpc".to_string()),
+                    result: Ok(Default::default()),
+                }
+            }
+        }
+        impl PostGetShieldedTransactionsByTagsResponse {
+            pub fn error<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    ::std::option::Option<
+                        super::PostGetShieldedTransactionsByTagsResponseError,
+                    >,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.error = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for error: {e}")
+                    });
+                self
+            }
+            pub fn id<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    super::PostGetShieldedTransactionsByTagsResponseId,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.id = value
+                    .try_into()
+                    .map_err(|e| format!("error converting supplied value for id: {e}"));
+                self
+            }
+            pub fn jsonrpc<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    super::PostGetShieldedTransactionsByTagsResponseJsonrpc,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.jsonrpc = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for jsonrpc: {e}")
+                    });
+                self
+            }
+            pub fn result<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<
+                    ::std::option::Option<
+                        super::PostGetShieldedTransactionsByTagsResponseResult,
+                    >,
+                >,
+                T::Error: ::std::fmt::Display,
+            {
+                self.result = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for result: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetShieldedTransactionsByTagsResponse>
+        for super::PostGetShieldedTransactionsByTagsResponse {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetShieldedTransactionsByTagsResponse,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    error: value.error?,
+                    id: value.id?,
+                    jsonrpc: value.jsonrpc?,
+                    result: value.result?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetShieldedTransactionsByTagsResponse>
+        for PostGetShieldedTransactionsByTagsResponse {
+            fn from(value: super::PostGetShieldedTransactionsByTagsResponse) -> Self {
+                Self {
+                    error: Ok(value.error),
+                    id: Ok(value.id),
+                    jsonrpc: Ok(value.jsonrpc),
+                    result: Ok(value.result),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetShieldedTransactionsByTagsResponseError {
+            code: ::std::result::Result<
+                ::std::option::Option<i64>,
+                ::std::string::String,
+            >,
+            message: ::std::result::Result<
+                ::std::option::Option<::std::string::String>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for PostGetShieldedTransactionsByTagsResponseError {
+            fn default() -> Self {
+                Self {
+                    code: Ok(Default::default()),
+                    message: Ok(Default::default()),
+                }
+            }
+        }
+        impl PostGetShieldedTransactionsByTagsResponseError {
+            pub fn code<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<i64>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.code = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for code: {e}")
+                    });
+                self
+            }
+            pub fn message<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<::std::string::String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.message = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for message: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetShieldedTransactionsByTagsResponseError>
+        for super::PostGetShieldedTransactionsByTagsResponseError {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetShieldedTransactionsByTagsResponseError,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    code: value.code?,
+                    message: value.message?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetShieldedTransactionsByTagsResponseError>
+        for PostGetShieldedTransactionsByTagsResponseError {
+            fn from(
+                value: super::PostGetShieldedTransactionsByTagsResponseError,
+            ) -> Self {
+                Self {
+                    code: Ok(value.code),
+                    message: Ok(value.message),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct PostGetShieldedTransactionsByTagsResponseResult {
+            context: ::std::result::Result<super::Context, ::std::string::String>,
+            next_cursor: ::std::result::Result<
+                ::std::option::Option<super::Base64String>,
+                ::std::string::String,
+            >,
+            transactions: ::std::result::Result<
+                ::std::vec::Vec<super::ShieldedTransaction>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default
+        for PostGetShieldedTransactionsByTagsResponseResult {
+            fn default() -> Self {
+                Self {
+                    context: Err("no value supplied for context".to_string()),
+                    next_cursor: Ok(Default::default()),
+                    transactions: Err("no value supplied for transactions".to_string()),
+                }
+            }
+        }
+        impl PostGetShieldedTransactionsByTagsResponseResult {
+            pub fn context<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Context>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.context = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for context: {e}")
+                    });
+                self
+            }
+            pub fn next_cursor<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<super::Base64String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.next_cursor = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for next_cursor: {e}")
+                    });
+                self
+            }
+            pub fn transactions<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::ShieldedTransaction>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.transactions = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for transactions: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<PostGetShieldedTransactionsByTagsResponseResult>
+        for super::PostGetShieldedTransactionsByTagsResponseResult {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: PostGetShieldedTransactionsByTagsResponseResult,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    context: value.context?,
+                    next_cursor: value.next_cursor?,
+                    transactions: value.transactions?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::PostGetShieldedTransactionsByTagsResponseResult>
+        for PostGetShieldedTransactionsByTagsResponseResult {
+            fn from(
+                value: super::PostGetShieldedTransactionsByTagsResponseResult,
+            ) -> Self {
+                Self {
+                    context: Ok(value.context),
+                    next_cursor: Ok(value.next_cursor),
+                    transactions: Ok(value.transactions),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct ShieldedTransaction {
+            nullifiers: ::std::result::Result<
+                ::std::vec::Vec<super::Hash>,
+                ::std::string::String,
+            >,
+            output_slots: ::std::result::Result<
+                ::std::vec::Vec<super::ZolanaOutputSlot>,
+                ::std::string::String,
+            >,
+            proofless: ::std::result::Result<bool, ::std::string::String>,
+            slot: ::std::result::Result<u64, ::std::string::String>,
+            tx_signature: ::std::result::Result<
+                super::SerializableSignature,
+                ::std::string::String,
+            >,
+            tx_viewing_pk: ::std::result::Result<
+                ::std::option::Option<super::Base64String>,
+                ::std::string::String,
+            >,
+        }
+        impl ::std::default::Default for ShieldedTransaction {
+            fn default() -> Self {
+                Self {
+                    nullifiers: Err("no value supplied for nullifiers".to_string()),
+                    output_slots: Err("no value supplied for output_slots".to_string()),
+                    proofless: Err("no value supplied for proofless".to_string()),
+                    slot: Err("no value supplied for slot".to_string()),
+                    tx_signature: Err("no value supplied for tx_signature".to_string()),
+                    tx_viewing_pk: Ok(Default::default()),
+                }
+            }
+        }
+        impl ShieldedTransaction {
+            pub fn nullifiers<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::Hash>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.nullifiers = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for nullifiers: {e}")
+                    });
+                self
+            }
+            pub fn output_slots<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::vec::Vec<super::ZolanaOutputSlot>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.output_slots = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for output_slots: {e}")
+                    });
+                self
+            }
+            pub fn proofless<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<bool>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.proofless = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for proofless: {e}")
+                    });
+                self
+            }
+            pub fn slot<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<u64>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.slot = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for slot: {e}")
+                    });
+                self
+            }
+            pub fn tx_signature<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::SerializableSignature>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.tx_signature = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for tx_signature: {e}")
+                    });
+                self
+            }
+            pub fn tx_viewing_pk<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<::std::option::Option<super::Base64String>>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.tx_viewing_pk = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for tx_viewing_pk: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<ShieldedTransaction>
+        for super::ShieldedTransaction {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: ShieldedTransaction,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    nullifiers: value.nullifiers?,
+                    output_slots: value.output_slots?,
+                    proofless: value.proofless?,
+                    slot: value.slot?,
+                    tx_signature: value.tx_signature?,
+                    tx_viewing_pk: value.tx_viewing_pk?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::ShieldedTransaction> for ShieldedTransaction {
+            fn from(value: super::ShieldedTransaction) -> Self {
+                Self {
+                    nullifiers: Ok(value.nullifiers),
+                    output_slots: Ok(value.output_slots),
+                    proofless: Ok(value.proofless),
+                    slot: Ok(value.slot),
+                    tx_signature: Ok(value.tx_signature),
+                    tx_viewing_pk: Ok(value.tx_viewing_pk),
+                }
+            }
+        }
+        #[derive(Clone, Debug)]
+        pub struct ZolanaOutputSlot {
+            hash: ::std::result::Result<super::Hash, ::std::string::String>,
+            payload: ::std::result::Result<super::Base64String, ::std::string::String>,
+            view_tag: ::std::result::Result<super::Hash, ::std::string::String>,
+        }
+        impl ::std::default::Default for ZolanaOutputSlot {
+            fn default() -> Self {
+                Self {
+                    hash: Err("no value supplied for hash".to_string()),
+                    payload: Err("no value supplied for payload".to_string()),
+                    view_tag: Err("no value supplied for view_tag".to_string()),
+                }
+            }
+        }
+        impl ZolanaOutputSlot {
+            pub fn hash<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Hash>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.hash = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for hash: {e}")
+                    });
+                self
+            }
+            pub fn payload<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Base64String>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.payload = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for payload: {e}")
+                    });
+                self
+            }
+            pub fn view_tag<T>(mut self, value: T) -> Self
+            where
+                T: ::std::convert::TryInto<super::Hash>,
+                T::Error: ::std::fmt::Display,
+            {
+                self.view_tag = value
+                    .try_into()
+                    .map_err(|e| {
+                        format!("error converting supplied value for view_tag: {e}")
+                    });
+                self
+            }
+        }
+        impl ::std::convert::TryFrom<ZolanaOutputSlot> for super::ZolanaOutputSlot {
+            type Error = super::error::ConversionError;
+            fn try_from(
+                value: ZolanaOutputSlot,
+            ) -> ::std::result::Result<Self, super::error::ConversionError> {
+                Ok(Self {
+                    hash: value.hash?,
+                    payload: value.payload?,
+                    view_tag: value.view_tag?,
+                })
+            }
+        }
+        impl ::std::convert::From<super::ZolanaOutputSlot> for ZolanaOutputSlot {
+            fn from(value: super::ZolanaOutputSlot) -> Self {
+                Self {
+                    hash: Ok(value.hash),
+                    payload: Ok(value.payload),
+                    view_tag: Ok(value.view_tag),
+                }
+            }
+        }
+    }
+}
+#[derive(Clone, Debug)]
+/**Client for zolana-indexer-api
+
+Zolana indexer API
+
+Version: 0.51.2*/
+pub struct Client {
+    pub(crate) baseurl: String,
+    pub(crate) client: reqwest::Client,
+}
+impl Client {
+    /// Create a new client.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new(baseurl: &str) -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let dur = ::std::time::Duration::from_secs(15u64);
+            reqwest::ClientBuilder::new().connect_timeout(dur).timeout(dur)
+        };
+        #[cfg(target_arch = "wasm32")]
+        let client = reqwest::ClientBuilder::new();
+        Self::new_with_client(baseurl, client.build().unwrap())
+    }
+    /// Construct a new client with an existing `reqwest::Client`,
+    /// allowing more control over its configuration.
+    ///
+    /// `baseurl` is the base URL provided to the internal
+    /// `reqwest::Client`, and should include a scheme and hostname,
+    /// as well as port and a path stem if applicable.
+    pub fn new_with_client(baseurl: &str, client: reqwest::Client) -> Self {
+        Self {
+            baseurl: baseurl.to_string(),
+            client,
+        }
+    }
+}
+impl ClientInfo<()> for Client {
+    fn api_version() -> &'static str {
+        "0.51.2"
+    }
+    fn baseurl(&self) -> &str {
+        self.baseurl.as_str()
+    }
+    fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+    fn inner(&self) -> &() {
+        &()
+    }
+}
+impl ClientHooks<()> for &Client {}
+impl Client {
+    /**Sends a `POST` request to `/get_encrypted_utxos_by_tags`
+
+```ignore
+let response = client.post_get_encrypted_utxos_by_tags()
+    .body(body)
+    .send()
+    .await;
+```*/
+    pub fn post_get_encrypted_utxos_by_tags(
+        &self,
+    ) -> builder::PostGetEncryptedUtxosByTags<'_> {
+        builder::PostGetEncryptedUtxosByTags::new(self)
+    }
+    /**Sends a `POST` request to `/get_merkle_proofs`
+
+```ignore
+let response = client.post_get_merkle_proofs()
+    .body(body)
+    .send()
+    .await;
+```*/
+    pub fn post_get_merkle_proofs(&self) -> builder::PostGetMerkleProofs<'_> {
+        builder::PostGetMerkleProofs::new(self)
+    }
+    /**Sends a `POST` request to `/get_non_inclusion_proofs`
+
+```ignore
+let response = client.post_get_non_inclusion_proofs()
+    .body(body)
+    .send()
+    .await;
+```*/
+    pub fn post_get_non_inclusion_proofs(
+        &self,
+    ) -> builder::PostGetNonInclusionProofs<'_> {
+        builder::PostGetNonInclusionProofs::new(self)
+    }
+    /**Sends a `POST` request to `/get_shielded_transactions_by_tags`
+
+```ignore
+let response = client.post_get_shielded_transactions_by_tags()
+    .body(body)
+    .send()
+    .await;
+```*/
+    pub fn post_get_shielded_transactions_by_tags(
+        &self,
+    ) -> builder::PostGetShieldedTransactionsByTags<'_> {
+        builder::PostGetShieldedTransactionsByTags::new(self)
+    }
+}
+/// Types for composing operation parameters.
+#[allow(clippy::all)]
+pub mod builder {
+    use super::types;
+    #[allow(unused_imports)]
+    use super::{
+        encode_path, ByteStream, ClientInfo, ClientHooks, Error, OperationInfo,
+        RequestBuilderExt, ResponseValue,
+    };
+    /**Builder for [`Client::post_get_encrypted_utxos_by_tags`]
+
+[`Client::post_get_encrypted_utxos_by_tags`]: super::Client::post_get_encrypted_utxos_by_tags*/
+    #[derive(Debug, Clone)]
+    pub struct PostGetEncryptedUtxosByTags<'a> {
+        client: &'a super::Client,
+        body: Result<types::builder::PostGetEncryptedUtxosByTagsBody, String>,
+    }
+    impl<'a> PostGetEncryptedUtxosByTags<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                body: Ok(::std::default::Default::default()),
+            }
+        }
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::PostGetEncryptedUtxosByTagsBody>,
+            <V as std::convert::TryInto<
+                types::PostGetEncryptedUtxosByTagsBody,
+            >>::Error: std::fmt::Display,
+        {
+            self.body = value
+                .try_into()
+                .map(From::from)
+                .map_err(|s| {
+                    format!(
+                        "conversion to `PostGetEncryptedUtxosByTagsBody` for body failed: {}",
+                        s
+                    )
+                });
+            self
+        }
+        pub fn body_map<F>(mut self, f: F) -> Self
+        where
+            F: std::ops::FnOnce(
+                types::builder::PostGetEncryptedUtxosByTagsBody,
+            ) -> types::builder::PostGetEncryptedUtxosByTagsBody,
+        {
+            self.body = self.body.map(f);
+            self
+        }
+        ///Sends a `POST` request to `/get_encrypted_utxos_by_tags`
+        pub async fn send(
+            self,
+        ) -> Result<
+            ResponseValue<types::PostGetEncryptedUtxosByTagsResponse>,
+            Error<types::PostGetEncryptedUtxosByTagsResponse>,
+        > {
+            let Self { client, body } = self;
+            let body = body
+                .and_then(|v| {
+                    types::PostGetEncryptedUtxosByTagsBody::try_from(v)
+                        .map_err(|e| e.to_string())
+                })
+                .map_err(Error::InvalidRequest)?;
+            let url = format!("{}/get_encrypted_utxos_by_tags", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map
+                .append(
+                    ::reqwest::header::HeaderName::from_static("api-version"),
+                    ::reqwest::header::HeaderValue::from_static(
+                        super::Client::api_version(),
+                    ),
+                );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .post(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .json(&body)
+                .headers(header_map)
+                .build()?;
+            let info = OperationInfo {
+                operation_id: "post_get_encrypted_utxos_by_tags",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                429u16 => {
+                    Err(
+                        Error::ErrorResponse(
+                            ResponseValue::from_response(response).await?,
+                        ),
+                    )
+                }
+                500u16 => {
+                    Err(
+                        Error::ErrorResponse(
+                            ResponseValue::from_response(response).await?,
+                        ),
+                    )
+                }
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+    /**Builder for [`Client::post_get_merkle_proofs`]
+
+[`Client::post_get_merkle_proofs`]: super::Client::post_get_merkle_proofs*/
+    #[derive(Debug, Clone)]
+    pub struct PostGetMerkleProofs<'a> {
+        client: &'a super::Client,
+        body: Result<types::builder::PostGetMerkleProofsBody, String>,
+    }
+    impl<'a> PostGetMerkleProofs<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                body: Ok(::std::default::Default::default()),
+            }
+        }
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::PostGetMerkleProofsBody>,
+            <V as std::convert::TryInto<
+                types::PostGetMerkleProofsBody,
+            >>::Error: std::fmt::Display,
+        {
+            self.body = value
+                .try_into()
+                .map(From::from)
+                .map_err(|s| {
+                    format!(
+                        "conversion to `PostGetMerkleProofsBody` for body failed: {}", s
+                    )
+                });
+            self
+        }
+        pub fn body_map<F>(mut self, f: F) -> Self
+        where
+            F: std::ops::FnOnce(
+                types::builder::PostGetMerkleProofsBody,
+            ) -> types::builder::PostGetMerkleProofsBody,
+        {
+            self.body = self.body.map(f);
+            self
+        }
+        ///Sends a `POST` request to `/get_merkle_proofs`
+        pub async fn send(
+            self,
+        ) -> Result<
+            ResponseValue<types::PostGetMerkleProofsResponse>,
+            Error<types::PostGetMerkleProofsResponse>,
+        > {
+            let Self { client, body } = self;
+            let body = body
+                .and_then(|v| {
+                    types::PostGetMerkleProofsBody::try_from(v)
+                        .map_err(|e| e.to_string())
+                })
+                .map_err(Error::InvalidRequest)?;
+            let url = format!("{}/get_merkle_proofs", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map
+                .append(
+                    ::reqwest::header::HeaderName::from_static("api-version"),
+                    ::reqwest::header::HeaderValue::from_static(
+                        super::Client::api_version(),
+                    ),
+                );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .post(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .json(&body)
+                .headers(header_map)
+                .build()?;
+            let info = OperationInfo {
+                operation_id: "post_get_merkle_proofs",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                429u16 => {
+                    Err(
+                        Error::ErrorResponse(
+                            ResponseValue::from_response(response).await?,
+                        ),
+                    )
+                }
+                500u16 => {
+                    Err(
+                        Error::ErrorResponse(
+                            ResponseValue::from_response(response).await?,
+                        ),
+                    )
+                }
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+    /**Builder for [`Client::post_get_non_inclusion_proofs`]
+
+[`Client::post_get_non_inclusion_proofs`]: super::Client::post_get_non_inclusion_proofs*/
+    #[derive(Debug, Clone)]
+    pub struct PostGetNonInclusionProofs<'a> {
+        client: &'a super::Client,
+        body: Result<types::builder::PostGetNonInclusionProofsBody, String>,
+    }
+    impl<'a> PostGetNonInclusionProofs<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                body: Ok(::std::default::Default::default()),
+            }
+        }
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::PostGetNonInclusionProofsBody>,
+            <V as std::convert::TryInto<
+                types::PostGetNonInclusionProofsBody,
+            >>::Error: std::fmt::Display,
+        {
+            self.body = value
+                .try_into()
+                .map(From::from)
+                .map_err(|s| {
+                    format!(
+                        "conversion to `PostGetNonInclusionProofsBody` for body failed: {}",
+                        s
+                    )
+                });
+            self
+        }
+        pub fn body_map<F>(mut self, f: F) -> Self
+        where
+            F: std::ops::FnOnce(
+                types::builder::PostGetNonInclusionProofsBody,
+            ) -> types::builder::PostGetNonInclusionProofsBody,
+        {
+            self.body = self.body.map(f);
+            self
+        }
+        ///Sends a `POST` request to `/get_non_inclusion_proofs`
+        pub async fn send(
+            self,
+        ) -> Result<
+            ResponseValue<types::PostGetNonInclusionProofsResponse>,
+            Error<types::PostGetNonInclusionProofsResponse>,
+        > {
+            let Self { client, body } = self;
+            let body = body
+                .and_then(|v| {
+                    types::PostGetNonInclusionProofsBody::try_from(v)
+                        .map_err(|e| e.to_string())
+                })
+                .map_err(Error::InvalidRequest)?;
+            let url = format!("{}/get_non_inclusion_proofs", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map
+                .append(
+                    ::reqwest::header::HeaderName::from_static("api-version"),
+                    ::reqwest::header::HeaderValue::from_static(
+                        super::Client::api_version(),
+                    ),
+                );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .post(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .json(&body)
+                .headers(header_map)
+                .build()?;
+            let info = OperationInfo {
+                operation_id: "post_get_non_inclusion_proofs",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                429u16 => {
+                    Err(
+                        Error::ErrorResponse(
+                            ResponseValue::from_response(response).await?,
+                        ),
+                    )
+                }
+                500u16 => {
+                    Err(
+                        Error::ErrorResponse(
+                            ResponseValue::from_response(response).await?,
+                        ),
+                    )
+                }
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+    /**Builder for [`Client::post_get_shielded_transactions_by_tags`]
+
+[`Client::post_get_shielded_transactions_by_tags`]: super::Client::post_get_shielded_transactions_by_tags*/
+    #[derive(Debug, Clone)]
+    pub struct PostGetShieldedTransactionsByTags<'a> {
+        client: &'a super::Client,
+        body: Result<types::builder::PostGetShieldedTransactionsByTagsBody, String>,
+    }
+    impl<'a> PostGetShieldedTransactionsByTags<'a> {
+        pub fn new(client: &'a super::Client) -> Self {
+            Self {
+                client: client,
+                body: Ok(::std::default::Default::default()),
+            }
+        }
+        pub fn body<V>(mut self, value: V) -> Self
+        where
+            V: std::convert::TryInto<types::PostGetShieldedTransactionsByTagsBody>,
+            <V as std::convert::TryInto<
+                types::PostGetShieldedTransactionsByTagsBody,
+            >>::Error: std::fmt::Display,
+        {
+            self.body = value
+                .try_into()
+                .map(From::from)
+                .map_err(|s| {
+                    format!(
+                        "conversion to `PostGetShieldedTransactionsByTagsBody` for body failed: {}",
+                        s
+                    )
+                });
+            self
+        }
+        pub fn body_map<F>(mut self, f: F) -> Self
+        where
+            F: std::ops::FnOnce(
+                types::builder::PostGetShieldedTransactionsByTagsBody,
+            ) -> types::builder::PostGetShieldedTransactionsByTagsBody,
+        {
+            self.body = self.body.map(f);
+            self
+        }
+        ///Sends a `POST` request to `/get_shielded_transactions_by_tags`
+        pub async fn send(
+            self,
+        ) -> Result<
+            ResponseValue<types::PostGetShieldedTransactionsByTagsResponse>,
+            Error<types::PostGetShieldedTransactionsByTagsResponse>,
+        > {
+            let Self { client, body } = self;
+            let body = body
+                .and_then(|v| {
+                    types::PostGetShieldedTransactionsByTagsBody::try_from(v)
+                        .map_err(|e| e.to_string())
+                })
+                .map_err(Error::InvalidRequest)?;
+            let url = format!("{}/get_shielded_transactions_by_tags", client.baseurl,);
+            let mut header_map = ::reqwest::header::HeaderMap::with_capacity(1usize);
+            header_map
+                .append(
+                    ::reqwest::header::HeaderName::from_static("api-version"),
+                    ::reqwest::header::HeaderValue::from_static(
+                        super::Client::api_version(),
+                    ),
+                );
+            #[allow(unused_mut)]
+            let mut request = client
+                .client
+                .post(url)
+                .header(
+                    ::reqwest::header::ACCEPT,
+                    ::reqwest::header::HeaderValue::from_static("application/json"),
+                )
+                .json(&body)
+                .headers(header_map)
+                .build()?;
+            let info = OperationInfo {
+                operation_id: "post_get_shielded_transactions_by_tags",
+            };
+            client.pre(&mut request, &info).await?;
+            let result = client.exec(request, &info).await;
+            client.post(&result, &info).await?;
+            let response = result?;
+            match response.status().as_u16() {
+                200u16 => ResponseValue::from_response(response).await,
+                429u16 => {
+                    Err(
+                        Error::ErrorResponse(
+                            ResponseValue::from_response(response).await?,
+                        ),
+                    )
+                }
+                500u16 => {
+                    Err(
+                        Error::ErrorResponse(
+                            ResponseValue::from_response(response).await?,
+                        ),
+                    )
+                }
+                _ => Err(Error::UnexpectedResponse(response)),
+            }
+        }
+    }
+}
+/// Items consumers will typically use such as the Client.
+pub mod prelude {
+    pub use self::super::Client;
+}

--- a/sdk-libs/zolana-api/src/lib.rs
+++ b/sdk-libs/zolana-api/src/lib.rs
@@ -1,0 +1,566 @@
+//! Typed client for Photon's Zolana-only indexer API.
+//!
+//! Types are generated from `src/openapi/specs/zolana.yaml` in the Photon
+//! checkout and checked in as `src/codegen.rs`.
+
+#![allow(clippy::large_enum_variant)]
+
+use serde::{de::DeserializeOwned, Serialize};
+use std::{error::Error as StdError, fmt, sync::Once};
+
+pub mod generated {
+    #![allow(unused_imports, clippy::all, dead_code)]
+    #![allow(mismatched_lifetime_syntaxes)]
+
+    include!("codegen.rs");
+}
+
+pub use generated::types;
+
+pub type Base64String = types::Base64String;
+pub type Context = types::Context;
+pub type EncryptedUtxoMatch = types::EncryptedUtxoMatch;
+pub type GetEncryptedUtxosByTagsResponse = types::PostGetEncryptedUtxosByTagsResponseResult;
+pub type GetMerkleProofsResponse = types::PostGetMerkleProofsResponseResult;
+pub type GetNonInclusionProofsResponse = types::PostGetNonInclusionProofsResponseResult;
+pub type GetShieldedTransactionsByTagsResponse =
+    types::PostGetShieldedTransactionsByTagsResponseResult;
+pub type Hash = types::Hash;
+pub type Limit = types::Limit;
+pub type MerkleContext = types::MerkleContext;
+pub type MerkleProof = types::MerkleProof;
+pub type NonInclusionProof = types::NonInclusionProof;
+pub type SerializablePubkey = types::SerializablePubkey;
+pub type SerializableSignature = types::SerializableSignature;
+pub type ShieldedTransaction = types::ShieldedTransaction;
+pub type ZolanaOutputSlot = types::ZolanaOutputSlot;
+
+#[derive(Clone, Debug)]
+pub struct ZolanaApi {
+    base_path: String,
+    api_key: Option<String>,
+    client: reqwest::Client,
+    trace_http: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct BlockingZolanaApi {
+    base_path: String,
+    api_key: Option<String>,
+    client: reqwest::blocking::Client,
+    trace_http: bool,
+}
+
+#[derive(Debug)]
+pub enum ApiError {
+    Request(reqwest::Error),
+    Response {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+    JsonRpc {
+        method: &'static str,
+        code: Option<i64>,
+        message: Option<String>,
+    },
+    MissingResult(&'static str),
+}
+
+impl fmt::Display for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Request(err) => write!(f, "request error: {err}"),
+            Self::Response { status, body } => {
+                write!(f, "HTTP response error {status}: {body}")
+            }
+            Self::JsonRpc {
+                method,
+                code,
+                message,
+            } => write!(
+                f,
+                "JSON-RPC error from {method}: code={code:?} message={message:?}"
+            ),
+            Self::MissingResult(method) => {
+                write!(f, "JSON-RPC response from {method} omitted result")
+            }
+        }
+    }
+}
+
+impl StdError for ApiError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match self {
+            Self::Request(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<reqwest::Error> for ApiError {
+    fn from(err: reqwest::Error) -> Self {
+        Self::Request(err)
+    }
+}
+
+impl ZolanaApi {
+    pub fn new(url: impl AsRef<str>) -> Self {
+        ensure_ring_provider();
+        let (base_path, api_key) = parse_url(url.as_ref());
+        Self {
+            base_path,
+            api_key,
+            client: reqwest::Client::new(),
+            trace_http: false,
+        }
+    }
+
+    pub fn with_client(url: impl AsRef<str>, client: reqwest::Client) -> Self {
+        ensure_ring_provider();
+        let (base_path, api_key) = parse_url(url.as_ref());
+        Self {
+            base_path,
+            api_key,
+            client,
+            trace_http: false,
+        }
+    }
+
+    pub fn base_path(&self) -> &str {
+        &self.base_path
+    }
+
+    pub fn api_key(&self) -> Option<&str> {
+        self.api_key.as_deref()
+    }
+
+    pub fn with_http_trace(mut self) -> Self {
+        self.trace_http = true;
+        self
+    }
+
+    pub async fn get_encrypted_utxos_by_tags(
+        &self,
+        tags: Vec<Hash>,
+        cursor: Option<Base64String>,
+        limit: Option<u64>,
+    ) -> Result<GetEncryptedUtxosByTagsResponse, ApiError> {
+        let method = "get_encrypted_utxos_by_tags";
+        let body = types::PostGetEncryptedUtxosByTagsBody {
+            id: types::PostGetEncryptedUtxosByTagsBodyId::TestAccount,
+            jsonrpc: types::PostGetEncryptedUtxosByTagsBodyJsonrpc::X20,
+            method: types::PostGetEncryptedUtxosByTagsBodyMethod::GetEncryptedUtxosByTags,
+            params: types::PostGetEncryptedUtxosByTagsBodyParams {
+                cursor,
+                limit: limit.map(types::Limit),
+                tags,
+            },
+        };
+        let response: types::PostGetEncryptedUtxosByTagsResponse = self.post(method, &body).await?;
+        if let Some(error) = response.error {
+            return Err(ApiError::JsonRpc {
+                method,
+                code: error.code,
+                message: error.message,
+            });
+        }
+        response.result.ok_or(ApiError::MissingResult(method))
+    }
+
+    pub async fn get_shielded_transactions_by_tags(
+        &self,
+        tags: Vec<Hash>,
+        cursor: Option<Base64String>,
+        limit: Option<u64>,
+    ) -> Result<GetShieldedTransactionsByTagsResponse, ApiError> {
+        let method = "get_shielded_transactions_by_tags";
+        let body = types::PostGetShieldedTransactionsByTagsBody {
+            id: types::PostGetShieldedTransactionsByTagsBodyId::TestAccount,
+            jsonrpc: types::PostGetShieldedTransactionsByTagsBodyJsonrpc::X20,
+            method:
+                types::PostGetShieldedTransactionsByTagsBodyMethod::GetShieldedTransactionsByTags,
+            params: types::PostGetShieldedTransactionsByTagsBodyParams {
+                cursor,
+                limit: limit.map(types::Limit),
+                tags,
+            },
+        };
+        let response: types::PostGetShieldedTransactionsByTagsResponse =
+            self.post(method, &body).await?;
+        if let Some(error) = response.error {
+            return Err(ApiError::JsonRpc {
+                method,
+                code: error.code,
+                message: error.message,
+            });
+        }
+        response.result.ok_or(ApiError::MissingResult(method))
+    }
+
+    pub async fn get_merkle_proofs(
+        &self,
+        tree_account: SerializablePubkey,
+        leaves: Vec<Hash>,
+    ) -> Result<GetMerkleProofsResponse, ApiError> {
+        let method = "get_merkle_proofs";
+        let body = types::PostGetMerkleProofsBody {
+            id: types::PostGetMerkleProofsBodyId::TestAccount,
+            jsonrpc: types::PostGetMerkleProofsBodyJsonrpc::X20,
+            method: types::PostGetMerkleProofsBodyMethod::GetMerkleProofs,
+            params: types::PostGetMerkleProofsBodyParams {
+                leaves,
+                tree_account,
+            },
+        };
+        let response: types::PostGetMerkleProofsResponse = self.post(method, &body).await?;
+        if let Some(error) = response.error {
+            return Err(ApiError::JsonRpc {
+                method,
+                code: error.code,
+                message: error.message,
+            });
+        }
+        response.result.ok_or(ApiError::MissingResult(method))
+    }
+
+    pub async fn get_non_inclusion_proofs(
+        &self,
+        tree_account: SerializablePubkey,
+        leaves: Vec<Hash>,
+    ) -> Result<GetNonInclusionProofsResponse, ApiError> {
+        let method = "get_non_inclusion_proofs";
+        let body = types::PostGetNonInclusionProofsBody {
+            id: types::PostGetNonInclusionProofsBodyId::TestAccount,
+            jsonrpc: types::PostGetNonInclusionProofsBodyJsonrpc::X20,
+            method: types::PostGetNonInclusionProofsBodyMethod::GetNonInclusionProofs,
+            params: types::PostGetNonInclusionProofsBodyParams {
+                leaves,
+                tree_account,
+            },
+        };
+        let response: types::PostGetNonInclusionProofsResponse = self.post(method, &body).await?;
+        if let Some(error) = response.error {
+            return Err(ApiError::JsonRpc {
+                method,
+                code: error.code,
+                message: error.message,
+            });
+        }
+        response.result.ok_or(ApiError::MissingResult(method))
+    }
+
+    async fn post<B, R>(&self, method: &'static str, body: &B) -> Result<R, ApiError>
+    where
+        B: Serialize + ?Sized,
+        R: DeserializeOwned,
+    {
+        let url = self.url(method);
+        if self.trace_http {
+            print_api_request(&url, body);
+        }
+        let response = self.client.post(&url).json(body).send().await?;
+        let status = response.status();
+        let response_body = response.text().await?;
+        if self.trace_http {
+            print_api_response(method, status, &response_body);
+        }
+        if !status.is_success() {
+            return Err(ApiError::Response {
+                status,
+                body: response_body,
+            });
+        }
+        parse_json_response(status, response_body)
+    }
+
+    fn url(&self, method: &str) -> String {
+        api_url(&self.base_path, self.api_key.as_deref(), method)
+    }
+}
+
+impl BlockingZolanaApi {
+    pub fn new(url: impl AsRef<str>) -> Self {
+        ensure_ring_provider();
+        let (base_path, api_key) = parse_url(url.as_ref());
+        Self {
+            base_path,
+            api_key,
+            client: reqwest::blocking::Client::new(),
+            trace_http: false,
+        }
+    }
+
+    pub fn with_client(url: impl AsRef<str>, client: reqwest::blocking::Client) -> Self {
+        ensure_ring_provider();
+        let (base_path, api_key) = parse_url(url.as_ref());
+        Self {
+            base_path,
+            api_key,
+            client,
+            trace_http: false,
+        }
+    }
+
+    pub fn base_path(&self) -> &str {
+        &self.base_path
+    }
+
+    pub fn api_key(&self) -> Option<&str> {
+        self.api_key.as_deref()
+    }
+
+    pub fn with_http_trace(mut self) -> Self {
+        self.trace_http = true;
+        self
+    }
+
+    pub fn get_encrypted_utxos_by_tags(
+        &self,
+        tags: Vec<Hash>,
+        cursor: Option<Base64String>,
+        limit: Option<u64>,
+    ) -> Result<GetEncryptedUtxosByTagsResponse, ApiError> {
+        let method = "get_encrypted_utxos_by_tags";
+        let body = types::PostGetEncryptedUtxosByTagsBody {
+            id: types::PostGetEncryptedUtxosByTagsBodyId::TestAccount,
+            jsonrpc: types::PostGetEncryptedUtxosByTagsBodyJsonrpc::X20,
+            method: types::PostGetEncryptedUtxosByTagsBodyMethod::GetEncryptedUtxosByTags,
+            params: types::PostGetEncryptedUtxosByTagsBodyParams {
+                cursor,
+                limit: limit.map(types::Limit),
+                tags,
+            },
+        };
+        let response: types::PostGetEncryptedUtxosByTagsResponse = self.post(method, &body)?;
+        if let Some(error) = response.error {
+            return Err(ApiError::JsonRpc {
+                method,
+                code: error.code,
+                message: error.message,
+            });
+        }
+        response.result.ok_or(ApiError::MissingResult(method))
+    }
+
+    pub fn get_shielded_transactions_by_tags(
+        &self,
+        tags: Vec<Hash>,
+        cursor: Option<Base64String>,
+        limit: Option<u64>,
+    ) -> Result<GetShieldedTransactionsByTagsResponse, ApiError> {
+        let method = "get_shielded_transactions_by_tags";
+        let body = types::PostGetShieldedTransactionsByTagsBody {
+            id: types::PostGetShieldedTransactionsByTagsBodyId::TestAccount,
+            jsonrpc: types::PostGetShieldedTransactionsByTagsBodyJsonrpc::X20,
+            method:
+                types::PostGetShieldedTransactionsByTagsBodyMethod::GetShieldedTransactionsByTags,
+            params: types::PostGetShieldedTransactionsByTagsBodyParams {
+                cursor,
+                limit: limit.map(types::Limit),
+                tags,
+            },
+        };
+        let response: types::PostGetShieldedTransactionsByTagsResponse =
+            self.post(method, &body)?;
+        if let Some(error) = response.error {
+            return Err(ApiError::JsonRpc {
+                method,
+                code: error.code,
+                message: error.message,
+            });
+        }
+        response.result.ok_or(ApiError::MissingResult(method))
+    }
+
+    pub fn get_merkle_proofs(
+        &self,
+        tree_account: SerializablePubkey,
+        leaves: Vec<Hash>,
+    ) -> Result<GetMerkleProofsResponse, ApiError> {
+        let method = "get_merkle_proofs";
+        let body = types::PostGetMerkleProofsBody {
+            id: types::PostGetMerkleProofsBodyId::TestAccount,
+            jsonrpc: types::PostGetMerkleProofsBodyJsonrpc::X20,
+            method: types::PostGetMerkleProofsBodyMethod::GetMerkleProofs,
+            params: types::PostGetMerkleProofsBodyParams {
+                leaves,
+                tree_account,
+            },
+        };
+        let response: types::PostGetMerkleProofsResponse = self.post(method, &body)?;
+        if let Some(error) = response.error {
+            return Err(ApiError::JsonRpc {
+                method,
+                code: error.code,
+                message: error.message,
+            });
+        }
+        response.result.ok_or(ApiError::MissingResult(method))
+    }
+
+    pub fn get_non_inclusion_proofs(
+        &self,
+        tree_account: SerializablePubkey,
+        leaves: Vec<Hash>,
+    ) -> Result<GetNonInclusionProofsResponse, ApiError> {
+        let method = "get_non_inclusion_proofs";
+        let body = types::PostGetNonInclusionProofsBody {
+            id: types::PostGetNonInclusionProofsBodyId::TestAccount,
+            jsonrpc: types::PostGetNonInclusionProofsBodyJsonrpc::X20,
+            method: types::PostGetNonInclusionProofsBodyMethod::GetNonInclusionProofs,
+            params: types::PostGetNonInclusionProofsBodyParams {
+                leaves,
+                tree_account,
+            },
+        };
+        let response: types::PostGetNonInclusionProofsResponse = self.post(method, &body)?;
+        if let Some(error) = response.error {
+            return Err(ApiError::JsonRpc {
+                method,
+                code: error.code,
+                message: error.message,
+            });
+        }
+        response.result.ok_or(ApiError::MissingResult(method))
+    }
+
+    fn post<B, R>(&self, method: &'static str, body: &B) -> Result<R, ApiError>
+    where
+        B: Serialize + ?Sized,
+        R: DeserializeOwned,
+    {
+        let url = self.url(method);
+        if self.trace_http {
+            print_api_request(&url, body);
+        }
+        let response = self.client.post(&url).json(body).send()?;
+        let status = response.status();
+        let response_body = response.text()?;
+        if self.trace_http {
+            print_api_response(method, status, &response_body);
+        }
+        if !status.is_success() {
+            return Err(ApiError::Response {
+                status,
+                body: response_body,
+            });
+        }
+        parse_json_response(status, response_body)
+    }
+
+    fn url(&self, method: &str) -> String {
+        api_url(&self.base_path, self.api_key.as_deref(), method)
+    }
+}
+
+fn parse_url(url: &str) -> (String, Option<String>) {
+    let Some(query_start) = url.find('?') else {
+        return (url.to_string(), None);
+    };
+    let base = &url[..query_start];
+    let query = &url[query_start + 1..];
+    for param in query.split('&') {
+        if let Some(value) = param.strip_prefix("api-key=") {
+            return (base.to_string(), Some(value.to_string()));
+        }
+    }
+    (url.to_string(), None)
+}
+
+fn api_url(base_path: &str, api_key: Option<&str>, method: &str) -> String {
+    let mut url = format!("{}/{}", base_path.trim_end_matches('/'), method);
+    if let Some(api_key) = api_key {
+        url.push_str("?api-key=");
+        url.push_str(api_key);
+    }
+    url
+}
+
+fn print_api_request<B>(url: &str, body: &B)
+where
+    B: Serialize + ?Sized,
+{
+    let body_json = serde_json::to_string(body)
+        .unwrap_or_else(|error| format!(r#"{{"serialization_error":"{error}"}}"#));
+    println!("Photon API request:\n{}", curl_command(url, &body_json));
+}
+
+fn print_api_response(method: &str, status: reqwest::StatusCode, body: &str) {
+    println!(
+        "Photon API response {method} {status}:\n{}",
+        pretty_json(body)
+    );
+}
+
+fn curl_command(url: &str, body_json: &str) -> String {
+    format!(
+        "curl -sS -X POST {} -H 'content-type: application/json' -d {}",
+        shell_quote(url),
+        shell_quote(body_json)
+    )
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r#"'\''"#))
+}
+
+fn pretty_json(body: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(body)
+        .and_then(|value| serde_json::to_string_pretty(&value))
+        .unwrap_or_else(|_| body.to_string())
+}
+
+fn parse_json_response<R>(status: reqwest::StatusCode, body: String) -> Result<R, ApiError>
+where
+    R: DeserializeOwned,
+{
+    serde_json::from_str(&body).map_err(|error| ApiError::Response {
+        status,
+        body: format!("failed to decode JSON response: {error}; body: {body}"),
+    })
+}
+
+fn ensure_ring_provider() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_api_key_from_url() {
+        let api = ZolanaApi::new("https://rpc.example.test?api-key=secret");
+        assert_eq!(api.base_path(), "https://rpc.example.test");
+        assert_eq!(api.api_key(), Some("secret"));
+        assert_eq!(
+            api.url("get_merkle_proofs"),
+            "https://rpc.example.test/get_merkle_proofs?api-key=secret"
+        );
+    }
+
+    #[test]
+    fn leaves_plain_urls_unchanged() {
+        let api = ZolanaApi::new("http://127.0.0.1:8784");
+        assert_eq!(api.base_path(), "http://127.0.0.1:8784");
+        assert_eq!(api.api_key(), None);
+        assert_eq!(
+            api.url("get_encrypted_utxos_by_tags"),
+            "http://127.0.0.1:8784/get_encrypted_utxos_by_tags"
+        );
+    }
+
+    #[test]
+    fn blocking_client_uses_same_url_shape() {
+        let api = BlockingZolanaApi::new("https://rpc.example.test?api-key=secret");
+        assert_eq!(api.base_path(), "https://rpc.example.test");
+        assert_eq!(api.api_key(), Some("secret"));
+        assert_eq!(
+            api.url("get_non_inclusion_proofs"),
+            "https://rpc.example.test/get_non_inclusion_proofs?api-key=secret"
+        );
+    }
+}

--- a/tools/install-photon.sh
+++ b/tools/install-photon.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+release_tag="${PHOTON_ZOLANA_RELEASE_TAG:-photon-zolana-ae5234d0c9e8}"
+asset="${PHOTON_ZOLANA_ASSET:-photon-zolana-linux-x86_64.tar.gz}"
+expected_sha256="${PHOTON_ZOLANA_SHA256:-be260fd8b7f6fae86e8da258b07882698b4d6abbc0a22eba3ada5fb9d4a8ccee}"
+repo="${PHOTON_ZOLANA_RELEASE_REPO:-helius-labs/zolana}"
+out_dir="${PHOTON_BIN_DIR:-target/bin}"
+out_bin="${PHOTON_BIN_PATH:-${out_dir}/photon}"
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64|Linux-amd64) ;;
+  *)
+    echo "unsupported Photon release platform: $(uname -s)-$(uname -m)" >&2
+    echo "Only ${asset} is pinned right now; build Photon locally with 'just build-photon' on this host." >&2
+    exit 1
+    ;;
+esac
+
+url="https://github.com/${repo}/releases/download/${release_tag}/${asset}"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+mkdir -p "$out_dir"
+
+echo "Downloading ${asset} from ${repo}@${release_tag}"
+if command -v gh >/dev/null 2>&1; then
+  if [[ -n "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ]]; then
+    export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  fi
+  gh release download "$release_tag" --repo "$repo" --pattern "$asset" --dir "$tmpdir" --clobber
+else
+  curl -fsSL "$url" -o "${tmpdir}/${asset}"
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  echo "${expected_sha256}  ${tmpdir}/${asset}" | sha256sum -c -
+else
+  actual_sha256="$(shasum -a 256 "${tmpdir}/${asset}" | awk '{print $1}')"
+  if [[ "$actual_sha256" != "$expected_sha256" ]]; then
+    echo "checksum mismatch for ${asset}" >&2
+    echo "expected: ${expected_sha256}" >&2
+    echo "actual:   ${actual_sha256}" >&2
+    exit 1
+  fi
+fi
+
+tar -xzf "${tmpdir}/${asset}" -C "$tmpdir"
+if [[ ! -f "${tmpdir}/photon" ]]; then
+  echo "photon binary not found in ${asset}" >&2
+  exit 1
+fi
+
+install -m 0755 "${tmpdir}/photon" "$out_bin"
+"$out_bin" --help >/dev/null
+echo "Installed Photon to ${out_bin}"


### PR DESCRIPTION
Adds Zolana-only Photon integration for localnet E2E coverage.

- Adds generated `zolana-api` client support for the Photon Zolana API.
- Wires `ZolanaIndexer` to the typed Photon-backed API.
- Adds `localnet_photon_e2e` using a real Photon indexer instead of the test indexer.
- Adds CI tooling to install a pinned Photon release binary and run `just test-localnet-e2e-photon`.

For testing use:
- `just test-localnet-e2e-photon`