### PR TITLE
refactor: make prover auto-download configurable

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -189,6 +189,16 @@ pub(crate) struct TestValidatorOptions {
     pub(crate) prover_port: u16,
 
     #[arg(
+        long = "prover-auto-download",
+        env = "ZOLANA_PROVER_AUTO_DOWNLOAD",
+        default_value_t = true,
+        action = ArgAction::Set,
+        value_parser = clap::builder::FalseyValueParser::new(),
+        help = "Allow the prover to download missing proving keys"
+    )]
+    pub(crate) prover_auto_download: bool,
+
+    #[arg(
         long,
         default_value_t = DEFAULT_PHOTON_PORT,
         help = "Photon indexer API port"
@@ -291,6 +301,16 @@ pub(crate) struct StartProverOptions {
         help = "Redis URL for prover state"
     )]
     pub(crate) redis_url: Option<String>,
+
+    #[arg(
+        long = "auto-download",
+        env = "ZOLANA_PROVER_AUTO_DOWNLOAD",
+        default_value_t = true,
+        action = ArgAction::Set,
+        value_parser = clap::builder::FalseyValueParser::new(),
+        help = "Allow the prover to download missing proving keys"
+    )]
+    pub(crate) auto_download: bool,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -684,6 +704,25 @@ mod tests {
 
         assert_eq!(opts.prover_port, 3002);
         assert_eq!(opts.redis_url.as_deref(), Some("redis://localhost:6379/15"));
+    }
+
+    #[test]
+    fn parses_start_prover_auto_download_option() {
+        let command = parse_cli(&["start-prover", "--auto-download", "off"])
+            .command
+            .expect("command");
+        let CliCommand::StartProver(opts) = command else {
+            panic!("expected start-prover command");
+        };
+
+        assert!(!opts.auto_download);
+    }
+
+    #[test]
+    fn parses_test_validator_prover_auto_download_option() {
+        let opts = parse_validator(&["--prover-auto-download", "off"]);
+
+        assert!(!opts.prover_auto_download);
     }
 
     #[test]

--- a/cli/src/localnet.rs
+++ b/cli/src/localnet.rs
@@ -57,7 +57,12 @@ pub(crate) fn run_test_validator(opts: TestValidatorOptions) -> Result<()> {
     })?;
 
     if !opts.skip_prover {
-        start_prover_service(opts.prover_port, None, &opts.log_dir)?;
+        start_prover_service(
+            opts.prover_port,
+            None,
+            opts.prover_auto_download,
+            &opts.log_dir,
+        )?;
     }
 
     if opts.with_photon {

--- a/cli/src/prover.rs
+++ b/cli/src/prover.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::Path};
+use std::{env, fs, path::Path};
 
 use anyhow::{Context, Result};
 
@@ -13,12 +13,18 @@ use crate::{
 };
 
 pub(crate) fn run_start_prover(opts: StartProverOptions) -> Result<()> {
-    start_prover_service(opts.prover_port, opts.redis_url.as_deref(), DEFAULT_LOG_DIR)
+    start_prover_service(
+        opts.prover_port,
+        opts.redis_url.as_deref(),
+        opts.auto_download,
+        DEFAULT_LOG_DIR,
+    )
 }
 
 pub(crate) fn start_prover_service(
     prover_port: u16,
     redis_url: Option<&str>,
+    auto_download: bool,
     log_dir: &str,
 ) -> Result<()> {
     // The prover's Prometheus metrics server defaults to the fixed port 9998, so
@@ -41,23 +47,13 @@ pub(crate) fn start_prover_service(
     fs::create_dir_all(&keys_dir)
         .with_context(|| format!("failed to create prover keys dir {}", keys_dir.display()))?;
 
-    let mut args = vec![
-        "start".to_string(),
-        "--keys-dir".to_string(),
-        path_string_with_trailing_separator(&keys_dir)?,
-        "--prover-address".to_string(),
-        format!("0.0.0.0:{prover_port}"),
-        "--metrics-address".to_string(),
-        format!("0.0.0.0:{metrics_port}"),
-        "--auto-download".to_string(),
-        "true".to_string(),
-    ];
-
-    if let Some(redis_url) = redis_url {
-        args.push("--redis-url".to_string());
-        args.push(redis_url.to_string());
-    }
-
+    let args = prover_start_args(
+        prover_port,
+        metrics_port,
+        redis_url,
+        auto_download,
+        &keys_dir,
+    )?;
     println!("Starting prover: {} {}", prover.display(), args.join(" "));
     let mut child = spawn_service(&prover, &args, "prover-server", log_dir)?;
     wait_for_http_get_with_child(
@@ -74,11 +70,73 @@ pub(crate) fn start_prover_service(
     Ok(())
 }
 
+fn prover_start_args(
+    prover_port: u16,
+    metrics_port: u16,
+    redis_url: Option<&str>,
+    auto_download: bool,
+    keys_dir: &Path,
+) -> Result<Vec<String>> {
+    let mut args = vec![
+        "start".into(),
+        "--keys-dir".into(),
+        path_string_with_trailing_separator(keys_dir)?,
+        "--prover-address".into(),
+        format!("0.0.0.0:{prover_port}"),
+        "--metrics-address".into(),
+        format!("0.0.0.0:{metrics_port}"),
+        "--auto-download".into(),
+        auto_download.to_string(),
+    ];
+
+    if let Some(redis_url) = redis_url {
+        args.extend(["--redis-url".into(), redis_url.into()]);
+    }
+
+    Ok(args)
+}
+
 fn prover_keys_dir() -> Result<std::path::PathBuf> {
-    if let Ok(path) = std::env::var("ZOLANA_PROVER_KEYS_DIR") {
+    if let Ok(path) = env::var("ZOLANA_PROVER_KEYS_DIR") {
         return Ok(path.into());
     }
 
-    let home = std::env::var("HOME").context("HOME is not set")?;
+    let home = env::var("HOME").context("HOME is not set")?;
     Ok(Path::new(&home).join(".config/zolana/proving-keys"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::prover_start_args;
+
+    #[test]
+    fn prover_args_forward_auto_download_and_metrics_port() {
+        let args = prover_start_args(
+            3002,
+            9999,
+            Some("redis://localhost:6379/15"),
+            false,
+            Path::new("/tmp/zolana-keys"),
+        )
+        .expect("build prover args");
+
+        assert_eq!(
+            args,
+            vec![
+                "start",
+                "--keys-dir",
+                "/tmp/zolana-keys/",
+                "--prover-address",
+                "0.0.0.0:3002",
+                "--metrics-address",
+                "0.0.0.0:9999",
+                "--auto-download",
+                "false",
+                "--redis-url",
+                "redis://localhost:6379/15",
+            ]
+        );
+    }
 }


### PR DESCRIPTION
## Current CLI state (as of 2026-07-07)

This PR is narrow: it only makes prover key auto-download configurable. It does not change the wallet transaction surface.

- `zolana start-prover --auto-download <bool>` controls whether the child prover may download missing proving keys.
- `zolana test-validator --prover-auto-download <bool>` forwards the same setting when the local validator launcher starts the prover; it has no effect with `--skip-prover`.
- `ZOLANA_PROVER_AUTO_DOWNLOAD` provides the same setting for both commands.
- The default remains `true`, preserving the current local-dev behavior.
- The prover still uses `ZOLANA_PROVER_KEYS_DIR` when set, otherwise `~/.config/zolana/proving-keys`.

## Why this exists

The CLI currently starts the prover in a convenience-first mode where missing keys can be fetched implicitly. That is good for local development, but awkward for CI, offline runs, preloaded-key environments, or production-shaped smoke tests where startup should fail fast instead of reaching the network. This keeps the convenient default while giving callers a deterministic `--auto-download false` / `ZOLANA_PROVER_AUTO_DOWNLOAD=false` path.

## Rebase notes

- Rebased onto current `main` (`2e1d7c81`).
- Resolved the only conflict in `cli/src/prover.rs` by preserving current main's offset `--metrics-address` behavior and threading this PR's configurable `--auto-download` through the same helper.
- Kept the diff scoped to `cli/src/args.rs`, `cli/src/localnet.rs`, and `cli/src/prover.rs`.

## Validation

- `cargo fmt -p zolana-cli`
- `cargo test -p zolana-cli -- --nocapture` (27 passed)
