### PR TITLE
feat: permissionless spl interface creation

### DIFF
--- a/cli/src/wallet_cli/tree.rs
+++ b/cli/src/wallet_cli/tree.rs
@@ -42,6 +42,7 @@ pub(super) fn run_create_tree(opts: CreateTreeOptions) -> Result<()> {
             forester_authority: authority_address,
             zone_creation_authority: authority_address,
             zone_creation_is_permissionless: false,
+            spl_interface_creation_is_permissionless: false,
         }
         .instruction();
         let signature =

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1112,6 +1112,9 @@ struct ProtocolConfig {
     /// Permitted to call `create_zone_config` unless `zone_creation_is_permissionless`.
     zone_creation_authority: Address,
     zone_creation_is_permissionless: bool,
+    /// When set, any signer may call `create_spl_interface`; otherwise it is
+    /// gated by `protocol_authority`.
+    spl_interface_creation_is_permissionless: bool,
 }
 ```
 
@@ -1180,7 +1183,7 @@ Usage by instruction:
 | zone_transact | Tag 2; implements shield/unshield/shielded transfer; verifies proofs, updates trees; checks that the encrypted UTXOs decrypt under the zone auditor key and the recipient keys named in the policy proof |
 | zone_proofless_shield | Tag 1; public deposit without a proof; the recipient `owner` and `blinding` are sent in the clear. See [`proofless_shield`](#proofless_shield). |
 | zone_authority_transact | Tag 3; checks zone pda is signer, checks state transition only includes zone program owned UTXOs. UTXO owners don't sign zone has full control subject to its policy.  |
-| create_spl_interface | Tag 4; gated by `protocol_config.protocol_authority`; reads + bumps the `Asset counter`, creates the per-mint SPL interface vault and writes the assigned `asset_id` into the per-mint `Asset registry` PDA. |
+| create_spl_interface | Tag 4; gated by `protocol_config.protocol_authority` unless `spl_interface_creation_is_permissionless`; reads + bumps the `Asset counter`, creates the per-mint SPL interface vault and writes the assigned `asset_id` into the per-mint `Asset registry` PDA. |
 | create_tree | Tag 5; gated by `protocol_config.tree_creation_authority` unless `tree_creation_is_permissionless`; initializes the shared Tree account (nullifier tree + queue, UTXO tree) |
 | create_protocol_config | Tag 6; the transaction signer must equal the `protocol_authority` it writes |
 | update_protocol_config | Tag 7; gated by `protocol_config.protocol_authority`; rewrites every authority and flag |

--- a/program-libs/interface/src/instruction/builders/protocol_config/mod.rs
+++ b/program-libs/interface/src/instruction/builders/protocol_config/mod.rs
@@ -20,6 +20,7 @@ pub struct CreateProtocolConfig {
     pub forester_authority: Address,
     pub zone_creation_authority: Address,
     pub zone_creation_is_permissionless: bool,
+    pub spl_interface_creation_is_permissionless: bool,
 }
 
 impl CreateProtocolConfig {
@@ -31,6 +32,8 @@ impl CreateProtocolConfig {
             forester_authority: self.forester_authority,
             zone_creation_authority: self.zone_creation_authority,
             zone_creation_is_permissionless: self.zone_creation_is_permissionless as u8,
+            spl_interface_creation_is_permissionless: self.spl_interface_creation_is_permissionless
+                as u8,
         };
 
         Instruction {

--- a/program-libs/interface/src/instruction/instruction_data/protocol_config.rs
+++ b/program-libs/interface/src/instruction/instruction_data/protocol_config.rs
@@ -11,6 +11,7 @@ pub struct CreateProtocolConfigData {
     pub forester_authority: Address,
     pub zone_creation_authority: Address,
     pub zone_creation_is_permissionless: u8,
+    pub spl_interface_creation_is_permissionless: u8,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
@@ -21,6 +22,7 @@ pub enum UpdateProtocolConfigData {
     ZoneCreationAuthority(Address),
     TreeCreationPermissionless(bool),
     ZoneCreationPermissionless(bool),
+    SplInterfaceCreationPermissionless(bool),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize, Pod, Zeroable)]

--- a/program-libs/interface/src/state/protocol_config.rs
+++ b/program-libs/interface/src/state/protocol_config.rs
@@ -14,6 +14,7 @@ pub struct ProtocolConfig {
     pub zone_creation_authority: Address,
     pub tree_creation_is_permissionless: u8,
     pub zone_creation_is_permissionless: u8,
+    pub spl_interface_creation_is_permissionless: u8,
 }
 
 impl ProtocolConfig {
@@ -56,7 +57,11 @@ impl ProtocolConfig {
     pub fn allows_permissionless_zone_creation(&self) -> bool {
         self.zone_creation_is_permissionless != 0
     }
+
+    pub fn allows_permissionless_spl_interface_creation(&self) -> bool {
+        self.spl_interface_creation_is_permissionless != 0
+    }
 }
 
-const _: () = assert!(ProtocolConfig::SIZE == 131);
+const _: () = assert!(ProtocolConfig::SIZE == 132);
 const _: () = assert!(core::mem::align_of::<ProtocolConfig>() == 1);

--- a/program-tests/shielded-pool/tests/features/spl.feature
+++ b/program-tests/shielded-pool/tests/features/spl.feature
@@ -17,6 +17,11 @@ Feature: SPL asset registration and deposits
     When a non-authority registers an SPL interface for a mint
     Then the operation is rejected as unauthorized
 
+  Scenario: Permissionless SPL interface creation lets any signer register
+    When the authority makes SPL interface creation permissionless
+    And a non-authority successfully registers an SPL interface for a mint
+    Then the registry and vault are initialized with indices 2 and 3
+
   Scenario: An SPL deposit succeeds and the event is faithful
     Given an SPL depositor holding 1000000 tokens
     When the SPL depositor shields 400000 tokens to a fresh recipient

--- a/program-tests/shielded-pool/tests/localnet_deposit.rs
+++ b/program-tests/shielded-pool/tests/localnet_deposit.rs
@@ -63,6 +63,7 @@ fn deposit_sol_on_localnet_prints_signatures() -> TestResult {
         forester_authority: authority_bytes.into(),
         zone_creation_authority: authority_bytes.into(),
         zone_creation_is_permissionless: false,
+        spl_interface_creation_is_permissionless: false,
     }
     .instruction();
     let create_config_tx = send_indexed(

--- a/program-tests/shielded-pool/tests/localnet_e2e.rs
+++ b/program-tests/shielded-pool/tests/localnet_e2e.rs
@@ -90,6 +90,7 @@ fn shield_transfer_unshield_sol_on_localnet_prints_signatures() -> TestResult {
         forester_authority: authority_bytes.into(),
         zone_creation_authority: authority_bytes.into(),
         zone_creation_is_permissionless: false,
+        spl_interface_creation_is_permissionless: false,
     }
     .instruction();
     let create_config_tx = send_indexed(

--- a/program-tests/shielded-pool/tests/localnet_photon_e2e.rs
+++ b/program-tests/shielded-pool/tests/localnet_photon_e2e.rs
@@ -173,6 +173,7 @@ fn shield_transfer_unshield_sol_with_photon_indexer() -> TestResult {
         forester_authority: authority_bytes.into(),
         zone_creation_authority: authority_bytes.into(),
         zone_creation_is_permissionless: false,
+        spl_interface_creation_is_permissionless: false,
     }
     .instruction();
     let create_config_sig = send_transaction(
@@ -675,6 +676,7 @@ fn nullifier_test_forester_batches_queued_nullifiers_with_photon_indexer() -> Te
         forester_authority: accounts.forester_vault.to_bytes().into(),
         zone_creation_authority: accounts.zone_vault.to_bytes().into(),
         zone_creation_is_permissionless: false,
+        spl_interface_creation_is_permissionless: false,
     }
     .instruction();
     let create_config = execute_sync_ix(
@@ -1494,6 +1496,7 @@ fn shield_encrypted_transfer_recovered_by_decryption_for(expected_rail: SpendRai
         forester_authority: authority_bytes.into(),
         zone_creation_authority: authority_bytes.into(),
         zone_creation_is_permissionless: false,
+        spl_interface_creation_is_permissionless: false,
     }
     .instruction();
     send_transaction(

--- a/program-tests/shielded-pool/tests/steps/pool_admin.rs
+++ b/program-tests/shielded-pool/tests/steps/pool_admin.rs
@@ -83,6 +83,7 @@ fn create_config_mismatched_authority(world: &mut ShieldedPoolWorld) {
         forester_authority: named.into(),
         zone_creation_authority: named.into(),
         zone_creation_is_permissionless: false,
+        spl_interface_creation_is_permissionless: false,
     }
     .instruction();
     let err = world

--- a/program-tests/shielded-pool/tests/steps/spl.rs
+++ b/program-tests/shielded-pool/tests/steps/spl.rs
@@ -5,7 +5,7 @@ use solana_instruction::AccountMeta;
 use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
-use zolana_interface::{pda, PROGRAM_ID_PUBKEY};
+use zolana_interface::{instruction::UpdateProtocolConfigData, pda, PROGRAM_ID_PUBKEY};
 use zolana_keypair::{constants::BLINDING_LEN, ShieldedKeypair};
 use zolana_program_test::ZolanaProgramTest;
 use zolana_test_utils::litesvm_asserts::{
@@ -110,6 +110,40 @@ fn register_interface_non_authority(world: &mut ShieldedPoolWorld) {
         .create_spl_interface(&impostor, &mint)
         .unwrap_err();
     world.last_error = Some(err);
+}
+
+#[when(expr = "the authority makes SPL interface creation permissionless")]
+fn make_spl_interface_permissionless(world: &mut ShieldedPoolWorld) {
+    let authority = world.authority().insecure_clone();
+    world
+        .rpc()
+        .send_protocol_config_update(
+            &authority,
+            UpdateProtocolConfigData::SplInterfaceCreationPermissionless(true),
+        )
+        .expect("enable permissionless SPL interface creation");
+}
+
+#[when(expr = "a non-authority successfully registers an SPL interface for a mint")]
+fn register_interface_non_authority_permissionless(world: &mut ShieldedPoolWorld) {
+    let mint = world.rpc().create_mint().expect("create_mint");
+    let authority = world.authority().insecure_clone();
+    world
+        .rpc()
+        .ensure_asset_counter(&authority)
+        .expect("create_asset_counter");
+    let signer = Keypair::new();
+    world
+        .rpc()
+        .airdrop(&signer.pubkey(), 1_000_000_000)
+        .expect("fund");
+    let (registry, vault) = world
+        .rpc()
+        .create_spl_interface(&signer, &mint)
+        .expect("permissionless create_spl_interface");
+    world.mint = Some(mint);
+    world.spl_registry = Some(registry);
+    world.spl_vault = Some(vault);
 }
 
 // === SPL deposit setup ===

--- a/program-tests/spp-test-validator/tests/world.rs
+++ b/program-tests/spp-test-validator/tests/world.rs
@@ -137,6 +137,7 @@ impl LifecycleWorld {
             forester_authority: accounts.forester_vault.to_bytes().into(),
             zone_creation_authority: accounts.zone_vault.to_bytes().into(),
             zone_creation_is_permissionless: false,
+            spl_interface_creation_is_permissionless: false,
         }
         .instruction();
         let create_config_sync = execute_sync_ix(

--- a/program-tests/test-utils/src/test_validator_asserts/protocol_config.rs
+++ b/program-tests/test-utils/src/test_validator_asserts/protocol_config.rs
@@ -21,6 +21,7 @@ pub fn assert_protocol_config<R: Rpc>(
         zone_creation_authority: authority,
         tree_creation_is_permissionless: 0,
         zone_creation_is_permissionless: 0,
+        spl_interface_creation_is_permissionless: 0,
     };
     assert_eq!(cfg, expected, "protocol config");
     Ok(())

--- a/program-tests/zone-test-program/tests/world.rs
+++ b/program-tests/zone-test-program/tests/world.rs
@@ -146,6 +146,7 @@ impl ZoneLifecycleWorld {
             forester_authority: accounts.forester_vault.to_bytes().into(),
             zone_creation_authority: accounts.zone_vault.to_bytes().into(),
             zone_creation_is_permissionless: true,
+            spl_interface_creation_is_permissionless: false,
         }
         .instruction();
         let create_config_sync = execute_sync_ix(

--- a/programs/shielded-pool/src/instructions/create_spl_interface/processor.rs
+++ b/programs/shielded-pool/src/instructions/create_spl_interface/processor.rs
@@ -36,9 +36,11 @@ pub fn process_create_spl_interface(accounts: &mut [AccountView], data: &[u8]) -
 
     {
         let config = load_protocol_config(protocol_config)?;
-        config
-            .check_protocol_authority(authority.address())
-            .map_err(ShieldedPoolError::from)?;
+        if !config.allows_permissionless_spl_interface_creation() {
+            config
+                .check_protocol_authority(authority.address())
+                .map_err(ShieldedPoolError::from)?;
+        }
     }
 
     let mint_key = *mint.address();

--- a/programs/shielded-pool/src/instructions/protocol_config/create.rs
+++ b/programs/shielded-pool/src/instructions/protocol_config/create.rs
@@ -48,6 +48,7 @@ pub fn process_create_protocol_config(accounts: &mut [AccountView], data: &[u8])
         forester_authority: data.forester_authority,
         zone_creation_authority: data.zone_creation_authority,
         zone_creation_is_permissionless: data.zone_creation_is_permissionless,
+        spl_interface_creation_is_permissionless: data.spl_interface_creation_is_permissionless,
     }
     .init(protocol_config)
 }
@@ -59,6 +60,7 @@ struct ProtocolConfigInitParams {
     forester_authority: Address,
     zone_creation_authority: Address,
     zone_creation_is_permissionless: u8,
+    spl_interface_creation_is_permissionless: u8,
 }
 
 impl ProtocolConfigInitParams {
@@ -74,6 +76,8 @@ impl ProtocolConfigInitParams {
         config.forester_authority = self.forester_authority;
         config.zone_creation_authority = self.zone_creation_authority;
         config.zone_creation_is_permissionless = self.zone_creation_is_permissionless;
+        config.spl_interface_creation_is_permissionless =
+            self.spl_interface_creation_is_permissionless;
         Ok(())
     }
 }

--- a/programs/shielded-pool/src/instructions/protocol_config/update.rs
+++ b/programs/shielded-pool/src/instructions/protocol_config/update.rs
@@ -31,6 +31,9 @@ pub fn process_update_protocol_config(accounts: &mut [AccountView], data: &[u8])
         UpdateProtocolConfigData::ZoneCreationPermissionless(b) => {
             current.zone_creation_is_permissionless = u8::from(b)
         }
+        UpdateProtocolConfigData::SplInterfaceCreationPermissionless(b) => {
+            current.spl_interface_creation_is_permissionless = u8::from(b)
+        }
     }
     Ok(())
 }

--- a/sdk-libs/program-test/src/admin.rs
+++ b/sdk-libs/program-test/src/admin.rs
@@ -43,6 +43,8 @@ impl ZolanaProgramTest {
             forester_authority: data.forester_authority,
             zone_creation_authority: data.zone_creation_authority,
             zone_creation_is_permissionless: data.zone_creation_is_permissionless != 0,
+            spl_interface_creation_is_permissionless: data.spl_interface_creation_is_permissionless
+                != 0,
         }
         .instruction();
         self.send(&[ix], &[authority])?;
@@ -76,6 +78,19 @@ impl ZolanaProgramTest {
             signers.push(new_authority);
         }
         self.send(&ixs, &signers)
+    }
+
+    pub fn send_protocol_config_update(
+        &mut self,
+        authority: &Keypair,
+        update: UpdateProtocolConfigData,
+    ) -> Result<(), ProgramTestError> {
+        let ix = UpdateProtocolConfig {
+            authority: authority.pubkey(),
+            update,
+        }
+        .instruction();
+        self.send(&[ix], &[authority])
     }
 
     pub fn pause_tree(
@@ -119,5 +134,6 @@ fn create_protocol_config_data(
         forester_authority: authority.into(),
         zone_creation_authority: authority.into(),
         zone_creation_is_permissionless: u8::from(permissionless),
+        spl_interface_creation_is_permissionless: u8::from(permissionless),
     }
 }

--- a/xtask/src/init_protocol.rs
+++ b/xtask/src/init_protocol.rs
@@ -57,7 +57,7 @@ pub enum Cluster {
 }
 
 impl Cluster {
-    fn parse(value: &str) -> Result<Self> {
+    pub(crate) fn parse(value: &str) -> Result<Self> {
         match value {
             "localnet" => Ok(Self::Localnet),
             "devnet" => Ok(Self::Devnet),
@@ -66,7 +66,7 @@ impl Cluster {
         }
     }
 
-    fn default_url(self) -> &'static str {
+    pub(crate) fn default_url(self) -> &'static str {
         match self {
             Self::Localnet => "http://127.0.0.1:8899",
             Self::Devnet => "https://api.devnet.solana.com",
@@ -74,7 +74,7 @@ impl Cluster {
         }
     }
 
-    fn name(self) -> &'static str {
+    pub(crate) fn name(self) -> &'static str {
         match self {
             Self::Localnet => "localnet",
             Self::Devnet => "devnet",
@@ -181,7 +181,7 @@ struct Signers {
     tree_keypair: Keypair,
 }
 
-fn load_keypair(path: &PathBuf, label: &str) -> Result<Keypair> {
+pub(crate) fn load_keypair(path: &PathBuf, label: &str) -> Result<Keypair> {
     read_keypair_file(path)
         .map_err(|e| anyhow!("failed to read {label} keypair {}: {e}", path.display()))
 }
@@ -212,8 +212,8 @@ fn load_signers(options: &Options) -> Result<Signers> {
     })
 }
 
-struct ProgramConfig {
-    smart_account_index: u128,
+pub(crate) struct ProgramConfig {
+    pub(crate) smart_account_index: u128,
     treasury: Pubkey,
 }
 
@@ -224,7 +224,7 @@ struct RoleAddrs {
     vault: Pubkey,
 }
 
-fn to_address(key: &Pubkey) -> Address {
+pub(crate) fn to_address(key: &Pubkey) -> Address {
     Address::new_from_array(key.to_bytes())
 }
 
@@ -256,7 +256,7 @@ fn parse_program_config(account: &Account) -> Result<ProgramConfig> {
     })
 }
 
-fn read_program_config(rpc: &SolanaRpc) -> Result<ProgramConfig> {
+pub(crate) fn read_program_config(rpc: &SolanaRpc) -> Result<ProgramConfig> {
     let (pc_pda, _) = program_config_pda();
     let account = rpc
         .get_account(to_address(&pc_pda))
@@ -471,6 +471,7 @@ fn send_protocol_config(
         forester_authority: forester.vault.to_bytes().into(),
         zone_creation_authority: zone.vault.to_bytes().into(),
         zone_creation_is_permissionless: false,
+        spl_interface_creation_is_permissionless: false,
     }
     .instruction();
     let sync = execute_sync_ix(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,7 @@ use std::{
 use sha2::{Digest, Sha256};
 
 mod init_protocol;
+mod update_protocol_config;
 
 fn main() {
     let mut args = env::args().skip(1);
@@ -54,6 +55,14 @@ fn main() {
         Some("init-protocol") => {
             if let Err(error) = init_protocol::run(init_protocol::Options::parse(args.collect())) {
                 eprintln!("init-protocol failed: {error:?}");
+                std::process::exit(1);
+            }
+        }
+        Some("update-protocol-config") => {
+            if let Err(error) =
+                update_protocol_config::run(update_protocol_config::Options::parse(args.collect()))
+            {
+                eprintln!("update-protocol-config failed: {error:?}");
                 std::process::exit(1);
             }
         }
@@ -308,6 +317,7 @@ fn print_help() {
     println!("  vk-json                  Export one JSON verifying key as Rust source");
     println!("  program-ids              Print local validator program ids as shell assignments");
     println!("  init-protocol            Initialize the protocol on a cluster (see --help)");
+    println!("  update-protocol-config   Update protocol config flags on a cluster (see --help)");
     println!("  tx-size [N:M ...]        Compute serialized transaction sizes per circuit shape");
 }
 

--- a/xtask/src/update_protocol_config.rs
+++ b/xtask/src/update_protocol_config.rs
@@ -1,0 +1,321 @@
+use std::path::PathBuf;
+
+use anyhow::{anyhow, bail, Context, Result};
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use zolana_client::{Rpc, SolanaRpc};
+use zolana_interface::{
+    instruction::{UpdateProtocolConfig, UpdateProtocolConfigData},
+    pda,
+    state::ProtocolConfig,
+};
+use zolana_test_utils::smart_account::{execute_sync_ix, settings_pda, smart_account_pda};
+
+use crate::init_protocol::{authorities, load_keypair, read_program_config, to_address, Cluster};
+
+pub struct Options {
+    cluster: Cluster,
+    rpc_url: Option<String>,
+    payer: PathBuf,
+    protocol_signer: PathBuf,
+    tree_creation_permissionless: Option<bool>,
+    zone_creation_permissionless: Option<bool>,
+    spl_interface_creation_permissionless: Option<bool>,
+    yes: bool,
+    dry_run: bool,
+}
+
+impl Options {
+    pub fn parse(args: Vec<String>) -> Self {
+        let mut cluster = Cluster::Localnet;
+        let mut rpc_url = None;
+        let mut payer = None;
+        let mut protocol_signer = None;
+        let mut tree_creation_permissionless = None;
+        let mut zone_creation_permissionless = None;
+        let mut spl_interface_creation_permissionless = None;
+        let mut yes = false;
+        let mut dry_run = false;
+
+        let mut args = args.into_iter();
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--cluster" => {
+                    let value = args
+                        .next()
+                        .unwrap_or_else(|| usage_and_exit("--cluster missing value"));
+                    cluster =
+                        Cluster::parse(&value).unwrap_or_else(|e| usage_and_exit(&e.to_string()));
+                }
+                "--rpc-url" => {
+                    rpc_url = Some(
+                        args.next()
+                            .unwrap_or_else(|| usage_and_exit("--rpc-url missing value")),
+                    );
+                }
+                "--payer" => {
+                    payer = Some(PathBuf::from(
+                        args.next()
+                            .unwrap_or_else(|| usage_and_exit("--payer missing value")),
+                    ));
+                }
+                "--protocol-signer" => {
+                    protocol_signer =
+                        Some(PathBuf::from(args.next().unwrap_or_else(|| {
+                            usage_and_exit("--protocol-signer missing value")
+                        })));
+                }
+                "--tree-creation-permissionless" => {
+                    tree_creation_permissionless =
+                        Some(parse_bool(args.next(), "--tree-creation-permissionless"));
+                }
+                "--zone-creation-permissionless" => {
+                    zone_creation_permissionless =
+                        Some(parse_bool(args.next(), "--zone-creation-permissionless"));
+                }
+                "--spl-interface-creation-permissionless" => {
+                    spl_interface_creation_permissionless = Some(parse_bool(
+                        args.next(),
+                        "--spl-interface-creation-permissionless",
+                    ));
+                }
+                "--yes" => yes = true,
+                "--dry-run" => dry_run = true,
+                "--help" | "-h" => {
+                    print_help();
+                    std::process::exit(0);
+                }
+                other => usage_and_exit(&format!("unexpected arg {other:?}")),
+            }
+        }
+
+        let payer = payer.unwrap_or_else(|| usage_and_exit("--payer is required"));
+        let protocol_signer =
+            protocol_signer.unwrap_or_else(|| usage_and_exit("--protocol-signer is required"));
+        if tree_creation_permissionless.is_none()
+            && zone_creation_permissionless.is_none()
+            && spl_interface_creation_permissionless.is_none()
+        {
+            usage_and_exit("at least one --*-permissionless flag is required");
+        }
+
+        Self {
+            cluster,
+            rpc_url,
+            payer,
+            protocol_signer,
+            tree_creation_permissionless,
+            zone_creation_permissionless,
+            spl_interface_creation_permissionless,
+            yes,
+            dry_run,
+        }
+    }
+
+    fn url(&self) -> String {
+        self.rpc_url
+            .clone()
+            .unwrap_or_else(|| self.cluster.default_url().to_string())
+    }
+
+    fn updates(&self) -> Vec<UpdateProtocolConfigData> {
+        let mut updates = Vec::new();
+        if let Some(value) = self.tree_creation_permissionless {
+            updates.push(UpdateProtocolConfigData::TreeCreationPermissionless(value));
+        }
+        if let Some(value) = self.zone_creation_permissionless {
+            updates.push(UpdateProtocolConfigData::ZoneCreationPermissionless(value));
+        }
+        if let Some(value) = self.spl_interface_creation_permissionless {
+            updates.push(UpdateProtocolConfigData::SplInterfaceCreationPermissionless(value));
+        }
+        updates
+    }
+}
+
+struct OnChainConfig {
+    protocol_authority: Pubkey,
+    tree_creation_is_permissionless: u8,
+    zone_creation_is_permissionless: u8,
+    spl_interface_creation_is_permissionless: u8,
+    lamports: u64,
+    len: usize,
+}
+
+fn field<const N: usize>(data: &[u8], offset: usize, name: &str) -> Result<[u8; N]> {
+    data.get(offset..offset + N)
+        .and_then(|bytes| <[u8; N]>::try_from(bytes).ok())
+        .ok_or_else(|| anyhow!("protocol config too small for {name}"))
+}
+
+fn read_protocol_config(rpc: &SolanaRpc) -> Result<OnChainConfig> {
+    let config_pda = pda::protocol_config();
+    let account = rpc
+        .get_account(to_address(&config_pda))
+        .context("fetching protocol_config")?
+        .ok_or_else(|| anyhow!("protocol config {config_pda} does not exist on this cluster"))?;
+    let data = &account.data;
+    if data.len() != ProtocolConfig::SIZE {
+        bail!(
+            "protocol config has unexpected size {} (expected {})",
+            data.len(),
+            ProtocolConfig::SIZE
+        );
+    }
+    Ok(OnChainConfig {
+        protocol_authority: Pubkey::new_from_array(field::<32>(data, 1, "protocol_authority")?),
+        tree_creation_is_permissionless: field::<1>(data, 129, "tree flag")?[0],
+        zone_creation_is_permissionless: field::<1>(data, 130, "zone flag")?[0],
+        spl_interface_creation_is_permissionless: field::<1>(data, 131, "spl interface flag")?[0],
+        lamports: account.lamports,
+        len: data.len(),
+    })
+}
+
+fn print_config(label: &str, config: &OnChainConfig) {
+    println!("{label}:");
+    println!("  size={} lamports={}", config.len, config.lamports);
+    println!("  protocol_authority={}", config.protocol_authority);
+    println!(
+        "  tree_creation_is_permissionless={}",
+        config.tree_creation_is_permissionless != 0
+    );
+    println!(
+        "  zone_creation_is_permissionless={}",
+        config.zone_creation_is_permissionless != 0
+    );
+    println!(
+        "  spl_interface_creation_is_permissionless={}",
+        config.spl_interface_creation_is_permissionless != 0
+    );
+}
+
+/// The protocol authority is a Squads vault PDA; recover its settings account
+/// by scanning every seed the smart-account program has handed out so far.
+fn find_protocol_settings(rpc: &SolanaRpc, protocol_authority: &Pubkey) -> Result<Pubkey> {
+    let program_config = read_program_config(rpc)?;
+    for seed in 1..=program_config.smart_account_index {
+        let (settings, _) = settings_pda(seed);
+        let (vault, _) = smart_account_pda(&settings, 0);
+        if vault == *protocol_authority {
+            return Ok(settings);
+        }
+    }
+    bail!(
+        "no smart-account settings found whose vault matches protocol authority {protocol_authority} \
+         (scanned seeds 1..={})",
+        program_config.smart_account_index
+    )
+}
+
+pub fn run(options: Options) -> Result<()> {
+    let payer = load_keypair(&options.payer, "payer")?;
+    let protocol_signer = load_keypair(&options.protocol_signer, "protocol-signer")?;
+    if !options.dry_run && !authorities::PROTOCOL.contains(&protocol_signer.pubkey()) {
+        bail!(
+            "protocol-signer {} is not one of the hardcoded protocol authorities",
+            protocol_signer.pubkey()
+        );
+    }
+    if options.cluster == Cluster::Mainnet && !options.dry_run && !options.yes {
+        bail!("refusing to send mainnet transactions without --yes");
+    }
+
+    let url = options.url();
+    let rpc = SolanaRpc::new(url.clone());
+
+    let config = read_protocol_config(&rpc)?;
+    println!("cluster={}", options.cluster.name());
+    println!("rpc_url={url}");
+    println!("dry_run={}", options.dry_run);
+    println!("payer={}", payer.pubkey());
+    println!("protocol_signer={}", protocol_signer.pubkey());
+    println!("protocol_config={}", pda::protocol_config());
+    print_config("current config", &config);
+
+    let settings = find_protocol_settings(&rpc, &config.protocol_authority)?;
+    println!("protocol_settings={settings}");
+
+    let mut instructions = Vec::new();
+
+    let updates = options.updates();
+    for update in &updates {
+        println!("update: {update:?}");
+    }
+    let inner: Vec<_> = updates
+        .into_iter()
+        .map(|update| {
+            UpdateProtocolConfig {
+                authority: config.protocol_authority,
+                update,
+            }
+            .instruction()
+        })
+        .collect();
+    instructions.push(execute_sync_ix(
+        &settings,
+        0,
+        &[protocol_signer.pubkey()],
+        &inner,
+    ));
+
+    if options.dry_run {
+        println!("dry_run: no transactions sent");
+        return Ok(());
+    }
+
+    let signature = rpc
+        .create_and_send_transaction(
+            &instructions,
+            to_address(&payer.pubkey()),
+            &[&payer, &protocol_signer],
+        )
+        .map_err(|e| anyhow!("update_protocol_config failed: {e}"))?;
+    println!("update_protocol_config sig={signature}");
+
+    let config = read_protocol_config(&rpc)?;
+    print_config("updated config", &config);
+    Ok(())
+}
+
+fn parse_bool(value: Option<String>, flag: &str) -> bool {
+    match value.as_deref() {
+        Some("true") => true,
+        Some("false") => false,
+        _ => usage_and_exit(&format!("{flag} expects true|false")),
+    }
+}
+
+fn usage_and_exit(message: &str) -> ! {
+    eprintln!("error: {message}");
+    print_help();
+    std::process::exit(2);
+}
+
+fn print_help() {
+    println!("xtask update-protocol-config [flags]");
+    println!();
+    println!("Update shielded-pool protocol config flags on a cluster. The update is");
+    println!("wrapped in a Squads execute_sync signed by one protocol authority member.");
+    println!();
+    println!("Flags:");
+    println!("  --cluster <localnet|devnet|mainnet>              default: localnet");
+    println!(
+        "  --rpc-url <URL>                                  override the cluster default RPC URL"
+    );
+    println!("  --payer <KEYPAIR_PATH>                           outer fee payer (required)");
+    println!("  --protocol-signer <KEYPAIR_PATH>                 one of the protocol authorities (required)");
+    println!(
+        "  --tree-creation-permissionless <true|false>      set tree_creation_is_permissionless"
+    );
+    println!(
+        "  --zone-creation-permissionless <true|false>      set zone_creation_is_permissionless"
+    );
+    println!("  --spl-interface-creation-permissionless <true|false>");
+    println!("                                                   set spl_interface_creation_is_permissionless");
+    println!("  --yes                                            confirm mainnet sends");
+    println!(
+        "  --dry-run                                        print current state, send nothing"
+    );
+    println!("  -h | --help                                      print this help");
+}


### PR DESCRIPTION
## Summary

- Add `spl_interface_creation_is_permissionless` to `ProtocolConfig` (131 -> 132 bytes). When set, any signer can call `create_spl_interface`; otherwise it remains gated by `protocol_authority`.
- Add `UpdateProtocolConfigData::SplInterfaceCreationPermissionless` (appended, existing borsh variant indices unchanged) and wire it through `create_protocol_config`, the builders, and the program-test admin helpers.
- Add an `update-protocol-config` xtask: reads and prints the on-chain config, resolves the protocol Squads settings by scanning smart-account seeds for the vault matching `protocol_authority`, and sends flag updates wrapped in `execute_sync`.
- Update `docs/spec.md` (ProtocolConfig struct, tag 4 gating).

## Devnet state

The devnet config account was already migrated to the new 132-byte layout with a temporary resize path in `update_protocol_config` (sig `2NeHFo4Tin6DwcuZRNewdnMTJcid2GYycdV33EurwVZyotiDoTQDxkCrRMeBgyFKfaKm3MKYdWd8rQCj6wAmDpUM`), and `spl_interface_creation_is_permissionless` is now `true` there. The resize code is removed again in this branch; the currently deployed devnet program still contains it and should be redeployed from this branch.

## Testing

- New BDD scenario: a non-authority registers an SPL interface once the flag is enabled.
- Full shielded-pool BDD suite passes (33 scenarios, 151 steps), plus workspace check, clippy, and fmt.