### PR TITLE
feat: spec SLIP-0010 key derivation + create_private_wallet onboarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9742,6 +9742,7 @@ dependencies = [
  "ed25519-dalek 2.2.0",
  "hex",
  "hkdf",
+ "hmac 0.12.1",
  "p256",
  "rand 0.8.6",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,7 @@ ed25519-dalek = "2.2.0"
 aes = { version = "0.8", default-features = false }
 ctr = { version = "0.9", default-features = false }
 hkdf = "0.12"
+hmac = "0.12"
 zeroize = "1"
 criterion = "0.5"
 proptest = "1"

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -48,9 +48,9 @@ pub use rpc::{
 #[cfg(feature = "solana-rpc")]
 pub use solana_rpc::{ConfirmedInstructionGroups, SolanaRpc};
 pub use user_registry::{
-    decode_user_record_account, ensure_registered, fetch_user_record_checked,
-    fetch_user_record_optional_checked, resolve_registered_address, resolved_address_from_record,
-    try_resolve_registered_address, validate_registered_keypair,
+    create_private_wallet, decode_user_record_account, ensure_registered,
+    fetch_user_record_checked, fetch_user_record_optional_checked, resolve_registered_address,
+    resolved_address_from_record, try_resolve_registered_address, validate_registered_keypair,
 };
 pub use wallet_authority::{
     AnonymousRecipientSlot, ApprovalRequest, ConfidentialRecipientSlot, EncryptedTransfer,

--- a/sdk-libs/client/src/user_registry.rs
+++ b/sdk-libs/client/src/user_registry.rs
@@ -4,6 +4,7 @@ use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
 use zolana_keypair::{P256Pubkey, PublicKey, ShieldedAddress, ShieldedKeypair, SignatureType};
+use zolana_transaction::{AssetRegistry, Wallet};
 use zolana_user_registry_interface::{
     instruction::{register, update_keys, RegisterData, UpdateKeysData},
     user_record_pda, user_registry_program_id, UserRecord,
@@ -78,6 +79,28 @@ pub fn ensure_registered<R: Rpc>(
         owner_address,
         &[funding],
     )?))
+}
+
+/// Create a private wallet for `keypair` and register it for private
+/// transfers. `owner` is the wallet's Solana identity: the user record is
+/// keyed under its address and it signs (and pays for) the registration — a
+/// third party cannot register on someone's behalf. Idempotent: re-running
+/// refreshes the registration. The returned wallet starts empty; sync it
+/// (e.g. [`crate::sync_wallet`]) to load existing balances.
+///
+/// Built for embedded wallets: derive `keypair` from the user's BIP-39 seed
+/// via [`ShieldedKeypair::from_seed`], so the mnemonic reproduces the shielded
+/// keys. The Solana identity is a separate secret. Self-custody flows
+/// construct the [`ShieldedKeypair`] from their own key management; the SDK
+/// never reads raw Solana secrets.
+pub fn create_private_wallet<R: Rpc>(
+    rpc: &R,
+    owner: &Keypair,
+    keypair: ShieldedKeypair,
+    registry: AssetRegistry,
+) -> Result<Wallet, ClientError> {
+    ensure_registered(rpc, owner, &keypair)?;
+    Ok(Wallet::new(keypair, registry)?)
 }
 
 pub fn fetch_user_record_checked<R: Rpc>(

--- a/sdk-libs/keypair/Cargo.toml
+++ b/sdk-libs/keypair/Cargo.toml
@@ -11,6 +11,7 @@ ed25519-dalek = { workspace = true }
 aes = { workspace = true }
 ctr = { workspace = true }
 hkdf = { workspace = true }
+hmac = { workspace = true }
 zeroize = { workspace = true }
 sha2 = { workspace = true }
 zolana-hasher = { workspace = true, features = ["poseidon", "std"] }

--- a/sdk-libs/keypair/src/error.rs
+++ b/sdk-libs/keypair/src/error.rs
@@ -14,6 +14,9 @@ pub enum KeypairError {
     #[error("invalid signature-type prefix: {0}")]
     InvalidSignatureType(u8),
 
+    #[error("derivation account index must be below 2^31")]
+    DerivationIndexTooLarge,
+
     #[error("HKDF expansion failed")]
     Hkdf,
 

--- a/sdk-libs/keypair/src/lib.rs
+++ b/sdk-libs/keypair/src/lib.rs
@@ -47,6 +47,7 @@ pub mod nullifier_key;
 pub mod pubkey;
 pub mod shielded;
 pub mod signing_key;
+pub(crate) mod slip10;
 pub mod traits;
 pub mod viewing_key;
 

--- a/sdk-libs/keypair/src/shielded.rs
+++ b/sdk-libs/keypair/src/shielded.rs
@@ -74,6 +74,19 @@ impl ShieldedKeypair {
         Self::from_keys(SigningKey::new(), ViewingKey::new())
     }
 
+    /// Spec wallet keys from a BIP-39 `wallet_seed`: signing and viewing at
+    /// sibling SLIP-0010 paths, nullifier from the derived signing secret —
+    /// one seed reproduces the whole shielded keypair. Signs on the P256 rail;
+    /// [`ShieldedKeypair::from_ed25519`] wallets sign on the Solana rail with
+    /// a caller-provided viewing key, and are not an alternative encoding of
+    /// the same wallet.
+    pub fn from_seed(wallet_seed: &[u8], account: u32) -> Result<Self, KeypairError> {
+        Self::from_keys(
+            SigningKey::from_seed(wallet_seed, account)?,
+            ViewingKey::from_seed(wallet_seed, account)?,
+        )
+    }
+
     pub fn from_ed25519(
         signing_secret: &[u8; 32],
         viewing_key: ViewingKey,

--- a/sdk-libs/keypair/src/signing_key.rs
+++ b/sdk-libs/keypair/src/signing_key.rs
@@ -52,6 +52,14 @@ impl SigningKey {
         })
     }
 
+    /// Spec signing key: SLIP-0010-P256 at `m/44'/TSPP_COIN_TYPE'/account'/0'/0'`
+    /// on a BIP-39 `wallet_seed` (typically 64 bytes) — the mnemonic reproduces it.
+    pub fn from_seed(wallet_seed: &[u8], account: u32) -> Result<Self, KeypairError> {
+        let secret =
+            crate::slip10::derive_wallet_key(wallet_seed, account, crate::slip10::CHANGE_SIGNING)?;
+        Self::from_bytes(&secret)
+    }
+
     pub fn from_ed25519(bytes: &[u8; 32]) -> Self {
         Self {
             inner: SigningKeyInner::Ed25519(DalekSigningKey::from_bytes(bytes)),

--- a/sdk-libs/keypair/src/slip10.rs
+++ b/sdk-libs/keypair/src/slip10.rs
@@ -1,0 +1,279 @@
+//! SLIP-0010 hierarchical key derivation on NIST P-256.
+//!
+//! Backs the spec's wallet key hierarchy (`docs/spec.md`, "Signing Key" /
+//! "ViewingKey"): `m/44'/TSPP_COIN_TYPE'/account'/change'/0'` on a BIP-39
+//! `wallet_seed`, so a mnemonic reproduces the wallet's shielded keys.
+
+use hmac::{Hmac, Mac};
+use p256::{
+    elliptic_curve::{sec1::ToEncodedPoint, Field, PrimeField},
+    NonZeroScalar, PublicKey, Scalar,
+};
+use sha2::Sha512;
+use zeroize::Zeroizing;
+
+use crate::error::KeypairError;
+
+/// Registered coin type for TSPP derivation paths, as declared by the spec.
+/// The spec marks the value a placeholder; re-pinning it would change every
+/// derived key, so wallets derived under it would stop being recoverable.
+pub(crate) const TSPP_COIN_TYPE: u32 = 1_445_561_917;
+
+/// Change-level index for the spend-authorizing key path.
+pub(crate) const CHANGE_SIGNING: u32 = 0;
+/// Change-level index for the viewing key path.
+pub(crate) const CHANGE_VIEWING: u32 = 1;
+
+const MASTER_HMAC_KEY: &[u8] = b"Nist256p1 seed";
+const HARDENED: u32 = 1 << 31;
+
+fn hmac_sha512(key: &[u8], parts: &[&[u8]]) -> Zeroizing<[u8; 64]> {
+    let mut mac = Hmac::<Sha512>::new_from_slice(key).expect("HMAC-SHA512 accepts any key length");
+    for part in parts {
+        mac.update(part);
+    }
+    let mut out = Zeroizing::new([0u8; 64]);
+    out.copy_from_slice(&mac.finalize().into_bytes());
+    out
+}
+
+/// Left half of `I` as a P-256 scalar; `None` when `IL ≥ n` — the SLIP-0010
+/// retry condition.
+fn parse_scalar(il: &[u8]) -> Option<Scalar> {
+    let mut repr = [0u8; 32];
+    repr.copy_from_slice(il);
+    Option::<Scalar>::from(Scalar::from_repr(repr.into()))
+}
+
+/// A derivation node: a non-zero private scalar plus its chain code.
+pub(crate) struct ExtendedKey {
+    key: Scalar,
+    chain_code: [u8; 32],
+}
+
+impl ExtendedKey {
+    /// Master node: `I = HMAC-SHA512("Nist256p1 seed", seed)`; while `IL` is
+    /// not a valid non-zero scalar, `I = HMAC-SHA512("Nist256p1 seed", I)`.
+    pub(crate) fn master(seed: &[u8]) -> Self {
+        let mut i = hmac_sha512(MASTER_HMAC_KEY, &[seed]);
+        loop {
+            if let Some(key) = parse_scalar(&i[..32]) {
+                if !bool::from(key.is_zero()) {
+                    let mut chain_code = [0u8; 32];
+                    chain_code.copy_from_slice(&i[32..]);
+                    return Self { key, chain_code };
+                }
+            }
+            i = hmac_sha512(MASTER_HMAC_KEY, &[i.as_slice()]);
+        }
+    }
+
+    /// SLIP-0010 CKDpriv. Hardened data is `0x00 ‖ ser256(k_par) ‖ ser32(i)`,
+    /// normal data is `serP(k_par·G) ‖ ser32(i)`; on an invalid child
+    /// (`IL ≥ n` or `k_i = 0`) it retries with `0x01 ‖ IR ‖ ser32(i)`.
+    pub(crate) fn child(&self, index: u32) -> Self {
+        let index_be = index.to_be_bytes();
+        let mut i = if index >= HARDENED {
+            let key_bytes = Zeroizing::new(self.key.to_bytes());
+            hmac_sha512(&self.chain_code, &[&[0u8], key_bytes.as_slice(), &index_be])
+        } else {
+            hmac_sha512(&self.chain_code, &[&self.public_bytes(), &index_be])
+        };
+        loop {
+            if let Some(il) = parse_scalar(&i[..32]) {
+                let key = il + self.key;
+                if !bool::from(key.is_zero()) {
+                    let mut chain_code = [0u8; 32];
+                    chain_code.copy_from_slice(&i[32..]);
+                    return Self { key, chain_code };
+                }
+            }
+            let retry = hmac_sha512(&self.chain_code, &[&[1u8], &i[32..], &index_be]);
+            i = retry;
+        }
+    }
+
+    pub(crate) fn secret_bytes(&self) -> Zeroizing<[u8; 32]> {
+        let mut out = Zeroizing::new([0u8; 32]);
+        out.copy_from_slice(&self.key.to_bytes());
+        out
+    }
+
+    /// Compressed SEC1 public point of this node's key.
+    pub(crate) fn public_bytes(&self) -> [u8; 33] {
+        let scalar = NonZeroScalar::new(self.key).expect("node keys are non-zero by construction");
+        let point = PublicKey::from_secret_scalar(&scalar).to_encoded_point(true);
+        let mut out = [0u8; 33];
+        out.copy_from_slice(point.as_bytes());
+        out
+    }
+
+    #[cfg(test)]
+    fn chain_code(&self) -> [u8; 32] {
+        self.chain_code
+    }
+}
+
+/// Derived secret at `m/44'/TSPP_COIN_TYPE'/account'/change'/0'` (all levels
+/// hardened).
+pub(crate) fn derive_wallet_key(
+    wallet_seed: &[u8],
+    account: u32,
+    change: u32,
+) -> Result<Zeroizing<[u8; 32]>, KeypairError> {
+    if account >= HARDENED {
+        return Err(KeypairError::DerivationIndexTooLarge);
+    }
+    let mut node = ExtendedKey::master(wallet_seed);
+    for index in [44, TSPP_COIN_TYPE, account, change, 0] {
+        node = node.child(index | HARDENED);
+    }
+    Ok(node.secret_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ShieldedKeypair, SigningKey, ViewingKey};
+
+    const HARD: u32 = HARDENED;
+
+    fn walk(seed_hex: &str, path: &[u32]) -> ExtendedKey {
+        let seed = hex::decode(seed_hex).unwrap();
+        let mut node = ExtendedKey::master(&seed);
+        for &index in path {
+            node = node.child(index);
+        }
+        node
+    }
+
+    fn assert_node(node: &ExtendedKey, chain_code: &str, private: &str, public: &str) {
+        assert_eq!(hex::encode(node.chain_code()), chain_code);
+        assert_eq!(hex::encode(node.secret_bytes().as_slice()), private);
+        assert_eq!(hex::encode(node.public_bytes()), public);
+    }
+
+    // SLIP-0010 test vector 1 for nist256p1, seed 000102030405060708090a0b0c0d0e0f.
+    #[test]
+    fn slip10_nist256p1_vector_1() {
+        let seed = "000102030405060708090a0b0c0d0e0f";
+        assert_node(
+            &walk(seed, &[]),
+            "beeb672fe4621673f722f38529c07392fecaa61015c80c34f29ce8b41b3cb6ea",
+            "612091aaa12e22dd2abef664f8a01a82cae99ad7441b7ef8110424915c268bc2",
+            "0266874dc6ade47b3ecd096745ca09bcd29638dd52c2c12117b11ed3e458cfa9e8",
+        );
+        assert_node(
+            &walk(seed, &[HARD]),
+            "3460cea53e6a6bb5fb391eeef3237ffd8724bf0a40e94943c98b83825342ee11",
+            "6939694369114c67917a182c59ddb8cafc3004e63ca5d3b84403ba8613debc0c",
+            "0384610f5ecffe8fda089363a41f56a5c7ffc1d81b59a612d0d649b2d22355590c",
+        );
+        assert_node(
+            &walk(seed, &[HARD, 1]),
+            "4187afff1aafa8445010097fb99d23aee9f599450c7bd140b6826ac22ba21d0c",
+            "284e9d38d07d21e4e281b645089a94f4cf5a5a81369acf151a1c3a57f18b2129",
+            "03526c63f8d0b4bbbf9c80df553fe66742df4676b241dabefdef67733e070f6844",
+        );
+        assert_node(
+            &walk(seed, &[HARD, 1, 2 | HARD, 2, 1000000000]),
+            "b9b7b82d326bb9cb5b5b121066feea4eb93d5241103c9e7a18aad40f1dde8059",
+            "21c4f269ef0a5fd1badf47eeacebeeaa3de22eb8e5b0adcd0f27dd99d34d0119",
+            "02216cd26d31147f72427a453c443ed2cde8a1e53c9cc44e5ddf739725413fe3f4",
+        );
+    }
+
+    // SLIP-0010 test vector 2 for nist256p1 (64-byte seed).
+    #[test]
+    fn slip10_nist256p1_vector_2() {
+        let seed = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c99969\
+                    3908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
+        assert_node(
+            &walk(seed, &[]),
+            "96cd4465a9644e31528eda3592aa35eb39a9527769ce1855beafc1b81055e75d",
+            "eaa31c2e46ca2962227cf21d73a7ef0ce8b31c756897521eb6c7b39796633357",
+            "02c9e16154474b3ed5b38218bb0463e008f89ee03e62d22fdcc8014beab25b48fa",
+        );
+        assert_node(
+            &walk(seed, &[0, 2147483647 | HARD, 1, 2147483646 | HARD, 2]),
+            "3bfb29ee8ac4484f09db09c2079b520ea5616df7820f071a20320366fbe226a7",
+            "bb0a77ba01cc31d77205d51d08bd313b979a71ef4de9b062f8958297e746bd67",
+            "020ee02e18967237cf62672983b253ee62fa4dd431f8243bfeccdf39dbe181387f",
+        );
+    }
+
+    // SLIP-0010 "derivation retry" vector: deriving m/28578H hits an invalid
+    // child key and exercises the 0x01‖IR‖ser32(i) retry branch.
+    #[test]
+    fn slip10_nist256p1_derivation_retry() {
+        let seed = "000102030405060708090a0b0c0d0e0f";
+        assert_node(
+            &walk(seed, &[28578 | HARD]),
+            "e94c8ebe30c2250a14713212f6449b20f3329105ea15b652ca5bdfc68f6c65c2",
+            "06f0db126f023755d0b8d86d4591718a5210dd8d024e3e14b6159d63f53aa669",
+            "02519b5554a4872e8c9c1c847115363051ec43e93400e030ba3c36b52a3e70a5b7",
+        );
+        assert_node(
+            &walk(seed, &[28578 | HARD, 33941]),
+            "9e87fe95031f14736774cd82f25fd885065cb7c358c1edf813c72af535e83071",
+            "092154eed4af83e078ff9b84322015aefe5769e31270f62c3f66c33888335f3a",
+            "0235bfee614c0d5b2cae260000bb1d0d84b270099ad790022c1ae0b2e782efe120",
+        );
+    }
+
+    // SLIP-0010 "seed retry" vector: the first master HMAC yields an invalid
+    // key and exercises the master retry loop.
+    #[test]
+    fn slip10_nist256p1_seed_retry() {
+        let seed = "a7305bc8df8d0951f0cb224c0e95d7707cbdf2c6ce7e8d481fec69c7ff5e9446";
+        assert_node(
+            &walk(seed, &[]),
+            "7762f9729fed06121fd13f326884c82f59aa95c57ac492ce8c9654e60efd130c",
+            "3b8c18469a4634517d6d0b65448f8e6c62091b45540a1743c5846be55d47d88f",
+            "0383619fadcde31063d8c5cb00dbfe1713f3e6fa169d8541a798752a1c1ca0cb20",
+        );
+    }
+
+    // The declared spec literal. The spec's own derivation formula does not
+    // reproduce it (flagged as a spec gap); the literal is normative.
+    #[test]
+    fn coin_type_is_pinned() {
+        assert_eq!(TSPP_COIN_TYPE, 1_445_561_917);
+    }
+
+    #[test]
+    fn wallet_paths_are_deterministic_and_distinct() {
+        let seed = [7u8; 64];
+        let signing = derive_wallet_key(&seed, 0, CHANGE_SIGNING).unwrap();
+        let signing_again = derive_wallet_key(&seed, 0, CHANGE_SIGNING).unwrap();
+        let viewing = derive_wallet_key(&seed, 0, CHANGE_VIEWING).unwrap();
+        let other_account = derive_wallet_key(&seed, 1, CHANGE_SIGNING).unwrap();
+        assert_eq!(signing.as_slice(), signing_again.as_slice());
+        assert_ne!(signing.as_slice(), viewing.as_slice());
+        assert_ne!(signing.as_slice(), other_account.as_slice());
+
+        assert_eq!(
+            derive_wallet_key(&seed, HARDENED, CHANGE_SIGNING).unwrap_err(),
+            KeypairError::DerivationIndexTooLarge
+        );
+    }
+
+    #[test]
+    fn from_seed_reproduces_the_shielded_keypair() {
+        let seed = [9u8; 64];
+        let a = ShieldedKeypair::from_seed(&seed, 0).unwrap();
+        let b = ShieldedKeypair::from_seed(&seed, 0).unwrap();
+        assert_eq!(a.signing_pubkey(), b.signing_pubkey());
+        assert_eq!(a.viewing_pubkey(), b.viewing_pubkey());
+        assert_eq!(a.owner_hash().unwrap(), b.owner_hash().unwrap());
+
+        let signing = SigningKey::from_seed(&seed, 0).unwrap();
+        let viewing = ViewingKey::from_seed(&seed, 0).unwrap();
+        assert_eq!(a.signing_pubkey(), signing.pubkey());
+        assert_eq!(a.viewing_pubkey(), viewing.pubkey());
+        assert_ne!(
+            signing.secret_bytes().as_slice(),
+            viewing.secret_bytes().as_slice()
+        );
+    }
+}

--- a/sdk-libs/keypair/src/viewing_key.rs
+++ b/sdk-libs/keypair/src/viewing_key.rs
@@ -99,6 +99,15 @@ impl ViewingKey {
         Ok(Self::from_secret_key(secret))
     }
 
+    /// Spec viewing key: SLIP-0010-P256 at `m/44'/TSPP_COIN_TYPE'/account'/1'/0'`,
+    /// a sibling of the signing path on the same BIP-39 `wallet_seed` — the
+    /// mnemonic reproduces it.
+    pub fn from_seed(wallet_seed: &[u8], account: u32) -> Result<Self, KeypairError> {
+        let secret =
+            crate::slip10::derive_wallet_key(wallet_seed, account, crate::slip10::CHANGE_VIEWING)?;
+        Self::from_bytes(&secret)
+    }
+
     pub fn secret_bytes(&self) -> Zeroizing<[u8; 32]> {
         let mut out = [0u8; 32];
         out.copy_from_slice(self.secret.to_bytes().as_slice());


### PR DESCRIPTION
## Summary

Embedded-wallet onboarding for the SDK, in two parts. Stacked on #109 so the examples get one lineage (`main` ← #108 ← #109 ← this).

**Part 1 — `zolana-keypair`: spec SLIP-0010-P256 derivation.** Implements the spec's wallet key hierarchy (`docs/spec.md`, "Signing Key" / "ViewingKey"): `SigningKey::from_seed` (`m/44'/TSPP_COIN_TYPE'/account'/0'/0'`), `ViewingKey::from_seed` (`.../1'/0'`), and `ShieldedKeypair::from_seed` (both siblings + the nullifier key from the derived signing secret). One BIP-39 seed reproduces the wallet's shielded keys — mnemonic-recoverable. Verified against the official SLIP-0010 nist256p1 test vectors, including both invalid-key retry branches.

**Part 2 — `zolana-client`: `create_private_wallet(rpc, owner, keypair, registry)`.** The onboarding call every integrator writes, composed from the existing primitives: `ensure_registered` + `Wallet::new`. Replaces the example-crate helper of the same name, with two corrections:
- The caller supplies the `ShieldedKeypair` — the SDK never reads `owner.secret_bytes()` (same input-model rule that kept `Transaction::from_wallet` out in #108).
- `owner` is named for what it is: the registered on-chain identity (record PDA keyed under its address, must sign). It is not a third-party fee payer; nobody can register on someone else's behalf.

## Use case: embedded wallets

The app custodies a per-user BIP-39 `wallet_seed` and derives the full shielded keypair from it. Precisely: one seed reproduces the *shielded keypair*; the Solana identity (`owner`) is a separate secret (apps can derive both from one mnemonic — TSPP paths + Solana's `m/44'/501'`). Self-custody flows construct the `ShieldedKeypair` from their own key management and call the same function. `from_seed` wallets sign on the P256 rail; `from_ed25519` (Solana-keypair-only, caller-provided viewing key) stays on the eddsa rail — the two are different wallets, not encodings of one.

## Spec gap (flagged, no spec edit)

`docs/spec.md` declares `TSPP_COIN_TYPE = 1445561917' (placeholder)` but its own formula `SHA-256("luminous.TSPP.v1")[0..4] & 0x7FFF_FFFF` computes `1392955331` (BE) / `1137641043` (LE). The declared literal is implemented as normative and pinned in a test; the formula assertion is deliberately omitted. Note: the constant is a spec placeholder — re-pinning it later orphans every wallet derived under it, so it should be finalized before mainnet.

## Test plan
- [x] `cargo test -p zolana-keypair --lib` — 10 passed: SLIP-0010 nist256p1 vectors 1+2, derivation-retry vector (`m/28578H/33941`), seed-retry vector, path determinism/distinctness, coin-type pin, `from_seed` reproducibility
- [x] `cargo build -p zolana-client` (no features) and `--features "indexer-api solana-rpc"`
- [x] `cargo clippy -p zolana-keypair --all-targets -- -D warnings`; `cargo clippy -p zolana-client --all-targets --features "indexer-api solana-rpc" -- -D warnings`
- [x] `cargo test -p zolana-client --lib --features "indexer-api solana-rpc"` — 56 passed; doc-tests pass
- [x] `cargo +nightly fmt --all -- --check`