### PR TITLE
feat(client): deposit send_and_sync, asset-id lookup/registration, registry-refresh contract

### DIFF
--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -30,7 +30,7 @@ pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
         authority: &ctx.material,
         owner_pubkey: ctx.material.owner_pubkey(),
         payer: Address::new_from_array(ctx.material.funding.pubkey().to_bytes()),
-        recipient_owner,
+        recipient: recipient_owner,
         asset,
         amount: opts.amount,
     })?;

--- a/sdk-libs/client/src/actions/deposit.rs
+++ b/sdk-libs/client/src/actions/deposit.rs
@@ -1,5 +1,10 @@
 //! Proofless shield action.
 
+use std::{
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
 use solana_address::Address;
 use solana_instruction::Instruction;
 use solana_keypair::Keypair;
@@ -11,9 +16,15 @@ use zolana_interface::{
     pda, SPL_TOKEN_PROGRAM_ID,
 };
 use zolana_keypair::{random_blinding, ShieldedAddress};
-use zolana_transaction::{owner_utxo_hash, utxo_hash, SOL_MINT};
+use zolana_transaction::{owner_utxo_hash, utxo_hash, Wallet, SOL_MINT};
 
-use crate::{error::ClientError, rpc::Rpc};
+use crate::{error::ClientError, rpc::Rpc, wallet_sync::sync_wallet};
+
+/// How long [`Deposit::send_and_sync`] waits for the indexer to pick up the
+/// deposited UTXO before giving up.
+const INDEXER_TIMEOUT: Duration = Duration::from_secs(120);
+/// Delay between indexer polls.
+const INDEXER_POLL: Duration = Duration::from_millis(500);
 
 /// Prepared direct proofless SOL shield.
 ///
@@ -83,8 +94,85 @@ impl Deposit {
         deposit(rpc, payer, tree, depositor, self.spl, &self.data)
     }
 
+    /// [`Deposit::send`], then sync `wallet` until the deposited UTXO is
+    /// visible. The indexer lags the chain, so a single sync straight after
+    /// the send can miss the deposit — the next transfer would then select
+    /// stale inputs. Polls up to 120s; on timeout the deposit has still been
+    /// sent and confirmed ([`ClientError::DepositNotIndexed`] carries the
+    /// signature).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use solana_keypair::Keypair;
+    /// use solana_pubkey::Pubkey;
+    /// use zolana_client::{create_deposit, ClientError, CreateDeposit, Rpc};
+    /// use zolana_keypair::ShieldedAddress;
+    /// use zolana_transaction::{Wallet, SOL_MINT};
+    ///
+    /// fn deposit_sol<R: Rpc, I: Rpc>(
+    ///     rpc: &R,
+    ///     indexer: &I,
+    ///     payer: &Keypair,
+    ///     tree: Pubkey,
+    ///     recipient: &ShieldedAddress,
+    ///     wallet: &mut Wallet,
+    /// ) -> Result<(), ClientError> {
+    ///     let prepared = create_deposit(CreateDeposit {
+    ///         recipient,
+    ///         asset: SOL_MINT,
+    ///         amount: 1_000_000,
+    ///         spl_token_account: None,
+    ///         memo: None,
+    ///     })?;
+    ///     prepared.send_and_sync(rpc, payer, tree, payer, wallet, indexer)?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn send_and_sync<R: Rpc, I: Rpc>(
+        &self,
+        rpc: &R,
+        payer: &Keypair,
+        tree: Pubkey,
+        depositor: &Keypair,
+        wallet: &mut Wallet,
+        indexer: &I,
+    ) -> Result<Signature, ClientError> {
+        let signature = self.send(rpc, payer, tree, depositor)?;
+        wait_for_deposited_utxo(wallet, indexer, self.utxo_hash, signature)?;
+        Ok(signature)
+    }
+
     pub fn view_tag(&self) -> [u8; 32] {
         self.data.view_tag
+    }
+}
+
+/// Poll [`sync_wallet`] until the wallet holds the UTXO with `utxo_hash`, or
+/// [`INDEXER_TIMEOUT`] elapses.
+fn wait_for_deposited_utxo<I: Rpc>(
+    wallet: &mut Wallet,
+    indexer: &I,
+    utxo_hash: [u8; 32],
+    signature: Signature,
+) -> Result<(), ClientError> {
+    let started = Instant::now();
+    loop {
+        sync_wallet(wallet, indexer)?;
+        if wallet
+            .utxos
+            .iter()
+            .any(|utxo| utxo.output_context.hash == utxo_hash)
+        {
+            return Ok(());
+        }
+        if started.elapsed() >= INDEXER_TIMEOUT {
+            return Err(ClientError::DepositNotIndexed {
+                utxo_hash,
+                signature,
+            });
+        }
+        sleep(INDEXER_POLL);
     }
 }
 

--- a/sdk-libs/client/src/actions/deposit.rs
+++ b/sdk-libs/client/src/actions/deposit.rs
@@ -25,8 +25,8 @@ use crate::{error::ClientError, rpc::Rpc, wallet_sync::sync_wallet};
 /// ~34k CU (`program-tests/shielded-pool/CU_BENCHMARK.md`).
 pub const DEFAULT_DEPOSIT_CU_LIMIT: u32 = 40_000;
 
-/// How long [`Deposit::send_and_sync`] waits for the indexer to pick up the
-/// deposited UTXO before giving up.
+/// How long [`Deposit::wait_until_synced`] waits for the indexer to pick up
+/// the deposited UTXO before giving up.
 const INDEXER_TIMEOUT: Duration = Duration::from_secs(120);
 /// Delay between indexer polls.
 const INDEXER_POLL: Duration = Duration::from_millis(500);
@@ -89,6 +89,9 @@ impl Deposit {
         deposit_instruction(tree, depositor, self.spl, &self.data)
     }
 
+    /// Send the deposit. The recipient's wallet sees the deposited UTXO only
+    /// after a sync; a recipient who needs to block until it is visible calls
+    /// [`Deposit::wait_until_synced`].
     pub fn send<R: Rpc>(
         &self,
         rpc: &R,
@@ -99,12 +102,16 @@ impl Deposit {
         deposit(rpc, payer, tree, depositor, self.spl, &self.data)
     }
 
-    /// [`Deposit::send`], then sync `wallet` until the deposited UTXO is
-    /// visible. The indexer lags the chain, so a single sync straight after
-    /// the send can miss the deposit — the next transfer would then select
-    /// stale inputs. Polls up to 120s; on timeout the deposit has still been
-    /// sent and confirmed ([`ClientError::DepositNotIndexed`] carries the
-    /// signature).
+    /// Sync `wallet` until the deposited UTXO is visible: the recipient-side
+    /// read-your-write step after [`Deposit::send`], for callers that spend or
+    /// display the balance immediately.
+    ///
+    /// `wallet` must be the deposit recipient's (a self-deposit, or an
+    /// app-held recipient wallet). A wallet that is not the recipient can
+    /// never see the UTXO: the call waits the full 120s and returns
+    /// [`ClientError::DepositNotIndexed`] even though the deposit succeeded.
+    /// For a deposit to a third party there is nothing to wait for on the
+    /// sender side — the recipient's own sync discovers the UTXO.
     ///
     /// # Examples
     ///
@@ -130,22 +137,18 @@ impl Deposit {
     ///         spl_token_account: None,
     ///         memo: None,
     ///     })?;
-    ///     prepared.send_and_sync(rpc, payer, tree, payer, wallet, indexer)?;
+    ///     let signature = prepared.send(rpc, payer, tree, payer)?;
+    ///     prepared.wait_until_synced(wallet, indexer, signature)?;
     ///     Ok(())
     /// }
     /// ```
-    pub fn send_and_sync<R: Rpc, I: Rpc>(
+    pub fn wait_until_synced<I: Rpc>(
         &self,
-        rpc: &R,
-        payer: &Keypair,
-        tree: Pubkey,
-        depositor: &Keypair,
         wallet: &mut Wallet,
         indexer: &I,
-    ) -> Result<Signature, ClientError> {
-        let signature = self.send(rpc, payer, tree, depositor)?;
-        wait_for_deposited_utxo(wallet, indexer, self.utxo_hash, signature)?;
-        Ok(signature)
+        signature: Signature,
+    ) -> Result<(), ClientError> {
+        wait_for_deposited_utxo(wallet, indexer, self.utxo_hash, signature)
     }
 
     pub fn view_tag(&self) -> [u8; 32] {

--- a/sdk-libs/client/src/actions/deposit.rs
+++ b/sdk-libs/client/src/actions/deposit.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use solana_address::Address;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_instruction::Instruction;
 use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
@@ -19,6 +20,10 @@ use zolana_keypair::{random_blinding, ShieldedAddress};
 use zolana_transaction::{owner_utxo_hash, utxo_hash, Wallet, SOL_MINT};
 
 use crate::{error::ClientError, rpc::Rpc, wallet_sync::sync_wallet};
+
+/// Compute-unit ceiling [`deposit`] is submitted with. Benchmarked deposits run
+/// ~34k CU (`program-tests/shielded-pool/CU_BENCHMARK.md`).
+pub const DEFAULT_DEPOSIT_CU_LIMIT: u32 = 40_000;
 
 /// How long [`Deposit::send_and_sync`] waits for the indexer to pick up the
 /// deposited UTXO before giving up.
@@ -194,13 +199,14 @@ pub fn deposit<R: Rpc>(
     spl: Option<DepositSplAccounts>,
     data: &DepositIxData,
 ) -> Result<Signature, ClientError> {
+    let cu_ix = ComputeBudgetInstruction::set_compute_unit_limit(DEFAULT_DEPOSIT_CU_LIMIT);
     let ix = deposit_instruction(tree, depositor.pubkey(), spl, data);
     let mut signers: Vec<&Keypair> = vec![payer];
     if depositor.pubkey() != payer.pubkey() {
         signers.push(depositor);
     }
     let payer_address = Address::new_from_array(payer.pubkey().to_bytes());
-    rpc.create_and_send_transaction(&[ix], payer_address, &signers)
+    rpc.create_and_send_transaction(&[cu_ix, ix], payer_address, &signers)
 }
 
 fn deposit_instruction(
@@ -299,8 +305,11 @@ mod tests {
             memo: data.memo.clone(),
         }
         .instruction();
-        assert_eq!(sent.message.instructions.len(), 1);
-        assert_eq!(sent.message.instructions[0].data, expected.data);
+        let cu_expected =
+            ComputeBudgetInstruction::set_compute_unit_limit(DEFAULT_DEPOSIT_CU_LIMIT);
+        assert_eq!(sent.message.instructions.len(), 2);
+        assert_eq!(sent.message.instructions[0].data, cu_expected.data);
+        assert_eq!(sent.message.instructions[1].data, expected.data);
         assert!(sent.message.account_keys.contains(&payer.pubkey()));
         assert!(sent.message.account_keys.contains(&depositor.pubkey()));
     }

--- a/sdk-libs/client/src/actions/mod.rs
+++ b/sdk-libs/client/src/actions/mod.rs
@@ -4,12 +4,14 @@
 
 pub mod create_associated_token_account;
 pub mod deposit;
+pub mod spl_interface;
 #[cfg(feature = "indexer-api")]
 pub mod submit;
 pub mod transaction;
 
 pub use create_associated_token_account::create_associated_token_account;
 pub use deposit::{create_deposit, deposit, CreateDeposit, Deposit};
+pub use spl_interface::{fetch_asset_id, register_spl_interface};
 #[cfg(feature = "indexer-api")]
 pub use submit::{Submit, DEFAULT_TRANSACT_CU_LIMIT};
 pub use transaction::{

--- a/sdk-libs/client/src/actions/mod.rs
+++ b/sdk-libs/client/src/actions/mod.rs
@@ -10,7 +10,7 @@ pub mod submit;
 pub mod transaction;
 
 pub use create_associated_token_account::create_associated_token_account;
-pub use deposit::{create_deposit, deposit, CreateDeposit, Deposit};
+pub use deposit::{create_deposit, deposit, CreateDeposit, Deposit, DEFAULT_DEPOSIT_CU_LIMIT};
 pub use spl_interface::{fetch_asset_id, register_spl_interface};
 #[cfg(feature = "indexer-api")]
 pub use submit::{Submit, DEFAULT_TRANSACT_CU_LIMIT};

--- a/sdk-libs/client/src/actions/spl_interface.rs
+++ b/sdk-libs/client/src/actions/spl_interface.rs
@@ -1,0 +1,217 @@
+//! SPL asset interface lookup and registration.
+//!
+//! Every SPL mint used in the shielded pool has a per-mint Asset registry PDA,
+//! written when its interface is created; it is the canonical source of the
+//! mint's `asset_id` on every deployment. SOL is asset id 1 and has no
+//! registry entry.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use solana_keypair::Keypair;
+//! use solana_pubkey::Pubkey;
+//! use zolana_client::{fetch_asset_id, register_spl_interface, ClientError, Rpc};
+//!
+//! fn asset_id<R: Rpc>(
+//!     rpc: &R,
+//!     authority: &Keypair,
+//!     mint: Pubkey,
+//! ) -> Result<u64, ClientError> {
+//!     // Production path: read the canonical per-mint registry PDA.
+//!     match fetch_asset_id(rpc, mint) {
+//!         Err(ClientError::AssetNotRegistered { .. }) => {
+//!             // Devnet / permissionless deployments only (see gating docs).
+//!             register_spl_interface(rpc, authority, mint)
+//!         }
+//!         result => result,
+//!     }
+//! }
+//! ```
+
+use solana_address::Address;
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use zolana_interface::{
+    instruction::{CreateAssetCounter, CreateSplInterface},
+    pda,
+    state::SplAssetRegistry,
+};
+
+use crate::{error::ClientError, rpc::Rpc};
+
+/// Asset id assigned to `mint`, read from the canonical per-mint Asset
+/// registry PDA. Works on every deployment regardless of who registered the
+/// asset. SOL (asset id 1) has no registry entry; this lookup is for SPL
+/// mints (ids >= 2).
+pub fn fetch_asset_id<R: Rpc>(rpc: &R, mint: Pubkey) -> Result<u64, ClientError> {
+    let registry_pda = pda::spl_asset_registry(&mint);
+    let account = rpc
+        .get_account(Address::new_from_array(registry_pda.to_bytes()))?
+        .ok_or(ClientError::AssetNotRegistered { mint })?;
+    let registry = SplAssetRegistry::from_account_bytes(&account.data).map_err(|err| {
+        ClientError::Rpc(format!(
+            "invalid asset registry account for {mint}: {err:?}"
+        ))
+    })?;
+    // The PDA binds the mint; a mismatch means a forged account or program bug.
+    if registry.mint != Address::new_from_array(mint.to_bytes()) {
+        return Err(ClientError::Rpc(format!(
+            "asset registry for {mint} stores a different mint"
+        )));
+    }
+    Ok(registry.asset_id)
+}
+
+/// Create the SPL interface for `mint` and return its asset id; returns the
+/// existing id when the mint is already registered (also when a concurrent
+/// caller wins the registration race).
+///
+/// A devnet / permissionless-deployment tool, not a mainnet user API:
+/// `create_spl_interface` requires `protocol_config.protocol_authority` unless
+/// the deployment sets `spl_interface_creation_is_permissionless` (rejected
+/// on-chain with `UnauthorizedCaller`, code 7003), and the one-time asset
+/// counter bootstrap is always authority-gated. On gated deployments read ids
+/// with [`fetch_asset_id`] instead.
+pub fn register_spl_interface<R: Rpc>(
+    rpc: &R,
+    authority: &Keypair,
+    mint: Pubkey,
+) -> Result<u64, ClientError> {
+    match fetch_asset_id(rpc, mint) {
+        Err(ClientError::AssetNotRegistered { .. }) => {}
+        result => return result,
+    }
+
+    let authority_address = Address::new_from_array(authority.pubkey().to_bytes());
+    let counter = pda::spl_asset_counter();
+    if rpc
+        .get_account(Address::new_from_array(counter.to_bytes()))?
+        .is_none()
+    {
+        let ix = CreateAssetCounter {
+            authority: authority.pubkey(),
+        }
+        .instruction();
+        rpc.create_and_send_transaction(&[ix], authority_address, &[authority])?;
+    }
+
+    let ix = CreateSplInterface {
+        authority: authority.pubkey(),
+        mint,
+    }
+    .instruction();
+    if let Err(err) = rpc.create_and_send_transaction(&[ix], authority_address, &[authority]) {
+        // A concurrent caller may have registered the mint between the lookup
+        // and the send; the id is the outcome that matters.
+        return match fetch_asset_id(rpc, mint) {
+            Ok(asset_id) => Ok(asset_id),
+            Err(_) => Err(ClientError::Rpc(format!(
+                "create_spl_interface for {mint} rejected; interface creation is gated to the \
+                 protocol authority unless the deployment enables permissionless creation: {err}"
+            ))),
+        };
+    }
+    fetch_asset_id(rpc, mint)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, collections::HashMap};
+
+    use solana_account::Account;
+    use solana_hash::Hash;
+    use solana_signature::Signature;
+    use solana_transaction::Transaction;
+    use zolana_interface::SHIELDED_POOL_PROGRAM_ID;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MockRpc {
+        accounts: RefCell<HashMap<Address, Account>>,
+        sent: RefCell<usize>,
+    }
+
+    impl MockRpc {
+        fn with_registry(mint: Pubkey, asset_id: u64) -> Self {
+            let rpc = Self::default();
+            let registry_pda = pda::spl_asset_registry(&mint);
+            rpc.accounts.borrow_mut().insert(
+                Address::new_from_array(registry_pda.to_bytes()),
+                registry_account(mint, asset_id),
+            );
+            rpc
+        }
+    }
+
+    fn registry_account(mint: Pubkey, asset_id: u64) -> Account {
+        Account {
+            lamports: 1,
+            data: SplAssetRegistry::account_bytes(
+                Address::new_from_array(mint.to_bytes()),
+                asset_id,
+            )
+            .to_vec(),
+            owner: Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID),
+            executable: false,
+            rent_epoch: 0,
+        }
+    }
+
+    impl Rpc for MockRpc {
+        fn get_account(&self, address: Address) -> Result<Option<Account>, ClientError> {
+            Ok(self.accounts.borrow().get(&address).cloned())
+        }
+
+        fn get_latest_blockhash(&self) -> Result<(Hash, u64), ClientError> {
+            Ok((Hash::default(), 0))
+        }
+
+        fn send_transaction(&self, _transaction: &Transaction) -> Result<Signature, ClientError> {
+            *self.sent.borrow_mut() += 1;
+            Ok(Signature::default())
+        }
+    }
+
+    #[test]
+    fn fetch_returns_the_registered_id() {
+        let mint = Pubkey::new_unique();
+        let rpc = MockRpc::with_registry(mint, 7);
+        assert_eq!(fetch_asset_id(&rpc, mint).unwrap(), 7);
+    }
+
+    #[test]
+    fn fetch_without_registry_is_asset_not_registered() {
+        let mint = Pubkey::new_unique();
+        let rpc = MockRpc::default();
+        assert!(matches!(
+            fetch_asset_id(&rpc, mint),
+            Err(ClientError::AssetNotRegistered { mint: m }) if m == mint
+        ));
+    }
+
+    #[test]
+    fn fetch_rejects_a_registry_storing_a_different_mint() {
+        let mint = Pubkey::new_unique();
+        let rpc = MockRpc::default();
+        let registry_pda = pda::spl_asset_registry(&mint);
+        rpc.accounts.borrow_mut().insert(
+            Address::new_from_array(registry_pda.to_bytes()),
+            registry_account(Pubkey::new_unique(), 7),
+        );
+        assert!(matches!(
+            fetch_asset_id(&rpc, mint),
+            Err(ClientError::Rpc(message)) if message.contains("different mint")
+        ));
+    }
+
+    #[test]
+    fn register_short_circuits_to_the_existing_id() {
+        let mint = Pubkey::new_unique();
+        let rpc = MockRpc::with_registry(mint, 9);
+        let authority = Keypair::new();
+        assert_eq!(register_spl_interface(&rpc, &authority, mint).unwrap(), 9);
+        assert_eq!(*rpc.sent.borrow(), 0);
+    }
+}

--- a/sdk-libs/client/src/actions/submit.rs
+++ b/sdk-libs/client/src/actions/submit.rs
@@ -34,9 +34,9 @@ use crate::{
 };
 
 /// Compute-unit ceiling a private transaction is submitted with unless the
-/// caller overrides it. A shielded `Transact` verifies a Groth16 proof on-chain,
-/// which does not fit inside the default per-instruction budget.
-pub const DEFAULT_TRANSACT_CU_LIMIT: u32 = 1_400_000;
+/// caller overrides it. Benchmarked transfers and withdrawals run ~148k-152k CU
+/// (`program-tests/shielded-pool/CU_BENCHMARK.md`).
+pub const DEFAULT_TRANSACT_CU_LIMIT: u32 = 200_000;
 
 /// How long [`Submit::execute`] waits for the indexer to pick up the sent
 /// transaction before giving up.

--- a/sdk-libs/client/src/actions/transaction.rs
+++ b/sdk-libs/client/src/actions/transaction.rs
@@ -77,7 +77,7 @@ pub struct CreateTransfer<'a, R: Rpc, A: ?Sized> {
     pub authority: &'a A,
     pub owner_pubkey: Pubkey,
     pub payer: Address,
-    pub recipient_owner: Pubkey,
+    pub recipient: Pubkey,
     pub asset: Address,
     pub amount: u64,
 }
@@ -95,14 +95,13 @@ pub struct CreateWithdrawal<'a, A: ?Sized> {
 pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
     request: CreateTransfer<'_, R, A>,
 ) -> Result<CreatedTransfer, ClientError> {
-    let Some(recipient) = try_resolve_registered_address(request.rpc, request.recipient_owner)?
-    else {
+    let Some(recipient) = try_resolve_registered_address(request.rpc, request.recipient)? else {
         let withdrawal = create_withdrawal(CreateWithdrawal {
             wallet: request.wallet,
             authority: request.authority,
             owner_pubkey: request.owner_pubkey,
             payer: request.payer,
-            recipient: request.recipient_owner,
+            recipient: request.recipient,
             asset: request.asset,
             amount: request.amount,
         })
@@ -111,7 +110,7 @@ pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
             signed: withdrawal.signed,
             wait_tag: withdrawal.wait_tag,
             recipient: TransferRecipient::PublicWithdrawal {
-                recipient: request.recipient_owner,
+                recipient: request.recipient,
                 withdrawal: withdrawal.withdrawal,
             },
         });
@@ -140,7 +139,7 @@ pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
         &request.wallet.registry,
         format!(
             "private transfer of {} to {}",
-            request.amount, request.recipient_owner
+            request.amount, request.recipient
         ),
     )
     .await?;
@@ -459,7 +458,7 @@ mod tests {
             authority: &sender,
             owner_pubkey: Pubkey::default(),
             payer: Address::default(),
-            recipient_owner: owner,
+            recipient: owner,
             asset: SOL_MINT,
             amount: 1,
         })
@@ -485,7 +484,7 @@ mod tests {
             authority: &sender,
             owner_pubkey: Pubkey::default(),
             payer: Address::default(),
-            recipient_owner: recipient,
+            recipient,
             asset: SOL_MINT,
             amount: 1,
         })
@@ -516,7 +515,7 @@ mod tests {
             authority: &sender,
             owner_pubkey: Pubkey::default(),
             payer: Address::default(),
-            recipient_owner: recipient,
+            recipient,
             asset,
             amount: 1,
         })

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -1,4 +1,5 @@
 use solana_pubkey::Pubkey;
+use solana_signature::Signature;
 use thiserror::Error;
 use zolana_keypair::KeypairError;
 use zolana_transaction::TransactionError;
@@ -99,6 +100,15 @@ pub enum ClientError {
 
     #[error("deposit funding account not found: {address:?}")]
     AccountNotFound { address: [u8; 32] },
+
+    #[error("deposit {signature} confirmed but its UTXO {utxo_hash:?} was not indexed after 120s")]
+    DepositNotIndexed {
+        utxo_hash: [u8; 32],
+        signature: Signature,
+    },
+
+    #[error("asset registry entry not found for mint {mint}; the mint has no SPL interface on this deployment")]
+    AssetNotRegistered { mint: Pubkey },
 
     #[error("SOL deposit funding account {sender:?} must be the signing authority")]
     DepositSenderNotSigner { sender: [u8; 32] },

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -57,8 +57,8 @@ pub use wallet_authority::{
     P256Signature, SyncWalletAuthority, WalletAuthority,
 };
 pub use wallet_sync::{
-    get_private_token_balances, get_private_transactions, sync_wallet, sync_wallet_with_config,
-    SyncWalletConfig,
+    get_private_token_balances, get_private_transactions, refresh_registry_from_chain, sync_wallet,
+    sync_wallet_with_config, SyncWalletConfig,
 };
 pub use zolana_transaction::{
     instructions::{

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -15,9 +15,9 @@ pub mod wallet_sync;
 
 pub use actions::{
     create_associated_token_account, create_deposit, create_transfer, create_transfer_sync,
-    create_withdrawal, create_withdrawal_sync, sign_transaction, sign_transaction_sync,
-    CreateDeposit, CreateTransfer, CreateWithdrawal, CreatedTransfer, CreatedWithdrawal, Deposit,
-    ResolvedAddress, TransferRecipient,
+    create_withdrawal, create_withdrawal_sync, fetch_asset_id, register_spl_interface,
+    sign_transaction, sign_transaction_sync, CreateDeposit, CreateTransfer, CreateWithdrawal,
+    CreatedTransfer, CreatedWithdrawal, Deposit, ResolvedAddress, TransferRecipient,
 };
 #[cfg(feature = "indexer-api")]
 pub use actions::{Submit, DEFAULT_TRANSACT_CU_LIMIT};

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -18,6 +18,7 @@ pub use actions::{
     create_withdrawal, create_withdrawal_sync, fetch_asset_id, register_spl_interface,
     sign_transaction, sign_transaction_sync, CreateDeposit, CreateTransfer, CreateWithdrawal,
     CreatedTransfer, CreatedWithdrawal, Deposit, ResolvedAddress, TransferRecipient,
+    DEFAULT_DEPOSIT_CU_LIMIT,
 };
 #[cfg(feature = "indexer-api")]
 pub use actions::{Submit, DEFAULT_TRANSACT_CU_LIMIT};

--- a/sdk-libs/client/src/wallet_sync.rs
+++ b/sdk-libs/client/src/wallet_sync.rs
@@ -41,6 +41,18 @@ impl Default for SyncWalletConfig {
     }
 }
 
+/// Sync the wallet's UTXOs and history from the indexer.
+///
+/// Unknown asset ids are resolved best effort: when decode hits ids the
+/// wallet's registry does not know, sync scans the on-chain `SplAssetRegistry`
+/// accounts via `get_program_accounts` and retries once. On backends without
+/// that method the backfill silently resolves nothing — the stock
+/// `ZolanaIndexer` is such a backend (it implements only the indexer queries),
+/// so with Photon as the sync source the
+/// backfill never fires. Backfill eagerly with a `get_program_accounts`-capable
+/// backend via [`refresh_registry_from_chain`], or insert ids directly with
+/// [`fetch_asset_id`](crate::fetch_asset_id) + `wallet.registry.insert` — the
+/// path that works on every backend.
 pub fn sync_wallet<I>(wallet: &mut Wallet, indexer: &I) -> Result<SyncReport, ClientError>
 where
     I: Rpc,
@@ -111,8 +123,15 @@ where
 /// Fetch every `SplAssetRegistry` account owned by the shielded-pool program and
 /// insert any new `asset_id -> mint` pairs into the wallet's registry. Returns
 /// the number of newly inserted ids. `get_program_accounts` being unsupported on
-/// the RPC is treated as zero new ids (soft miss), not an error.
-fn refresh_registry_from_chain<I>(wallet: &mut Wallet, indexer: &I) -> Result<usize, ClientError>
+/// the backend is treated as zero new ids (soft miss), not an error — which is
+/// why this is public: a wallet synced against Photon (no `get_program_accounts`)
+/// can still backfill eagerly through a capable backend such as
+/// `SolanaRpc`. The guaranteed per-mint path is
+/// [`fetch_asset_id`](crate::fetch_asset_id) + `wallet.registry.insert`.
+pub fn refresh_registry_from_chain<I>(
+    wallet: &mut Wallet,
+    indexer: &I,
+) -> Result<usize, ClientError>
 where
     I: Rpc,
 {


### PR DESCRIPTION
## Summary

Three SDK DX additions that let the examples (and integrators) drop their local helper crate, plus benchmark-based CU limits. Stacked on the wallet-onboarding PR (`main` ← #108 ← #109 ← #112 ← this).

**1. `Deposit::send` + `Deposit::wait_until_synced`** — `send` is the deposit default. The recipient-side read-your-write step is a separate `wait_until_synced(wallet, indexer, signature)`: it polls `sync_wallet` until the deposited UTXO is visible (120s/500ms), for callers that spend or display the balance immediately. Its docs state the precondition the previously-planned fused `send_and_sync` hid: the wallet must be the deposit **recipient's** — a non-recipient wallet can never see the UTXO, so the wait times out with `DepositNotIndexed` (which carries the confirmed signature) despite a successful deposit. For third-party deposits there is nothing to wait for on the sender side.

**Also:** deposits are sent with a 40k CU ceiling (benchmarked ~34k) and `DEFAULT_TRANSACT_CU_LIMIT` drops 1.4M → 200k (benchmarked ~148–152k, `program-tests/shielded-pool/CU_BENCHMARK.md`); `CreateTransfer.recipient_owner` is renamed to `recipient`, matching `CreateWithdrawal`.

**2. `fetch_asset_id` + `register_spl_interface`** — the production asset-id path and the devnet registration tool, split:
- `fetch_asset_id(rpc, mint)` reads the canonical per-mint Asset registry PDA — works on every deployment (spec: the PDA is the canonical `asset_id` source; SOL is id 1 with no PDA). New named error `AssetNotRegistered { mint }`.
- `register_spl_interface(rpc, authority, mint)` creates the interface and returns the id, idempotently — existing registrations short-circuit, and a lost registration race re-fetches instead of erroring. **Gating documented per spec:** `create_spl_interface` requires `protocol_config.protocol_authority` unless the deployment sets `spl_interface_creation_is_permissionless` (on-chain rejection: `UnauthorizedCaller`, 7003); the one-time asset counter bootstrap is *always* authority-gated. This kills the examples' hardcoded `asset_id = 2`.

**3. Registry-refresh contract** — `refresh_registry_from_chain` is now public and the behavior is documented: the sync-time backfill needs `get_program_accounts`, which the stock `ZolanaIndexer` does not implement — **with Photon as the sync source the backfill always soft-misses.** The public refresh lets callers backfill eagerly through a capable backend (e.g. `SolanaRpc`); the guaranteed per-mint path is `fetch_asset_id` + `registry.insert`. No behavior change.

All three APIs are ungated (compile with no features) and ship `no_run` rustdoc examples.

## Deferred (from the DX task list)

- **A4** (env-based devnet constructor, tree constant, `assert_deployed`): blocked on reconciling the `ZolanaClient` redesign on `feat/sdk-submit-api` with the preset work in #109.
- **A5 — sponsor-paid registration (highest-leverage embedded-wallet follow-up):** investigated — the user-registry `register` instruction has 3 accounts and the owner is the *only* signer and rent payer, so apps must pre-fund users today. Enabling a separate sponsor requires a program + interface change (add a payer account); deserves its own PR with protocol review.
- **A6**: `zolana-test-utils` is `publish = false` and SDKs must not depend on it — examples will vendor labeled scaffolding.
- **A7** (prover trust-model docs) and the examples migration (B1–B5), incl. the devnet e2e verification of the registry backfill.

## Test plan
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo build -p zolana-client` (no features) and `--features "indexer-api solana-rpc"`
- [x] `cargo clippy -p zolana-client --all-targets --features "indexer-api solana-rpc" -- -D warnings` + `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p zolana-client --lib --features "indexer-api solana-rpc"` — 60 passed (4 new `spl_interface` tests)
- [x] doc-tests with both features (3) and featureless (2); `cargo test -p zolana-keypair --lib` — 10 passed

