### PR TITLE
refactor(client): rename CreateTransfer.recipient_owner to recipient

### DIFF
--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -26,7 +26,7 @@ pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
     let indexer = ZolanaIndexer::new(network.sync.indexer_url.clone());
     let ctx = sync_context(&opts.network.sync)?;
     maybe_airdrop(&mut rpc, &ctx.material, network.airdrop_lamports)?;
-    let recipient_owner = parse_pubkey(&opts.to)?;
+    let recipient = parse_pubkey(&opts.to)?;
     let tree = network.tree;
 
     let transfer = create_transfer_sync(CreateTransfer {
@@ -35,7 +35,7 @@ pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
         authority: &ctx.material,
         owner_pubkey: ctx.material.owner_pubkey(),
         payer: Address::new_from_array(ctx.material.funding.pubkey().to_bytes()),
-        recipient_owner,
+        recipient,
         asset,
         amount: opts.amount,
     })?;

--- a/sdk-libs/client/src/actions/transaction.rs
+++ b/sdk-libs/client/src/actions/transaction.rs
@@ -77,7 +77,7 @@ pub struct CreateTransfer<'a, R: Rpc, A: ?Sized> {
     pub authority: &'a A,
     pub owner_pubkey: Pubkey,
     pub payer: Address,
-    pub recipient_owner: Pubkey,
+    pub recipient: Pubkey,
     pub asset: Address,
     pub amount: u64,
 }
@@ -95,14 +95,13 @@ pub struct CreateWithdrawal<'a, A: ?Sized> {
 pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
     request: CreateTransfer<'_, R, A>,
 ) -> Result<CreatedTransfer, ClientError> {
-    let Some(recipient) = try_resolve_registered_address(request.rpc, request.recipient_owner)?
-    else {
+    let Some(recipient) = try_resolve_registered_address(request.rpc, request.recipient)? else {
         let withdrawal = create_withdrawal(CreateWithdrawal {
             wallet: request.wallet,
             authority: request.authority,
             owner_pubkey: request.owner_pubkey,
             payer: request.payer,
-            recipient: request.recipient_owner,
+            recipient: request.recipient,
             asset: request.asset,
             amount: request.amount,
         })
@@ -111,7 +110,7 @@ pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
             signed: withdrawal.signed,
             wait_tag: withdrawal.wait_tag,
             recipient: TransferRecipient::PublicWithdrawal {
-                recipient: request.recipient_owner,
+                recipient: request.recipient,
                 withdrawal: withdrawal.withdrawal,
             },
         });
@@ -140,7 +139,7 @@ pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
         &request.wallet.registry,
         format!(
             "private transfer of {} to {}",
-            request.amount, request.recipient_owner
+            request.amount, request.recipient
         ),
     )
     .await?;
@@ -459,7 +458,7 @@ mod tests {
             authority: &sender,
             owner_pubkey: Pubkey::default(),
             payer: Address::default(),
-            recipient_owner: owner,
+            recipient: owner,
             asset: SOL_MINT,
             amount: 1,
         })
@@ -485,7 +484,7 @@ mod tests {
             authority: &sender,
             owner_pubkey: Pubkey::default(),
             payer: Address::default(),
-            recipient_owner: recipient,
+            recipient: recipient,
             asset: SOL_MINT,
             amount: 1,
         })
@@ -516,7 +515,7 @@ mod tests {
             authority: &sender,
             owner_pubkey: Pubkey::default(),
             payer: Address::default(),
-            recipient_owner: recipient,
+            recipient: recipient,
             asset,
             amount: 1,
         })


### PR DESCRIPTION
## Why

The caller passes the recipient's Solana address and the SDK decides the delivery path itself (registered private wallet -> private transfer; otherwise -> public withdrawal to that address). Resolving the address to the owner's shielded address is internal mechanism, so the field should be named by caller intent. This also aligns the surface with `CreateWithdrawal.recipient`, which already takes the same concept under that name.

## What changed

- `CreateTransfer.recipient_owner` -> `recipient` (struct field and all uses in `create_transfer`, including the withdrawal fallback and approval summary).
- CLI `transfer` command updated, local renamed to keep field shorthand.
- Internal `owner` vocabulary (`ResolvedAddress.owner`, `owner_pubkey`) is untouched.

## Breaking

Struct literals constructing `CreateTransfer` must rename the field. No behavior change.

## Verification

- `cargo check --workspace` clean
- `cargo +nightly fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)