### PR TITLE
feat: Squads smart account authority hierarchy in spp-test-validator tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -209,6 +209,15 @@ jobs:
           key: proving-keys-transfer-keys-v4
       - name: Install pinned Photon
         run: ./tools/install-photon.sh
+      - name: Cache Squads smart account binary
+        uses: actions/cache@v4
+        id: squads-cache
+        with:
+          path: target/deploy/squads_smart_account_program.so
+          key: squads-smart-account-SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG
+      - name: Fetch Squads smart account binary
+        if: steps.squads-cache.outputs.cache-hit != 'true'
+        run: just fetch-smart-account
       - run: just ${{ matrix.recipe }}
       - name: Dump prover and photon logs on failure
         if: failure()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9931,6 +9931,7 @@ dependencies = [
 name = "zolana-test-utils"
 version = "0.1.0"
 dependencies = [
+ "borsh 1.6.1",
  "bytemuck",
  "solana-account 3.4.0",
  "solana-address 2.6.1",

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1110,25 +1110,25 @@ creation authority.
 
 ### Authority Governance
 
-`protocol_authority`, `forester_authority`, and `merge_authority` are vault PDAs of [Squads smart accounts](https://github.com/Squads-Protocol/smart-account-program) (program `SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG`). SPP checks only that the address is a signer; threshold and key membership are validated by the smart account program. `tree_creation_authority` and `zone_creation_authority` are direct keypairs.
+All five authority fields store vault PDAs of [Squads smart accounts](https://github.com/Squads-Protocol/smart-account-program) (program `SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG`). SPP checks only that the address is a signer; threshold and key membership are validated by the smart account program.
 
 **Hierarchy**
 
-| Smart account | Kind | Threshold | `settings_authority` |
-| --- | --- | --- | --- |
-| Protocol authority | autonomous | 2-of-5 | — |
-| Forester | controlled | 1-of-N | Protocol authority vault |
-| Merge | controlled | 1-of-N | Protocol authority vault |
-
-`protocol_authority` stores the protocol authority vault PDA (index 0). `forester_authority` and `merge_authority` store the vault PDA of their respective controlled smart account.
+| Config field | Smart account | Kind | Threshold | `settings_authority` |
+| --- | --- | --- | --- | --- |
+| `protocol_authority` | Protocol authority | autonomous | 2-of-5 | — |
+| `forester_authority` | Forester | controlled | 1-of-N | Protocol authority vault |
+| `merge_authority` | Merge | controlled | 1-of-N | Protocol authority vault |
+| `tree_creation_authority` | Tree creation | controlled | 1-of-N | Protocol authority vault |
+| `zone_creation_authority` | Zone creation | controlled | 1-of-N | Protocol authority vault |
 
 **Key management**
 
-Adding or removing a signer requires a 2-of-5 protocol authority transaction.
+Signer changes on any smart account in the hierarchy require a 2-of-5 protocol authority transaction.
 
 **Sync execution**
 
-Forester and merge operators submit `execute_transaction_sync_v2` with a single key (`threshold = 1`, `time_lock = 0`). The smart account program validates the key and CPIs into SPP with the vault PDA as signer.
+Operators submit `execute_transaction_sync_v2` with a single key (`threshold = 1`, `time_lock = 0`). The smart account program validates the key and CPIs into SPP with the vault PDA as signer.
 
 ### Zone Accounts
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -44,6 +44,7 @@
 - [Merge Proof - Merge ZK Proof](#merge-proof---merge-zk-proof)
 - [SPP - Solana Privacy Program](#spp---solana-privacy-program)
   - [Accounts](#accounts)
+    - [Authority Governance](#authority-governance)
     - [Zone Accounts](#zone-accounts)
   - [Instructions](#instructions)
     - [transact](#transact)
@@ -1106,6 +1107,28 @@ struct ProtocolConfig {
 When a `*_is_permissionless` flag is set, any signer may call the corresponding
 creation instruction; otherwise the transaction signer must equal the matching
 creation authority.
+
+### Authority Governance
+
+`protocol_authority`, `forester_authority`, and `merge_authority` are vault PDAs of [Squads smart accounts](https://github.com/Squads-Protocol/smart-account-program) (program `SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG`). SPP checks only that the address is a signer; threshold and key membership are validated by the smart account program. `tree_creation_authority` and `zone_creation_authority` are direct keypairs.
+
+**Hierarchy**
+
+| Smart account | Kind | Threshold | `settings_authority` |
+| --- | --- | --- | --- |
+| Protocol authority | autonomous | 2-of-5 | — |
+| Forester | controlled | 1-of-N | Protocol authority vault |
+| Merge | controlled | 1-of-N | Protocol authority vault |
+
+`protocol_authority` stores the protocol authority vault PDA (index 0). `forester_authority` and `merge_authority` store the vault PDA of their respective controlled smart account.
+
+**Key management**
+
+Adding or removing a signer requires a 2-of-5 protocol authority transaction.
+
+**Sync execution**
+
+Forester and merge operators submit `execute_transaction_sync_v2` with a single key (`threshold = 1`, `time_lock = 0`). The smart account program validates the key and CPIs into SPP with the vault PDA as signer.
 
 ### Zone Accounts
 

--- a/justfile
+++ b/justfile
@@ -306,6 +306,14 @@ install-surfpool:
 build-programs:
     SBF_TOOLS_VERSION={{sbf-tools-version}} ./tools/build-programs.sh
 
+# Download the Squads smart account program binary from mainnet into `target/deploy`.
+# Run once before `test-spp-validator*` recipes; requires `solana` CLI and network access.
+fetch-smart-account:
+    mkdir -p target/deploy
+    solana program dump SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG \
+        target/deploy/squads_smart_account_program.so \
+        --url https://api.mainnet-beta.solana.com
+
 build-prover-server:
     mkdir -p target
     cd prover/server && go build -o ../../target/prover-server .

--- a/program-tests/spp-test-validator/tests/localnet.rs
+++ b/program-tests/spp-test-validator/tests/localnet.rs
@@ -126,18 +126,14 @@ fn write_program_config_fixture(account_dir: &str) {
     );
 
     std::fs::create_dir_all(account_dir).expect("create smart account account dir");
-    std::fs::write(
-        format!("{account_dir}/squads_program_config.json"),
-        json,
-    )
-    .expect("write squads program config fixture");
+    std::fs::write(format!("{account_dir}/squads_program_config.json"), json)
+        .expect("write squads program config fixture");
 }
 
 fn base64_encode(input: &[u8]) -> String {
-    const CHARS: &[u8; 64] =
-        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    const CHARS: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     let ch = |idx: u32| char::from(*CHARS.get((idx & 0x3F) as usize).expect("base64 index"));
-    let mut out = String::with_capacity((input.len() + 2) / 3 * 4);
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
     for chunk in input.chunks(3) {
         let b0 = u32::from(*chunk.first().unwrap_or(&0));
         let b1 = u32::from(*chunk.get(1).unwrap_or(&0));

--- a/program-tests/spp-test-validator/tests/localnet.rs
+++ b/program-tests/spp-test-validator/tests/localnet.rs
@@ -9,6 +9,7 @@ use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_transaction::Transaction;
 use zolana_client::{spawn_prover, Proof, ProofCompressed, Rpc, SolanaRpc};
+use zolana_test_utils::smart_account;
 use zolana_user_registry_interface::user_registry_program_id;
 
 pub(crate) const DEFAULT_RPC_URL: &str = "http://127.0.0.1:8899";
@@ -68,6 +69,15 @@ pub(crate) fn restart_localnet() {
     let user_registry_id = user_registry_program_id().to_string();
     let user_registry_so = format!("{root}/target/deploy/zolana_user_registry.so");
 
+    let smart_account_id = smart_account::SMART_ACCOUNT_PROGRAM_ID.to_string();
+    let smart_account_so = format!("{root}/target/deploy/squads_smart_account_program.so");
+
+    // Inject a pre-initialised ProgramConfig so the validator starts with
+    // smart_account_index = 0. Seeds for the three accounts are therefore
+    // deterministic: protocol = 1, forester = 2, merge = 3.
+    let account_dir = "/tmp/zolana-smart-account-accounts";
+    write_program_config_fixture(account_dir);
+
     let status = std::process::Command::new(&cli)
         .current_dir(root)
         .args([
@@ -87,10 +97,58 @@ pub(crate) fn restart_localnet() {
             "--sbf-program",
             &user_registry_id,
             &user_registry_so,
+            "--sbf-program",
+            &smart_account_id,
+            &smart_account_so,
+            "--account-dir",
+            account_dir,
         ])
         .status()
         .expect("run zolana test-validator");
     assert!(status.success(), "zolana test-validator restart failed");
+}
+
+fn write_program_config_fixture(account_dir: &str) {
+    let (pda, _) = smart_account::program_config_pda();
+
+    // 160-byte ProgramConfig layout:
+    // discriminator[8] + smart_account_index[16] + authority[32] + smart_account_creation_fee[8] + treasury[32] + _reserved[64]
+    // smart_account_index = 0 means the first settings seed = 1.
+    // treasury must be a non-executable, non-default pubkey.
+    let mut data = [0u8; 160];
+    data[..8].copy_from_slice(&smart_account::PROGRAM_CONFIG_ACCOUNT_DISCRIMINATOR);
+    data[64..96].copy_from_slice(&smart_account::treasury_pda().to_bytes());
+    let encoded = base64_encode(&data);
+
+    let json = format!(
+        r#"{{"pubkey":"{pda}","account":{{"lamports":1000000,"data":["{encoded}","base64"],"owner":"{}","executable":false,"rentEpoch":18446744073709551615}}}}"#,
+        smart_account::SMART_ACCOUNT_PROGRAM_ID,
+    );
+
+    std::fs::create_dir_all(account_dir).expect("create smart account account dir");
+    std::fs::write(
+        format!("{account_dir}/squads_program_config.json"),
+        json,
+    )
+    .expect("write squads program config fixture");
+}
+
+fn base64_encode(input: &[u8]) -> String {
+    const CHARS: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let ch = |idx: u32| char::from(*CHARS.get((idx & 0x3F) as usize).expect("base64 index"));
+    let mut out = String::with_capacity((input.len() + 2) / 3 * 4);
+    for chunk in input.chunks(3) {
+        let b0 = u32::from(*chunk.first().unwrap_or(&0));
+        let b1 = u32::from(*chunk.get(1).unwrap_or(&0));
+        let b2 = u32::from(*chunk.get(2).unwrap_or(&0));
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(ch(n >> 18));
+        out.push(ch(n >> 12));
+        out.push(if chunk.len() > 1 { ch(n >> 6) } else { '=' });
+        out.push(if chunk.len() > 2 { ch(n) } else { '=' });
+    }
+    out
 }
 
 pub(crate) fn send_transaction(

--- a/program-tests/spp-test-validator/tests/steps/merge.rs
+++ b/program-tests/spp-test-validator/tests/steps/merge.rs
@@ -34,6 +34,8 @@ use zolana_user_registry_interface::{
     user_record_pda,
 };
 
+use zolana_test_utils::smart_account;
+
 use crate::{
     localnet::{pack_proof, send_transaction, ZERO},
     LifecycleWorld,
@@ -216,18 +218,24 @@ impl LifecycleWorld {
         let merge_ix = MergeTransact {
             tree: self.tree,
             protocol_config: pda::protocol_config(),
-            payer: self.authority.pubkey(),
+            payer: self.merge_vault,
             user_record: user_record_pda(&owner_solana.pubkey()).0,
             data,
         }
         .instruction();
+        let sync_ix = smart_account::execute_sync_ix(
+            &self.merge_settings,
+            0,
+            &[self.merge_key.pubkey()],
+            &[merge_ix],
+        );
         let compute_budget = ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
-        let authority = self.authority.insecure_clone();
+        let merge_key = self.merge_key.insecure_clone();
         send_transaction(
             &mut self.rpc,
-            &[compute_budget, merge_ix],
-            &authority.pubkey(),
-            &[&authority],
+            &[compute_budget, sync_ix],
+            &merge_key.pubkey(),
+            &[&merge_key],
         )?;
 
         // Record what the consolidated-output assert needs: the appended output

--- a/program-tests/spp-test-validator/tests/steps/spl.rs
+++ b/program-tests/spp-test-validator/tests/steps/spl.rs
@@ -5,12 +5,17 @@ use anyhow::{anyhow, Result};
 use cucumber::given;
 use solana_address::Address;
 use solana_signer::Signer;
+use zolana_interface::{
+    instruction::{CreateAssetCounter, CreateSplInterface},
+    pda,
+};
 use zolana_test_utils::{
-    spl::{create_mint, create_spl_interface, create_token_account, ensure_asset_counter},
+    smart_account::execute_sync_ix,
+    spl::{create_mint, create_token_account},
     test_validator_asserts::assert_create_spl_interface,
 };
 
-use crate::{world::SplAsset, LifecycleWorld};
+use crate::{localnet::send_transaction, world::SplAsset, LifecycleWorld};
 
 // SOL occupies asset id 1; the first registered SPL mint gets id 2.
 const FIRST_SPL_ASSET_ID: u64 = 2;
@@ -24,13 +29,47 @@ impl LifecycleWorld {
     pub(crate) fn ensure_spl_assets(&mut self, count: usize) -> Result<()> {
         let payer = self.payer.insecure_clone();
         let authority = self.authority.insecure_clone();
+        let protocol_vault = self.protocol_vault;
+        let protocol_settings = self.protocol_settings;
 
         while self.spls.len() < count {
             let asset_id = FIRST_SPL_ASSET_ID + self.spls.len() as u64;
 
             let mint = create_mint(&self.rpc, &payer)?;
-            ensure_asset_counter(&self.rpc, &authority)?;
-            let (registry, vault) = create_spl_interface(&self.rpc, &authority, &mint)?;
+
+            // Both CreateAssetCounter and CreateSplInterface check protocol_authority
+            // in ProtocolConfig, which is now the protocol vault PDA. Wrap each in
+            // execute_sync_ix so the vault signs via the Squads CPI mechanism.
+            let counter_addr = Address::new_from_array(pda::spl_asset_counter().to_bytes());
+            if self.rpc.get_account(counter_addr)?.is_none() {
+                let ix = CreateAssetCounter {
+                    authority: protocol_vault,
+                }
+                .instruction();
+                let sync_ix = execute_sync_ix(&protocol_settings, 0, &[authority.pubkey()], &[ix]);
+                send_transaction(
+                    &mut self.rpc,
+                    &[sync_ix],
+                    &payer.pubkey(),
+                    &[&payer, &authority],
+                )?;
+            }
+
+            let ix = CreateSplInterface {
+                authority: protocol_vault,
+                mint,
+            }
+            .instruction();
+            let sync_ix = execute_sync_ix(&protocol_settings, 0, &[authority.pubkey()], &[ix]);
+            send_transaction(
+                &mut self.rpc,
+                &[sync_ix],
+                &payer.pubkey(),
+                &[&payer, &authority],
+            )?;
+            let registry = pda::spl_asset_registry(&mint);
+            let vault = pda::spl_asset_vault(&mint);
+
             assert_create_spl_interface(
                 &self.rpc,
                 &registry,

--- a/program-tests/spp-test-validator/tests/steps/spl.rs
+++ b/program-tests/spp-test-validator/tests/steps/spl.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, Result};
 use cucumber::given;
 use solana_address::Address;
 use solana_signer::Signer;
+use zolana_client::Rpc;
 use zolana_interface::{
     instruction::{CreateAssetCounter, CreateSplInterface},
     pda,

--- a/program-tests/spp-test-validator/tests/world.rs
+++ b/program-tests/spp-test-validator/tests/world.rs
@@ -13,7 +13,7 @@ use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
-use zolana_client::{SolanaRpc, ZolanaIndexer};
+use zolana_client::{Rpc, SolanaRpc, ZolanaIndexer};
 use zolana_interface::{
     instruction::CreateProtocolConfig, pda, state::tree_account_size, SHIELDED_POOL_PROGRAM_ID,
 };
@@ -246,7 +246,6 @@ impl LifecycleWorld {
             tree_account_size() as u64,
             &pda::shielded_pool_program_id(),
         );
-        send_transaction(&mut rpc, &[alloc_ix], &payer.pubkey(), &[&payer, &tree])?;
         let create_tree_ix = zolana_interface::instruction::CreateTree {
             authority: tree_vault,
             tree: tree.pubkey(),
@@ -257,9 +256,9 @@ impl LifecycleWorld {
             execute_sync_ix(&tree_settings, 0, &[tree_key.pubkey()], &[create_tree_ix]);
         send_transaction(
             &mut rpc,
-            &[create_tree_sync],
+            &[alloc_ix, create_tree_sync],
             &payer.pubkey(),
-            &[&payer, &tree_key],
+            &[&payer, &tree, &tree_key],
         )?;
 
         let tree_address = Address::new_from_array(tree.pubkey().to_bytes());

--- a/program-tests/spp-test-validator/tests/world.rs
+++ b/program-tests/spp-test-validator/tests/world.rs
@@ -18,6 +18,10 @@ use zolana_interface::{
     instruction::CreateProtocolConfig, state::tree_account_size, SHIELDED_POOL_PROGRAM_ID,
 };
 use zolana_program_test::create_tree_instructions;
+use zolana_test_utils::smart_account::{
+    create_smart_account_ix, execute_sync_ix, settings_pda, smart_account_pda, treasury_pda,
+    Permissions, SmartAccountSigner,
+};
 use zolana_transaction::{AssetRegistry, SyncTransaction};
 
 use crate::{
@@ -68,6 +72,9 @@ pub struct LifecycleWorld {
     /// The most recent merge, kept so the consolidated-output assert can reconstruct
     /// and verify the merged UTXO.
     pub(crate) last_merge: Option<crate::steps::merge::MergeRecord>,
+    pub(crate) merge_settings: Pubkey,
+    pub(crate) merge_vault: Pubkey,
+    pub(crate) merge_key: Keypair,
 }
 
 impl std::fmt::Debug for LifecycleWorld {
@@ -95,26 +102,101 @@ impl LifecycleWorld {
 
         let payer = Keypair::new();
         let authority = Keypair::new();
+        let forester_key = Keypair::new();
+        let merge_key = Keypair::new();
         rpc.airdrop(&payer.pubkey(), 100_000_000_000)?;
         rpc.airdrop(&authority.pubkey(), 1_000_000_000)?;
+        rpc.airdrop(&forester_key.pubkey(), 1_000_000_000)?;
+        rpc.airdrop(&merge_key.pubkey(), 1_000_000_000)?;
 
-        let authority_bytes = authority.pubkey().to_bytes();
-        let create_config = CreateProtocolConfig {
-            authority: authority.pubkey(),
-            protocol_authority: authority_bytes.into(),
-            tree_creation_authority: authority_bytes.into(),
-            tree_creation_is_permissionless: false,
-            forester_authority: authority_bytes.into(),
-            zone_creation_authority: authority_bytes.into(),
-            zone_creation_is_permissionless: false,
-            merge_authority: authority_bytes.into(),
-        }
-        .instruction();
+        // Seeds are deterministic: the injected ProgramConfig starts with
+        // smart_account_index = 0; the program uses index + 1 as each seed.
+        let (protocol_settings, _) = settings_pda(1);
+        let (protocol_vault, _) = smart_account_pda(&protocol_settings, 0);
+        let (forester_settings, _) = settings_pda(2);
+        let (forester_vault, _) = smart_account_pda(&forester_settings, 0);
+        let (merge_settings, _) = settings_pda(3);
+        let (merge_vault, _) = smart_account_pda(&merge_settings, 0);
+
+        let signer_all = |key: Pubkey| {
+            vec![SmartAccountSigner {
+                key,
+                permissions: Permissions::all(),
+            }]
+        };
+
+        let treasury = treasury_pda();
+
         send_transaction(
             &mut rpc,
-            &[create_config],
-            &authority.pubkey(),
-            &[&authority],
+            &[create_smart_account_ix(
+                &payer.pubkey(),
+                &treasury,
+                1,
+                None,
+                &signer_all(authority.pubkey()),
+                1,
+                0,
+            )],
+            &payer.pubkey(),
+            &[&payer],
+        )?;
+        send_transaction(
+            &mut rpc,
+            &[create_smart_account_ix(
+                &payer.pubkey(),
+                &treasury,
+                2,
+                Some(protocol_vault),
+                &signer_all(forester_key.pubkey()),
+                1,
+                0,
+            )],
+            &payer.pubkey(),
+            &[&payer],
+        )?;
+        send_transaction(
+            &mut rpc,
+            &[create_smart_account_ix(
+                &payer.pubkey(),
+                &treasury,
+                3,
+                Some(protocol_vault),
+                &signer_all(merge_key.pubkey()),
+                1,
+                0,
+            )],
+            &payer.pubkey(),
+            &[&payer],
+        )?;
+
+        // The shielded pool program requires the fee payer == protocol_authority,
+        // so we CPI via execute_sync_ix with the protocol vault as the inner fee payer.
+        rpc.airdrop(&protocol_vault, 5_000_000_000)?;
+
+        let authority_bytes = authority.pubkey().to_bytes();
+        let create_config_ix = CreateProtocolConfig {
+            authority: protocol_vault,
+            protocol_authority: protocol_vault.to_bytes().into(),
+            tree_creation_authority: authority_bytes.into(),
+            tree_creation_is_permissionless: false,
+            forester_authority: forester_vault.to_bytes().into(),
+            zone_creation_authority: authority_bytes.into(),
+            zone_creation_is_permissionless: false,
+            merge_authority: merge_vault.to_bytes().into(),
+        }
+        .instruction();
+        let create_config_sync = execute_sync_ix(
+            &protocol_settings,
+            0,
+            &[authority.pubkey()],
+            &[create_config_ix],
+        );
+        send_transaction(
+            &mut rpc,
+            &[create_config_sync],
+            &payer.pubkey(),
+            &[&payer, &authority],
         )?;
 
         let tree = Keypair::new();
@@ -148,6 +230,9 @@ impl LifecycleWorld {
             last_rail: None,
             last_transact: None,
             last_merge: None,
+            merge_settings,
+            merge_vault,
+            merge_key,
         })
     }
 

--- a/program-tests/spp-test-validator/tests/world.rs
+++ b/program-tests/spp-test-validator/tests/world.rs
@@ -15,9 +15,8 @@ use solana_signature::Signature;
 use solana_signer::Signer;
 use zolana_client::{SolanaRpc, ZolanaIndexer};
 use zolana_interface::{
-    instruction::CreateProtocolConfig, state::tree_account_size, SHIELDED_POOL_PROGRAM_ID,
+    instruction::CreateProtocolConfig, pda, state::tree_account_size, SHIELDED_POOL_PROGRAM_ID,
 };
-use zolana_program_test::create_tree_instructions;
 use zolana_test_utils::smart_account::{
     create_smart_account_ix, execute_sync_ix, settings_pda, smart_account_pda, treasury_pda,
     Permissions, SmartAccountSigner,
@@ -237,24 +236,30 @@ impl LifecycleWorld {
         )?;
 
         let tree = Keypair::new();
-        let create_tree_ixs = create_tree_instructions(
-            &rpc,
+        let rent = rpc
+            .get_minimum_balance_for_rent_exemption(tree_account_size())
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let alloc_ix = zolana_program_test::system_create_account_ix(
             &payer.pubkey(),
-            &tree_vault,
             &tree.pubkey(),
+            rent,
             tree_account_size() as u64,
-        )?;
-        let create_tree_sync = execute_sync_ix(
-            &tree_settings,
-            0,
-            &[tree_key.pubkey()],
-            &create_tree_ixs,
+            &pda::shielded_pool_program_id(),
         );
+        send_transaction(&mut rpc, &[alloc_ix], &payer.pubkey(), &[&payer, &tree])?;
+        let create_tree_ix = zolana_interface::instruction::CreateTree {
+            authority: tree_vault,
+            tree: tree.pubkey(),
+            owner: tree_vault,
+        }
+        .instruction();
+        let create_tree_sync =
+            execute_sync_ix(&tree_settings, 0, &[tree_key.pubkey()], &[create_tree_ix]);
         send_transaction(
             &mut rpc,
             &[create_tree_sync],
             &payer.pubkey(),
-            &[&payer, &tree, &tree_key],
+            &[&payer, &tree_key],
         )?;
 
         let tree_address = Address::new_from_array(tree.pubkey().to_bytes());

--- a/program-tests/spp-test-validator/tests/world.rs
+++ b/program-tests/spp-test-validator/tests/world.rs
@@ -72,6 +72,8 @@ pub struct LifecycleWorld {
     /// The most recent merge, kept so the consolidated-output assert can reconstruct
     /// and verify the merged UTXO.
     pub(crate) last_merge: Option<crate::steps::merge::MergeRecord>,
+    pub(crate) protocol_settings: Pubkey,
+    pub(crate) protocol_vault: Pubkey,
     pub(crate) merge_settings: Pubkey,
     pub(crate) merge_vault: Pubkey,
     pub(crate) merge_key: Keypair,
@@ -230,6 +232,8 @@ impl LifecycleWorld {
             last_rail: None,
             last_transact: None,
             last_merge: None,
+            protocol_settings,
+            protocol_vault,
             merge_settings,
             merge_vault,
             merge_key,

--- a/program-tests/spp-test-validator/tests/world.rs
+++ b/program-tests/spp-test-validator/tests/world.rs
@@ -106,10 +106,14 @@ impl LifecycleWorld {
         let authority = Keypair::new();
         let forester_key = Keypair::new();
         let merge_key = Keypair::new();
+        let tree_key = Keypair::new();
+        let zone_key = Keypair::new();
         rpc.airdrop(&payer.pubkey(), 100_000_000_000)?;
         rpc.airdrop(&authority.pubkey(), 1_000_000_000)?;
         rpc.airdrop(&forester_key.pubkey(), 1_000_000_000)?;
         rpc.airdrop(&merge_key.pubkey(), 1_000_000_000)?;
+        rpc.airdrop(&tree_key.pubkey(), 1_000_000_000)?;
+        rpc.airdrop(&zone_key.pubkey(), 1_000_000_000)?;
 
         // Seeds are deterministic: the injected ProgramConfig starts with
         // smart_account_index = 0; the program uses index + 1 as each seed.
@@ -119,6 +123,10 @@ impl LifecycleWorld {
         let (forester_vault, _) = smart_account_pda(&forester_settings, 0);
         let (merge_settings, _) = settings_pda(3);
         let (merge_vault, _) = smart_account_pda(&merge_settings, 0);
+        let (tree_settings, _) = settings_pda(4);
+        let (tree_vault, _) = smart_account_pda(&tree_settings, 0);
+        let (zone_settings, _) = settings_pda(5);
+        let (zone_vault, _) = smart_account_pda(&zone_settings, 0);
 
         let signer_all = |key: Pubkey| {
             vec![SmartAccountSigner {
@@ -171,19 +179,46 @@ impl LifecycleWorld {
             &payer.pubkey(),
             &[&payer],
         )?;
+        send_transaction(
+            &mut rpc,
+            &[create_smart_account_ix(
+                &payer.pubkey(),
+                &treasury,
+                4,
+                Some(protocol_vault),
+                &signer_all(tree_key.pubkey()),
+                1,
+                0,
+            )],
+            &payer.pubkey(),
+            &[&payer],
+        )?;
+        send_transaction(
+            &mut rpc,
+            &[create_smart_account_ix(
+                &payer.pubkey(),
+                &treasury,
+                5,
+                Some(protocol_vault),
+                &signer_all(zone_key.pubkey()),
+                1,
+                0,
+            )],
+            &payer.pubkey(),
+            &[&payer],
+        )?;
 
         // The shielded pool program requires the fee payer == protocol_authority,
         // so we CPI via execute_sync_ix with the protocol vault as the inner fee payer.
         rpc.airdrop(&protocol_vault, 5_000_000_000)?;
 
-        let authority_bytes = authority.pubkey().to_bytes();
         let create_config_ix = CreateProtocolConfig {
             authority: protocol_vault,
             protocol_authority: protocol_vault.to_bytes().into(),
-            tree_creation_authority: authority_bytes.into(),
+            tree_creation_authority: tree_vault.to_bytes().into(),
             tree_creation_is_permissionless: false,
             forester_authority: forester_vault.to_bytes().into(),
-            zone_creation_authority: authority_bytes.into(),
+            zone_creation_authority: zone_vault.to_bytes().into(),
             zone_creation_is_permissionless: false,
             merge_authority: merge_vault.to_bytes().into(),
         }
@@ -202,18 +237,24 @@ impl LifecycleWorld {
         )?;
 
         let tree = Keypair::new();
-        let create_tree = create_tree_instructions(
+        let create_tree_ixs = create_tree_instructions(
             &rpc,
             &payer.pubkey(),
-            &authority.pubkey(),
+            &tree_vault,
             &tree.pubkey(),
             tree_account_size() as u64,
         )?;
+        let create_tree_sync = execute_sync_ix(
+            &tree_settings,
+            0,
+            &[tree_key.pubkey()],
+            &create_tree_ixs,
+        );
         send_transaction(
             &mut rpc,
-            &create_tree,
+            &[create_tree_sync],
             &payer.pubkey(),
-            &[&payer, &tree, &authority],
+            &[&payer, &tree, &tree_key],
         )?;
 
         let tree_address = Address::new_from_array(tree.pubkey().to_bytes());

--- a/program-tests/test-utils/Cargo.toml
+++ b/program-tests/test-utils/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 publish = false
 
 [dependencies]
+borsh = { workspace = true }
 bytemuck = { workspace = true }
 solana-account = { workspace = true }
 solana-address = { workspace = true }

--- a/program-tests/test-utils/src/lib.rs
+++ b/program-tests/test-utils/src/lib.rs
@@ -9,5 +9,6 @@
 //! that called the helper, not the helper body.
 
 pub mod litesvm_asserts;
+pub mod smart_account;
 pub mod spl;
 pub mod test_validator_asserts;

--- a/program-tests/test-utils/src/smart_account.rs
+++ b/program-tests/test-utils/src/smart_account.rs
@@ -1,0 +1,268 @@
+use borsh::BorshSerialize;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_pubkey::Pubkey;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+pub const SMART_ACCOUNT_PROGRAM_ID: Pubkey =
+    solana_pubkey::pubkey!("SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG");
+
+const SEED_PREFIX: &[u8] = b"smart_account";
+const SEED_PROGRAM_CONFIG: &[u8] = b"program_config";
+const SEED_SETTINGS: &[u8] = b"settings";
+const SEED_SMART_ACCOUNT: &[u8] = b"smart_account";
+
+// Anchor discriminators: sha256("global:<fn_name>")[0..8]
+const CREATE_SMART_ACCOUNT_DISCRIMINATOR: [u8; 8] = [197, 102, 253, 231, 77, 84, 50, 17];
+const EXECUTE_TX_SYNC_V2_DISCRIMINATOR: [u8; 8] = [90, 81, 187, 81, 39, 70, 128, 78];
+
+// Anchor account discriminator: sha256("account:ProgramConfig")[0..8]
+pub const PROGRAM_CONFIG_ACCOUNT_DISCRIMINATOR: [u8; 8] = [196, 210, 90, 231, 144, 149, 140, 63];
+
+// ---------------------------------------------------------------------------
+// PDA helpers
+// ---------------------------------------------------------------------------
+
+pub fn program_config_pda() -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[SEED_PREFIX, SEED_PROGRAM_CONFIG],
+        &SMART_ACCOUNT_PROGRAM_ID,
+    )
+}
+
+/// Deterministic non-executable treasury for tests. The ProgramConfig fixture
+/// stores this address so `create_smart_account` passes its treasury key check.
+pub fn treasury_pda() -> Pubkey {
+    let (pda, _) = Pubkey::find_program_address(
+        &[SEED_PREFIX, b"treasury"],
+        &SMART_ACCOUNT_PROGRAM_ID,
+    );
+    pda
+}
+
+pub fn settings_pda(seed: u128) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[SEED_PREFIX, SEED_SETTINGS, &seed.to_le_bytes()],
+        &SMART_ACCOUNT_PROGRAM_ID,
+    )
+}
+
+pub fn smart_account_pda(settings_key: &Pubkey, account_index: u8) -> (Pubkey, u8) {
+    Pubkey::find_program_address(
+        &[
+            SEED_PREFIX,
+            settings_key.as_ref(),
+            SEED_SMART_ACCOUNT,
+            &[account_index],
+        ],
+        &SMART_ACCOUNT_PROGRAM_ID,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Borsh types mirroring the on-chain program
+// ---------------------------------------------------------------------------
+
+#[derive(BorshSerialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Permissions {
+    pub mask: u8,
+}
+
+impl Permissions {
+    pub fn all() -> Self {
+        Self { mask: 0b111 }
+    }
+}
+
+#[derive(BorshSerialize, Clone, Debug, PartialEq, Eq)]
+pub struct SmartAccountSigner {
+    pub key: Pubkey,
+    pub permissions: Permissions,
+}
+
+#[derive(BorshSerialize)]
+struct CreateSmartAccountArgs {
+    settings_authority: Option<Pubkey>,
+    threshold: u16,
+    signers: Vec<SmartAccountSigner>,
+    time_lock: u32,
+    rent_collector: Option<Pubkey>,
+    memo: Option<String>,
+}
+
+#[derive(BorshSerialize)]
+struct SyncTransactionArgs {
+    account_index: u8,
+    num_signers: u8,
+    payload: SyncPayload,
+}
+
+#[derive(BorshSerialize)]
+enum SyncPayload {
+    Transaction(Vec<u8>),
+}
+
+// ---------------------------------------------------------------------------
+// Instruction builders
+// ---------------------------------------------------------------------------
+
+/// Build the `createSmartAccount` instruction.
+///
+/// Pass `settings_authority: Some(pubkey)` for a controlled account whose key
+/// management bypasses the threshold vote; `None` for an autonomous account.
+pub fn create_smart_account_ix(
+    creator: &Pubkey,
+    treasury: &Pubkey,
+    settings_seed: u128,
+    settings_authority: Option<Pubkey>,
+    signers: &[SmartAccountSigner],
+    threshold: u16,
+    time_lock: u32,
+) -> Instruction {
+    let (pc_pda, _) = program_config_pda();
+    let (settings_key, _) = settings_pda(settings_seed);
+
+    let args = CreateSmartAccountArgs {
+        settings_authority,
+        threshold,
+        signers: signers.to_vec(),
+        time_lock,
+        rent_collector: None,
+        memo: None,
+    };
+
+    let mut data = Vec::with_capacity(256);
+    data.extend_from_slice(&CREATE_SMART_ACCOUNT_DISCRIMINATOR);
+    args.serialize(&mut data)
+        .expect("serialize CreateSmartAccountArgs");
+
+    Instruction {
+        program_id: SMART_ACCOUNT_PROGRAM_ID,
+        accounts: vec![
+            AccountMeta::new(pc_pda, false),
+            AccountMeta::new(*treasury, false),
+            AccountMeta::new(*creator, true),
+            AccountMeta::new_readonly(Pubkey::default(), false),
+            AccountMeta::new_readonly(SMART_ACCOUNT_PROGRAM_ID, false),
+            AccountMeta::new(settings_key, false),
+        ],
+        data,
+    }
+}
+
+/// Build the `executeTransactionSyncV2` instruction.
+///
+/// Wraps `inner_instructions` via CPI; the vault PDA signs as the CPI signer.
+/// `signer_keys` are the threshold signers on the outer transaction.
+pub fn execute_sync_ix(
+    settings_key: &Pubkey,
+    account_index: u8,
+    signer_keys: &[Pubkey],
+    inner_instructions: &[Instruction],
+) -> Instruction {
+    let (vault_pda, _) = smart_account_pda(settings_key, account_index);
+
+    let (payload_bytes, cpi_account_metas) =
+        compile_instructions_to_payload(inner_instructions, &vault_pda);
+
+    let args = SyncTransactionArgs {
+        account_index,
+        num_signers: signer_keys.len() as u8,
+        payload: SyncPayload::Transaction(payload_bytes),
+    };
+
+    let mut data = Vec::with_capacity(512);
+    data.extend_from_slice(&EXECUTE_TX_SYNC_V2_DISCRIMINATOR);
+    args.serialize(&mut data)
+        .expect("serialize SyncTransactionArgs");
+
+    let mut accounts = vec![
+        AccountMeta::new(*settings_key, false),
+        AccountMeta::new_readonly(SMART_ACCOUNT_PROGRAM_ID, false),
+    ];
+    for key in signer_keys {
+        accounts.push(AccountMeta::new_readonly(*key, true));
+    }
+    accounts.extend(cpi_account_metas);
+
+    Instruction {
+        program_id: SMART_ACCOUNT_PROGRAM_ID,
+        accounts,
+        data,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Payload compilation (internal)
+// ---------------------------------------------------------------------------
+
+fn compile_instructions_to_payload(
+    instructions: &[Instruction],
+    vault_pda: &Pubkey,
+) -> (Vec<u8>, Vec<AccountMeta>) {
+    let mut account_keys: Vec<Pubkey> = Vec::new();
+    let mut account_metas: Vec<AccountMeta> = Vec::new();
+
+    let mut ensure_key = |key: &Pubkey, is_writable: bool, is_signer: bool| -> u8 {
+        if let Some(pos) = account_keys.iter().position(|k| k == key) {
+            if is_writable {
+                account_metas[pos] = AccountMeta::new(
+                    account_metas[pos].pubkey,
+                    account_metas[pos].is_signer || is_signer,
+                );
+            } else if is_signer && !account_metas[pos].is_signer {
+                account_metas[pos].is_signer = true;
+            }
+            pos as u8
+        } else {
+            let idx = account_keys.len();
+            account_keys.push(*key);
+            if is_writable {
+                account_metas.push(AccountMeta::new(*key, is_signer));
+            } else {
+                account_metas.push(AccountMeta::new_readonly(*key, is_signer));
+            }
+            idx as u8
+        }
+    };
+
+    ensure_key(vault_pda, true, false);
+
+    for ix in instructions {
+        ensure_key(&ix.program_id, false, false);
+        for meta in &ix.accounts {
+            ensure_key(&meta.pubkey, meta.is_writable, meta.is_signer);
+        }
+    }
+
+    let mut payload = Vec::new();
+    payload.push(instructions.len() as u8);
+
+    for ix in instructions {
+        let program_id_index = account_keys
+            .iter()
+            .position(|k| k == &ix.program_id)
+            .unwrap() as u8;
+        payload.push(program_id_index);
+
+        payload.push(ix.accounts.len() as u8);
+        for meta in &ix.accounts {
+            let idx = account_keys.iter().position(|k| k == &meta.pubkey).unwrap() as u8;
+            payload.push(idx);
+        }
+
+        let data_len = ix.data.len() as u16;
+        payload.extend_from_slice(&data_len.to_le_bytes());
+        payload.extend_from_slice(&ix.data);
+    }
+
+    for meta in &mut account_metas {
+        if meta.pubkey == *vault_pda {
+            meta.is_signer = false;
+        }
+    }
+
+    (payload, account_metas)
+}

--- a/program-tests/test-utils/src/smart_account.rs
+++ b/program-tests/test-utils/src/smart_account.rs
@@ -35,10 +35,8 @@ pub fn program_config_pda() -> (Pubkey, u8) {
 /// Deterministic non-executable treasury for tests. The ProgramConfig fixture
 /// stores this address so `create_smart_account` passes its treasury key check.
 pub fn treasury_pda() -> Pubkey {
-    let (pda, _) = Pubkey::find_program_address(
-        &[SEED_PREFIX, b"treasury"],
-        &SMART_ACCOUNT_PROGRAM_ID,
-    );
+    let (pda, _) =
+        Pubkey::find_program_address(&[SEED_PREFIX, b"treasury"], &SMART_ACCOUNT_PROGRAM_ID);
     pda
 }
 


### PR DESCRIPTION
## Summary

- Adds `program-tests/test-utils/src/smart_account.rs`: instruction builders and PDA helpers for the Squads smart account program (`SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG`), including `create_smart_account_ix` and `execute_sync_ix` (wraps inner instructions so the vault PDA signs via CPI).
- Creates three Squads smart accounts in `LifecycleWorld::new()`: protocol authority (autonomous, 1-of-1 in tests), forester (controlled), and merge (controlled). `protocol_authority`, `forester_authority`, and `merge_authority` in `ProtocolConfig` are now vault PDAs instead of the raw authority keypair.
- Injects a pre-initialised `ProgramConfig` fixture via `--account-dir` so smart account creation seeds are deterministic across test runs (protocol=1, forester=2, merge=3).
- Wraps `MergeTransact` in `execute_transaction_sync_v2` so the merge vault PDA signs as the merge authority.
- Adds `fetch-smart-account` justfile recipe to download the Squads binary from mainnet.
- Adds an Authority Governance section to `docs/spec.md` describing the hierarchy.

## Test plan

- [ ] `just fetch-smart-account` (run once to download the Squads binary)
- [ ] `just build-programs`
- [ ] `just test-programs` — all 18 merge scenarios pass