### PR TITLE
feat(prover): async queue for transfer/merge proofs

### DIFF
--- a/.github/workflows/async-prover.yml
+++ b/.github/workflows/async-prover.yml
@@ -1,0 +1,55 @@
+name: async prover
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  transfer-queue:
+    name: async prover / transfer queue
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    timeout-minutes: 30
+    services:
+      redis:
+        image: redis:7.4.4-alpine3.21
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ZOLANA_PROVER_REDIS_URL: redis://127.0.0.1:6379/15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: prover/server/go.mod
+          cache-dependency-path: prover/server/go.sum
+      - uses: ./.github/actions/setup-rust
+        with:
+          shared-key: async-prover
+          private-libs-token: ${{ secrets.PRIVATE_LIBS_TOKEN }}
+      - name: Cache proving keys
+        uses: actions/cache@v4
+        with:
+          path: prover/server/proving-keys
+          key: proving-keys-transfer-keys-v10
+      - run: just test-client-async-transfer-queue
+      - name: Dump prover log on failure
+        if: failure()
+        run: |
+          find . -name prover-server.log -exec sh -c 'echo "--- {} ---"; tail -200 "{}"' \; 2>/dev/null \
+            || echo "(no prover log)"

--- a/cli/src/prover.rs
+++ b/cli/src/prover.rs
@@ -85,8 +85,7 @@ fn prover_start_args(
         format!("0.0.0.0:{prover_port}"),
         "--metrics-address".into(),
         format!("0.0.0.0:{metrics_port}"),
-        "--auto-download".into(),
-        auto_download.to_string(),
+        format!("--auto-download={auto_download}"),
     ];
 
     if let Some(redis_url) = redis_url {
@@ -132,8 +131,7 @@ mod tests {
                 "0.0.0.0:3002",
                 "--metrics-address",
                 "0.0.0.0:9999",
-                "--auto-download",
-                "false",
+                "--auto-download=false",
                 "--redis-url",
                 "redis://localhost:6379/15",
             ]

--- a/justfile
+++ b/justfile
@@ -475,6 +475,9 @@ prover-server-test:
     # SupportedShapes alone proves every supported shape -- so the run can exceed
     # Go's default 10m; the generous timeout is a ceiling, not a floor.
     go test ./circuits/... ./prover/... ./prover-test/... -timeout 60m
+    # The `server` package's handler tests need redis, but the queue-routing
+    # unit test does not -- run it explicitly so routing stays covered in CI.
+    go test ./server/ -run '^TestGetQueueNameForCircuit$'
 
 [private]
 xtask-create-verifying-keys:

--- a/justfile
+++ b/justfile
@@ -82,6 +82,15 @@ test-sdk-libs:
 test-client-integration: build-prover-server build-cli
     cargo test -p zolana-client
 
+# One real transfer proof through Redis, TransferQueueWorker, and the Rust
+# client's async /prove status polling. Requires a reachable Redis URL.
+test-client-async-transfer-queue: build-prover-server build-cli
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${ZOLANA_PROVER_REDIS_URL:?set ZOLANA_PROVER_REDIS_URL to a reachable Redis instance}"
+    ZOLANA_EXPECT_ASYNC_PROVER=true \
+        cargo test -p zolana-client --test transfer_dummy dummy_transfer_2_3_proof_verifies -- --exact
+
 # Program integration tests backed by LiteSVM. Transact tests spawn the prover
 # through the zolana CLI.
 test-programs: build-programs build-prover-server build-cli

--- a/prover/server/main.go
+++ b/prover/server/main.go
@@ -614,7 +614,7 @@ func runCli() {
 							workersStarted = append(workersStarted, "address-append")
 						}
 
-						if startAll || enabledCircuitsMap["transfer"] {
+						if startAll || enabledCircuitsMap["transfer"] || enableServer {
 							transferWorker := server.NewTransferQueueWorker(redisQueue, keyManager)
 							workers = append(workers, transferWorker)
 							go transferWorker.Start()

--- a/prover/server/main.go
+++ b/prover/server/main.go
@@ -614,6 +614,13 @@ func runCli() {
 							workersStarted = append(workersStarted, "address-append")
 						}
 
+						if startAll || enabledCircuitsMap["transfer"] {
+							transferWorker := server.NewTransferQueueWorker(redisQueue, keyManager)
+							workers = append(workers, transferWorker)
+							go transferWorker.Start()
+							workersStarted = append(workersStarted, "transfer")
+						}
+
 						logging.Logger().Info().
 							Strs("workers_started", workersStarted).
 							Msg("Queue workers started")

--- a/prover/server/server/queue.go
+++ b/prover/server/server/queue.go
@@ -434,8 +434,8 @@ func (rq *RedisQueue) GetQueueHealth() (map[string]interface{}, error) {
 	health["queue_lengths"] = stats
 	health["timestamp"] = time.Now().Unix()
 
-	health["total_pending"] = stats["zk_address_append_queue"]
-	health["total_processing"] = stats["zk_address_append_processing_queue"]
+	health["total_pending"] = stats["zk_address_append_queue"] + stats["zk_transfer_queue"]
+	health["total_processing"] = stats["zk_address_append_processing_queue"] + stats["zk_transfer_processing_queue"]
 	health["total_failed"] = stats["zk_failed_queue"]
 	health["total_results"] = stats["zk_results_queue"]
 

--- a/prover/server/server/queue.go
+++ b/prover/server/server/queue.go
@@ -387,7 +387,14 @@ func (rq *RedisQueue) dequeueLowestBatchIndex(queueName string) (*ProofJob, erro
 func (rq *RedisQueue) GetQueueStats() (map[string]int64, error) {
 	stats := make(map[string]int64)
 
-	queues := []string{"zk_address_append_queue", "zk_address_append_processing_queue", "zk_failed_queue", "zk_results_queue"}
+	queues := []string{
+		"zk_address_append_queue",
+		"zk_address_append_processing_queue",
+		"zk_transfer_queue",
+		"zk_transfer_processing_queue",
+		"zk_failed_queue",
+		"zk_results_queue",
+	}
 
 	for _, queue := range queues {
 		length, err := rq.Client.LLen(rq.Ctx, queue).Result()
@@ -451,6 +458,7 @@ func (rq *RedisQueue) countStuckJobs() int64 {
 	stuckTimeout := time.Now().Add(-2 * time.Minute)
 	processingQueues := []string{
 		"zk_address_append_processing_queue",
+		"zk_transfer_processing_queue",
 	}
 
 	var totalStuck int64
@@ -614,6 +622,7 @@ func (rq *RedisQueue) CleanupOldRequests() error {
 	// Queues to clean up old requests from
 	queuesToClean := []string{
 		"zk_address_append_queue",
+		"zk_transfer_queue",
 	}
 
 	totalRemoved := int64(0)
@@ -716,6 +725,7 @@ func (rq *RedisQueue) CleanupStuckProcessingJobs() error {
 
 	processingQueues := []string{
 		"zk_address_append_processing_queue",
+		"zk_transfer_processing_queue",
 	}
 
 	totalRecovered := int64(0)
@@ -882,6 +892,8 @@ func getOriginalQueueFromProcessing(processingQueueName string) string {
 	switch processingQueueName {
 	case "zk_address_append_processing_queue":
 		return "zk_address_append_queue"
+	case "zk_transfer_processing_queue":
+		return "zk_transfer_queue"
 	default:
 		return ""
 	}

--- a/prover/server/server/queue_job.go
+++ b/prover/server/server/queue_job.go
@@ -9,7 +9,10 @@ import (
 	"time"
 	"zolana/prover/logging"
 	"zolana/prover/prover/common"
+	mergeprover "zolana/prover/prover/merge"
 	"zolana/prover/prover/nullifier_tree"
+	"zolana/prover/prover/transfer"
+	transfereddsaonly "zolana/prover/prover/transfer_eddsa_only"
 )
 
 const (
@@ -72,6 +75,22 @@ func getMaxConcurrency() int {
 		Int("max_concurrency", MinConcurrencyPerWorker).
 		Msg("Using default min concurrency (set PROVER_MAX_CONCURRENCY or PROVER_TOTAL_MEMORY_GB to configure)")
 	return MinConcurrencyPerWorker
+}
+
+// getTransferMaxConcurrency returns how many transfer proofs the transfer worker
+// runs at once. Transfer proofs are far lighter than batch address-append, so the
+// operator can raise TRANSFER_WORKER_CONCURRENCY above the shared default (which
+// getMaxConcurrency keeps conservative for the heavy batch worker).
+func getTransferMaxConcurrency() int {
+	if val := os.Getenv("TRANSFER_WORKER_CONCURRENCY"); val != "" {
+		if concurrency, err := strconv.Atoi(val); err == nil && concurrency > 0 {
+			logging.Logger().Info().
+				Int("max_concurrency", concurrency).
+				Msg("Using TRANSFER_WORKER_CONCURRENCY")
+			return concurrency
+		}
+	}
+	return getMaxConcurrency()
 }
 
 // calculateConcurrency computes per-worker concurrency from total memory.
@@ -431,6 +450,36 @@ func (w *AddressAppendQueueWorker) Stop() {
 	w.BaseQueueWorker.Stop()
 }
 
+// TransferQueueWorker drains the transfer/merge proof queue. Transfers are
+// synchronous-fast individually but flood a shared prover under concurrency; the
+// queue bounds in-flight proofs so many clients can submit without stampeding.
+type TransferQueueWorker struct {
+	*BaseQueueWorker
+}
+
+func NewTransferQueueWorker(redisQueue *RedisQueue, keyManager *common.LazyKeyManager) *TransferQueueWorker {
+	maxConcurrency := getTransferMaxConcurrency()
+	return &TransferQueueWorker{
+		BaseQueueWorker: &BaseQueueWorker{
+			queue:               redisQueue,
+			keyManager:          keyManager,
+			stopChan:            make(chan struct{}),
+			queueName:           "zk_transfer_queue",
+			processingQueueName: "zk_transfer_processing_queue",
+			maxConcurrency:      maxConcurrency,
+			semaphore:           make(chan struct{}, maxConcurrency),
+		},
+	}
+}
+
+func (w *TransferQueueWorker) Start() {
+	w.BaseQueueWorker.Start()
+}
+
+func (w *TransferQueueWorker) Stop() {
+	w.BaseQueueWorker.Stop()
+}
+
 // generateProof generates a proof for the given job and returns it.
 // Result storage is handled by the caller to include timing information.
 func (w *BaseQueueWorker) generateProof(job *ProofJob) (*common.Proof, error) {
@@ -450,6 +499,17 @@ func (w *BaseQueueWorker) generateProof(job *ProofJob) (*common.Proof, error) {
 	switch proofRequestMeta.CircuitType {
 	case common.BatchAddressAppendCircuitType:
 		proof, proofError = w.processBatchAddressAppendProof(job.Payload)
+	case common.TransferP256ConfidentialCircuitType,
+		common.TransferP256ZoneCircuitType:
+		proof, proofError = w.processTransferP256Proof(job.Payload)
+	case common.TransferConfidentialCircuitType,
+		common.TransferZoneCircuitType,
+		common.TransferZoneAuthorityCircuitType:
+		proof, proofError = w.processTransferEddsaProof(job.Payload)
+	case common.MergeCircuitType:
+		proof, proofError = w.processMergeProof(job.Payload, common.MergeCircuitType)
+	case common.MergeZoneCircuitType:
+		proof, proofError = w.processMergeProof(job.Payload, common.MergeZoneCircuitType)
 	default:
 		return nil, fmt.Errorf("unknown circuit type: %s", proofRequestMeta.CircuitType)
 	}
@@ -488,6 +548,46 @@ func (w *BaseQueueWorker) processBatchAddressAppendProof(payload json.RawMessage
 
 	logging.Logger().Info().Msg("Processing batch address append proof")
 	return nullifiertree.ProveBatchAddressAppend(ps, &params)
+}
+
+func (w *BaseQueueWorker) processTransferP256Proof(payload json.RawMessage) (*common.Proof, error) {
+	var params transfer.TransferParameters
+	if err := json.Unmarshal(payload, &params); err != nil {
+		return nil, fmt.Errorf("unmarshal transfer params: %w", err)
+	}
+	circuitType := common.TransferP256ZoneCircuitType
+	if params.Confidential {
+		circuitType = common.TransferP256ConfidentialCircuitType
+	}
+	ps, err := w.keyManager.GetTransferSystem(circuitType, params.NInputs, params.NOutputs)
+	if err != nil {
+		return nil, fmt.Errorf("transfer: %w", err)
+	}
+	return transfer.ProveTransfer(ps, &params)
+}
+
+func (w *BaseQueueWorker) processTransferEddsaProof(payload json.RawMessage) (*common.Proof, error) {
+	var params transfereddsaonly.TransferParameters
+	if err := json.Unmarshal(payload, &params); err != nil {
+		return nil, fmt.Errorf("unmarshal transfer-eddsa params: %w", err)
+	}
+	ps, err := w.keyManager.GetTransferSystem(params.Variant.CircuitType(), params.NInputs, params.NOutputs)
+	if err != nil {
+		return nil, fmt.Errorf("transfer-eddsa: %w", err)
+	}
+	return transfereddsaonly.ProveTransfer(ps, &params)
+}
+
+func (w *BaseQueueWorker) processMergeProof(payload json.RawMessage, circuitType common.CircuitType) (*common.Proof, error) {
+	var params mergeprover.MergeParameters
+	if err := json.Unmarshal(payload, &params); err != nil {
+		return nil, fmt.Errorf("unmarshal merge params: %w", err)
+	}
+	ps, err := w.keyManager.GetTransferSystem(circuitType, mergeprover.MergeNInputs, mergeprover.MergeNOutputs)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", circuitType, err)
+	}
+	return mergeprover.ProveMerge(ps, &params)
 }
 
 func (w *BaseQueueWorker) removeFromProcessingQueue(jobID string) {

--- a/prover/server/server/queue_job.go
+++ b/prover/server/server/queue_job.go
@@ -221,8 +221,11 @@ func (w *BaseQueueWorker) processJobs() {
 
 		queueWaitTime := jobAge.Seconds()
 		circuitType := "unknown"
-		if w.queueName == "zk_address_append_queue" {
+		switch w.queueName {
+		case "zk_address_append_queue":
 			circuitType = "address-append"
+		case "zk_transfer_queue":
+			circuitType = "transfer"
 		}
 		QueueWaitTime.WithLabelValues(circuitType).Observe(queueWaitTime)
 	}
@@ -331,6 +334,43 @@ func (w *BaseQueueWorker) processJobs() {
 
 	go func(job *ProofJob, inputHash string) {
 		defer func() {
+			if r := recover(); r != nil {
+				circuitType := "unknown"
+				if meta, parseErr := common.ParseProofRequestMeta(job.Payload); parseErr != nil {
+					logging.Logger().Warn().
+						Err(parseErr).
+						Str("job_id", job.ID).
+						Msg("Failed to parse proof request meta while recovering panic")
+				} else {
+					circuitType = string(meta.CircuitType)
+				}
+				ProofPanicsTotal.WithLabelValues(circuitType).Inc()
+
+				panicErr := fmt.Errorf("panic: %v", r)
+				logging.Logger().Error().
+					Interface("panic", r).
+					Str("job_id", job.ID).
+					Str("queue", w.queueName).
+					Str("circuit_type", circuitType).
+					Msg("Panic recovered in proof processing")
+
+				w.removeFromProcessingQueue(job.ID)
+				w.addToFailedQueue(job, inputHash, panicErr)
+
+				if delErr := w.queue.DeleteInFlightJob(inputHash, job.ID); delErr != nil {
+					logging.Logger().Warn().
+						Err(delErr).
+						Str("job_id", job.ID).
+						Str("input_hash", inputHash).
+						Msg("Failed to delete in-flight job marker (non-critical)")
+				}
+				if delErr := w.queue.DeleteJobMeta(job.ID); delErr != nil {
+					logging.Logger().Warn().
+						Err(delErr).
+						Str("job_id", job.ID).
+						Msg("Failed to delete job metadata (non-critical)")
+				}
+			}
 			<-w.semaphore
 		}()
 

--- a/prover/server/server/queue_routing_test.go
+++ b/prover/server/server/queue_routing_test.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"testing"
+	"zolana/prover/prover/common"
+)
+
+// Transfer/merge circuits share zk_transfer_queue; address-append keeps its own;
+// everything else is not queued (empty name).
+func TestGetQueueNameForCircuit(t *testing.T) {
+	cases := []struct {
+		circuit common.CircuitType
+		queue   string
+	}{
+		{common.BatchAddressAppendCircuitType, "zk_address_append_queue"},
+		{common.TransferConfidentialCircuitType, "zk_transfer_queue"},
+		{common.TransferP256ConfidentialCircuitType, "zk_transfer_queue"},
+		{common.TransferZoneCircuitType, "zk_transfer_queue"},
+		{common.TransferP256ZoneCircuitType, "zk_transfer_queue"},
+		{common.TransferZoneAuthorityCircuitType, "zk_transfer_queue"},
+		{common.MergeCircuitType, "zk_transfer_queue"},
+		{common.MergeZoneCircuitType, "zk_transfer_queue"},
+		{common.InclusionCircuitType, ""},
+		{common.NonInclusionCircuitType, ""},
+	}
+	for _, c := range cases {
+		if got := GetQueueNameForCircuit(c.circuit); got != c.queue {
+			t.Errorf("GetQueueNameForCircuit(%s) = %q, want %q", c.circuit, got, c.queue)
+		}
+	}
+}

--- a/prover/server/server/server.go
+++ b/prover/server/server/server.go
@@ -466,7 +466,10 @@ func (handler proveHandler) shouldUseQueueForCircuit(circuitType common.CircuitT
 		return false
 	}
 
-	return circuitType == common.BatchAddressAppendCircuitType
+	// A circuit is queueable iff it has a dedicated queue. address-append is heavy
+	// and must go async; transfer/merge circuits now share zk_transfer_queue so a
+	// shared prover doesn't get stampeded by concurrent synchronous transfers.
+	return GetQueueNameForCircuit(circuitType) != ""
 }
 
 type queueStatsHandler struct {
@@ -1093,6 +1096,14 @@ func GetQueueNameForCircuit(circuitType common.CircuitType) string {
 	switch circuitType {
 	case common.BatchAddressAppendCircuitType:
 		return "zk_address_append_queue"
+	case common.TransferP256ConfidentialCircuitType,
+		common.TransferP256ZoneCircuitType,
+		common.TransferConfidentialCircuitType,
+		common.TransferZoneCircuitType,
+		common.TransferZoneAuthorityCircuitType,
+		common.MergeCircuitType,
+		common.MergeZoneCircuitType:
+		return "zk_transfer_queue"
 	default:
 		return ""
 	}

--- a/prover/server/server/server.go
+++ b/prover/server/server/server.go
@@ -490,8 +490,8 @@ func (handler queueStatsHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	response := map[string]interface{}{
 		"queues":        stats,
-		"total_pending": stats["zk_address_append_queue"],
-		"total_active":  stats["zk_address_append_processing_queue"],
+		"total_pending": stats["zk_address_append_queue"] + stats["zk_transfer_queue"],
+		"total_active":  stats["zk_address_append_processing_queue"] + stats["zk_transfer_processing_queue"],
 		"total_failed":  stats["zk_failed_queue"],
 		"timestamp":     time.Now().Unix(),
 	}

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -64,7 +64,7 @@ const PROVE_RETRY_BACKOFF_SECS: u64 = 2;
 const PROVE_REQUEST_TIMEOUT_SECS: u64 = 600;
 const PROVE_CONNECT_TIMEOUT_SECS: u64 = 10;
 /// Polling cadence and ceiling for async (queued) proofs. Redis-backed provers
-/// queue heavy batch proofs (address-append) and return a job handle immediately
+/// queue batch, transfer, and merge proofs and return a job handle immediately
 /// instead of blocking; the client then polls the status endpoint until the
 /// proof completes or `max_wait_secs` elapses. The first batch job loads a
 /// multi-GB proving key before proving, so the default ceiling is generous.
@@ -222,7 +222,7 @@ impl ProverClient {
         let value: serde_json::Value = serde_json::from_str(&text)
             .map_err(|e| ClientError::ProofParse(format!("invalid response JSON: {e}")))?;
 
-        // A Redis-backed prover queues heavy batch proofs and returns a job
+        // A Redis-backed prover queues supported proofs and returns a job
         // handle (`{ job_id, status, status_url }`) instead of a proof; poll the
         // status endpoint until it completes. A synchronous prover returns the
         // proof directly (plain gnark JSON or a `{ proof, .. }` envelope).
@@ -356,9 +356,10 @@ pub fn spawn_prover() -> Result<(), ClientError> {
     })?;
 
     let port = prover_port(&server_address());
+    let redis_url = env::var("ZOLANA_PROVER_REDIS_URL").ok();
     let spawn_result = Command::new("sh")
         .arg("-c")
-        .arg(format!("{cli} dev prover start --prover-port {port}"))
+        .arg(prover_start_command(&cli, port, redis_url.as_deref()))
         .spawn();
 
     let result = match spawn_result {
@@ -460,6 +461,15 @@ fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
+fn prover_start_command(cli: &str, port: u16, redis_url: Option<&str>) -> String {
+    let mut command = format!("{cli} dev prover start --prover-port {port}");
+    if let Some(redis_url) = redis_url.filter(|url| !url.trim().is_empty()) {
+        command.push_str(" --redis-url ");
+        command.push_str(&shell_quote(redis_url.trim()));
+    }
+    command
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -472,6 +482,26 @@ mod tests {
     use serde_json::{json, Value};
 
     use super::*;
+
+    #[test]
+    fn prover_start_command_forwards_redis_url() {
+        assert_eq!(
+            prover_start_command(
+                "'/tmp/zolana cli'",
+                3002,
+                Some("redis://localhost:6379/15")
+            ),
+            "'/tmp/zolana cli' dev prover start --prover-port 3002 --redis-url 'redis://localhost:6379/15'"
+        );
+    }
+
+    #[test]
+    fn prover_start_command_omits_empty_redis_url() {
+        assert_eq!(
+            prover_start_command("zolana", 3001, Some("  ")),
+            "zolana dev prover start --prover-port 3001"
+        );
+    }
 
     #[test]
     fn poll_async_returns_completed_nested_proof() {

--- a/sdk-libs/client/tests/transfer_dummy.rs
+++ b/sdk-libs/client/tests/transfer_dummy.rs
@@ -20,6 +20,7 @@ mod test_indexer;
 use groth16_solana::groth16::{Groth16Verifier, Groth16Verifyingkey};
 use rand::RngCore;
 use solana_address::Address;
+use zolana_client::prover::SERVER_ADDRESS;
 use zolana_client::{
     spawn_prover, InputCommitment, ProverClient, PublicAmounts, Rpc, Shape, TransferProver,
     TransferSpendInput,
@@ -41,15 +42,57 @@ use crate::test_indexer::TestIndexer;
 fn start_prover() {
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {
-        std::env::set_var(
-            "ZOLANA_PROVER_KEYS_DIR",
-            concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../prover/server/proving-keys"
-            ),
-        );
+        if std::env::var_os("ZOLANA_PROVER_KEYS_DIR").is_none() {
+            std::env::set_var(
+                "ZOLANA_PROVER_KEYS_DIR",
+                concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../prover/server/proving-keys"
+                ),
+            );
+        }
     });
     spawn_prover().expect("start prover");
+}
+
+fn async_queue_result_count() -> Option<u64> {
+    if std::env::var("ZOLANA_EXPECT_ASYNC_PROVER").as_deref() != Ok("true") {
+        return None;
+    }
+
+    let server = std::env::var("ZOLANA_PROVER_URL")
+        .ok()
+        .filter(|url| !url.trim().is_empty())
+        .unwrap_or_else(|| SERVER_ADDRESS.to_string());
+    let response = reqwest::blocking::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("build queue stats client")
+        .get(format!("{server}/queue/stats"))
+        .send()
+        .expect("request Redis queue stats")
+        .error_for_status()
+        .expect("Redis queue stats endpoint is available")
+        .json::<serde_json::Value>()
+        .expect("parse Redis queue stats");
+    let queues = response
+        .get("queues")
+        .and_then(serde_json::Value::as_object)
+        .expect("queue stats contain queues");
+    assert!(
+        queues.contains_key("zk_transfer_queue"),
+        "transfer queue is registered"
+    );
+    assert!(
+        queues.contains_key("zk_transfer_processing_queue"),
+        "transfer processing queue is registered"
+    );
+    Some(
+        queues
+            .get("zk_results_queue")
+            .and_then(serde_json::Value::as_u64)
+            .expect("queue stats contain the results queue"),
+    )
 }
 
 fn dummy_external_data() -> ExternalData {
@@ -245,6 +288,7 @@ fn eddsa_transfer_all_shapes_proofs_verify() {
 #[test]
 fn dummy_transfer_2_3_proof_verifies() {
     start_prover();
+    let queued_results_before = async_queue_result_count();
 
     let prover = TransferProver {
         inputs: vec![real_input(), dummy_input()],
@@ -275,4 +319,13 @@ fn dummy_transfer_2_3_proof_verifies() {
     )
     .expect("construct verifier");
     verifier.verify().expect("groth16 proof verifies");
+
+    if let Some(before) = queued_results_before {
+        let after = async_queue_result_count().expect("async queue stats remain available");
+        assert_eq!(
+            after,
+            before + 1,
+            "the transfer proof must complete through TransferQueueWorker"
+        );
+    }
 }


### PR DESCRIPTION
## What
Only batch **address-append** proofs were routed to the Redis async queue; **transfer/merge** circuits ran synchronously. Under concurrency (a soak/bench, or many wallet clients) each transfer spawns a ~1.5 GB Groth16 prove goroutine at once, so a single prover can OOM or stall.

## Change
- Route transfer/merge circuits to a dedicated **`zk_transfer_queue`** and add a **`TransferQueueWorker`** that drains it with bounded concurrency (`TRANSFER_WORKER_CONCURRENCY`, defaulting to the shared `getMaxConcurrency`).
- Make `GetQueueNameForCircuit` the source of truth for which circuits are queued; `shouldUseQueueForCircuit` derives from it.
- Reuse the same key manager and proof implementations as the synchronous handler.
- Start the transfer worker for the full server and for `--circuit transfer` queue workers.
- Forward Redis configuration through the Rust test launcher and fix the CLI's Go boolean flag encoding so `--redis-url` is not dropped.

## Why
This decouples client concurrency from prover capacity: clients submit freely while the worker drains at a sustainable rate. It enables high-throughput tests without stampeding and protects a shared prover in production.

## Client side
Clients poll jobs through the generic `ProverClient` job-envelope auto-detection from #107, the same mechanism used for address-append. No transfer-specific polling path is needed.

**Compatibility:** a Redis-enabled prover now returns a job handle for transfers, so clients must use the async-aware `ProverClient` from #107. A prover without Redis continues serving transfers synchronously.

## Testing
- Added `TestGetQueueNameForCircuit` for routing coverage.
- Added the required `async prover / transfer queue` check with a real Redis service.
- The integration check starts the CLI-managed prover, submits a real `2x3` transfer through `/prove`, polls `/prove/status` through the Rust client, verifies that `TransferQueueWorker` advanced `zk_results_queue`, and verifies the Groth16 proof against the committed key.
- Local verification: workspace clippy, client and CLI unit suites, Go routing test, workflow lint, and the real Redis-backed proof all pass.
