### PR TITLE
fix(prover): fetch proving keys from the GitHub release, drop GCS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,8 +99,8 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     env:
       AGAVE_VERSION: v4.0.2
-      # The spawned prover lazily fetches transfer proving keys from this repo's
-      # release via `gh`; expose the workflow token to that child process.
+      # The spawned prover lazily fetches proving keys from the transfer-keys-v10
+      # release via the GitHub REST API using GH_TOKEN.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
@@ -140,8 +140,8 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     env:
       AGAVE_VERSION: v4.0.2
-      # The spawned prover lazily fetches transfer proving keys from this repo's
-      # release via `gh`; expose the workflow token to that child process.
+      # The spawned prover lazily fetches proving keys from the transfer-keys-v10
+      # release via the GitHub REST API using GH_TOKEN.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
@@ -257,9 +257,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     env:
-      # The spawned prover lazily fetches Zolana-specific proving keys from the
-      # transfer-keys-v10 release via `gh`. The release lives in this repo, so the
-      # workflow-issued GITHUB_TOKEN (contents:read) is sufficient -- no PAT.
+      # The spawned prover lazily fetches proving keys from the transfer-keys-v10
+      # release via the GitHub REST API using GH_TOKEN.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,23 +350,23 @@ cd prover/server && go build -o light-prover .
 
 ### Distribute proving keys via GitHub release
 
-Gitignored keys are published as assets on a private-repo GitHub release
-(`transfer-keys-v7` on `helius-labs/zolana`). The unauthenticated asset URL
-404s, so keys are fetched with `gh` (local `gh auth login`, or CI's same-repo
-`GITHUB_TOKEN` -- no PAT). Repo/tag are hardcoded as `TransferKeysRepo` /
-`TransferKeysReleaseTag` in `key_downloader.go` and must match
-`publish_keys_release.sh`; bump both (and the `proving-keys-transfer-keys-<tag>`
-cache key in `.github/workflows/rust.yml`) when rotating.
+All gitignored proving keys (merkle, batch, transfer, and merge) are published
+as assets on the single private-repo GitHub release `transfer-keys-v10` on
+`helius-labs/zolana`. The downloader fetches release metadata and assets through
+the GitHub REST API with a bearer token from `GITHUB_TOKEN` or `GH_TOKEN`. The
+tag is pinned as `ProvingKeysReleaseTag` in `key_downloader.go` and can be
+overridden with `PROVING_KEYS_RELEASE_TAG`; keep it aligned with
+`publish_keys_release.sh` and the `proving-keys-transfer-keys-<tag>` cache key in
+`.github/workflows/rust.yml` when rotating.
 
 ```bash
 prover/server/scripts/publish_keys_release.sh        # publish/refresh the release
 ```
 
-`loadTransferSystem` -> `EnsureTransferKeyFromRelease` verifies against the local
-`CHECKSUM` (offline, no network), else runs `gh release download` and re-checks
-the SHA256. Merkle/batch keys still use the GCS `DownloadKey` path. CI's
-`tests / client integration` job (`just test-client-integration`) sets
-`GH_TOKEN` and caches `prover/server/proving-keys` by tag.
+`EnsureProvingKeyFromRelease` verifies an existing key against the local
+`CHECKSUM` first (offline, no network). Missing or mismatched keys are downloaded
+from the release via the REST API, then verified against the merged release
+`CHECKSUM`. CI jobs set `GH_TOKEN` and cache `prover/server/proving-keys` by tag.
 
 ### Regenerate Rust verifying keys (`program-libs/interface/src/verifying_keys/`)
 

--- a/justfile
+++ b/justfile
@@ -75,10 +75,10 @@ test-sdk-libs:
 
 # All zolana-client tests (lib unit tests, the `transaction` integration test,
 # and the `transfer_2_3` BDD suite). The BDD scenario spawns the prover server
-# (via the zolana CLI), which lazily downloads transfer proving keys from the
-# transfer-keys-v1 GitHub release using `gh` -- so this needs `gh` on PATH with
-# auth (local `gh auth login`, or GH_TOKEN in CI). Builds the go prover binary
-# and the zolana CLI the spawned server/test rely on.
+# (via the zolana CLI), which lazily downloads proving keys from the
+# transfer-keys-v10 GitHub release via the GitHub REST API using GH_TOKEN or
+# GITHUB_TOKEN, or uses local keys verified by CHECKSUM. Builds the go prover
+# binary and the zolana CLI the spawned server/test rely on.
 test-client-integration: build-prover-server build-cli
     cargo test -p zolana-client
 
@@ -422,7 +422,7 @@ build-spp-keys:
     prover/server/scripts/regenerate_all_vkeys.sh "$(pwd)/{{spp-keys-dir}}"
 
 publish-spp-keys-release:
-    prover/server/scripts/publish_keys_release.sh transfer-keys-v9 "$(pwd)/{{spp-keys-dir}}"
+    prover/server/scripts/publish_keys_release.sh transfer-keys-v10 "$(pwd)/{{spp-keys-dir}}"
 
 build-photon:
     #!/usr/bin/env bash

--- a/prover/server/main.go
+++ b/prover/server/main.go
@@ -385,11 +385,6 @@ func runCli() {
 						Usage: "Directory where key files will be stored",
 						Value: "./proving-keys/",
 					},
-					&cli.StringFlag{
-						Name:  "download-url",
-						Usage: "Base URL for downloading key files",
-						Value: common.DefaultBaseURL,
-					},
 					&cli.IntFlag{
 						Name:  "max-retries",
 						Usage: "Maximum number of retries for downloading keys",
@@ -413,7 +408,6 @@ func runCli() {
 
 					// Configure download settings
 					downloadConfig := &common.DownloadConfig{
-						BaseURL:       context.String("download-url"),
 						MaxRetries:    context.Int("max-retries"),
 						RetryDelay:    common.DefaultRetryDelay,
 						MaxRetryDelay: common.DefaultMaxRetryDelay,
@@ -425,7 +419,6 @@ func runCli() {
 						Strs("circuits", circuits).
 						Str("keys_dir", keysDirPath).
 						Bool("verify_only", verifyOnly).
-						Str("download_url", downloadConfig.BaseURL).
 						Int("max_retries", downloadConfig.MaxRetries).
 						Msg("Download configuration")
 
@@ -494,11 +487,6 @@ func runCli() {
 						Usage: "Automatically download missing key files",
 						Value: false,
 					},
-					&cli.StringFlag{
-						Name:  "download-url",
-						Usage: "Base URL for downloading key files",
-						Value: common.DefaultBaseURL,
-					},
 					&cli.IntFlag{
 						Name:  "download-max-retries",
 						Usage: "Maximum number of retries for downloading keys",
@@ -514,7 +502,6 @@ func runCli() {
 
 					// Configure download settings
 					downloadConfig := &common.DownloadConfig{
-						BaseURL:       context.String("download-url"),
 						MaxRetries:    context.Int("download-max-retries"),
 						RetryDelay:    common.DefaultRetryDelay,
 						MaxRetryDelay: common.DefaultMaxRetryDelay,

--- a/prover/server/prover/common/key_downloader.go
+++ b/prover/server/prover/common/key_downloader.go
@@ -3,37 +3,36 @@ package common
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 	"zolana/prover/logging"
 )
 
 const (
-	DefaultBaseURL       = "https://storage.googleapis.com/light-protocol-proving-keys/light-protocol-keys"
 	DefaultMaxRetries    = 10
 	DefaultRetryDelay    = 5 * time.Second
 	DefaultMaxRetryDelay = 5 * time.Minute
 
-	// ProvingKeysRepo and ProvingKeysReleaseTag identify the GitHub release
-	// that hosts Zolana-specific proving keys and their CHECKSUM. They must
-	// match the repo/tag used by scripts/publish_keys_release.sh. The repo is
-	// private, so the keys are fetched with the `gh` CLI (which carries the
-	// caller's auth, or CI's same-repo GITHUB_TOKEN) rather than an
-	// unauthenticated URL.
-	ProvingKeysRepo       = "helius-labs/zolana"
-	ProvingKeysReleaseTag = "transfer-keys-v10"
+	// ProvingKeysRepo and ProvingKeysReleaseTag identify the GitHub release that
+	// hosts every Zolana proving key and its CHECKSUM. They must match the
+	// repo/tag used by scripts/publish_keys_release.sh. The repo is private, so
+	// assets are fetched from the GitHub REST API with a bearer token from
+	// GITHUB_TOKEN / GH_TOKEN -- this works in the distroless prover image, which
+	// has no `gh` CLI. The tag is overridable via PROVING_KEYS_RELEASE_TAG so key
+	// rotations don't require a prover rebuild.
+	ProvingKeysRepo             = "helius-labs/zolana"
+	ProvingKeysReleaseTag       = "transfer-keys-v10"
+	provingKeysReleaseTagEnvVar = "PROVING_KEYS_RELEASE_TAG"
 )
 
 type DownloadConfig struct {
-	BaseURL       string
 	MaxRetries    int
 	RetryDelay    time.Duration
 	MaxRetryDelay time.Duration
@@ -42,7 +41,6 @@ type DownloadConfig struct {
 
 func DefaultDownloadConfig() *DownloadConfig {
 	return &DownloadConfig{
-		BaseURL:       DefaultBaseURL,
 		MaxRetries:    DefaultMaxRetries,
 		RetryDelay:    DefaultRetryDelay,
 		MaxRetryDelay: DefaultMaxRetryDelay,
@@ -50,84 +48,24 @@ func DefaultDownloadConfig() *DownloadConfig {
 	}
 }
 
-type checksumCacheEntry struct {
-	checksums map[string]string
-	loaded    bool
+// releaseTag returns the release tag to fetch keys from, honoring the
+// PROVING_KEYS_RELEASE_TAG override.
+func releaseTag() string {
+	if v := strings.TrimSpace(os.Getenv(provingKeysReleaseTagEnvVar)); v != "" {
+		return v
+	}
+	return ProvingKeysReleaseTag
 }
 
-type checksumCacheManager struct {
-	mu     sync.RWMutex
-	caches map[string]*checksumCacheEntry
-}
-
-var globalChecksumCaches = &checksumCacheManager{
-	caches: make(map[string]*checksumCacheEntry),
-}
-
-func downloadChecksum(config *DownloadConfig) error {
-	globalChecksumCaches.mu.RLock()
-	if entry, exists := globalChecksumCaches.caches[config.BaseURL]; exists && entry.loaded {
-		globalChecksumCaches.mu.RUnlock()
-		return nil
-	}
-	globalChecksumCaches.mu.RUnlock()
-
-	globalChecksumCaches.mu.Lock()
-	defer globalChecksumCaches.mu.Unlock()
-
-	if entry, exists := globalChecksumCaches.caches[config.BaseURL]; exists && entry.loaded {
-		return nil
-	}
-
-	checksumURL := config.BaseURL + "/CHECKSUM"
-	logging.Logger().Info().
-		Str("url", checksumURL).
-		Msg("Downloading CHECKSUM file")
-
-	resp, err := http.Get(checksumURL)
-	if err != nil {
-		return fmt.Errorf("failed to download CHECKSUM file: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download CHECKSUM file: HTTP %d", resp.StatusCode)
-	}
-
-	content, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read CHECKSUM file: %w", err)
-	}
-
-	entry := &checksumCacheEntry{
-		checksums: make(map[string]string),
-		loaded:    false,
-	}
-
-	// Parse CHECKSUM file (format: "checksum  filename")
-	lines := strings.Split(string(content), "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		parts := strings.Fields(line)
-		if len(parts) >= 2 {
-			checksum := parts[0]
-			filename := parts[1]
-			entry.checksums[filename] = checksum
+// githubToken returns the bearer token used to reach the private proving-keys
+// release, honoring the env names the `gh` CLI also reads.
+func githubToken() string {
+	for _, env := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
+		if v := strings.TrimSpace(os.Getenv(env)); v != "" {
+			return v
 		}
 	}
-
-	entry.loaded = true
-	globalChecksumCaches.caches[config.BaseURL] = entry
-
-	logging.Logger().Info().
-		Int("count", len(entry.checksums)).
-		Str("base_url", config.BaseURL).
-		Msg("Loaded checksums")
-
-	return nil
+	return ""
 }
 
 // readLocalChecksum looks up filename in a CHECKSUM file located in dir (format:
@@ -170,254 +108,150 @@ func calculateBackoff(attempt int, initialDelay, maxDelay time.Duration) time.Du
 	return delay
 }
 
-func downloadFileWithResume(url, outputPath string, config *DownloadConfig) error {
-	tempPath := outputPath + ".tmp"
-
-	for attempt := 1; attempt <= config.MaxRetries; attempt++ {
-		var existingSize int64 = 0
-		if fileInfo, err := os.Stat(tempPath); err == nil {
-			existingSize = fileInfo.Size()
-		}
-
-		req, err := http.NewRequest("GET", url, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create request: %w", err)
-		}
-
-		if existingSize > 0 {
-			req.Header.Set("Range", fmt.Sprintf("bytes=%d-", existingSize))
-			logging.Logger().Info().
-				Str("url", url).
-				Int64("resume_from", existingSize).
-				Int("attempt", attempt).
-				Int("max_retries", config.MaxRetries).
-				Msg("Resuming download")
-		} else {
-			logging.Logger().Info().
-				Str("url", url).
-				Int("attempt", attempt).
-				Int("max_retries", config.MaxRetries).
-				Msg("Starting download")
-		}
-
-		client := &http.Client{
-			Timeout: 60 * time.Minute,
-		}
-		resp, err := client.Do(req)
-		if err != nil {
-			if attempt < config.MaxRetries {
-				delay := calculateBackoff(attempt, config.RetryDelay, config.MaxRetryDelay)
-				logging.Logger().Warn().
-					Err(err).
-					Dur("retry_delay", delay).
-					Msg("Download failed, retrying")
-				time.Sleep(delay)
-				continue
-			}
-			return fmt.Errorf("failed to download after %d attempts: %w", config.MaxRetries, err)
-		}
-
-		// Check response status
-		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
-			resp.Body.Close()
-			if attempt < config.MaxRetries {
-				delay := calculateBackoff(attempt, config.RetryDelay, config.MaxRetryDelay)
-				logging.Logger().Warn().
-					Int("status_code", resp.StatusCode).
-					Dur("retry_delay", delay).
-					Msg("Unexpected status code, retrying")
-				time.Sleep(delay)
-				continue
-			}
-			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		}
-
-		var file *os.File
-		if existingSize > 0 && resp.StatusCode == http.StatusPartialContent {
-			file, err = os.OpenFile(tempPath, os.O_APPEND|os.O_WRONLY, 0644)
-		} else {
-			file, err = os.Create(tempPath)
-			existingSize = 0
-		}
-		if err != nil {
-			resp.Body.Close()
-			return fmt.Errorf("failed to open file: %w", err)
-		}
-
-		totalSize := existingSize + resp.ContentLength
-		downloadedBytes := existingSize
-		lastLogTime := time.Now()
-		logInterval := 5 * time.Second
-
-		buffer := make([]byte, 32*1024)
-		for {
-			n, err := resp.Body.Read(buffer)
-			if n > 0 {
-				if _, writeErr := file.Write(buffer[:n]); writeErr != nil {
-					file.Close()
-					resp.Body.Close()
-					return fmt.Errorf("failed to write to file: %w", writeErr)
-				}
-				downloadedBytes += int64(n)
-
-				if time.Since(lastLogTime) >= logInterval {
-					if totalSize > 0 {
-						progress := float64(downloadedBytes) / float64(totalSize) * 100
-						logging.Logger().Info().
-							Int64("downloaded", downloadedBytes).
-							Int64("total", totalSize).
-							Float64("progress", progress).
-							Msg("Download progress")
-					}
-					lastLogTime = time.Now()
-				}
-			}
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				file.Close()
-				resp.Body.Close()
-				if attempt < config.MaxRetries {
-					delay := calculateBackoff(attempt, config.RetryDelay, config.MaxRetryDelay)
-					logging.Logger().Warn().
-						Err(err).
-						Dur("retry_delay", delay).
-						Msg("Download interrupted, retrying")
-					time.Sleep(delay)
-					continue
-				}
-				return fmt.Errorf("download failed: %w", err)
-			}
-		}
-
-		file.Close()
-		resp.Body.Close()
-
-		if err := os.Rename(tempPath, outputPath); err != nil {
-			return fmt.Errorf("failed to rename temp file: %w", err)
-		}
-
-		logging.Logger().Info().
-			Str("file", filepath.Base(outputPath)).
-			Int64("size", downloadedBytes).
-			Msg("Download completed successfully")
-
-		return nil
-	}
-
-	return fmt.Errorf("failed to download after %d attempts", config.MaxRetries)
+type releaseAsset struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
 }
 
-func DownloadKey(keyPath string, config *DownloadConfig) error {
-	filename := filepath.Base(keyPath)
+// githubAPIRequest builds a GitHub REST API request carrying the bearer token
+// (when set) and the standard API headers.
+func githubAPIRequest(method, url, accept string) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", accept)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if tok := githubToken(); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	return req, nil
+}
 
-	// Offline path: a CHECKSUM file in the key's directory (written by
-	// scripts/generate_checksums.py) is authoritative for locally-generated keys
-	// such as the transfer proving keys, which are not published to the CDN. If it
-	// covers this file and the on-disk key verifies, accept it without any network.
-	if localChecksum, ok := readLocalChecksum(filepath.Dir(keyPath), filename); ok {
-		if _, err := os.Stat(keyPath); err == nil {
-			valid, verr := verifyChecksum(keyPath, localChecksum)
-			if verr == nil && valid {
-				logging.Logger().Info().
-					Str("file", filename).
-					Msg("Key file verified against local CHECKSUM, skipping download")
-				return nil
-			}
+// listReleaseAssets fetches the asset list for the configured release tag. The
+// proving-keys repo is private, so the request carries a bearer token.
+func listReleaseAssets() ([]releaseAsset, error) {
+	tag := releaseTag()
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/tags/%s", ProvingKeysRepo, tag)
+	req, err := githubAPIRequest(http.MethodGet, url, "application/vnd.github+json")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query release %s@%s: %w", ProvingKeysRepo, tag, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		hint := ""
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			hint = " (set GITHUB_TOKEN/GH_TOKEN with read access to the private proving-keys repo)"
 		}
+		return nil, fmt.Errorf("failed to query release %s@%s: HTTP %d%s: %s", ProvingKeysRepo, tag, resp.StatusCode, hint, strings.TrimSpace(string(body)))
 	}
-
-	if err := downloadChecksum(config); err != nil {
-		return fmt.Errorf("failed to load checksums: %w", err)
+	var release struct {
+		Assets []releaseAsset `json:"assets"`
 	}
-
-	globalChecksumCaches.mu.RLock()
-	entry, exists := globalChecksumCaches.caches[config.BaseURL]
-	if !exists {
-		globalChecksumCaches.mu.RUnlock()
-		return fmt.Errorf("checksum cache not found for BaseURL: %s", config.BaseURL)
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, fmt.Errorf("failed to decode release metadata: %w", err)
 	}
-	expectedChecksum, checksumExists := entry.checksums[filename]
-	globalChecksumCaches.mu.RUnlock()
+	return release.Assets, nil
+}
 
-	if !checksumExists {
-		return fmt.Errorf("no checksum found for %s", filename)
-	}
-
-	if fileInfo, err := os.Stat(keyPath); err == nil {
-		logging.Logger().Info().
-			Str("file", filename).
-			Int64("size", fileInfo.Size()).
-			Msg("Verifying existing key file")
-
-		valid, err := verifyChecksum(keyPath, expectedChecksum)
-		if err != nil {
-			if !config.AutoDownload {
-				return fmt.Errorf("key file %s exists but failed verification (auto-download disabled): %w", filename, err)
-			}
-			logging.Logger().Warn().
-				Err(err).
-				Str("file", filename).
-				Msg("Failed to verify checksum, will re-download")
-		} else if valid {
-			logging.Logger().Info().
-				Str("file", filename).
-				Msg("Key file is valid, skipping download")
-			return nil
-		} else {
-			if !config.AutoDownload {
-				return fmt.Errorf("key file %s checksum mismatch (auto-download disabled)", filename)
-			}
-			logging.Logger().Warn().
-				Str("file", filename).
-				Msg("Checksum mismatch, re-downloading")
-			os.Remove(keyPath)
-		}
-	} else if os.IsNotExist(err) {
-		if !config.AutoDownload {
-			return fmt.Errorf("required key file not found: %s (auto-download disabled)", filename)
-		}
-	} else {
-		return fmt.Errorf("failed to check key file %s: %w", filename, err)
-	}
-
-	if err := os.MkdirAll(filepath.Dir(keyPath), 0755); err != nil {
-		return fmt.Errorf("failed to create directory: %w", err)
-	}
-
-	url := fmt.Sprintf("%s/%s", config.BaseURL, filename)
-	logging.Logger().Info().
-		Str("file", filename).
-		Str("url", url).
-		Msg("Downloading key file")
-
-	if err := downloadFileWithResume(url, keyPath, config); err != nil {
+// downloadReleaseAsset downloads every asset whose name matches pattern (a
+// filepath.Match glob) into dir via the GitHub REST API. Errors if nothing
+// matches. Replaces the `gh` CLI so downloads work in the distroless image.
+func downloadReleaseAsset(pattern string, dir string) error {
+	assets, err := listReleaseAssets()
+	if err != nil {
 		return err
 	}
-
-	valid, err := verifyChecksum(keyPath, expectedChecksum)
-	if err != nil {
-		return fmt.Errorf("failed to verify downloaded file: %w", err)
+	matched := 0
+	for _, asset := range assets {
+		ok, err := filepath.Match(pattern, asset.Name)
+		if err != nil {
+			return fmt.Errorf("invalid asset pattern %q: %w", pattern, err)
+		}
+		if !ok {
+			continue
+		}
+		if err := downloadAssetByID(asset.ID, filepath.Join(dir, asset.Name)); err != nil {
+			return fmt.Errorf("failed to download asset %s: %w", asset.Name, err)
+		}
+		matched++
 	}
-	if !valid {
-		os.Remove(keyPath)
-		return fmt.Errorf("downloaded file checksum mismatch")
+	if matched == 0 {
+		return fmt.Errorf("no asset matches %q in release %s@%s", pattern, ProvingKeysRepo, releaseTag())
 	}
-
-	logging.Logger().Info().
-		Str("file", filename).
-		Msg("Key file downloaded and verified successfully")
-
 	return nil
 }
 
-// EnsureProvingKeyFromRelease makes a Zolana-specific proving key available at
-// keyPath, fetching it (and the release CHECKSUM) from the private GitHub
-// release via the `gh` CLI. `gh` carries the caller's auth locally and CI's
-// same-repo GITHUB_TOKEN, so this works without an unauthenticated URL. If the
-// file is already present and verifies against the local CHECKSUM, no download
-// happens. When autoDownload is false, a missing file is an error.
+// downloadAssetByID streams a release asset (by numeric id) to outputPath,
+// retrying with backoff. With Accept: application/octet-stream GitHub redirects
+// to signed storage on a different host; the default client follows it and drops
+// the bearer token on that hop (the redirect URL is already signed).
+func downloadAssetByID(id int64, outputPath string) error {
+	assetURL := fmt.Sprintf("https://api.github.com/repos/%s/releases/assets/%d", ProvingKeysRepo, id)
+	tempPath := outputPath + ".tmp"
+	var lastErr error
+	for attempt := 1; attempt <= DefaultMaxRetries; attempt++ {
+		if attempt > 1 {
+			delay := calculateBackoff(attempt-1, DefaultRetryDelay, DefaultMaxRetryDelay)
+			logging.Logger().Warn().
+				Err(lastErr).
+				Dur("retry_delay", delay).
+				Str("file", filepath.Base(outputPath)).
+				Msg("Release asset download failed, retrying")
+			time.Sleep(delay)
+		}
+		req, err := githubAPIRequest(http.MethodGet, assetURL, "application/octet-stream")
+		if err != nil {
+			return err
+		}
+		client := &http.Client{Timeout: 60 * time.Minute}
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+			resp.Body.Close()
+			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+			continue
+		}
+		file, err := os.Create(tempPath)
+		if err != nil {
+			resp.Body.Close()
+			return fmt.Errorf("failed to create temp file %s: %w", tempPath, err)
+		}
+		_, copyErr := io.Copy(file, resp.Body)
+		resp.Body.Close()
+		if closeErr := file.Close(); closeErr != nil && copyErr == nil {
+			copyErr = closeErr
+		}
+		if copyErr != nil {
+			os.Remove(tempPath)
+			lastErr = copyErr
+			continue
+		}
+		if err := os.Rename(tempPath, outputPath); err != nil {
+			return fmt.Errorf("failed to rename temp file to %s: %w", outputPath, err)
+		}
+		logging.Logger().Info().
+			Str("file", filepath.Base(outputPath)).
+			Msg("Release asset downloaded")
+		return nil
+	}
+	return fmt.Errorf("failed to download asset after %d attempts: %w", DefaultMaxRetries, lastErr)
+}
+
+// EnsureProvingKeyFromRelease makes a Zolana proving key available at keyPath,
+// fetching it (and the release CHECKSUM) from the private GitHub release via the
+// REST API with a bearer token (GITHUB_TOKEN / GH_TOKEN). If the file is already
+// present and verifies against the local CHECKSUM, no download happens. When
+// autoDownload is false, a missing file is an error.
 func EnsureProvingKeyFromRelease(keyPath string, autoDownload bool) error {
 	filename := filepath.Base(keyPath)
 	dir := filepath.Dir(keyPath)
@@ -447,8 +281,8 @@ func EnsureProvingKeyFromRelease(keyPath string, autoDownload bool) error {
 	logging.Logger().Info().
 		Str("file", filename).
 		Str("repo", ProvingKeysRepo).
-		Str("tag", ProvingKeysReleaseTag).
-		Msg("Downloading proving key from GitHub release via gh")
+		Str("tag", releaseTag()).
+		Msg("Downloading proving key from GitHub release via REST API")
 
 	if err := downloadReleaseAsset("CHECKSUM", dir); err != nil {
 		return fmt.Errorf("failed to download release CHECKSUM: %w", err)
@@ -483,19 +317,6 @@ func EnsureProvingKeyFromRelease(keyPath string, autoDownload bool) error {
 	logging.Logger().Info().
 		Str("file", filename).
 		Msg("Proving key downloaded and verified successfully")
-	return nil
-}
-
-func downloadReleaseAsset(pattern string, dir string) error {
-	cmd := exec.Command("gh", "release", "download", ProvingKeysReleaseTag,
-		"--repo", ProvingKeysRepo,
-		"--pattern", pattern,
-		"--dir", dir,
-		"--clobber",
-	)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("gh release download failed for pattern %s: %w: %s", pattern, err, strings.TrimSpace(string(out)))
-	}
 	return nil
 }
 
@@ -560,10 +381,6 @@ func EnsureKeysExist(keys []string, config *DownloadConfig) error {
 		return nil
 	}
 
-	if err := downloadChecksum(config); err != nil {
-		return fmt.Errorf("failed to download checksums: %w", err)
-	}
-
 	var missingKeys []string
 	for _, key := range keys {
 		if _, err := os.Stat(key); os.IsNotExist(err) {
@@ -584,7 +401,7 @@ func EnsureKeysExist(keys []string, config *DownloadConfig) error {
 				Str("file", filepath.Base(key)).
 				Msg("Downloading missing key")
 
-			if err := DownloadKey(key, config); err != nil {
+			if err := EnsureProvingKeyFromRelease(key, config.AutoDownload); err != nil {
 				return fmt.Errorf("failed to download key %s: %w", filepath.Base(key), err)
 			}
 		}

--- a/prover/server/prover/common/key_downloader.go
+++ b/prover/server/prover/common/key_downloader.go
@@ -11,9 +11,33 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"zolana/prover/logging"
 )
+
+// metadataHTTPClient fetches the small release-metadata JSON. Asset downloads
+// use their own long-timeout client (see downloadAssetByID); metadata is a tiny
+// GET, so a short bounded timeout keeps a stalled connection from hanging the
+// whole key-download path forever.
+var metadataHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+// checksumMergeOnce serializes the once-per-release CHECKSUM merge. Preloading N
+// keys (see EnsureKeysExist) would otherwise re-download and re-merge the
+// identical release CHECKSUM N times, racing on dir/CHECKSUM. A sync.Once per
+// release tag (keyed under checksumMergeMu) makes the merge run exactly once per
+// process regardless of whether EnsureKeysExist iterates sequentially or
+// concurrently. The stored error is memoized so later callers see the same
+// outcome without retrying.
+var (
+	checksumMergeMu   sync.Mutex
+	checksumMergeOnce = map[string]*checksumMergeState{}
+)
+
+type checksumMergeState struct {
+	once sync.Once
+	err  error
+}
 
 const (
 	DefaultMaxRetries    = 10
@@ -84,6 +108,117 @@ func readLocalChecksum(dir string, filename string) (string, bool) {
 	return "", false
 }
 
+// parseChecksumFile reads a CHECKSUM file (format "checksum  filename" per
+// line, as written by scripts/generate_checksums.py) into a filename->checksum
+// map. A missing file yields an empty map (not an error) so a first-ever
+// download can still merge into a fresh CHECKSUM.
+func parseChecksumFile(path string) (map[string]string, error) {
+	entries := map[string]string{}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return entries, nil
+		}
+		return nil, err
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		parts := strings.Fields(strings.TrimSpace(line))
+		if len(parts) >= 2 {
+			entries[parts[1]] = parts[0]
+		}
+	}
+	return entries, nil
+}
+
+// writeChecksumFile writes entries to path in the canonical "checksum  filename"
+// format (two spaces, sorted by filename to match generate_checksums.py) via a
+// temp file + rename so a concurrent reader never sees a partial CHECKSUM.
+func writeChecksumFile(path string, entries map[string]string) error {
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	for _, name := range names {
+		fmt.Fprintf(&b, "%s  %s\n", entries[name], name)
+	}
+
+	tempPath := path + ".merge.tmp"
+	if err := os.WriteFile(tempPath, []byte(b.String()), 0644); err != nil {
+		return fmt.Errorf("failed to write temp CHECKSUM %s: %w", tempPath, err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		os.Remove(tempPath)
+		return fmt.Errorf("failed to rename temp CHECKSUM to %s: %w", path, err)
+	}
+	return nil
+}
+
+// mergeReleaseChecksum downloads the release CHECKSUM to a distinct temp path
+// (never dir/CHECKSUM, so the shared local manifest is not clobbered mid-merge),
+// parses it, and merges its entries into dir/CHECKSUM: local-only entries (e.g.
+// locally generated squads keys) are preserved and release entries override
+// same-filename local entries. The merged file is written atomically.
+func mergeReleaseChecksum(assets []releaseAsset, dir string) error {
+	localPath := filepath.Join(dir, "CHECKSUM")
+	local, err := parseChecksumFile(localPath)
+	if err != nil {
+		return fmt.Errorf("failed to read local CHECKSUM %s: %w", localPath, err)
+	}
+
+	// downloadMatchingAssets writes to <passed-dir>/<asset name>, i.e. it would
+	// clobber dir/CHECKSUM. Download into a temp subdirectory instead so the
+	// shared local CHECKSUM is never overwritten by the raw release manifest --
+	// even if the merge below fails partway through.
+	stageDir, err := os.MkdirTemp(dir, "checksum-release-")
+	if err != nil {
+		return fmt.Errorf("failed to create release CHECKSUM staging dir: %w", err)
+	}
+	defer os.RemoveAll(stageDir)
+
+	if err := downloadMatchingAssets(assets, "CHECKSUM", stageDir); err != nil {
+		return fmt.Errorf("failed to download release CHECKSUM: %w", err)
+	}
+	releasePath := filepath.Join(stageDir, "CHECKSUM")
+
+	release, err := parseChecksumFile(releasePath)
+	if err != nil {
+		return fmt.Errorf("failed to read release CHECKSUM: %w", err)
+	}
+
+	// Union: start from local, let release entries override same-filename ones.
+	merged := make(map[string]string, len(local)+len(release))
+	for name, sum := range local {
+		merged[name] = sum
+	}
+	for name, sum := range release {
+		merged[name] = sum
+	}
+	return writeChecksumFile(localPath, merged)
+}
+
+// ensureReleaseChecksum fetches and merges the release CHECKSUM into dir/CHECKSUM
+// exactly once per release tag for the lifetime of the process, regardless of
+// how many keys are being preloaded and whether they are handled sequentially or
+// concurrently. mergeReleaseChecksum reuses the already-fetched asset list.
+func ensureReleaseChecksum(assets []releaseAsset, dir string) error {
+	tag := releaseTag()
+	checksumMergeMu.Lock()
+	state, ok := checksumMergeOnce[tag]
+	if !ok {
+		state = &checksumMergeState{}
+		checksumMergeOnce[tag] = state
+	}
+	checksumMergeMu.Unlock()
+
+	state.once.Do(func() {
+		state.err = mergeReleaseChecksum(assets, dir)
+	})
+	return state.err
+}
+
 func verifyChecksum(filepath string, expectedChecksum string) (bool, error) {
 	file, err := os.Open(filepath)
 	if err != nil {
@@ -137,7 +272,7 @@ func listReleaseAssets() ([]releaseAsset, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := metadataHTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query release %s@%s: %w", ProvingKeysRepo, tag, err)
 	}
@@ -159,14 +294,11 @@ func listReleaseAssets() ([]releaseAsset, error) {
 	return release.Assets, nil
 }
 
-// downloadReleaseAsset downloads every asset whose name matches pattern (a
-// filepath.Match glob) into dir via the GitHub REST API. Errors if nothing
-// matches. Replaces the `gh` CLI so downloads work in the distroless image.
-func downloadReleaseAsset(pattern string, dir string) error {
-	assets, err := listReleaseAssets()
-	if err != nil {
-		return err
-	}
+// downloadMatchingAssets downloads every asset in assets whose name matches
+// pattern (a filepath.Match glob) into dir via the GitHub REST API. Errors if
+// nothing matches. Callers pass a pre-fetched asset list so a single
+// listReleaseAssets result can serve several patterns.
+func downloadMatchingAssets(assets []releaseAsset, pattern string, dir string) error {
 	matched := 0
 	for _, asset := range assets {
 		ok, err := filepath.Match(pattern, asset.Name)
@@ -185,6 +317,17 @@ func downloadReleaseAsset(pattern string, dir string) error {
 		return fmt.Errorf("no asset matches %q in release %s@%s", pattern, ProvingKeysRepo, releaseTag())
 	}
 	return nil
+}
+
+// downloadReleaseAsset downloads every asset whose name matches pattern (a
+// filepath.Match glob) into dir via the GitHub REST API. Errors if nothing
+// matches. Replaces the `gh` CLI so downloads work in the distroless image.
+func downloadReleaseAsset(pattern string, dir string) error {
+	assets, err := listReleaseAssets()
+	if err != nil {
+		return err
+	}
+	return downloadMatchingAssets(assets, pattern, dir)
 }
 
 // downloadAssetByID streams a release asset (by numeric id) to outputPath,
@@ -219,6 +362,12 @@ func downloadAssetByID(id int64, outputPath string) error {
 			body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
 			resp.Body.Close()
 			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+			// Permanent client errors (401/403/404, ...) will never succeed on
+			// retry -- fail fast instead of burning every retry with backoff.
+			// Rate limiting (429) and server errors (5xx) stay retryable.
+			if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
+				return lastErr
+			}
 			continue
 		}
 		file, err := os.Create(tempPath)
@@ -284,16 +433,25 @@ func EnsureProvingKeyFromRelease(keyPath string, autoDownload bool) error {
 		Str("tag", releaseTag()).
 		Msg("Downloading proving key from GitHub release via REST API")
 
-	if err := downloadReleaseAsset("CHECKSUM", dir); err != nil {
-		return fmt.Errorf("failed to download release CHECKSUM: %w", err)
+	// Fetch the asset list once and reuse it for both the CHECKSUM merge and the
+	// key/parts download, so preloading N keys does not make ~2N list calls.
+	assets, err := listReleaseAssets()
+	if err != nil {
+		return err
 	}
 
-	if err := downloadReleaseAsset(filename, dir); err != nil {
+	// Merge the release CHECKSUM into dir/CHECKSUM once per process (across all
+	// EnsureProvingKeyFromRelease calls), preserving locally generated entries.
+	if err := ensureReleaseChecksum(assets, dir); err != nil {
+		return err
+	}
+
+	if err := downloadMatchingAssets(assets, filename, dir); err != nil {
 		logging.Logger().Info().
 			Err(err).
 			Str("file", filename).
 			Msg("Exact release asset unavailable; trying split asset parts")
-		if partsErr := downloadReleaseAsset(filename+".part-*", dir); partsErr != nil {
+		if partsErr := downloadMatchingAssets(assets, filename+".part-*", dir); partsErr != nil {
 			return fmt.Errorf("failed to download release asset %s or split parts: exact: %w; parts: %w", filename, err, partsErr)
 		}
 		if err := assembleReleaseAssetParts(dir, filename, keyPath); err != nil {

--- a/prover/server/prover/common/key_downloader.go
+++ b/prover/server/prover/common/key_downloader.go
@@ -631,6 +631,14 @@ func assembleReleaseAssetParts(dir string, filename string, outputPath string) e
 	if err := os.Rename(tempPath, outputPath); err != nil {
 		return cleanupTempFile(tempPath, fmt.Errorf("failed to move assembled key to %s: %w", outputPath, err))
 	}
+	for _, part := range parts {
+		if err := removeFileIfExists(part); err != nil {
+			logging.Logger().Warn().
+				Err(err).
+				Str("file", filepath.Base(part)).
+				Msg("Failed to remove split release asset part")
+		}
+	}
 	return nil
 }
 

--- a/prover/server/prover/common/key_downloader.go
+++ b/prover/server/prover/common/key_downloader.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,22 +22,23 @@ import (
 // GET, so a short bounded timeout keeps a stalled connection from hanging the
 // whole key-download path forever.
 var metadataHTTPClient = &http.Client{Timeout: 30 * time.Second}
+var assetHTTPClient = &http.Client{Timeout: 60 * time.Minute}
+var githubAPIBaseURL = "https://api.github.com"
 
-// checksumMergeOnce serializes the once-per-release CHECKSUM merge. Preloading N
+// checksumMergeStates serializes the once-per-release-dir CHECKSUM merge. Preloading N
 // keys (see EnsureKeysExist) would otherwise re-download and re-merge the
-// identical release CHECKSUM N times, racing on dir/CHECKSUM. A sync.Once per
-// release tag (keyed under checksumMergeMu) makes the merge run exactly once per
-// process regardless of whether EnsureKeysExist iterates sequentially or
-// concurrently. The stored error is memoized so later callers see the same
-// outcome without retrying.
+// identical release CHECKSUM N times, racing on dir/CHECKSUM. A state per
+// release tag and destination dir (keyed under checksumMergeMu) makes the merge
+// run once per process after it succeeds, while transient failures remain
+// retryable by later callers.
 var (
-	checksumMergeMu   sync.Mutex
-	checksumMergeOnce = map[string]*checksumMergeState{}
+	checksumMergeMu     sync.Mutex
+	checksumMergeStates = map[string]*checksumMergeState{}
 )
 
 type checksumMergeState struct {
-	once sync.Once
-	err  error
+	mu   sync.Mutex
+	done bool
 }
 
 const (
@@ -72,6 +74,13 @@ func DefaultDownloadConfig() *DownloadConfig {
 	}
 }
 
+func normalizeDownloadConfig(config *DownloadConfig) *DownloadConfig {
+	if config == nil {
+		return DefaultDownloadConfig()
+	}
+	return config
+}
+
 // releaseTag returns the release tag to fetch keys from, honoring the
 // PROVING_KEYS_RELEASE_TAG override.
 func releaseTag() string {
@@ -82,7 +91,7 @@ func releaseTag() string {
 }
 
 // githubToken returns the bearer token used to reach the private proving-keys
-// release, honoring the env names the `gh` CLI also reads.
+// release, honoring both token env names used locally and in CI.
 func githubToken() string {
 	for _, env := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
 		if v := strings.TrimSpace(os.Getenv(env)); v != "" {
@@ -142,7 +151,9 @@ func writeChecksumFile(path string, entries map[string]string) error {
 
 	var b strings.Builder
 	for _, name := range names {
-		fmt.Fprintf(&b, "%s  %s\n", entries[name], name)
+		if _, err := fmt.Fprintf(&b, "%s  %s\n", entries[name], name); err != nil {
+			return fmt.Errorf("failed to format CHECKSUM entry %s: %w", name, err)
+		}
 	}
 
 	tempPath := path + ".merge.tmp"
@@ -150,8 +161,11 @@ func writeChecksumFile(path string, entries map[string]string) error {
 		return fmt.Errorf("failed to write temp CHECKSUM %s: %w", tempPath, err)
 	}
 	if err := os.Rename(tempPath, path); err != nil {
-		os.Remove(tempPath)
-		return fmt.Errorf("failed to rename temp CHECKSUM to %s: %w", path, err)
+		removeErr := removeFileIfExists(tempPath)
+		return errors.Join(
+			fmt.Errorf("failed to rename temp CHECKSUM to %s: %w", path, err),
+			wrapCleanupError("failed to remove temp CHECKSUM", tempPath, removeErr),
+		)
 	}
 	return nil
 }
@@ -161,7 +175,7 @@ func writeChecksumFile(path string, entries map[string]string) error {
 // parses it, and merges its entries into dir/CHECKSUM: local-only entries (e.g.
 // locally generated squads keys) are preserved and release entries override
 // same-filename local entries. The merged file is written atomically.
-func mergeReleaseChecksum(assets []releaseAsset, dir string) error {
+func mergeReleaseChecksum(assets []releaseAsset, dir string, config *DownloadConfig) error {
 	localPath := filepath.Join(dir, "CHECKSUM")
 	local, err := parseChecksumFile(localPath)
 	if err != nil {
@@ -176,16 +190,29 @@ func mergeReleaseChecksum(assets []releaseAsset, dir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create release CHECKSUM staging dir: %w", err)
 	}
-	defer os.RemoveAll(stageDir)
 
-	if err := downloadMatchingAssets(assets, "CHECKSUM", stageDir); err != nil {
-		return fmt.Errorf("failed to download release CHECKSUM: %w", err)
+	if err := downloadMatchingAssets(assets, "CHECKSUM", stageDir, config); err != nil {
+		cleanupErr := os.RemoveAll(stageDir)
+		if cleanupErr != nil {
+			cleanupErr = fmt.Errorf("failed to remove release CHECKSUM staging dir %s: %w", stageDir, cleanupErr)
+		}
+		return errors.Join(
+			fmt.Errorf("failed to download release CHECKSUM: %w", err),
+			cleanupErr,
+		)
 	}
 	releasePath := filepath.Join(stageDir, "CHECKSUM")
 
 	release, err := parseChecksumFile(releasePath)
 	if err != nil {
-		return fmt.Errorf("failed to read release CHECKSUM: %w", err)
+		cleanupErr := os.RemoveAll(stageDir)
+		if cleanupErr != nil {
+			cleanupErr = fmt.Errorf("failed to remove release CHECKSUM staging dir %s: %w", stageDir, cleanupErr)
+		}
+		return errors.Join(fmt.Errorf("failed to read release CHECKSUM: %w", err), cleanupErr)
+	}
+	if err := os.RemoveAll(stageDir); err != nil {
+		return fmt.Errorf("failed to remove release CHECKSUM staging dir %s: %w", stageDir, err)
 	}
 
 	// Union: start from local, let release entries override same-filename ones.
@@ -200,39 +227,107 @@ func mergeReleaseChecksum(assets []releaseAsset, dir string) error {
 }
 
 // ensureReleaseChecksum fetches and merges the release CHECKSUM into dir/CHECKSUM
-// exactly once per release tag for the lifetime of the process, regardless of
-// how many keys are being preloaded and whether they are handled sequentially or
-// concurrently. mergeReleaseChecksum reuses the already-fetched asset list.
-func ensureReleaseChecksum(assets []releaseAsset, dir string) error {
-	tag := releaseTag()
+// once per release tag and destination dir for the lifetime of the process,
+// after a successful merge. mergeReleaseChecksum reuses the already-fetched
+// asset list.
+func ensureReleaseChecksum(assets []releaseAsset, dir string, config *DownloadConfig) error {
+	key := releaseTag() + "\x00" + dir
 	checksumMergeMu.Lock()
-	state, ok := checksumMergeOnce[tag]
+	state, ok := checksumMergeStates[key]
 	if !ok {
 		state = &checksumMergeState{}
-		checksumMergeOnce[tag] = state
+		checksumMergeStates[key] = state
 	}
 	checksumMergeMu.Unlock()
 
-	state.once.Do(func() {
-		state.err = mergeReleaseChecksum(assets, dir)
-	})
-	return state.err
+	state.mu.Lock()
+	if state.done {
+		state.mu.Unlock()
+		return nil
+	}
+	if err := mergeReleaseChecksum(assets, dir, config); err != nil {
+		state.mu.Unlock()
+		return err
+	}
+	state.done = true
+	state.mu.Unlock()
+	return nil
 }
 
-func verifyChecksum(filepath string, expectedChecksum string) (bool, error) {
-	file, err := os.Open(filepath)
+func verifyChecksum(filePath string, expectedChecksum string) (bool, error) {
+	file, err := os.Open(filePath)
 	if err != nil {
 		return false, err
 	}
-	defer file.Close()
 
 	hash := sha256.New()
-	if _, err := io.Copy(hash, file); err != nil {
-		return false, err
+	_, copyErr := io.Copy(hash, file)
+	closeErr := file.Close()
+	if copyErr != nil {
+		return false, copyErr
 	}
-
+	if closeErr != nil {
+		return false, closeErr
+	}
 	actualChecksum := hex.EncodeToString(hash.Sum(nil))
 	return actualChecksum == expectedChecksum, nil
+}
+
+func removeFileIfExists(path string) error {
+	err := os.Remove(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func wrapCleanupError(msg string, path string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s %s: %w", msg, path, err)
+}
+
+func cleanupTempFile(path string, originalErr error) error {
+	if removeErr := removeFileIfExists(path); removeErr != nil {
+		return errors.Join(originalErr, fmt.Errorf("failed to remove temp file %s: %w", path, removeErr))
+	}
+	return originalErr
+}
+
+func cleanupOpenTempFile(file *os.File, path string, originalErr error) error {
+	closeErr := file.Close()
+	err := cleanupTempFile(path, originalErr)
+	if closeErr != nil {
+		err = errors.Join(err, fmt.Errorf("failed to close temp file %s: %w", path, closeErr))
+	}
+	return err
+}
+
+func readResponseSnippet(resp *http.Response) (string, error) {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2048))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(body)), nil
+}
+
+func closeResponse(resp *http.Response, originalErr error) error {
+	if closeErr := resp.Body.Close(); closeErr != nil {
+		return errors.Join(originalErr, fmt.Errorf("failed to close response body for %s: %w", resp.Request.URL.String(), closeErr))
+	}
+	return originalErr
+}
+
+func githubAPIURL(path string) string {
+	return strings.TrimRight(githubAPIBaseURL, "/") + path
+}
+
+func maxDownloadAttempts(config *DownloadConfig) int {
+	if config.MaxRetries < 1 {
+		return 1
+	}
+	return config.MaxRetries
 }
 
 func calculateBackoff(attempt int, initialDelay, maxDelay time.Duration) time.Duration {
@@ -267,7 +362,7 @@ func githubAPIRequest(method, url, accept string) (*http.Request, error) {
 // proving-keys repo is private, so the request carries a bearer token.
 func listReleaseAssets() ([]releaseAsset, error) {
 	tag := releaseTag()
-	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/tags/%s", ProvingKeysRepo, tag)
+	url := githubAPIURL(fmt.Sprintf("/repos/%s/releases/tags/%s", ProvingKeysRepo, tag))
 	req, err := githubAPIRequest(http.MethodGet, url, "application/vnd.github+json")
 	if err != nil {
 		return nil, err
@@ -276,20 +371,28 @@ func listReleaseAssets() ([]releaseAsset, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to query release %s@%s: %w", ProvingKeysRepo, tag, err)
 	}
-	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		body, readErr := readResponseSnippet(resp)
+		if readErr != nil {
+			return nil, closeResponse(resp, fmt.Errorf("failed to read release %s@%s error response: %w", ProvingKeysRepo, tag, readErr))
+		}
 		hint := ""
 		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 			hint = " (set GITHUB_TOKEN/GH_TOKEN with read access to the private proving-keys repo)"
 		}
-		return nil, fmt.Errorf("failed to query release %s@%s: HTTP %d%s: %s", ProvingKeysRepo, tag, resp.StatusCode, hint, strings.TrimSpace(string(body)))
+		err := fmt.Errorf("failed to query release %s@%s: HTTP %d%s: %s", ProvingKeysRepo, tag, resp.StatusCode, hint, body)
+		return nil, closeResponse(resp, err)
 	}
 	var release struct {
 		Assets []releaseAsset `json:"assets"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		return nil, fmt.Errorf("failed to decode release metadata: %w", err)
+	decodeErr := json.NewDecoder(resp.Body).Decode(&release)
+	closeErr := closeResponse(resp, nil)
+	if decodeErr != nil {
+		return nil, fmt.Errorf("failed to decode release metadata: %w", errors.Join(decodeErr, closeErr))
+	}
+	if closeErr != nil {
+		return nil, closeErr
 	}
 	return release.Assets, nil
 }
@@ -298,7 +401,7 @@ func listReleaseAssets() ([]releaseAsset, error) {
 // pattern (a filepath.Match glob) into dir via the GitHub REST API. Errors if
 // nothing matches. Callers pass a pre-fetched asset list so a single
 // listReleaseAssets result can serve several patterns.
-func downloadMatchingAssets(assets []releaseAsset, pattern string, dir string) error {
+func downloadMatchingAssets(assets []releaseAsset, pattern string, dir string, config *DownloadConfig) error {
 	matched := 0
 	for _, asset := range assets {
 		ok, err := filepath.Match(pattern, asset.Name)
@@ -308,7 +411,7 @@ func downloadMatchingAssets(assets []releaseAsset, pattern string, dir string) e
 		if !ok {
 			continue
 		}
-		if err := downloadAssetByID(asset.ID, filepath.Join(dir, asset.Name)); err != nil {
+		if err := downloadAssetByID(asset.ID, filepath.Join(dir, asset.Name), config); err != nil {
 			return fmt.Errorf("failed to download asset %s: %w", asset.Name, err)
 		}
 		matched++
@@ -319,28 +422,19 @@ func downloadMatchingAssets(assets []releaseAsset, pattern string, dir string) e
 	return nil
 }
 
-// downloadReleaseAsset downloads every asset whose name matches pattern (a
-// filepath.Match glob) into dir via the GitHub REST API. Errors if nothing
-// matches. Replaces the `gh` CLI so downloads work in the distroless image.
-func downloadReleaseAsset(pattern string, dir string) error {
-	assets, err := listReleaseAssets()
-	if err != nil {
-		return err
-	}
-	return downloadMatchingAssets(assets, pattern, dir)
-}
-
 // downloadAssetByID streams a release asset (by numeric id) to outputPath,
 // retrying with backoff. With Accept: application/octet-stream GitHub redirects
 // to signed storage on a different host; the default client follows it and drops
 // the bearer token on that hop (the redirect URL is already signed).
-func downloadAssetByID(id int64, outputPath string) error {
-	assetURL := fmt.Sprintf("https://api.github.com/repos/%s/releases/assets/%d", ProvingKeysRepo, id)
+func downloadAssetByID(id int64, outputPath string, config *DownloadConfig) error {
+	config = normalizeDownloadConfig(config)
+	assetURL := githubAPIURL(fmt.Sprintf("/repos/%s/releases/assets/%d", ProvingKeysRepo, id))
 	tempPath := outputPath + ".tmp"
 	var lastErr error
-	for attempt := 1; attempt <= DefaultMaxRetries; attempt++ {
+	attempts := maxDownloadAttempts(config)
+	for attempt := 1; attempt <= attempts; attempt++ {
 		if attempt > 1 {
-			delay := calculateBackoff(attempt-1, DefaultRetryDelay, DefaultMaxRetryDelay)
+			delay := calculateBackoff(attempt-1, config.RetryDelay, config.MaxRetryDelay)
 			logging.Logger().Warn().
 				Err(lastErr).
 				Dur("retry_delay", delay).
@@ -352,16 +446,19 @@ func downloadAssetByID(id int64, outputPath string) error {
 		if err != nil {
 			return err
 		}
-		client := &http.Client{Timeout: 60 * time.Minute}
-		resp, err := client.Do(req)
+		resp, err := assetHTTPClient.Do(req)
 		if err != nil {
 			lastErr = err
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
-			resp.Body.Close()
-			lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+			body, readErr := readResponseSnippet(resp)
+			if readErr != nil {
+				lastErr = fmt.Errorf("HTTP %d; failed to read error body: %w", resp.StatusCode, readErr)
+			} else {
+				lastErr = fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+			}
+			lastErr = closeResponse(resp, lastErr)
 			// Permanent client errors (401/403/404, ...) will never succeed on
 			// retry -- fail fast instead of burning every retry with backoff.
 			// Rate limiting (429) and server errors (5xx) stay retryable.
@@ -372,28 +469,26 @@ func downloadAssetByID(id int64, outputPath string) error {
 		}
 		file, err := os.Create(tempPath)
 		if err != nil {
-			resp.Body.Close()
-			return fmt.Errorf("failed to create temp file %s: %w", tempPath, err)
+			return closeResponse(resp, fmt.Errorf("failed to create temp file %s: %w", tempPath, err))
 		}
 		_, copyErr := io.Copy(file, resp.Body)
-		resp.Body.Close()
-		if closeErr := file.Close(); closeErr != nil && copyErr == nil {
-			copyErr = closeErr
+		copyErr = closeResponse(resp, copyErr)
+		if closeErr := file.Close(); closeErr != nil {
+			copyErr = errors.Join(copyErr, closeErr)
 		}
 		if copyErr != nil {
-			os.Remove(tempPath)
-			lastErr = copyErr
+			lastErr = cleanupTempFile(tempPath, copyErr)
 			continue
 		}
 		if err := os.Rename(tempPath, outputPath); err != nil {
-			return fmt.Errorf("failed to rename temp file to %s: %w", outputPath, err)
+			return cleanupTempFile(tempPath, fmt.Errorf("failed to rename temp file to %s: %w", outputPath, err))
 		}
 		logging.Logger().Info().
 			Str("file", filepath.Base(outputPath)).
 			Msg("Release asset downloaded")
 		return nil
 	}
-	return fmt.Errorf("failed to download asset after %d attempts: %w", DefaultMaxRetries, lastErr)
+	return fmt.Errorf("failed to download asset after %d attempts: %w", attempts, lastErr)
 }
 
 // EnsureProvingKeyFromRelease makes a Zolana proving key available at keyPath,
@@ -401,24 +496,42 @@ func downloadAssetByID(id int64, outputPath string) error {
 // REST API with a bearer token (GITHUB_TOKEN / GH_TOKEN). If the file is already
 // present and verifies against the local CHECKSUM, no download happens. When
 // autoDownload is false, a missing file is an error.
-func EnsureProvingKeyFromRelease(keyPath string, autoDownload bool) error {
+func EnsureProvingKeyFromRelease(keyPath string, autoDownload bool, config *DownloadConfig) error {
+	config = normalizeDownloadConfig(config)
 	filename := filepath.Base(keyPath)
 	dir := filepath.Dir(keyPath)
 
+	hadLocalChecksum := false
+	localChecksumVerified := false
+	var localChecksumErr error
 	if localChecksum, ok := readLocalChecksum(dir, filename); ok {
+		hadLocalChecksum = true
 		if _, err := os.Stat(keyPath); err == nil {
-			if valid, verr := verifyChecksum(keyPath, localChecksum); verr == nil && valid {
+			valid, verr := verifyChecksum(keyPath, localChecksum)
+			localChecksumErr = verr
+			localChecksumVerified = valid && verr == nil
+			if localChecksumVerified {
 				logging.Logger().Info().
 					Str("file", filename).
 					Msg("Proving key verified against local CHECKSUM, skipping download")
 				return nil
 			}
+		} else if !os.IsNotExist(err) {
+			localChecksumErr = err
 		}
 	}
 
 	if !autoDownload {
 		if _, err := os.Stat(keyPath); err == nil {
+			if hadLocalChecksum && !localChecksumVerified {
+				if localChecksumErr != nil {
+					return fmt.Errorf("key file %s exists but failed checksum verification (auto-download disabled): %w", filename, localChecksumErr)
+				}
+				return fmt.Errorf("key file %s exists but failed checksum verification (auto-download disabled)", filename)
+			}
 			return nil
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to stat key file %s: %w", filename, err)
 		}
 		return fmt.Errorf("required key file not found: %s (auto-download disabled)", filename)
 	}
@@ -442,16 +555,16 @@ func EnsureProvingKeyFromRelease(keyPath string, autoDownload bool) error {
 
 	// Merge the release CHECKSUM into dir/CHECKSUM once per process (across all
 	// EnsureProvingKeyFromRelease calls), preserving locally generated entries.
-	if err := ensureReleaseChecksum(assets, dir); err != nil {
+	if err := ensureReleaseChecksum(assets, dir, config); err != nil {
 		return err
 	}
 
-	if err := downloadMatchingAssets(assets, filename, dir); err != nil {
+	if err := downloadMatchingAssets(assets, filename, dir, config); err != nil {
 		logging.Logger().Info().
 			Err(err).
 			Str("file", filename).
 			Msg("Exact release asset unavailable; trying split asset parts")
-		if partsErr := downloadMatchingAssets(assets, filename+".part-*", dir); partsErr != nil {
+		if partsErr := downloadMatchingAssets(assets, filename+".part-*", dir, config); partsErr != nil {
 			return fmt.Errorf("failed to download release asset %s or split parts: exact: %w; parts: %w", filename, err, partsErr)
 		}
 		if err := assembleReleaseAssetParts(dir, filename, keyPath); err != nil {
@@ -468,8 +581,7 @@ func EnsureProvingKeyFromRelease(keyPath string, autoDownload bool) error {
 		return fmt.Errorf("failed to verify downloaded file %s: %w", filename, err)
 	}
 	if !valid {
-		os.Remove(keyPath)
-		return fmt.Errorf("downloaded file %s checksum mismatch", filename)
+		return cleanupTempFile(keyPath, fmt.Errorf("downloaded file %s checksum mismatch", filename))
 	}
 
 	logging.Logger().Info().
@@ -494,46 +606,40 @@ func assembleReleaseAssetParts(dir string, filename string, outputPath string) e
 	if err != nil {
 		return fmt.Errorf("failed to create assembled key %s: %w", tempPath, err)
 	}
-	defer out.Close()
 
 	for _, part := range parts {
 		in, err := os.Open(part)
 		if err != nil {
-			os.Remove(tempPath)
-			return fmt.Errorf("failed to open split asset %s: %w", part, err)
+			return cleanupOpenTempFile(out, tempPath, fmt.Errorf("failed to open split asset %s: %w", part, err))
 		}
-		if _, err := io.Copy(out, in); err != nil {
-			in.Close()
-			os.Remove(tempPath)
-			return fmt.Errorf("failed to append split asset %s: %w", part, err)
-		}
-		if err := in.Close(); err != nil {
-			os.Remove(tempPath)
-			return fmt.Errorf("failed to close split asset %s: %w", part, err)
+		_, copyErr := io.Copy(out, in)
+		closeErr := in.Close()
+		if copyErr != nil || closeErr != nil {
+			err := copyErr
+			if closeErr != nil {
+				err = errors.Join(err, fmt.Errorf("failed to close split asset %s: %w", part, closeErr))
+			}
+			if copyErr != nil {
+				err = fmt.Errorf("failed to append split asset %s: %w", part, err)
+			}
+			return cleanupOpenTempFile(out, tempPath, err)
 		}
 	}
 	if err := out.Close(); err != nil {
-		os.Remove(tempPath)
-		return fmt.Errorf("failed to close assembled key %s: %w", tempPath, err)
+		return cleanupTempFile(tempPath, fmt.Errorf("failed to close assembled key %s: %w", tempPath, err))
 	}
 	if err := os.Rename(tempPath, outputPath); err != nil {
-		os.Remove(tempPath)
-		return fmt.Errorf("failed to move assembled key to %s: %w", outputPath, err)
+		return cleanupTempFile(tempPath, fmt.Errorf("failed to move assembled key to %s: %w", outputPath, err))
 	}
 	return nil
 }
 
-// EnsureTransferKeyFromRelease is kept for call sites and tests that still use
-// the old transfer-specific name.
-func EnsureTransferKeyFromRelease(keyPath string, autoDownload bool) error {
-	return EnsureProvingKeyFromRelease(keyPath, autoDownload)
-}
-
 func EnsureKeysExist(keys []string, config *DownloadConfig) error {
+	config = normalizeDownloadConfig(config)
 	if !config.AutoDownload {
 		for _, key := range keys {
-			if _, err := os.Stat(key); os.IsNotExist(err) {
-				return fmt.Errorf("required key file not found: %s (auto-download disabled)", key)
+			if err := EnsureProvingKeyFromRelease(key, false, config); err != nil {
+				return err
 			}
 		}
 		return nil
@@ -541,8 +647,12 @@ func EnsureKeysExist(keys []string, config *DownloadConfig) error {
 
 	var missingKeys []string
 	for _, key := range keys {
-		if _, err := os.Stat(key); os.IsNotExist(err) {
-			missingKeys = append(missingKeys, key)
+		if _, err := os.Stat(key); err != nil {
+			if os.IsNotExist(err) {
+				missingKeys = append(missingKeys, key)
+				continue
+			}
+			return fmt.Errorf("failed to stat key file %s: %w", key, err)
 		}
 	}
 
@@ -559,7 +669,7 @@ func EnsureKeysExist(keys []string, config *DownloadConfig) error {
 				Str("file", filepath.Base(key)).
 				Msg("Downloading missing key")
 
-			if err := EnsureProvingKeyFromRelease(key, config.AutoDownload); err != nil {
+			if err := EnsureProvingKeyFromRelease(key, config.AutoDownload, config); err != nil {
 				return fmt.Errorf("failed to download key %s: %w", filepath.Base(key), err)
 			}
 		}

--- a/prover/server/prover/common/key_downloader_test.go
+++ b/prover/server/prover/common/key_downloader_test.go
@@ -1,0 +1,500 @@
+package common
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type testReleaseServer struct {
+	mu            sync.Mutex
+	assets        []releaseAsset
+	assetBodies   map[int64][]byte
+	assetStatuses map[int64][]int
+	releaseCount  int
+	assetCounts   map[int64]int
+	releaseTags   []string
+	authHeaders   []string
+}
+
+func newTestReleaseServer(_ *testing.T, assets []releaseAsset, assetBodies map[int64][]byte) *testReleaseServer {
+	s := &testReleaseServer{
+		assets:        append([]releaseAsset(nil), assets...),
+		assetBodies:   assetBodies,
+		assetStatuses: map[int64][]int{},
+		assetCounts:   map[int64]int{},
+	}
+	return s
+}
+
+func (s *testReleaseServer) RoundTrip(req *http.Request) (*http.Response, error) {
+	recorder := httptest.NewRecorder()
+	s.handle(recorder, req)
+	resp := recorder.Result()
+	resp.Request = req
+	return resp, nil
+}
+
+func (s *testReleaseServer) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	releasePrefix := "/repos/" + ProvingKeysRepo + "/releases/tags/"
+	if strings.HasPrefix(r.URL.Path, releasePrefix) {
+		tag := strings.TrimPrefix(r.URL.Path, releasePrefix)
+		s.mu.Lock()
+		s.releaseCount++
+		s.releaseTags = append(s.releaseTags, tag)
+		s.authHeaders = append(s.authHeaders, r.Header.Get("Authorization"))
+		assets := append([]releaseAsset(nil), s.assets...)
+		s.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(struct {
+			Assets []releaseAsset `json:"assets"`
+		}{Assets: assets})
+		if err != nil {
+			panic(fmt.Sprintf("encode release response: %v", err))
+		}
+		return
+	}
+
+	assetPrefix := "/repos/" + ProvingKeysRepo + "/releases/assets/"
+	if strings.HasPrefix(r.URL.Path, assetPrefix) {
+		idText := strings.TrimPrefix(r.URL.Path, assetPrefix)
+		id, err := strconv.ParseInt(idText, 10, 64)
+		if err != nil {
+			http.Error(w, "bad asset id", http.StatusBadRequest)
+			return
+		}
+
+		s.mu.Lock()
+		s.assetCounts[id]++
+		count := s.assetCounts[id]
+		s.authHeaders = append(s.authHeaders, r.Header.Get("Authorization"))
+		statuses := append([]int(nil), s.assetStatuses[id]...)
+		body, ok := s.assetBodies[id]
+		s.mu.Unlock()
+
+		if !ok {
+			http.Error(w, "missing asset", http.StatusNotFound)
+			return
+		}
+
+		status := http.StatusOK
+		if len(statuses) > 0 {
+			idx := count - 1
+			if idx >= len(statuses) {
+				idx = len(statuses) - 1
+			}
+			status = statuses[idx]
+		}
+		if status != http.StatusOK {
+			http.Error(w, fmt.Sprintf("status %d", status), status)
+			return
+		}
+
+		if _, err := w.Write(body); err != nil {
+			panic(fmt.Sprintf("write asset response: %v", err))
+		}
+		return
+	}
+
+	http.NotFound(w, r)
+}
+
+func (s *testReleaseServer) setAssetStatuses(id int64, statuses ...int) {
+	s.mu.Lock()
+	s.assetStatuses[id] = append([]int(nil), statuses...)
+	s.mu.Unlock()
+}
+
+func (s *testReleaseServer) requestsForAsset(id int64) int {
+	s.mu.Lock()
+	count := s.assetCounts[id]
+	s.mu.Unlock()
+	return count
+}
+
+func (s *testReleaseServer) requestsForRelease() int {
+	s.mu.Lock()
+	count := s.releaseCount
+	s.mu.Unlock()
+	return count
+}
+
+func (s *testReleaseServer) sawReleaseTag(tag string) bool {
+	s.mu.Lock()
+	tags := append([]string(nil), s.releaseTags...)
+	s.mu.Unlock()
+	for _, got := range tags {
+		if got == tag {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *testReleaseServer) sawAuthorization(header string) bool {
+	s.mu.Lock()
+	headers := append([]string(nil), s.authHeaders...)
+	s.mu.Unlock()
+	for _, got := range headers {
+		if got == header {
+			return true
+		}
+	}
+	return false
+}
+
+func useTestGitHub(t *testing.T, s *testReleaseServer) {
+	oldBaseURL := githubAPIBaseURL
+	oldMetadataClient := metadataHTTPClient
+	oldAssetClient := assetHTTPClient
+	checksumMergeMu.Lock()
+	oldChecksumStates := checksumMergeStates
+	checksumMergeStates = map[string]*checksumMergeState{}
+	checksumMergeMu.Unlock()
+
+	githubAPIBaseURL = "https://api.github.test"
+	metadataHTTPClient = &http.Client{Transport: s}
+	assetHTTPClient = &http.Client{Transport: s}
+
+	t.Cleanup(func() {
+		githubAPIBaseURL = oldBaseURL
+		metadataHTTPClient = oldMetadataClient
+		assetHTTPClient = oldAssetClient
+		checksumMergeMu.Lock()
+		checksumMergeStates = oldChecksumStates
+		checksumMergeMu.Unlock()
+	})
+}
+
+func testDownloadConfig(maxRetries int) *DownloadConfig {
+	return &DownloadConfig{
+		MaxRetries:    maxRetries,
+		RetryDelay:    time.Millisecond,
+		MaxRetryDelay: time.Millisecond,
+		AutoDownload:  true,
+	}
+}
+
+func checksumHex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func writeTestFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readTestFile(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return data
+}
+
+func writeTestChecksum(t *testing.T, dir string, entries map[string]string) {
+	t.Helper()
+	var b strings.Builder
+	for name, sum := range entries {
+		if _, err := fmt.Fprintf(&b, "%s  %s\n", sum, name); err != nil {
+			t.Fatalf("format checksum entry: %v", err)
+		}
+	}
+	writeTestFile(t, filepath.Join(dir, "CHECKSUM"), []byte(b.String()))
+}
+
+func releaseWithChecksumAndKey(filename string, body []byte) ([]releaseAsset, map[int64][]byte) {
+	checksum := []byte(fmt.Sprintf("%s  %s\n", checksumHex(body), filename))
+	return []releaseAsset{
+			{ID: 1, Name: "CHECKSUM"},
+			{ID: 2, Name: filename},
+		}, map[int64][]byte{
+			1: checksum,
+			2: body,
+		}
+}
+
+func TestEnsureProvingKeyLocalChecksumVerifiedSkipsNetwork(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "local.key")
+	keyBody := []byte("local key")
+	writeTestFile(t, keyPath, keyBody)
+	writeTestChecksum(t, dir, map[string]string{"local.key": checksumHex(keyBody)})
+
+	server := newTestReleaseServer(t, nil, nil)
+	useTestGitHub(t, server)
+
+	if err := EnsureProvingKeyFromRelease(keyPath, true, testDownloadConfig(1)); err != nil {
+		t.Fatalf("ensure local key: %v", err)
+	}
+	if got := server.requestsForRelease(); got != 0 {
+		t.Fatalf("release requests = %d, want 0", got)
+	}
+}
+
+func TestEnsureProvingKeyAutoDownloadDisabled(t *testing.T) {
+	t.Run("missing file errors without network", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "missing.key")
+		server := newTestReleaseServer(t, nil, nil)
+		useTestGitHub(t, server)
+
+		err := EnsureProvingKeyFromRelease(keyPath, false, testDownloadConfig(1))
+		if err == nil || !strings.Contains(err.Error(), "required key file not found") {
+			t.Fatalf("error = %v, want missing-file error", err)
+		}
+		if got := server.requestsForRelease(); got != 0 {
+			t.Fatalf("release requests = %d, want 0", got)
+		}
+	})
+
+	t.Run("checksum failure errors without network", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "bad.key")
+		writeTestFile(t, keyPath, []byte("bad key"))
+		writeTestChecksum(t, dir, map[string]string{"bad.key": checksumHex([]byte("expected key"))})
+		server := newTestReleaseServer(t, nil, nil)
+		useTestGitHub(t, server)
+
+		err := EnsureProvingKeyFromRelease(keyPath, false, testDownloadConfig(1))
+		if err == nil || !strings.Contains(err.Error(), "failed checksum verification") {
+			t.Fatalf("error = %v, want checksum verification error", err)
+		}
+		if got := server.requestsForRelease(); got != 0 {
+			t.Fatalf("release requests = %d, want 0", got)
+		}
+	})
+}
+
+func TestEnsureProvingKeyExactAssetDownload(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "exact.key")
+	keyBody := []byte("downloaded exact key")
+	assets, bodies := releaseWithChecksumAndKey("exact.key", keyBody)
+	server := newTestReleaseServer(t, assets, bodies)
+	useTestGitHub(t, server)
+
+	if err := EnsureProvingKeyFromRelease(keyPath, true, testDownloadConfig(1)); err != nil {
+		t.Fatalf("ensure exact key: %v", err)
+	}
+	if got := readTestFile(t, keyPath); !bytes.Equal(got, keyBody) {
+		t.Fatalf("downloaded file = %q, want %q", got, keyBody)
+	}
+	if got := server.requestsForAsset(1); got != 1 {
+		t.Fatalf("CHECKSUM requests = %d, want 1", got)
+	}
+	if got := server.requestsForAsset(2); got != 1 {
+		t.Fatalf("key requests = %d, want 1", got)
+	}
+}
+
+func TestEnsureProvingKeySplitAssetDownload(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "split.key")
+	partA := []byte("left-")
+	partB := []byte("right")
+	keyBody := append(append([]byte(nil), partA...), partB...)
+	checksum := []byte(fmt.Sprintf("%s  split.key\n", checksumHex(keyBody)))
+	server := newTestReleaseServer(t, []releaseAsset{
+		{ID: 1, Name: "CHECKSUM"},
+		{ID: 2, Name: "split.key.part-000"},
+		{ID: 3, Name: "split.key.part-001"},
+	}, map[int64][]byte{
+		1: checksum,
+		2: partA,
+		3: partB,
+	})
+	useTestGitHub(t, server)
+
+	if err := EnsureProvingKeyFromRelease(keyPath, true, testDownloadConfig(1)); err != nil {
+		t.Fatalf("ensure split key: %v", err)
+	}
+	if got := readTestFile(t, keyPath); !bytes.Equal(got, keyBody) {
+		t.Fatalf("assembled file = %q, want %q", got, keyBody)
+	}
+	if got := server.requestsForAsset(2); got != 1 {
+		t.Fatalf("part 000 requests = %d, want 1", got)
+	}
+	if got := server.requestsForAsset(3); got != 1 {
+		t.Fatalf("part 001 requests = %d, want 1", got)
+	}
+}
+
+func TestEnsureProvingKeyChecksumMismatchRemovesFile(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "mismatch.key")
+	keyBody := []byte("actual key")
+	checksum := []byte(fmt.Sprintf("%s  mismatch.key\n", checksumHex([]byte("expected key"))))
+	server := newTestReleaseServer(t, []releaseAsset{
+		{ID: 1, Name: "CHECKSUM"},
+		{ID: 2, Name: "mismatch.key"},
+	}, map[int64][]byte{
+		1: checksum,
+		2: keyBody,
+	})
+	useTestGitHub(t, server)
+
+	err := EnsureProvingKeyFromRelease(keyPath, true, testDownloadConfig(1))
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("error = %v, want checksum mismatch", err)
+	}
+	if _, statErr := os.Stat(keyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("downloaded file still exists or stat failed with unexpected error: %v", statErr)
+	}
+}
+
+func TestDownloadAssetRetries(t *testing.T) {
+	t.Run("404 fails fast", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "not-found.key")
+		keyBody := []byte("key")
+		assets, bodies := releaseWithChecksumAndKey("not-found.key", keyBody)
+		server := newTestReleaseServer(t, assets, bodies)
+		server.setAssetStatuses(2, http.StatusNotFound)
+		useTestGitHub(t, server)
+
+		err := EnsureProvingKeyFromRelease(keyPath, true, testDownloadConfig(3))
+		if err == nil || !strings.Contains(err.Error(), "HTTP 404") {
+			t.Fatalf("error = %v, want HTTP 404", err)
+		}
+		if got := server.requestsForAsset(2); got != 1 {
+			t.Fatalf("key requests = %d, want 1", got)
+		}
+	})
+
+	t.Run("500 retries", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "retry.key")
+		keyBody := []byte("key")
+		assets, bodies := releaseWithChecksumAndKey("retry.key", keyBody)
+		server := newTestReleaseServer(t, assets, bodies)
+		server.setAssetStatuses(2, http.StatusInternalServerError, http.StatusInternalServerError)
+		useTestGitHub(t, server)
+
+		err := EnsureProvingKeyFromRelease(keyPath, true, testDownloadConfig(2))
+		if err == nil || !strings.Contains(err.Error(), "HTTP 500") {
+			t.Fatalf("error = %v, want HTTP 500", err)
+		}
+		if got := server.requestsForAsset(2); got != 2 {
+			t.Fatalf("key requests = %d, want 2", got)
+		}
+	})
+}
+
+func TestChecksumMergePreservesLocalEntriesAndReleaseWins(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "download.key")
+	keyBody := []byte("download")
+	localOnlySum := checksumHex([]byte("local only"))
+	oldConflictSum := checksumHex([]byte("old conflict"))
+	newConflictSum := checksumHex([]byte("new conflict"))
+	writeTestChecksum(t, dir, map[string]string{
+		"local-only.key": localOnlySum,
+		"conflict.key":   oldConflictSum,
+	})
+
+	releaseChecksum := []byte(fmt.Sprintf("%s  conflict.key\n%s  download.key\n", newConflictSum, checksumHex(keyBody)))
+	server := newTestReleaseServer(t, []releaseAsset{
+		{ID: 1, Name: "CHECKSUM"},
+		{ID: 2, Name: "download.key"},
+	}, map[int64][]byte{
+		1: releaseChecksum,
+		2: keyBody,
+	})
+	useTestGitHub(t, server)
+
+	if err := EnsureProvingKeyFromRelease(keyPath, true, testDownloadConfig(1)); err != nil {
+		t.Fatalf("ensure key: %v", err)
+	}
+	entries, err := parseChecksumFile(filepath.Join(dir, "CHECKSUM"))
+	if err != nil {
+		t.Fatalf("parse merged CHECKSUM: %v", err)
+	}
+	if got := entries["local-only.key"]; got != localOnlySum {
+		t.Fatalf("local-only checksum = %q, want %q", got, localOnlySum)
+	}
+	if got := entries["conflict.key"]; got != newConflictSum {
+		t.Fatalf("conflict checksum = %q, want release checksum %q", got, newConflictSum)
+	}
+}
+
+func TestChecksumMergeRetriesAfterFailure(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "retry-checksum.key")
+	keyBody := []byte("key")
+	assets, bodies := releaseWithChecksumAndKey("retry-checksum.key", keyBody)
+	server := newTestReleaseServer(t, assets, bodies)
+	server.setAssetStatuses(1, http.StatusInternalServerError, http.StatusOK)
+	useTestGitHub(t, server)
+
+	if err := EnsureProvingKeyFromRelease(keyPath, true, testDownloadConfig(1)); err == nil {
+		t.Fatalf("first ensure succeeded, want CHECKSUM download failure")
+	}
+	if err := EnsureProvingKeyFromRelease(keyPath, true, testDownloadConfig(1)); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	if got := server.requestsForAsset(1); got != 2 {
+		t.Fatalf("CHECKSUM requests = %d, want 2", got)
+	}
+}
+
+func TestChecksumMergeRunsPerTagAndDir(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	keyBody := []byte("shared")
+	assets, bodies := releaseWithChecksumAndKey("shared.key", keyBody)
+	server := newTestReleaseServer(t, assets, bodies)
+	useTestGitHub(t, server)
+
+	if err := EnsureProvingKeyFromRelease(filepath.Join(dir1, "shared.key"), true, testDownloadConfig(1)); err != nil {
+		t.Fatalf("ensure dir1: %v", err)
+	}
+	if err := EnsureProvingKeyFromRelease(filepath.Join(dir2, "shared.key"), true, testDownloadConfig(1)); err != nil {
+		t.Fatalf("ensure dir2: %v", err)
+	}
+	if got := server.requestsForAsset(1); got != 2 {
+		t.Fatalf("CHECKSUM requests = %d, want 2", got)
+	}
+}
+
+func TestProvingKeysReleaseTagOverride(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "override.key")
+	keyBody := []byte("key")
+	assets, bodies := releaseWithChecksumAndKey("override.key", keyBody)
+	server := newTestReleaseServer(t, assets, bodies)
+	useTestGitHub(t, server)
+	t.Setenv(provingKeysReleaseTagEnvVar, "custom-tag")
+	t.Setenv("GH_TOKEN", "test-token")
+
+	if err := EnsureProvingKeyFromRelease(keyPath, true, testDownloadConfig(1)); err != nil {
+		t.Fatalf("ensure override key: %v", err)
+	}
+	if !server.sawReleaseTag("custom-tag") {
+		t.Fatalf("release tag override was not used")
+	}
+	if !server.sawAuthorization("Bearer test-token") {
+		t.Fatalf("authorization bearer token was not sent")
+	}
+}

--- a/prover/server/prover/common/key_downloader_test.go
+++ b/prover/server/prover/common/key_downloader_test.go
@@ -339,6 +339,12 @@ func TestEnsureProvingKeySplitAssetDownload(t *testing.T) {
 	if got := server.requestsForAsset(3); got != 1 {
 		t.Fatalf("part 001 requests = %d, want 1", got)
 	}
+	for _, partName := range []string{"split.key.part-000", "split.key.part-001"} {
+		partPath := filepath.Join(dir, partName)
+		if _, statErr := os.Stat(partPath); !os.IsNotExist(statErr) {
+			t.Fatalf("split part %s still exists or stat failed with unexpected error: %v", partName, statErr)
+		}
+	}
 }
 
 func TestEnsureProvingKeyChecksumMismatchRemovesFile(t *testing.T) {
@@ -486,6 +492,7 @@ func TestProvingKeysReleaseTagOverride(t *testing.T) {
 	server := newTestReleaseServer(t, assets, bodies)
 	useTestGitHub(t, server)
 	t.Setenv(provingKeysReleaseTagEnvVar, "custom-tag")
+	t.Setenv("GITHUB_TOKEN", "")
 	t.Setenv("GH_TOKEN", "test-token")
 
 	if err := EnsureProvingKeyFromRelease(keyPath, true, testDownloadConfig(1)); err != nil {

--- a/prover/server/prover/common/lazy_key_manager.go
+++ b/prover/server/prover/common/lazy_key_manager.go
@@ -127,7 +127,7 @@ func (m *LazyKeyManager) loadMerkleSystem(
 		Str("cache_key", key).
 		Msg("Loading MerkleProofSystem")
 
-	if err := DownloadKey(keyPath, m.downloadConfig); err != nil {
+	if err := EnsureProvingKeyFromRelease(keyPath, m.downloadConfig.AutoDownload); err != nil {
 		return nil, fmt.Errorf("failed to download key %s: %w", keyPath, err)
 	}
 
@@ -180,11 +180,7 @@ func (m *LazyKeyManager) loadBatchSystem(key string, circuitType CircuitType, tr
 		Str("cache_key", key).
 		Msg("Loading BatchProofSystem")
 
-	if usesProvingKeysRelease(circuitType, treeHeight, batchSize) {
-		if err := EnsureProvingKeyFromRelease(keyPath, m.downloadConfig.AutoDownload); err != nil {
-			return nil, fmt.Errorf("failed to download key %s: %w", keyPath, err)
-		}
-	} else if err := DownloadKey(keyPath, m.downloadConfig); err != nil {
+	if err := EnsureProvingKeyFromRelease(keyPath, m.downloadConfig.AutoDownload); err != nil {
 		return nil, fmt.Errorf("failed to download key %s: %w", keyPath, err)
 	}
 
@@ -354,10 +350,6 @@ func (m *LazyKeyManager) determineBatchKeyPath(circuitType CircuitType, treeHeig
 	return ""
 }
 
-func usesProvingKeysRelease(circuitType CircuitType, treeHeight uint32, batchSize uint32) bool {
-	return circuitType == BatchAddressAppendCircuitType && treeHeight == 40 && (batchSize == 10 || batchSize == 250)
-}
-
 // transferSupportedShapes mirrors protocol.SupportedShapes (the on-chain
 // canonical shape set). Kept here because common must not import prover-test;
 // keep in sync with prover-test/spp/protocol/shape.go.
@@ -507,7 +499,7 @@ func (m *LazyKeyManager) preloadKeys(keyPaths []string) error {
 			Str("key_path", keyPath).
 			Msg("Preloading key")
 
-		if err := DownloadKey(keyPath, m.downloadConfig); err != nil {
+		if err := EnsureProvingKeyFromRelease(keyPath, m.downloadConfig.AutoDownload); err != nil {
 			return fmt.Errorf("failed to download key %s: %w", keyPath, err)
 		}
 

--- a/prover/server/prover/common/lazy_key_manager.go
+++ b/prover/server/prover/common/lazy_key_manager.go
@@ -127,7 +127,7 @@ func (m *LazyKeyManager) loadMerkleSystem(
 		Str("cache_key", key).
 		Msg("Loading MerkleProofSystem")
 
-	if err := EnsureProvingKeyFromRelease(keyPath, m.downloadConfig.AutoDownload); err != nil {
+	if err := EnsureProvingKeyFromRelease(keyPath, m.downloadConfig.AutoDownload, m.downloadConfig); err != nil {
 		return nil, fmt.Errorf("failed to download key %s: %w", keyPath, err)
 	}
 
@@ -180,7 +180,7 @@ func (m *LazyKeyManager) loadBatchSystem(key string, circuitType CircuitType, tr
 		Str("cache_key", key).
 		Msg("Loading BatchProofSystem")
 
-	if err := EnsureProvingKeyFromRelease(keyPath, m.downloadConfig.AutoDownload); err != nil {
+	if err := EnsureProvingKeyFromRelease(keyPath, m.downloadConfig.AutoDownload, m.downloadConfig); err != nil {
 		return nil, fmt.Errorf("failed to download key %s: %w", keyPath, err)
 	}
 
@@ -232,7 +232,7 @@ func (m *LazyKeyManager) loadTransferSystem(key string, circuitType CircuitType,
 		Str("cache_key", key).
 		Msg("Loading TransferProofSystem")
 
-	if err := EnsureTransferKeyFromRelease(keyPath, m.downloadConfig.AutoDownload); err != nil {
+	if err := EnsureProvingKeyFromRelease(keyPath, m.downloadConfig.AutoDownload, m.downloadConfig); err != nil {
 		return nil, fmt.Errorf("failed to download key %s: %w", keyPath, err)
 	}
 
@@ -499,7 +499,7 @@ func (m *LazyKeyManager) preloadKeys(keyPaths []string) error {
 			Str("key_path", keyPath).
 			Msg("Preloading key")
 
-		if err := EnsureProvingKeyFromRelease(keyPath, m.downloadConfig.AutoDownload); err != nil {
+		if err := EnsureProvingKeyFromRelease(keyPath, m.downloadConfig.AutoDownload, m.downloadConfig); err != nil {
 			return fmt.Errorf("failed to download key %s: %w", keyPath, err)
 		}
 


### PR DESCRIPTION
## What
The prover key downloader still routed all keys except batch address-append through the light-protocol **GCS bucket** (`DefaultBaseURL` + `DownloadKey`). rings/zolana doesn't use GCS — Zolana keys live only on the private `helius-labs/zolana` GitHub release — so auto-downloading transfer/merge keys fetched from a bucket that never holds them.

## Changes
- **Route every key through the release path**; delete the GCS code (`DefaultBaseURL`, `DownloadKey`, `downloadChecksum`, `downloadFileWithResume`, `DownloadConfig.BaseURL`, the `--download-url` flag, `usesProvingKeysRelease`).
- **Download via the GitHub REST API + bearer token** (`GITHUB_TOKEN`/`GH_TOKEN`) instead of the `gh` CLI, so auto-download works in the **distroless** prover image (which has no `gh`).
- Release tag overridable via `PROVING_KEYS_RELEASE_TAG` (key rotations without a rebuild).
- Split assets (`.key.part-*`) still assembled + checksum-verified.

## Notes
- The proving-keys repo is **private**, so auto-download requires a token with read access; without one the API returns `404` with a hint. Deployments that **bake** keys into the image need no token and never hit this path.

## Testing
- `go build ./...` + `go vet` clean.
- Verified against the private `transfer-keys-v10` release: with a token it fetched + checksum-verified a key; without a token it 404s with the hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
