### PR TITLE
feat: optional memo on proofless deposit output

### DIFF
--- a/cli/src/wallet_cli/deposit.rs
+++ b/cli/src/wallet_cli/deposit.rs
@@ -38,6 +38,7 @@ pub(super) fn run_deposit(opts: DepositOptions) -> Result<()> {
         asset,
         amount: opts.amount,
         spl_token_account,
+        memo: None,
     })?;
     let signature = deposit.send(&rpc, &material.funding, tree, &material.funding)?;
     wait_for_indexed_utxo(&indexer, deposit.view_tag(), signature)?;

--- a/program-libs/event/src/proofless.rs
+++ b/program-libs/event/src/proofless.rs
@@ -11,6 +11,9 @@ pub struct ProoflessOutput {
     pub zone_program_id: Option<[u8; 32]>,
     pub zone_data_hash: Option<[u8; 32]>,
     pub zone_data: Option<Vec<u8>>,
+    /// Optional free-form memo, emitted in the clear. Not committed into any
+    /// hash, so it is informational only.
+    pub memo: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
@@ -37,4 +40,29 @@ pub fn encode_output_data(data: ProoflessOutput) -> Vec<u8> {
 pub fn encode_verifiably_encrypted(blob: Vec<u8>) -> Vec<u8> {
     borsh::to_vec(&OutputData::VerifiablyEncrypted(blob))
         .expect("shielded-pool output data serialization is infallible")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proofless_output_memo_round_trips() {
+        let output = ProoflessOutput {
+            owner: [1u8; 32],
+            blinding: [2u8; 31],
+            asset: [3u8; 32],
+            amount: 99,
+            data_hash: None,
+            utxo_data: None,
+            zone_program_id: None,
+            zone_data_hash: None,
+            zone_data: None,
+            memo: Some(b"hello".to_vec()),
+        };
+        let bytes = borsh::to_vec(&output).unwrap();
+        let parsed = ProoflessOutput::try_from_slice(&bytes).unwrap();
+        assert_eq!(parsed, output);
+        assert_eq!(parsed.memo.as_deref(), Some(b"hello".as_slice()));
+    }
 }

--- a/program-libs/interface/src/instruction/builders/deposit.rs
+++ b/program-libs/interface/src/instruction/builders/deposit.rs
@@ -25,6 +25,8 @@ pub struct Deposit {
     /// Application data committed into the deposited UTXO's `data_hash`,
     /// authorized by the payer; `None` for a plain user deposit.
     pub utxo_data: Option<UtxoData>,
+    /// Optional free-form memo emitted in the clear with the proofless output.
+    pub memo: Option<Vec<u8>>,
 }
 
 impl Deposit {
@@ -35,6 +37,7 @@ impl Deposit {
             blinding: self.blinding,
             public_amount: self.public_amount,
             utxo_data: self.utxo_data.clone(),
+            memo: self.memo.clone(),
         };
 
         let mut data = vec![tag::DEPOSIT];

--- a/program-libs/interface/src/instruction/builders/zone_deposit.rs
+++ b/program-libs/interface/src/instruction/builders/zone_deposit.rs
@@ -23,6 +23,8 @@ pub struct ZoneDeposit {
     /// `ZoneConfig` account; `None` if the zone deposit carries no application
     /// data.
     pub utxo_data: Option<UtxoData>,
+    /// Optional free-form memo emitted in the clear with the proofless output.
+    pub memo: Option<Vec<u8>>,
 }
 
 impl ZoneDeposit {
@@ -47,6 +49,7 @@ impl ZoneDeposit {
             zone_data_hash: self.zone_data_hash,
             zone_data: self.zone_data.clone(),
             utxo_data: self.utxo_data.clone(),
+            memo: self.memo.clone(),
         };
 
         let mut data = vec![tag::ZONE_DEPOSIT];

--- a/program-libs/interface/src/instruction/instruction_data/deposit.rs
+++ b/program-libs/interface/src/instruction/instruction_data/deposit.rs
@@ -33,6 +33,10 @@ pub struct DepositIxData {
     /// payer; `None` for a plain user deposit. Policy-zone deposits use
     /// [`ZoneDepositIxData`].
     pub utxo_data: Option<UtxoData>,
+    /// Optional free-form memo emitted in the clear with the proofless output.
+    /// Not committed into any hash, so it is informational only.
+    #[wincode(with = "Option<containers::Vec<u8, FixIntLen<u16>>>")]
+    pub memo: Option<Vec<u8>>,
 }
 
 impl DepositIxData {
@@ -68,6 +72,10 @@ pub struct ZoneDepositIxData {
     /// `ZoneConfig` account; `None` if the zone deposit carries no application
     /// data.
     pub utxo_data: Option<UtxoData>,
+    /// Optional free-form memo emitted in the clear with the proofless output.
+    /// Not committed into any hash, so it is informational only.
+    #[wincode(with = "Option<containers::Vec<u8, FixIntLen<u16>>>")]
+    pub memo: Option<Vec<u8>>,
 }
 
 impl ZoneDepositIxData {
@@ -77,5 +85,26 @@ impl ZoneDepositIxData {
 
     pub fn deserialize(data: &[u8]) -> Result<Self, wincode::Error> {
         Ok(wincode::deserialize_exact(data)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deposit_ix_data_memo_round_trips() {
+        let data = DepositIxData {
+            view_tag: [1u8; 32],
+            owner: [2u8; 32],
+            blinding: [3u8; 31],
+            public_amount: Some(1_000),
+            utxo_data: None,
+            memo: Some(b"hello memo".to_vec()),
+        };
+        let bytes = data.serialize().unwrap();
+        let parsed = DepositIxData::deserialize(&bytes).unwrap();
+        assert_eq!(parsed, data);
+        assert_eq!(parsed.memo.as_deref(), Some(b"hello memo".as_slice()));
     }
 }

--- a/program-tests/shielded-pool/tests/bench_cu.rs
+++ b/program-tests/shielded-pool/tests/bench_cu.rs
@@ -271,6 +271,7 @@ fn bench_deposit_sol(mollusk: &Mollusk, program_id: &MolluskPubkey, bench: &mut 
         blinding: data.blinding,
         public_amount: data.public_amount,
         utxo_data: data.utxo_data.clone(),
+        memo: None,
     }
     .instruction();
 
@@ -330,6 +331,7 @@ fn bench_deposit_spl(
         blinding: data.blinding,
         public_amount: data.public_amount,
         utxo_data: data.utxo_data.clone(),
+        memo: None,
     }
     .instruction();
 

--- a/program-tests/shielded-pool/tests/steps/deposit.rs
+++ b/program-tests/shielded-pool/tests/steps/deposit.rs
@@ -67,8 +67,11 @@ fn shield_sol(world: &mut ShieldedPoolWorld, amount: u64) {
     let mut recipient =
         Wallet::new(ShieldedKeypair::new().expect("recipient keypair")).expect("wallet");
     let seed = [3u8; BLINDING_LEN];
-    let data = ZolanaProgramTest::wallet_sol_shield_data(amount, &recipient, &seed, 0)
+    let mut data = ZolanaProgramTest::wallet_sol_shield_data(amount, &recipient, &seed, 0)
         .expect("wallet deposit data");
+    // Exercise the proofless memo end-to-end: instruction data -> emitted event
+    // -> recipient wallet discovery.
+    data.memo = Some(b"shielded memo".to_vec());
     let root_before = world.rpc().state_root(&tree).expect("root");
     let depositor = world.depositor().insecure_clone();
     let event = world

--- a/program-tests/shielded-pool/tests/steps/zone_deposit.rs
+++ b/program-tests/shielded-pool/tests/steps/zone_deposit.rs
@@ -148,6 +148,7 @@ fn zone_shield_wrong_signer(world: &mut ShieldedPoolWorld) {
         zone_data_hash: data.zone_data_hash,
         zone_data: data.zone_data.clone(),
         utxo_data: data.utxo_data.clone(),
+        memo: None,
     }
     .cpi_instruction();
     if let Some(meta) = ix.accounts.get_mut(2) {

--- a/program-tests/spp-test-validator/tests/deposit_action.rs
+++ b/program-tests/spp-test-validator/tests/deposit_action.rs
@@ -109,6 +109,7 @@ impl Deposit<'_> {
             blinding,
             public_amount: Some(self.amount),
             utxo_data: None,
+            memo: None,
         };
         let ix = DepositInstruction {
             tree: self.tree,
@@ -119,6 +120,7 @@ impl Deposit<'_> {
             blinding: data.blinding,
             public_amount: data.public_amount,
             utxo_data: data.utxo_data.clone(),
+            memo: data.memo.clone(),
         }
         .instruction();
         let mut signers: Vec<&Keypair> = vec![payer];

--- a/program-tests/test-utils/src/litesvm_asserts/deposit.rs
+++ b/program-tests/test-utils/src/litesvm_asserts/deposit.rs
@@ -29,6 +29,10 @@ pub fn litesvm_assert_deposit(
     assert_eq!(event.output.owner, data.owner, "owner");
     assert_eq!(event.view_tag, data.view_tag, "view tag");
     assert_eq!(event.output.blinding, data.blinding, "blinding");
+    assert_eq!(
+        event.output.memo, data.memo,
+        "event memo mirrors instruction data"
+    );
 
     let root_after = program_test.state_root(tree).expect("state root");
     assert_ne!(root_after, root_before, "leaf must be appended");
@@ -69,4 +73,9 @@ pub fn litesvm_assert_deposit(
         "wallet UTXO hash"
     );
     assert_eq!(utxo.utxo.amount, event.output.amount, "wallet UTXO amount");
+    assert_eq!(
+        utxo.utxo.data.memo().map(<[u8]>::to_vec),
+        data.memo,
+        "wallet UTXO memo mirrors the deposited memo"
+    );
 }

--- a/program-tests/test-utils/src/test_validator_asserts/mod.rs
+++ b/program-tests/test-utils/src/test_validator_asserts/mod.rs
@@ -56,6 +56,7 @@ pub fn expected_deposit_view(
             zone_program_id: None,
             zone_data_hash: None,
             zone_data: None,
+            memo: None,
         },
     }
 }

--- a/program-tests/test-utils/src/test_validator_asserts/zone_deposit.rs
+++ b/program-tests/test-utils/src/test_validator_asserts/zone_deposit.rs
@@ -56,6 +56,7 @@ pub fn assert_zone_deposit<R: Rpc, I: Rpc>(
             zone_program_id: Some(expected_zone_program_id),
             zone_data_hash: Some(data.zone_data_hash),
             zone_data: Some(data.zone_data.clone()),
+            memo: None,
         },
     };
     assert_eq!(*event, expected, "zone deposit event");

--- a/program-tests/zone-test-program/tests/steps/zone_deposit.rs
+++ b/program-tests/zone-test-program/tests/steps/zone_deposit.rs
@@ -46,6 +46,7 @@ impl ZoneLifecycleWorld {
             zone_data_hash: [0u8; 32],
             zone_data: Vec::new(),
             utxo_data: None,
+            memo: None,
         })
     }
 
@@ -75,6 +76,7 @@ impl ZoneLifecycleWorld {
             zone_data_hash: data.zone_data_hash,
             zone_data: data.zone_data.clone(),
             utxo_data: data.utxo_data.clone(),
+            memo: None,
         }
         .instruction();
         let signature = send_transaction(&mut self.rpc, &[ix], &depositor.pubkey(), &[&depositor])?;
@@ -143,6 +145,7 @@ impl ZoneLifecycleWorld {
             zone_data_hash: data.zone_data_hash,
             zone_data: data.zone_data.clone(),
             utxo_data: data.utxo_data.clone(),
+            memo: None,
         }
         .instruction();
         let signature = send_transaction(&mut self.rpc, &[ix], &payer.pubkey(), &[&payer])?;
@@ -227,6 +230,7 @@ impl ZoneLifecycleWorld {
             zone_data_hash: [0u8; 32],
             zone_data: Vec::new(),
             utxo_data: None,
+            memo: None,
         }
         .cpi_instruction();
         // Swap the zone config account (index 2) for a non-PDA signer.

--- a/programs/shielded-pool/src/instructions/deposit/event.rs
+++ b/programs/shielded-pool/src/instructions/deposit/event.rs
@@ -36,6 +36,7 @@ pub(crate) fn emit_proofless_event(d: DepositParams, ctx: ProoflessOutputCtx) ->
         zone_program_id: ctx.zone_program_id,
         zone_data_hash,
         zone_data,
+        memo: d.memo,
     });
     let event = GeneralEvent {
         inputs: Vec::new(),

--- a/programs/shielded-pool/src/instructions/deposit/processor.rs
+++ b/programs/shielded-pool/src/instructions/deposit/processor.rs
@@ -30,6 +30,7 @@ pub(crate) struct DepositParams {
     pub public_amount: Option<u64>,
     pub utxo_data: Option<UtxoData>,
     pub zone: Option<ZoneData>,
+    pub memo: Option<Vec<u8>>,
 }
 
 #[profile]
@@ -52,6 +53,7 @@ pub fn process_deposit(accounts: &mut [AccountView], data: &[u8]) -> ProgramResu
             public_amount: data.public_amount,
             utxo_data: data.utxo_data,
             zone: None,
+            memo: data.memo,
         },
     )
 }
@@ -78,6 +80,7 @@ pub fn process_zone_deposit(accounts: &mut [AccountView], data: &[u8]) -> Progra
                 data_hash: data.zone_data_hash,
                 data: data.zone_data,
             }),
+            memo: data.memo,
         },
     )
 }

--- a/sdk-libs/client/src/actions/deposit.rs
+++ b/sdk-libs/client/src/actions/deposit.rs
@@ -32,6 +32,8 @@ pub struct CreateDeposit<'a> {
     pub asset: Address,
     pub amount: u64,
     pub spl_token_account: Option<Pubkey>,
+    /// Optional free-form memo emitted in the clear with the deposit.
+    pub memo: Option<Vec<u8>>,
 }
 
 impl Deposit {
@@ -59,6 +61,7 @@ impl Deposit {
                 blinding,
                 public_amount: Some(request.amount),
                 utxo_data: None,
+                memo: request.memo,
             },
             utxo_hash,
             asset: request.asset,
@@ -127,6 +130,7 @@ fn deposit_instruction(
         blinding: data.blinding,
         public_amount: data.public_amount,
         utxo_data: data.utxo_data.clone(),
+        memo: data.memo.clone(),
     }
     .instruction()
 }
@@ -189,6 +193,7 @@ mod tests {
             blinding: [3u8; 31],
             public_amount: Some(1_000),
             utxo_data: None,
+            memo: Some(b"thanks".to_vec()),
         };
 
         deposit(&rpc, &payer, tree, &depositor, None, &data).expect("action");
@@ -203,6 +208,7 @@ mod tests {
             blinding: data.blinding,
             public_amount: data.public_amount,
             utxo_data: data.utxo_data.clone(),
+            memo: data.memo.clone(),
         }
         .instruction();
         assert_eq!(sent.message.instructions.len(), 1);
@@ -220,6 +226,7 @@ mod tests {
             asset: SOL_MINT,
             amount: 1_000,
             spl_token_account: None,
+            memo: None,
         })
         .expect("prepared deposit");
 
@@ -242,6 +249,7 @@ mod tests {
             recipient: &recipient_address,
             asset,
             amount: 1_000,
+            memo: None,
             spl_token_account: Some(user_token),
         })
         .expect("prepared deposit");

--- a/sdk-libs/client/src/wallet_sync.rs
+++ b/sdk-libs/client/src/wallet_sync.rs
@@ -935,6 +935,7 @@ mod tests {
             zone_program_id: None,
             zone_data_hash: None,
             zone_data: None,
+            memo: None,
         }
     }
 

--- a/sdk-libs/program-test/src/indexer.rs
+++ b/sdk-libs/program-test/src/indexer.rs
@@ -50,6 +50,8 @@ pub struct ProoflessOutput {
     pub amount: u64,
     /// Blinding sent in the clear for the recipient to spend the note.
     pub blinding: [u8; 31],
+    /// Optional free-form memo emitted in the clear with the deposit.
+    pub memo: Option<Vec<u8>>,
 }
 
 impl IndexedUtxo {
@@ -112,6 +114,7 @@ impl TestIndexer {
                 asset: event.output.asset,
                 amount: event.output.amount,
                 blinding: event.output.blinding,
+                memo: event.output.memo.clone(),
             }),
         });
         Ok(&self.utxos[record_index])

--- a/sdk-libs/program-test/src/proofless.rs
+++ b/sdk-libs/program-test/src/proofless.rs
@@ -25,6 +25,7 @@ impl ZolanaProgramTest {
             blinding: data.blinding,
             public_amount: data.public_amount,
             utxo_data: data.utxo_data.clone(),
+            memo: data.memo.clone(),
         }
         .instruction();
         self.send_deposit_ix(ix, depositor)
@@ -52,6 +53,7 @@ impl ZolanaProgramTest {
             blinding: data.blinding,
             public_amount: data.public_amount,
             utxo_data: data.utxo_data.clone(),
+            memo: data.memo.clone(),
         }
         .instruction();
         self.send_deposit_ix(ix, depositor)
@@ -72,6 +74,7 @@ impl ZolanaProgramTest {
             blinding: data.blinding,
             public_amount: data.public_amount,
             utxo_data: data.utxo_data.clone(),
+            memo: data.memo.clone(),
         }
         .instruction();
         ix.program_id = self.program_id;

--- a/sdk-libs/program-test/src/wallet_data.rs
+++ b/sdk-libs/program-test/src/wallet_data.rs
@@ -39,6 +39,7 @@ impl ZolanaProgramTest {
             blinding,
             public_amount: Some(lamports),
             utxo_data: None,
+            memo: None,
         }
     }
 
@@ -53,6 +54,7 @@ impl ZolanaProgramTest {
             blinding,
             public_amount: Some(amount),
             utxo_data: None,
+            memo: None,
         }
     }
 
@@ -69,6 +71,7 @@ impl ZolanaProgramTest {
             blinding: fields.blinding,
             public_amount: Some(lamports),
             utxo_data: None,
+            memo: None,
         })
     }
 
@@ -85,6 +88,7 @@ impl ZolanaProgramTest {
             blinding: fields.blinding,
             public_amount: Some(amount),
             utxo_data: None,
+            memo: None,
         })
     }
 }

--- a/sdk-libs/program-test/src/zone.rs
+++ b/sdk-libs/program-test/src/zone.rs
@@ -111,6 +111,7 @@ impl ZolanaProgramTest {
             zone_data_hash: [0u8; 32],
             zone_data: Vec::new(),
             utxo_data: None,
+            memo: None,
         }
     }
 
@@ -129,6 +130,7 @@ impl ZolanaProgramTest {
             zone_data_hash: [0u8; 32],
             zone_data: Vec::new(),
             utxo_data: None,
+            memo: None,
         })
     }
 
@@ -147,6 +149,7 @@ impl ZolanaProgramTest {
             zone_data_hash: [0u8; 32],
             zone_data: Vec::new(),
             utxo_data: None,
+            memo: None,
         })
     }
 
@@ -168,6 +171,7 @@ impl ZolanaProgramTest {
             zone_data_hash: data.zone_data_hash,
             zone_data: data.zone_data.clone(),
             utxo_data: data.utxo_data.clone(),
+            memo: data.memo.clone(),
         }
         .instruction();
         let outcome = self.create_and_send_default_payer_transaction(&[ix], &[depositor])?;
@@ -199,6 +203,7 @@ impl ZolanaProgramTest {
             zone_data_hash: data.zone_data_hash,
             zone_data: data.zone_data.clone(),
             utxo_data: data.utxo_data.clone(),
+            memo: data.memo.clone(),
         }
         .instruction();
         let outcome = self.create_and_send_default_payer_transaction(&[ix], &[depositor])?;

--- a/sdk-libs/transaction/src/serialization/proofless.rs
+++ b/sdk-libs/transaction/src/serialization/proofless.rs
@@ -40,6 +40,9 @@ impl UtxoSerialization for Proofless {
         if let Some(utxo_data) = output.utxo_data {
             records.push(DataRecord::UtxoData(utxo_data));
         }
+        if let Some(memo) = output.memo {
+            records.push(DataRecord::Memo(memo));
+        }
         Ok(vec![Utxo {
             owner: cx.owner,
             asset: Address::new_from_array(output.asset),
@@ -66,6 +69,7 @@ impl UtxoSerialization for Proofless {
             zone_program_id: utxo.zone_program_id.map(|address| address.to_bytes()),
             zone_data_hash: cx.zone_data_hash,
             zone_data: utxo.data.zone_data().map(<[u8]>::to_vec),
+            memo: utxo.data.memo().map(<[u8]>::to_vec),
         })
     }
 
@@ -75,5 +79,46 @@ impl UtxoSerialization for Proofless {
 
     fn encrypt(bytes: &[u8], _cx: &Self::EncodeCx) -> Result<Vec<u8>, TransactionError> {
         Ok(bytes.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zolana_keypair::PublicKey;
+
+    use super::*;
+    use crate::{AssetRegistry, SOL_MINT};
+
+    #[test]
+    fn memo_round_trips_through_proofless_serialization() {
+        let owner = PublicKey::zeroed();
+        let utxo = Utxo {
+            owner,
+            asset: SOL_MINT,
+            amount: 42,
+            blinding: [3u8; 31],
+            zone_program_id: None,
+            data: Data::new(vec![DataRecord::Memo(b"gm".to_vec())]),
+        };
+        let assets = AssetRegistry::default();
+        let owner_cx = OwnerCx {
+            owner,
+            assets: &assets,
+            zone_program_id: None,
+        };
+        let encode_cx = ProoflessEncode {
+            owner_hash: [0u8; 32],
+            data_hash: None,
+            zone_data_hash: None,
+        };
+
+        let plaintext = Proofless::from_utxos(&[utxo], &owner_cx, &encode_cx).unwrap();
+        assert_eq!(plaintext.memo.as_deref(), Some(b"gm".as_slice()));
+
+        let bytes = Proofless::serialize(&plaintext).unwrap();
+        let parsed = Proofless::deserialize(&bytes).unwrap();
+        let utxos = Proofless::into_utxos(parsed, &owner_cx).unwrap();
+        let recovered = utxos.first().expect("one utxo");
+        assert_eq!(recovered.data.memo(), Some(b"gm".as_slice()));
     }
 }

--- a/sdk-libs/transaction/tests/wallet_proofless.rs
+++ b/sdk-libs/transaction/tests/wallet_proofless.rs
@@ -29,6 +29,7 @@ fn self_consistent_deposit(wallet: &Wallet, amount: u64) -> ShieldedTransaction 
         zone_program_id: None,
         zone_data_hash: None,
         zone_data: None,
+        memo: Some(b"deposit memo".to_vec()),
     };
 
     ShieldedTransaction {
@@ -75,6 +76,11 @@ fn sync_discovers_and_spends_proofless_deposit() {
     let discovered = wallet.utxos.first().expect("discovered utxo");
     assert_eq!(discovered.output_context.hash, deposit_hash);
     assert!(!discovered.spent);
+    assert_eq!(
+        discovered.utxo.data.memo(),
+        Some(b"deposit memo".as_slice()),
+        "proofless memo survives decode into the discovered UTXO"
+    );
     let nullifier = discovered.nullifier;
 
     wallet


### PR DESCRIPTION
## Summary

Extends the optional **memo** to the proofless (deposit) rail, completing the memo work begun for the transfer rails in #93.

**Stacked on `jorrit/feat-memo-field` (#93)** — it depends on the `DataRecord::Memo` variant introduced there. GitHub will auto-retarget this PR to `main` once #93 merges.

### Design: plaintext, uncommitted

Unlike the transfer rails (where the memo rides inside the recipient's encrypted `Data`), a proofless deposit emits its output **in the clear** on-chain. So the memo travels:

```
DepositIxData (depositor-signed) -> program -> emitted ProoflessOutput event -> wallet discovery
```

It is **not committed** into any hash (`data_hash`/`zone_data_hash` cover only `utxo_data`/`zone_data`), so it stays optional and informational. It is still authenticated by the deposit transaction signature, but is not bound to the UTXO commitment (so it does not affect spendability).

## Changes

- **interface**: `memo: Option<Vec<u8>>` on `DepositIxData`/`ZoneDepositIxData` (wincode `Option<Vec<u8, u16>>`) and the `Deposit`/`ZoneDeposit` builders.
- **event**: `memo` field on `ProoflessOutput` (borsh).
- **program**: threaded through `DepositParams` into the emitted event for both `deposit` and `zone_deposit`.
- **sdk transaction**: `Proofless::from_utxos` sets `memo`; `into_utxos` restores it as `DataRecord::Memo` in canonical order.
- **client + test harness**: forward `memo` through the deposit actions and the program-test `deposit`/`zone_deposit` helpers (they previously dropped it).

## Tests (all green)

- `ProoflessOutput` borsh round-trip; `DepositIxData` wincode round-trip (both full-struct `assert_eq`).
- SDK `Proofless` `from_utxos` -> serialize -> deserialize -> `into_utxos` round-trip.
- `wallet_proofless` end-to-end: the synced wallet UTXO carries the memo.
- litesvm deposit BDD scenario asserting the emitted event **and** the discovered wallet UTXO carry the memo (32/32 BDD scenarios pass).
- `cargo check --workspace --all-targets`, nightly `rustfmt`, and `clippy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
