### PR TITLE
feat(client): Signer-trait payer, tree/commitment config, transfer memo

### DIFF
--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -33,6 +33,7 @@ pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
         recipient: recipient_owner,
         asset,
         amount: opts.amount,
+        memo: None,
     })?;
     let prover = ProverClient::new(network.prover_url.clone());
     let signature = Submit {

--- a/program-tests/test-utils/src/spl.rs
+++ b/program-tests/test-utils/src/spl.rs
@@ -45,7 +45,7 @@ fn system_create_account_ix(
 }
 
 /// Create and initialize a fresh SPL mint (9 decimals, mint authority = `payer`).
-pub fn create_mint<R: Rpc>(rpc: &R, payer: &Keypair) -> Result<Pubkey, ClientError> {
+pub fn create_mint<R: Rpc>(rpc: &R, payer: &dyn Signer) -> Result<Pubkey, ClientError> {
     let mint = Keypair::new();
     let rent = rpc.get_minimum_balance_for_rent_exemption(SPL_TOKEN_MINT_ACCOUNT_LEN)?;
     let create_ix = system_create_account_ix(
@@ -74,7 +74,7 @@ pub fn create_mint<R: Rpc>(rpc: &R, payer: &Keypair) -> Result<Pubkey, ClientErr
 /// Create and initialize an SPL token account for `mint` owned by `owner`.
 pub fn create_token_account<R: Rpc>(
     rpc: &R,
-    payer: &Keypair,
+    payer: &dyn Signer,
     mint: &Pubkey,
     owner: &Pubkey,
 ) -> Result<Pubkey, ClientError> {
@@ -108,7 +108,7 @@ pub fn create_token_account<R: Rpc>(
 /// Mint `amount` of `mint` to `account` (authority = `payer`).
 pub fn mint_to<R: Rpc>(
     rpc: &R,
-    payer: &Keypair,
+    payer: &dyn Signer,
     mint: &Pubkey,
     account: &Pubkey,
     amount: u64,
@@ -129,7 +129,7 @@ pub fn mint_to<R: Rpc>(
 }
 
 /// Create the singleton SPL asset counter if it does not exist yet.
-pub fn ensure_asset_counter<R: Rpc>(rpc: &R, authority: &Keypair) -> Result<(), ClientError> {
+pub fn ensure_asset_counter<R: Rpc>(rpc: &R, authority: &dyn Signer) -> Result<(), ClientError> {
     if rpc
         .get_account(to_address(&pda::spl_asset_counter()))?
         .is_none()
@@ -147,7 +147,7 @@ pub fn ensure_asset_counter<R: Rpc>(rpc: &R, authority: &Keypair) -> Result<(), 
 /// Returns `(registry, vault)`.
 pub fn create_spl_interface<R: Rpc>(
     rpc: &R,
-    authority: &Keypair,
+    authority: &dyn Signer,
     mint: &Pubkey,
 ) -> Result<(Pubkey, Pubkey), ClientError> {
     let registry = pda::spl_asset_registry(mint);

--- a/sdk-libs/client/src/actions/create_associated_token_account.rs
+++ b/sdk-libs/client/src/actions/create_associated_token_account.rs
@@ -1,7 +1,6 @@
 //! Idempotent associated-token-account creation action.
 
 use solana_address::Address;
-use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
@@ -17,7 +16,7 @@ use crate::{error::ClientError, rpc::Rpc};
 /// signature and the created ATA address.
 pub fn create_associated_token_account<R: Rpc>(
     rpc: &R,
-    payer: &Keypair,
+    payer: &dyn Signer,
     owner: &Pubkey,
     mint: &Pubkey,
 ) -> Result<(Signature, Pubkey), ClientError> {
@@ -38,6 +37,7 @@ mod tests {
     use std::cell::RefCell;
 
     use solana_hash::Hash;
+    use solana_keypair::Keypair;
     use solana_transaction::Transaction;
     use zolana_interface::pda;
 

--- a/sdk-libs/client/src/actions/deposit.rs
+++ b/sdk-libs/client/src/actions/deposit.rs
@@ -21,8 +21,9 @@ use zolana_transaction::{owner_utxo_hash, utxo_hash, Wallet, SOL_MINT};
 use crate::{error::ClientError, rpc::Rpc, wallet_sync::sync_wallet};
 
 /// Compute-unit ceiling [`deposit`] is submitted with. Benchmarked deposits run
-/// ~34k CU (`program-tests/shielded-pool/CU_BENCHMARK.md`).
-pub const DEFAULT_DEPOSIT_CU_LIMIT: u32 = 40_000;
+/// ~34k CU (`program-tests/shielded-pool/CU_BENCHMARK.md`), but a live devnet
+/// SPL deposit was observed exceeding 40k, so the ceiling leaves headroom.
+pub const DEFAULT_DEPOSIT_CU_LIMIT: u32 = 80_000;
 
 /// How long [`Deposit::wait_until_synced`] waits for the indexer to pick up
 /// the deposited UTXO before giving up.

--- a/sdk-libs/client/src/actions/deposit.rs
+++ b/sdk-libs/client/src/actions/deposit.rs
@@ -8,7 +8,6 @@ use std::{
 use solana_address::Address;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_instruction::Instruction;
-use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
@@ -95,9 +94,9 @@ impl Deposit {
     pub fn send<R: Rpc>(
         &self,
         rpc: &R,
-        payer: &Keypair,
+        payer: &dyn Signer,
         tree: Pubkey,
-        depositor: &Keypair,
+        depositor: &dyn Signer,
     ) -> Result<Signature, ClientError> {
         deposit(rpc, payer, tree, depositor, self.spl, &self.data)
     }
@@ -116,8 +115,8 @@ impl Deposit {
     /// # Examples
     ///
     /// ```no_run
-    /// use solana_keypair::Keypair;
     /// use solana_pubkey::Pubkey;
+    /// use solana_signer::Signer;
     /// use zolana_client::{create_deposit, ClientError, CreateDeposit, Rpc};
     /// use zolana_keypair::ShieldedAddress;
     /// use zolana_transaction::{Wallet, SOL_MINT};
@@ -125,7 +124,7 @@ impl Deposit {
     /// fn deposit_sol<R: Rpc, I: Rpc>(
     ///     rpc: &R,
     ///     indexer: &I,
-    ///     payer: &Keypair,
+    ///     payer: &dyn Signer,
     ///     tree: Pubkey,
     ///     recipient: &ShieldedAddress,
     ///     wallet: &mut Wallet,
@@ -196,15 +195,15 @@ pub fn create_deposit(request: CreateDeposit<'_>) -> Result<Deposit, ClientError
 /// Returns the transaction signature; event indexing is the caller's concern.
 pub fn deposit<R: Rpc>(
     rpc: &R,
-    payer: &Keypair,
+    payer: &dyn Signer,
     tree: Pubkey,
-    depositor: &Keypair,
+    depositor: &dyn Signer,
     spl: Option<DepositSplAccounts>,
     data: &DepositIxData,
 ) -> Result<Signature, ClientError> {
     let cu_ix = ComputeBudgetInstruction::set_compute_unit_limit(DEFAULT_DEPOSIT_CU_LIMIT);
     let ix = deposit_instruction(tree, depositor.pubkey(), spl, data);
-    let mut signers: Vec<&Keypair> = vec![payer];
+    let mut signers: Vec<&dyn Signer> = vec![payer];
     if depositor.pubkey() != payer.pubkey() {
         signers.push(depositor);
     }
@@ -254,6 +253,7 @@ mod tests {
     use std::cell::RefCell;
 
     use solana_hash::Hash;
+    use solana_keypair::Keypair;
     use solana_transaction::Transaction;
     use zolana_keypair::ShieldedKeypair;
 

--- a/sdk-libs/client/src/actions/spl_interface.rs
+++ b/sdk-libs/client/src/actions/spl_interface.rs
@@ -8,13 +8,13 @@
 //! # Examples
 //!
 //! ```no_run
-//! use solana_keypair::Keypair;
 //! use solana_pubkey::Pubkey;
+//! use solana_signer::Signer;
 //! use zolana_client::{fetch_asset_id, register_spl_interface, ClientError, Rpc};
 //!
 //! fn asset_id<R: Rpc>(
 //!     rpc: &R,
-//!     authority: &Keypair,
+//!     authority: &dyn Signer,
 //!     mint: Pubkey,
 //! ) -> Result<u64, ClientError> {
 //!     // Production path: read the canonical per-mint registry PDA.
@@ -29,7 +29,6 @@
 //! ```
 
 use solana_address::Address;
-use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use zolana_interface::{
@@ -75,7 +74,7 @@ pub fn fetch_asset_id<R: Rpc>(rpc: &R, mint: Pubkey) -> Result<u64, ClientError>
 /// with [`fetch_asset_id`] instead.
 pub fn register_spl_interface<R: Rpc>(
     rpc: &R,
-    authority: &Keypair,
+    authority: &dyn Signer,
     mint: Pubkey,
 ) -> Result<u64, ClientError> {
     match fetch_asset_id(rpc, mint) {
@@ -121,6 +120,7 @@ mod tests {
 
     use solana_account::Account;
     use solana_hash::Hash;
+    use solana_keypair::Keypair;
     use solana_signature::Signature;
     use solana_transaction::Transaction;
     use zolana_interface::SHIELDED_POOL_PROGRAM_ID;

--- a/sdk-libs/client/src/actions/submit.rs
+++ b/sdk-libs/client/src/actions/submit.rs
@@ -16,7 +16,6 @@ use std::{
 
 use solana_address::Address;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
-use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
@@ -60,7 +59,7 @@ pub struct Submit<'a, R: Rpc> {
     /// Sends the transaction (a Solana RPC).
     pub rpc: &'a R,
     pub prover: &'a ProverClient,
-    pub payer: &'a Keypair,
+    pub payer: &'a dyn Signer,
     pub tree: Pubkey,
     /// Compute-unit limit; `None` uses [`DEFAULT_TRANSACT_CU_LIMIT`].
     pub cu_limit: Option<u32>,

--- a/sdk-libs/client/src/actions/transaction.rs
+++ b/sdk-libs/client/src/actions/transaction.rs
@@ -80,6 +80,12 @@ pub struct CreateTransfer<'a, R: Rpc, A: ?Sized> {
     pub recipient: Pubkey,
     pub asset: Address,
     pub amount: u64,
+    /// Free-form note for the recipient, encrypted into their output
+    /// ciphertext and not committed into any hash. It lengthens that
+    /// ciphertext, so its presence and byte length are visible onchain; the
+    /// contents are not. Ignored when the transfer falls back to a public
+    /// withdrawal (public funds carry no ciphertext).
+    pub memo: Option<Vec<u8>>,
 }
 
 pub struct CreateWithdrawal<'a, A: ?Sized> {
@@ -129,7 +135,12 @@ pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
         .await?;
     let wait_tag = address.signing_pubkey.confidential_view_tag()?;
     let mut tx = Transaction::new(address, inputs, request.payer);
-    tx.send(&recipient.address, request.asset, request.amount)?;
+    tx.send_with_memo(
+        &recipient.address,
+        request.asset,
+        request.amount,
+        request.memo,
+    )?;
     let prepared = tx.prepare(&request.wallet.registry)?;
     let signed = sign_prepared(
         prepared,
@@ -461,6 +472,7 @@ mod tests {
             recipient: owner,
             asset: SOL_MINT,
             amount: 1,
+            memo: None,
         })
         .expect("transfer");
 
@@ -487,6 +499,7 @@ mod tests {
             recipient,
             asset: SOL_MINT,
             amount: 1,
+            memo: None,
         })
         .expect("public withdrawal fallback");
 
@@ -518,6 +531,7 @@ mod tests {
             recipient,
             asset,
             amount: 1,
+            memo: None,
         })
         .expect("public withdrawal fallback");
 

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -2,7 +2,7 @@
 //! wallet needs, plus the fee payer. Requires both the `indexer-api` and
 //! `solana-rpc` features.
 
-use solana_keypair::Keypair;
+use solana_signer::Signer;
 
 use crate::{
     indexer::{indexer_url, ZolanaIndexer, DEVNET_INDEXER_URL},
@@ -10,26 +10,27 @@ use crate::{
     solana_rpc::{rpc_url, SolanaRpc, HELIUS_DEVNET_RPC_URL},
 };
 
-/// Endpoints and fee payer for [`ZolanaClient`]. The payer is always supplied
-/// by the caller: the SDK never generates keypairs or loads them from disk
-/// (devnet has no faucet). To use an API key, embed it in the URL:
-/// `https://...?api-key=YOUR_KEY`.
+/// Endpoints and fee payer for [`ZolanaClient`]. The payer is any [`Signer`]:
+/// a local keypair on a server, or a wallet-backed signer in an app. It is
+/// always supplied by the caller: the SDK never generates keypairs or loads
+/// them from disk (devnet has no faucet). To use an API key, embed it in the
+/// URL: `https://...?api-key=YOUR_KEY`.
 pub struct ZolanaClientConfig {
     pub rpc_url: String,
     pub indexer_url: String,
     pub prover_url: String,
-    pub payer: Keypair,
+    pub payer: Box<dyn Signer + Send + Sync>,
 }
 
 impl ZolanaClientConfig {
     /// Local defaults, honoring the per-clone `ZOLANA_LOCALNET_URL` /
     /// `ZOLANA_INDEXER_URL` / `ZOLANA_PROVER_URL` overrides.
-    pub fn local(payer: Keypair) -> Self {
+    pub fn local(payer: impl Signer + Send + Sync + 'static) -> Self {
         Self {
             rpc_url: rpc_url(),
             indexer_url: indexer_url(),
             prover_url: server_address(),
-            payer,
+            payer: Box::new(payer),
         }
     }
 
@@ -37,12 +38,12 @@ impl ZolanaClientConfig {
     /// key. The key is embedded in the RPC URL and never read from env or
     /// stored elsewhere. No env overrides: those exist for local port
     /// contention only; set custom URLs on the struct fields instead.
-    pub fn devnet(payer: Keypair, api_key: &str) -> Self {
+    pub fn devnet(payer: impl Signer + Send + Sync + 'static, api_key: &str) -> Self {
         Self {
             rpc_url: format!("{HELIUS_DEVNET_RPC_URL}/?api-key={api_key}"),
             indexer_url: DEVNET_INDEXER_URL.to_string(),
             prover_url: DEVNET_SERVER_ADDRESS.to_string(),
-            payer,
+            payer: Box::new(payer),
         }
     }
 }
@@ -66,7 +67,7 @@ pub struct ZolanaClient {
     rpc: SolanaRpc,
     indexer: ZolanaIndexer,
     prover: ProverClient,
-    payer: Keypair,
+    payer: Box<dyn Signer + Send + Sync>,
 }
 
 impl ZolanaClient {
@@ -79,18 +80,23 @@ impl ZolanaClient {
         }
     }
 
-    pub fn local(payer: Keypair) -> Self {
+    pub fn local(payer: impl Signer + Send + Sync + 'static) -> Self {
         Self::new(ZolanaClientConfig::local(payer))
     }
 
-    pub fn devnet(payer: Keypair, api_key: &str) -> Self {
+    pub fn devnet(payer: impl Signer + Send + Sync + 'static, api_key: &str) -> Self {
         Self::new(ZolanaClientConfig::devnet(payer, api_key))
     }
 
     /// Borrow every connection and the payer at once, as disjoint fields, so
     /// a `&mut` RPC call can take the payer in the same expression.
-    pub fn parts(&mut self) -> (&mut SolanaRpc, &ZolanaIndexer, &ProverClient, &Keypair) {
-        (&mut self.rpc, &self.indexer, &self.prover, &self.payer)
+    pub fn parts(&mut self) -> (&mut SolanaRpc, &ZolanaIndexer, &ProverClient, &dyn Signer) {
+        (
+            &mut self.rpc,
+            &self.indexer,
+            &self.prover,
+            self.payer.as_ref(),
+        )
     }
 
     pub fn rpc(&self) -> &SolanaRpc {
@@ -110,14 +116,17 @@ impl ZolanaClient {
         &self.prover
     }
 
-    pub fn payer(&self) -> &Keypair {
-        &self.payer
+    pub fn payer(&self) -> &dyn Signer {
+        self.payer.as_ref()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use solana_signer::Signer;
+    use solana_keypair::Keypair;
+    use solana_pubkey::Pubkey;
+    use solana_signature::Signature;
+    use solana_signer::SignerError;
 
     use super::*;
 
@@ -164,11 +173,36 @@ mod tests {
             rpc_url: "http://127.0.0.1:9899".to_string(),
             indexer_url: "http://127.0.0.1:9784".to_string(),
             prover_url: "http://127.0.0.1:9001".to_string(),
-            payer,
+            payer: Box::new(payer),
         });
         assert_eq!(client.rpc().client().url(), "http://127.0.0.1:9899");
         assert_eq!(client.indexer().api().base_path(), "http://127.0.0.1:9784");
         assert_eq!(client.prover().server_address(), "http://127.0.0.1:9001");
         assert_eq!(client.payer().pubkey(), payer_pubkey);
+    }
+
+    /// A signer that is not a keypair — the shape a wallet adapter provides.
+    struct StubSigner(Pubkey);
+
+    impl Signer for StubSigner {
+        fn try_pubkey(&self) -> Result<Pubkey, SignerError> {
+            Ok(self.0)
+        }
+
+        fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
+            Ok(Signature::default())
+        }
+
+        fn is_interactive(&self) -> bool {
+            true
+        }
+    }
+
+    // Compiling is the point: the payer needs no secret key on hand.
+    #[test]
+    fn client_accepts_a_non_keypair_signer() {
+        let pubkey = Pubkey::new_unique();
+        let client = ZolanaClient::devnet(StubSigner(pubkey), "test-key");
+        assert_eq!(client.payer().pubkey(), pubkey);
     }
 }

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -2,6 +2,8 @@
 //! wallet needs, plus the fee payer. Requires both the `indexer-api` and
 //! `solana-rpc` features.
 
+use solana_commitment_config::CommitmentConfig;
+use solana_pubkey::{pubkey, Pubkey};
 use solana_signer::Signer;
 
 use crate::{
@@ -9,6 +11,12 @@ use crate::{
     prover::{server_address, ProverClient, DEVNET_SERVER_ADDRESS},
     solana_rpc::{rpc_url, SolanaRpc, HELIUS_DEVNET_RPC_URL},
 };
+
+/// The protocol's state-tree account. One fixed address, created from the same
+/// keypair on localnet and devnet, so the presets fill it in. Verified for
+/// localnet and devnet only; on other networks set [`ZolanaClientConfig::tree`]
+/// to the deployed tree.
+pub const DEFAULT_TREE: Pubkey = pubkey!("treeYbr45LjxovKvtD46uEphM64kwoFFPYhVNw1A8x8");
 
 /// Endpoints and fee payer for [`ZolanaClient`]. The payer is any [`Signer`]:
 /// a local keypair on a server, or a wallet-backed signer in an app. It is
@@ -20,6 +28,11 @@ pub struct ZolanaClientConfig {
     pub indexer_url: String,
     pub prover_url: String,
     pub payer: Box<dyn Signer + Send + Sync>,
+    /// State tree private transactions write to; the presets fill
+    /// [`DEFAULT_TREE`].
+    pub tree: Pubkey,
+    /// Commitment level for every read and send; `None` means `confirmed`.
+    pub commitment: Option<CommitmentConfig>,
 }
 
 impl ZolanaClientConfig {
@@ -31,6 +44,8 @@ impl ZolanaClientConfig {
             indexer_url: indexer_url(),
             prover_url: server_address(),
             payer: Box::new(payer),
+            tree: DEFAULT_TREE,
+            commitment: None,
         }
     }
 
@@ -44,6 +59,8 @@ impl ZolanaClientConfig {
             indexer_url: DEVNET_INDEXER_URL.to_string(),
             prover_url: DEVNET_SERVER_ADDRESS.to_string(),
             payer: Box::new(payer),
+            tree: DEFAULT_TREE,
+            commitment: None,
         }
     }
 }
@@ -68,15 +85,20 @@ pub struct ZolanaClient {
     indexer: ZolanaIndexer,
     prover: ProverClient,
     payer: Box<dyn Signer + Send + Sync>,
+    tree: Pubkey,
 }
 
 impl ZolanaClient {
     pub fn new(config: ZolanaClientConfig) -> Self {
+        let commitment = config
+            .commitment
+            .unwrap_or_else(CommitmentConfig::confirmed);
         Self {
-            rpc: SolanaRpc::new(config.rpc_url),
+            rpc: SolanaRpc::new_with_commitment(config.rpc_url, commitment),
             indexer: ZolanaIndexer::new(config.indexer_url),
             prover: ProverClient::new(config.prover_url),
             payer: config.payer,
+            tree: config.tree,
         }
     }
 
@@ -118,6 +140,11 @@ impl ZolanaClient {
 
     pub fn payer(&self) -> &dyn Signer {
         self.payer.as_ref()
+    }
+
+    /// State tree private transactions write to.
+    pub fn tree(&self) -> Pubkey {
+        self.tree
     }
 }
 
@@ -169,16 +196,34 @@ mod tests {
     fn new_wires_all_connections_and_payer() {
         let payer = Keypair::new();
         let payer_pubkey = payer.pubkey();
+        let tree = Pubkey::new_unique();
         let client = ZolanaClient::new(ZolanaClientConfig {
             rpc_url: "http://127.0.0.1:9899".to_string(),
             indexer_url: "http://127.0.0.1:9784".to_string(),
             prover_url: "http://127.0.0.1:9001".to_string(),
             payer: Box::new(payer),
+            tree,
+            commitment: Some(CommitmentConfig::processed()),
         });
         assert_eq!(client.rpc().client().url(), "http://127.0.0.1:9899");
         assert_eq!(client.indexer().api().base_path(), "http://127.0.0.1:9784");
         assert_eq!(client.prover().server_address(), "http://127.0.0.1:9001");
         assert_eq!(client.payer().pubkey(), payer_pubkey);
+        assert_eq!(client.tree(), tree);
+        assert_eq!(
+            client.rpc().client().commitment(),
+            CommitmentConfig::processed()
+        );
+    }
+
+    #[test]
+    fn presets_fill_default_tree_and_confirmed_commitment() {
+        let client = ZolanaClient::devnet(Keypair::new(), "test-key");
+        assert_eq!(client.tree(), DEFAULT_TREE);
+        assert_eq!(
+            client.rpc().client().commitment(),
+            CommitmentConfig::confirmed()
+        );
     }
 
     /// A signer that is not a keypair — the shape a wallet adapter provides.

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -23,7 +23,7 @@ pub use actions::{
 #[cfg(feature = "indexer-api")]
 pub use actions::{Submit, DEFAULT_TRANSACT_CU_LIMIT};
 #[cfg(all(feature = "indexer-api", feature = "solana-rpc"))]
-pub use client::{ZolanaClient, ZolanaClientConfig};
+pub use client::{ZolanaClient, ZolanaClientConfig, DEFAULT_TREE};
 pub use error::ClientError;
 #[cfg(feature = "indexer-api")]
 pub use indexer::ZolanaIndexer;

--- a/sdk-libs/client/src/rpc.rs
+++ b/sdk-libs/client/src/rpc.rs
@@ -6,11 +6,11 @@ use solana_address::Address;
 use solana_clock::Slot;
 use solana_hash::Hash;
 use solana_instruction::Instruction;
-use solana_keypair::Keypair;
 use solana_message::{AddressLookupTableAccount, Message};
 use solana_pubkey::Pubkey;
 use solana_rpc_client_api::config::RpcSendTransactionConfig;
 use solana_signature::Signature;
+use solana_signer::Signer;
 use solana_transaction::{versioned::VersionedTransaction, Transaction};
 use solana_transaction_status_client_types::TransactionStatus;
 use zolana_keypair::P256Pubkey;
@@ -223,7 +223,7 @@ pub trait Rpc {
         &self,
         instructions: &[Instruction],
         payer: Address,
-        signers: &[&Keypair],
+        signers: &[&dyn Signer],
     ) -> Result<Signature, ClientError> {
         let (blockhash, _) = self.get_latest_blockhash()?;
         let payer = Pubkey::new_from_array(payer.to_bytes());
@@ -236,7 +236,7 @@ pub trait Rpc {
         &self,
         instructions: &[Instruction],
         payer: Address,
-        signers: &[&Keypair],
+        signers: &[&dyn Signer],
         address_lookup_tables: &[AddressLookupTableAccount],
     ) -> Result<Signature, ClientError> {
         Err(unsupported("create_and_send_versioned_transaction"))

--- a/sdk-libs/client/src/solana_rpc.rs
+++ b/sdk-libs/client/src/solana_rpc.rs
@@ -53,11 +53,15 @@ pub struct ConfirmedInstructionGroups {
 }
 
 impl SolanaRpc {
+    /// Connect with the `confirmed` commitment level.
     pub fn new(url: impl Into<String>) -> Self {
-        Self::with_client(RpcClient::new_with_commitment(
-            url.into(),
-            CommitmentConfig::confirmed(),
-        ))
+        Self::new_with_commitment(url, CommitmentConfig::confirmed())
+    }
+
+    /// Connect with a caller-chosen commitment level. Every read and send on
+    /// this client uses it.
+    pub fn new_with_commitment(url: impl Into<String>, commitment: CommitmentConfig) -> Self {
+        Self::with_client(RpcClient::new_with_commitment(url.into(), commitment))
     }
 
     pub fn local() -> Self {
@@ -195,7 +199,7 @@ impl SolanaRpc {
         loop {
             let config = RpcTransactionConfig {
                 encoding: Some(UiTransactionEncoding::Json),
-                commitment: Some(CommitmentConfig::confirmed()),
+                commitment: Some(self.client.commitment()),
                 max_supported_transaction_version: Some(0),
             };
             match self.client.get_transaction_with_config(signature, config) {
@@ -315,7 +319,7 @@ impl Rpc for SolanaRpc {
     fn get_account(&self, address: Address) -> Result<Option<Account>, ClientError> {
         let pubkey = pubkey_from_address(&address);
         self.client
-            .get_account_with_commitment(&pubkey, CommitmentConfig::confirmed())
+            .get_account_with_commitment(&pubkey, self.client.commitment())
             .map(|response| response.value)
             .map_err(|err| ClientError::Rpc(format!("get_account {pubkey}: {err}")))
     }

--- a/sdk-libs/client/src/user_registry.rs
+++ b/sdk-libs/client/src/user_registry.rs
@@ -1,5 +1,4 @@
 use solana_address::Address;
-use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
@@ -42,7 +41,7 @@ fn register_fields(keypair: &ShieldedKeypair) -> Result<RegisterData, ClientErro
 /// publish or update it.
 pub fn ensure_registered<R: Rpc>(
     rpc: &R,
-    funding: &Keypair,
+    funding: &dyn Signer,
     keypair: &ShieldedKeypair,
 ) -> Result<Option<Signature>, ClientError> {
     let owner = funding.pubkey();
@@ -95,7 +94,7 @@ pub fn ensure_registered<R: Rpc>(
 /// never reads raw Solana secrets.
 pub fn create_private_wallet<R: Rpc>(
     rpc: &R,
-    owner: &Keypair,
+    owner: &dyn Signer,
     keypair: ShieldedKeypair,
     registry: AssetRegistry,
 ) -> Result<Wallet, ClientError> {
@@ -233,6 +232,7 @@ pub fn resolved_address_from_record(
 mod tests {
     use borsh::to_vec;
     use solana_account::Account;
+    use solana_keypair::Keypair;
     use solana_signer::Signer;
     use zolana_keypair::{ShieldedKeypair, ViewingKey};
     use zolana_user_registry_interface::{user_registry_program_id, SyncDelegateEntry};

--- a/sdk-libs/client/src/wallet_sync.rs
+++ b/sdk-libs/client/src/wallet_sync.rs
@@ -436,6 +436,46 @@ mod tests {
     const SPL_MINT: Address = Address::new_from_array([2u8; 32]);
 
     #[test]
+    fn transfer_memo_round_trips_to_the_recipient_wallet() {
+        let assets = AssetRegistry::default();
+        let sender = ShieldedKeypair::new().expect("sender");
+        let recipient = ShieldedKeypair::new().expect("recipient");
+
+        let input = SpendUtxo::from_keypair(test_utxo(&sender, SOL_MINT, 100, 1), &sender);
+        let mut tx = Transaction::new(
+            sender.shielded_address().expect("sender address"),
+            vec![input],
+            Address::default(),
+        );
+        tx.send_with_memo(
+            &recipient.shielded_address().expect("recipient address"),
+            SOL_MINT,
+            40,
+            Some(b"gm".to_vec()),
+        )
+        .expect("send");
+        let transfer = signed_to_shielded_tx(tx.sign(&sender, &assets).expect("sign"), 1);
+
+        let mut wallet = Wallet::new(recipient.clone(), assets).expect("wallet");
+        sync_wallet(
+            &mut wallet,
+            &MockIndexer {
+                transactions: vec![transfer],
+                matches: Vec::new(),
+                program_accounts: Vec::new(),
+            },
+        )
+        .expect("sync");
+
+        let received = wallet
+            .utxos
+            .iter()
+            .find(|entry| entry.utxo.amount == 40)
+            .expect("received utxo");
+        assert_eq!(received.utxo.data.memo(), Some(b"gm".as_slice()));
+    }
+
+    #[test]
     fn sync_wallet_records_confidential_transfer_history_without_duplicates() {
         let assets = AssetRegistry::default();
         let alice = ShieldedKeypair::new().expect("alice");

--- a/sdk-libs/transaction/src/instructions/transact/builder.rs
+++ b/sdk-libs/transaction/src/instructions/transact/builder.rs
@@ -80,6 +80,7 @@ struct Recipient {
     address: ShieldedAddress,
     asset: Address,
     amount: u64,
+    memo: Option<Vec<u8>>,
 }
 
 pub enum WithdrawalTarget {
@@ -215,10 +216,25 @@ impl Transaction {
         asset: Address,
         amount: u64,
     ) -> Result<&mut Self, TransactionError> {
+        self.send_with_memo(recipient, asset, amount, None)
+    }
+
+    /// [`Self::send`] with a free-form note for the recipient. The memo is
+    /// encrypted into the recipient's output ciphertext and not committed into
+    /// any hash. It lengthens that ciphertext, so its presence and byte length
+    /// are visible onchain; the contents are not.
+    pub fn send_with_memo(
+        &mut self,
+        recipient: &ShieldedAddress,
+        asset: Address,
+        amount: u64,
+        memo: Option<Vec<u8>>,
+    ) -> Result<&mut Self, TransactionError> {
         self.recipients.push(Recipient {
             address: *recipient,
             asset,
             amount,
+            memo,
         });
         Ok(self)
     }
@@ -346,13 +362,16 @@ impl Transaction {
             let position = RECIPIENT_POSITION_BASE + i as u8;
             let blinding = derive_blinding(&self.blinding_seed, position);
             let asset_id = self.asset_id(assets, &recipient.asset)?;
-            outputs.push(OutputUtxo {
+            let mut output = OutputUtxo {
                 owner_address: Some(recipient.address),
                 asset: recipient.asset,
                 amount: recipient.amount,
                 blinding,
                 ..Default::default()
-            });
+            };
+            if let Some(memo) = &recipient.memo {
+                output = output.with_memo(memo.clone());
+            }
             recipient_viewing_pks.push(recipient.address.viewing_pubkey);
             recipients.push(PreparedRecipient {
                 view_tag: recipient.address.signing_pubkey.confidential_view_tag()?,
@@ -362,9 +381,10 @@ impl Transaction {
                     amount: recipient.amount,
                     blinding,
                     zone_program_id: None,
-                    data: Data::default(),
+                    data: output.data.clone(),
                 },
             });
+            outputs.push(output);
         }
 
         for output in &self.custom_outputs {


### PR DESCRIPTION
## Summary

Three client changes that shrink what an integrator wires by hand, plus a CU fix. Stacked on `feat/sdk-asset-dx` (#114); retarget to `main` after #114 merges.

### Signer-trait fee payer (client-side wallet compatibility)
No public API requires a concrete `Keypair` anymore. Every fee-payer/owner/depositor parameter takes `&dyn Signer` (`Rpc::create_and_send_transaction`, deposit send, `Submit.payer`, ATA, `ensure_registered`/`create_private_wallet`, SPL interface + test-utils helpers), and `ZolanaClient` stores `Box<dyn Signer + Send + Sync>`. A browser dapp's wallet-adapter signer or an HSM key now works everywhere a keypair did; `Keypair` callers are source-compatible since `Keypair: Signer`. This applies the #97 `Transaction::from_wallet` lesson (key material stays behind a trait boundary) to the Solana side. A unit test constructs the client with a stub non-keypair signer.

### Tree + commitment in `ZolanaClientConfig`
`tree: Pubkey` (presets fill the fixed `DEFAULT_TREE` — the same state-tree account on localnet and devnet; other networks set their own) and `commitment: Option<CommitmentConfig>` (`None` = confirmed). `SolanaRpc` gains `new_with_commitment` and honors the configured level on every read instead of hardcoding confirmed — closes the deferred follow-up noted on #109. The examples' `ZOLANA_TREE` env var is gone.

### Optional encrypted memo on private transfers
`CreateTransfer.memo`: a free-form note encrypted into the recipient's output ciphertext, carried as `DataRecord::Memo` on both the confidential and anonymous rails (`Transaction::send_with_memo`; `send` unchanged). It never enters `utxo_hash`/`data_hash` — those read the separate `data_hash` fields, which stay `None` on this path. Caveat documented on the field: a memo lengthens its ciphertext, so its presence and byte length are visible onchain; the contents are not. Withdrawals carry no memo (a public output has no ciphertext). Round-trip test decrypts the memo from the recipient wallet after a sync.

### Deposit CU ceiling 40k → 80k
A live devnet SPL deposit ran past the 40k ceiling from the benchmark commit (consumed the full budget and aborted). 80k leaves headroom; the transact 200k default is untouched, and multi-input spends can still override via `Submit.cu_limit`.

## Not included
A one-call op facade on `ZolanaClient` (client.transfer/withdraw/deposit) was built and rolled back in-branch before pushing — the layered API (`create_*_sync` + `Submit`) stays the single operations surface.

## Testing
- `cargo build -p zolana-client` (no-default / default / full features), `cargo build -p zolana-cli`, `cargo clippy --all-targets -D warnings`, `cargo test -p zolana-client --lib`, `cargo test -p zolana-transaction`, `cargo +nightly fmt --all -- --check` — clean.
- All five zolana-examples run green on live devnet through this branch (create_private_wallet, deposit, sync_balance, transfer incl. registered-recipient assertion, withdraw).