### PR TITLE
feat(client): builder-style actions, source/destination fields, per-wallet authority, one-call send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9746,6 +9746,7 @@ dependencies = [
  "p256",
  "rand 0.8.6",
  "sha2 0.10.9",
+ "solana-keypair",
  "thiserror 2.0.18",
  "tokio",
  "zeroize",

--- a/cli/src/wallet_cli/deposit.rs
+++ b/cli/src/wallet_cli/deposit.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
+use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use zolana_client::{
-    create_deposit, resolve_registered_address, CreateDeposit, SolanaRpc, ZolanaIndexer,
+    create_deposit, resolve_registered_address, Deposit, SolanaRpc, ZolanaIndexer,
 };
 
 use super::{
@@ -32,10 +33,12 @@ pub(super) fn run_deposit(opts: DepositOptions) -> Result<()> {
         .map(parse_pubkey)
         .transpose()?
         .unwrap_or_else(|| material.funding.pubkey());
+    // A deposit needs the registered private wallet; there is no public
+    // fallback for it, so unregistered recipients are an error here.
     let recipient = resolve_registered_address(&rpc, recipient_pubkey)?;
-    let deposit = create_deposit(CreateDeposit {
-        recipient: &recipient.address,
-        asset,
+    let deposit = create_deposit(Deposit {
+        destination: &recipient.address,
+        asset: Pubkey::new_from_array(asset.to_bytes()),
         amount: opts.amount,
         spl_token_account,
         memo: None,

--- a/cli/src/wallet_cli/material.rs
+++ b/cli/src/wallet_cli/material.rs
@@ -9,11 +9,10 @@ use std::{
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use solana_keypair::Keypair;
-use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use zolana_client::{
-    AnonymousRecipientSlot, ApprovalRequest, ClientError, ConfidentialRecipientSlot,
-    EncryptedTransfer, P256Signature, SolanaRpc, SyncWalletAuthority,
+    AnonymousRecipientSlot, ClientError, ConfidentialRecipientSlot, EncryptedTransfer,
+    P256Signature, SolanaRpc, SyncWalletAuthority,
 };
 use zolana_keypair::{
     shielded::ShieldedAddress, viewing_key::ViewTag, NullifierKey, ShieldedKeypair, SigningKey,
@@ -53,44 +52,20 @@ pub(super) struct WalletMaterial {
     pub(super) funding: Keypair,
 }
 
-impl WalletMaterial {
-    pub(super) fn owner_pubkey(&self) -> Pubkey {
-        self.funding.pubkey()
-    }
-
-    fn check_owner_pubkey(&self, owner_pubkey: Pubkey) -> std::result::Result<(), ClientError> {
-        if owner_pubkey == self.owner_pubkey() {
-            Ok(())
-        } else {
-            Err(ClientError::AddressResolution(format!(
-                "wallet file belongs to owner_pubkey {}, got {owner_pubkey}",
-                self.owner_pubkey()
-            )))
-        }
-    }
-}
-
 impl SyncWalletAuthority for WalletMaterial {
-    fn shielded_address(
-        &self,
-        owner_pubkey: Pubkey,
-    ) -> std::result::Result<ShieldedAddress, ClientError> {
-        self.check_owner_pubkey(owner_pubkey)?;
+    fn shielded_address(&self) -> std::result::Result<ShieldedAddress, ClientError> {
         Ok(self.keypair.shielded_address()?)
     }
 
     fn encrypt_confidential_transfer(
         &self,
-        owner_pubkey: Pubkey,
         first_nullifier: &[u8; 32],
         sender_tag: ViewTag,
         sender: &TransferSenderPlaintext,
         recipients: &[ConfidentialRecipientSlot],
     ) -> std::result::Result<EncryptedTransfer, ClientError> {
-        self.check_owner_pubkey(owner_pubkey)?;
         SyncWalletAuthority::encrypt_confidential_transfer(
             &self.keypair,
-            owner_pubkey,
             first_nullifier,
             sender_tag,
             sender,
@@ -100,16 +75,13 @@ impl SyncWalletAuthority for WalletMaterial {
 
     fn encrypt_anonymous_transfer(
         &self,
-        owner_pubkey: Pubkey,
         first_nullifier: &[u8; 32],
         sender_view_tag: ViewTag,
         sender: &AnonymousTransferSenderPlaintext,
         recipients: &[AnonymousRecipientSlot],
     ) -> std::result::Result<EncryptedTransfer, ClientError> {
-        self.check_owner_pubkey(owner_pubkey)?;
         SyncWalletAuthority::encrypt_anonymous_transfer(
             &self.keypair,
-            owner_pubkey,
             first_nullifier,
             sender_view_tag,
             sender,
@@ -117,27 +89,14 @@ impl SyncWalletAuthority for WalletMaterial {
         )
     }
 
-    fn request_user_approval(
-        &self,
-        request: ApprovalRequest,
-    ) -> std::result::Result<(), ClientError> {
-        self.check_owner_pubkey(request.owner_pubkey)
-    }
-
     fn sign_p256(
         &self,
-        owner_pubkey: Pubkey,
         message_hash: &[u8; 32],
     ) -> std::result::Result<P256Signature, ClientError> {
-        self.check_owner_pubkey(owner_pubkey)?;
-        SyncWalletAuthority::sign_p256(&self.keypair, owner_pubkey, message_hash)
+        SyncWalletAuthority::sign_p256(&self.keypair, message_hash)
     }
 
-    fn spend_nullifier_key(
-        &self,
-        owner_pubkey: Pubkey,
-    ) -> std::result::Result<NullifierKey, ClientError> {
-        self.check_owner_pubkey(owner_pubkey)?;
+    fn spend_nullifier_key(&self) -> std::result::Result<NullifierKey, ClientError> {
         Ok(self.keypair.nullifier_key.clone())
     }
 }
@@ -281,6 +240,8 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
+    use solana_pubkey::Pubkey;
+
     use super::*;
 
     fn temp_root(prefix: &str) -> PathBuf {
@@ -311,62 +272,5 @@ mod tests {
         );
         assert_ne!(loaded.funding.pubkey(), Pubkey::default());
         assert_eq!(loaded.funding.pubkey(), funding.pubkey());
-    }
-
-    #[test]
-    fn wrong_owner_pubkey_is_rejected() {
-        let keypair = ShieldedKeypair::new().expect("shielded keypair");
-        let funding = Keypair::new();
-        let material = WalletMaterial { keypair, funding };
-        let owner_pubkey = material.owner_pubkey();
-        let wrong = Pubkey::new_unique();
-
-        let err = match material.shielded_address(wrong) {
-            Ok(_) => panic!("wrong owner_pubkey should fail"),
-            Err(err) => err,
-        };
-        assert!(matches!(err, ClientError::AddressResolution(_)));
-        assert!(err.to_string().contains(&owner_pubkey.to_string()));
-
-        material
-            .shielded_address(owner_pubkey)
-            .expect("correct owner_pubkey should succeed");
-    }
-
-    #[test]
-    fn wrong_owner_pubkey_rejected_for_spend_nullifier_key() {
-        let keypair = ShieldedKeypair::new().expect("shielded keypair");
-        let funding = Keypair::new();
-        let material = WalletMaterial { keypair, funding };
-        let wrong = Pubkey::new_unique();
-
-        let err = match material.spend_nullifier_key(wrong) {
-            Ok(_) => panic!("wrong owner_pubkey should fail"),
-            Err(err) => err,
-        };
-        assert!(matches!(err, ClientError::AddressResolution(_)));
-
-        material
-            .spend_nullifier_key(material.owner_pubkey())
-            .expect("correct owner_pubkey should succeed");
-    }
-
-    #[test]
-    fn wrong_owner_pubkey_rejected_for_sign_p256() {
-        let keypair = ShieldedKeypair::new().expect("shielded keypair");
-        let funding = Keypair::new();
-        let material = WalletMaterial { keypair, funding };
-        let wrong = Pubkey::new_unique();
-        let message_hash = [7u8; 32];
-
-        let err = match material.sign_p256(wrong, &message_hash) {
-            Ok(_) => panic!("wrong owner_pubkey should fail"),
-            Err(err) => err,
-        };
-        assert!(matches!(err, ClientError::AddressResolution(_)));
-
-        material
-            .sign_p256(material.owner_pubkey(), &message_hash)
-            .expect("correct owner_pubkey should succeed");
     }
 }

--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -21,7 +21,7 @@ pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
     let indexer = ZolanaIndexer::new(network.sync.indexer_url.clone());
     let ctx = sync_context(&opts.network.sync)?;
     maybe_airdrop(&mut rpc, &ctx.material, network.airdrop_lamports)?;
-    let recipient_owner = parse_pubkey(&opts.to)?;
+    let recipient = parse_pubkey(&opts.to)?;
     let tree = network.tree;
 
     let transfer = create_transfer_sync(CreateTransfer {
@@ -30,7 +30,7 @@ pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
         authority: &ctx.material,
         owner_pubkey: ctx.material.owner_pubkey(),
         payer: Address::new_from_array(ctx.material.funding.pubkey().to_bytes()),
-        recipient: recipient_owner,
+        recipient,
         asset,
         amount: opts.amount,
         memo: None,

--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -30,7 +30,7 @@ pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
         authority: &ctx.material,
         owner_pubkey: ctx.material.owner_pubkey(),
         payer: Address::new_from_array(ctx.material.funding.pubkey().to_bytes()),
-        recipient_owner,
+        recipient: recipient_owner,
         asset,
         amount: opts.amount,
     })?;

--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
+use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use zolana_client::{
-    create_transfer_sync, CreateTransfer, ProverClient, SolanaRpc, Submit, ZolanaIndexer,
+    resolve_recipient, PrivateTransfer, ProverClient, SolanaRpc, Submit, ZolanaIndexer,
 };
-use zolana_transaction::Address;
 
 use super::{
     material::WalletMaterial,
@@ -16,6 +16,7 @@ use crate::args::TransferOptions;
 pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
     ensure_positive(opts.amount)?;
     let asset = parse_address(&opts.mint)?;
+    let mint = Pubkey::new_from_array(asset.to_bytes());
     let network = get_network(&opts.network)?;
     let mut rpc = SolanaRpc::new(network.sync.rpc_url.clone());
     let indexer = ZolanaIndexer::new(network.sync.indexer_url.clone());
@@ -24,32 +25,29 @@ pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
     let recipient = parse_pubkey(&opts.to)?;
     let tree = network.tree;
 
-    let transfer = create_transfer_sync(CreateTransfer {
-        rpc: &rpc,
-        wallet: &ctx.wallet,
-        authority: &ctx.material,
-        owner_pubkey: ctx.material.owner_pubkey(),
-        payer: Address::new_from_array(ctx.material.funding.pubkey().to_bytes()),
-        recipient,
-        asset,
-        amount: opts.amount,
-        memo: None,
-    })?;
     let prover = ProverClient::new(network.prover_url.clone());
-    let signature = Submit {
+    let submit = Submit {
         indexer: &indexer,
         rpc: &rpc,
         prover: &prover,
         payer: &ctx.material.funding,
         tree,
         cu_limit: None,
+    };
+    // An unregistered recipient resolves to a public withdrawal; the mode in
+    // the output reports which way the transfer settled.
+    let transfer = PrivateTransfer {
+        source: &ctx.wallet,
+        destination: resolve_recipient(&rpc, recipient)?,
+        asset: mint,
+        amount: opts.amount,
+        authority: &ctx.material,
+        payer: ctx.material.funding.pubkey(),
+        memo: None,
     }
-    .execute(
-        transfer.signed,
-        transfer.recipient.withdrawal().cloned(),
-        transfer.wait_tag,
-    )?;
-    let mode = if transfer.recipient.is_public_withdrawal() {
+    .instruction()?;
+    let signature = submit.execute(&transfer)?;
+    let mode = if transfer.recipient.is_public() {
         "withdraw"
     } else {
         "shielded"
@@ -58,7 +56,7 @@ pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
         "ok transfer amount={} mint={} to={} mode={} signature={}",
         opts.amount,
         format_address(asset),
-        transfer.recipient.pubkey(),
+        recipient,
         mode,
         signature
     );

--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -33,6 +33,7 @@ pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
         recipient: recipient_owner,
         asset,
         amount: opts.amount,
+        memo: None,
     })?;
     let prover = ProverClient::new(network.prover_url.clone());
     let signature = Submit {

--- a/cli/src/wallet_cli/withdraw.rs
+++ b/cli/src/wallet_cli/withdraw.rs
@@ -1,9 +1,7 @@
 use anyhow::Result;
+use solana_pubkey::Pubkey;
 use solana_signer::Signer;
-use zolana_client::{
-    create_withdrawal_sync, CreateWithdrawal, ProverClient, SolanaRpc, Submit, ZolanaIndexer,
-};
-use zolana_transaction::Address;
+use zolana_client::{ProverClient, SolanaRpc, Submit, Withdrawal, ZolanaIndexer};
 
 use super::{
     resolve::get_network,
@@ -24,15 +22,15 @@ pub(super) fn run_withdraw(opts: WithdrawOptions) -> Result<()> {
     let tree = network.tree;
     let recipient = parse_pubkey(&opts.to)?;
 
-    let withdrawal = create_withdrawal_sync(CreateWithdrawal {
-        wallet: &ctx.wallet,
-        authority: &ctx.material,
-        owner_pubkey: ctx.material.owner_pubkey(),
-        payer: Address::new_from_array(ctx.material.funding.pubkey().to_bytes()),
-        recipient,
-        asset,
+    let withdrawal = Withdrawal {
+        source: &ctx.wallet,
+        destination: recipient,
+        asset: Pubkey::new_from_array(asset.to_bytes()),
         amount: opts.amount,
-    })?;
+        authority: &ctx.material,
+        payer: ctx.material.funding.pubkey(),
+    }
+    .instruction()?;
     let prover = ProverClient::new(network.prover_url.clone());
     let signature = Submit {
         indexer: &indexer,
@@ -42,11 +40,7 @@ pub(super) fn run_withdraw(opts: WithdrawOptions) -> Result<()> {
         tree,
         cu_limit: None,
     }
-    .execute(
-        withdrawal.signed,
-        Some(withdrawal.withdrawal),
-        withdrawal.wait_tag,
-    )?;
+    .execute(&withdrawal)?;
     println!(
         "ok withdraw amount={} mint={} to={} signature={}",
         opts.amount,

--- a/program-tests/shielded-pool/tests/localnet_photon_e2e.rs
+++ b/program-tests/shielded-pool/tests/localnet_photon_e2e.rs
@@ -1393,10 +1393,7 @@ fn capture_fixture(rpc: &SolanaRpc, label: &str, signature: &Signature) {
 }
 
 fn shielded_ed25519_from_solana(signer: &Keypair) -> TestResult<ShieldedKeypair> {
-    let seed: [u8; 32] = signer.to_bytes()[..32]
-        .try_into()
-        .expect("ed25519 seed is the first 32 bytes");
-    Ok(ShieldedKeypair::from_ed25519(&seed, ViewingKey::new())?)
+    Ok(ShieldedKeypair::from_ed25519(signer, ViewingKey::new())?)
 }
 
 /// Restart a fresh validator + Photon indexer so each test runs against clean

--- a/program-tests/spp-test-validator/tests/actor.rs
+++ b/program-tests/spp-test-validator/tests/actor.rs
@@ -67,10 +67,7 @@ impl Actor {
     /// seed (so its shielded signing pubkey equals `signer`'s pubkey) and which
     /// authorizes its own spends with `signer`.
     pub(crate) fn eddsa(signer: Keypair) -> Result<Self> {
-        let seed: [u8; 32] = signer.to_bytes()[..32]
-            .try_into()
-            .expect("ed25519 seed is the first 32 bytes");
-        let keypair = ShieldedKeypair::from_ed25519(&seed, ViewingKey::new())?;
+        let keypair = ShieldedKeypair::from_ed25519(&signer, ViewingKey::new())?;
         let mut actor = Self::with_keypair(keypair)?;
         actor.solana_signer = Some(signer);
         Ok(actor)

--- a/program-tests/spp-test-validator/tests/deposit_action.rs
+++ b/program-tests/spp-test-validator/tests/deposit_action.rs
@@ -123,7 +123,7 @@ impl Deposit<'_> {
             memo: data.memo.clone(),
         }
         .instruction();
-        let mut signers: Vec<&Keypair> = vec![payer];
+        let mut signers: Vec<&dyn Signer> = vec![payer];
         if authority.pubkey() != payer.pubkey() {
             signers.push(authority);
         }

--- a/program-tests/test-utils/src/spl.rs
+++ b/program-tests/test-utils/src/spl.rs
@@ -45,7 +45,7 @@ fn system_create_account_ix(
 }
 
 /// Create and initialize a fresh SPL mint (9 decimals, mint authority = `payer`).
-pub fn create_mint<R: Rpc>(rpc: &R, payer: &Keypair) -> Result<Pubkey, ClientError> {
+pub fn create_mint<R: Rpc>(rpc: &R, payer: &dyn Signer) -> Result<Pubkey, ClientError> {
     let mint = Keypair::new();
     let rent = rpc.get_minimum_balance_for_rent_exemption(SPL_TOKEN_MINT_ACCOUNT_LEN)?;
     let create_ix = system_create_account_ix(
@@ -74,7 +74,7 @@ pub fn create_mint<R: Rpc>(rpc: &R, payer: &Keypair) -> Result<Pubkey, ClientErr
 /// Create and initialize an SPL token account for `mint` owned by `owner`.
 pub fn create_token_account<R: Rpc>(
     rpc: &R,
-    payer: &Keypair,
+    payer: &dyn Signer,
     mint: &Pubkey,
     owner: &Pubkey,
 ) -> Result<Pubkey, ClientError> {
@@ -108,7 +108,7 @@ pub fn create_token_account<R: Rpc>(
 /// Mint `amount` of `mint` to `account` (authority = `payer`).
 pub fn mint_to<R: Rpc>(
     rpc: &R,
-    payer: &Keypair,
+    payer: &dyn Signer,
     mint: &Pubkey,
     account: &Pubkey,
     amount: u64,
@@ -129,7 +129,7 @@ pub fn mint_to<R: Rpc>(
 }
 
 /// Create the singleton SPL asset counter if it does not exist yet.
-pub fn ensure_asset_counter<R: Rpc>(rpc: &R, authority: &Keypair) -> Result<(), ClientError> {
+pub fn ensure_asset_counter<R: Rpc>(rpc: &R, authority: &dyn Signer) -> Result<(), ClientError> {
     if rpc
         .get_account(to_address(&pda::spl_asset_counter()))?
         .is_none()
@@ -147,7 +147,7 @@ pub fn ensure_asset_counter<R: Rpc>(rpc: &R, authority: &Keypair) -> Result<(), 
 /// Returns `(registry, vault)`.
 pub fn create_spl_interface<R: Rpc>(
     rpc: &R,
-    authority: &Keypair,
+    authority: &dyn Signer,
     mint: &Pubkey,
 ) -> Result<(Pubkey, Pubkey), ClientError> {
     let registry = pda::spl_asset_registry(mint);

--- a/program-tests/zone-test-program/tests/actor.rs
+++ b/program-tests/zone-test-program/tests/actor.rs
@@ -69,10 +69,7 @@ impl Actor {
     /// seed (so its shielded signing pubkey equals `signer`'s pubkey) and which
     /// authorizes its own spends with `signer`.
     pub(crate) fn eddsa(signer: Keypair) -> Result<Self> {
-        let seed: [u8; 32] = signer.to_bytes()[..32]
-            .try_into()
-            .expect("ed25519 seed is the first 32 bytes");
-        let keypair = ShieldedKeypair::from_ed25519(&seed, ViewingKey::new())?;
+        let keypair = ShieldedKeypair::from_ed25519(&signer, ViewingKey::new())?;
         let mut actor = Self::with_keypair(keypair)?;
         actor.solana_signer = Some(signer);
         Ok(actor)

--- a/sdk-libs/client/src/actions/create_associated_token_account.rs
+++ b/sdk-libs/client/src/actions/create_associated_token_account.rs
@@ -1,7 +1,6 @@
 //! Idempotent associated-token-account creation action.
 
 use solana_address::Address;
-use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
@@ -17,7 +16,7 @@ use crate::{error::ClientError, rpc::Rpc};
 /// signature and the created ATA address.
 pub fn create_associated_token_account<R: Rpc>(
     rpc: &R,
-    payer: &Keypair,
+    payer: &dyn Signer,
     owner: &Pubkey,
     mint: &Pubkey,
 ) -> Result<(Signature, Pubkey), ClientError> {
@@ -38,6 +37,7 @@ mod tests {
     use std::cell::RefCell;
 
     use solana_hash::Hash;
+    use solana_keypair::Keypair;
     use solana_transaction::Transaction;
     use zolana_interface::pda;
 

--- a/sdk-libs/client/src/actions/deposit.rs
+++ b/sdk-libs/client/src/actions/deposit.rs
@@ -1,5 +1,10 @@
 //! Proofless shield action.
 
+use std::{
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
 use solana_address::Address;
 use solana_instruction::Instruction;
 use solana_keypair::Keypair;
@@ -11,9 +16,15 @@ use zolana_interface::{
     pda, SPL_TOKEN_PROGRAM_ID,
 };
 use zolana_keypair::{random_blinding, ShieldedAddress};
-use zolana_transaction::{owner_utxo_hash, utxo_hash, SOL_MINT};
+use zolana_transaction::{owner_utxo_hash, utxo_hash, Wallet, SOL_MINT};
 
-use crate::{error::ClientError, rpc::Rpc};
+use crate::{error::ClientError, rpc::Rpc, wallet_sync::sync_wallet};
+
+/// How long [`Deposit::send_and_sync`] waits for the indexer to pick up the
+/// deposited UTXO before giving up.
+const INDEXER_TIMEOUT: Duration = Duration::from_secs(120);
+/// Delay between indexer polls.
+const INDEXER_POLL: Duration = Duration::from_millis(500);
 
 /// Prepared direct proofless SOL shield.
 ///
@@ -83,8 +94,85 @@ impl Deposit {
         deposit(rpc, payer, tree, depositor, self.spl, &self.data)
     }
 
+    /// [`Deposit::send`], then sync `wallet` until the deposited UTXO is
+    /// visible. The indexer lags the chain, so a single sync straight after
+    /// the send can miss the deposit — the next transfer would then select
+    /// stale inputs. Polls up to 120s; on timeout the deposit has still been
+    /// sent and confirmed ([`ClientError::DepositNotIndexed`] carries the
+    /// signature).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use solana_keypair::Keypair;
+    /// use solana_pubkey::Pubkey;
+    /// use zolana_client::{create_deposit, ClientError, CreateDeposit, Rpc};
+    /// use zolana_keypair::ShieldedAddress;
+    /// use zolana_transaction::{Wallet, SOL_MINT};
+    ///
+    /// fn deposit_sol<R: Rpc, I: Rpc>(
+    ///     rpc: &R,
+    ///     indexer: &I,
+    ///     payer: &Keypair,
+    ///     tree: Pubkey,
+    ///     recipient: &ShieldedAddress,
+    ///     wallet: &mut Wallet,
+    /// ) -> Result<(), ClientError> {
+    ///     let prepared = create_deposit(CreateDeposit {
+    ///         recipient,
+    ///         asset: SOL_MINT,
+    ///         amount: 1_000_000,
+    ///         spl_token_account: None,
+    ///         memo: None,
+    ///     })?;
+    ///     prepared.send_and_sync(rpc, payer, tree, payer, wallet, indexer)?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn send_and_sync<R: Rpc, I: Rpc>(
+        &self,
+        rpc: &R,
+        payer: &Keypair,
+        tree: Pubkey,
+        depositor: &Keypair,
+        wallet: &mut Wallet,
+        indexer: &I,
+    ) -> Result<Signature, ClientError> {
+        let signature = self.send(rpc, payer, tree, depositor)?;
+        wait_for_deposited_utxo(wallet, indexer, self.utxo_hash, signature)?;
+        Ok(signature)
+    }
+
     pub fn view_tag(&self) -> [u8; 32] {
         self.data.view_tag
+    }
+}
+
+/// Poll [`sync_wallet`] until the wallet holds the UTXO with `utxo_hash`, or
+/// [`INDEXER_TIMEOUT`] elapses.
+fn wait_for_deposited_utxo<I: Rpc>(
+    wallet: &mut Wallet,
+    indexer: &I,
+    utxo_hash: [u8; 32],
+    signature: Signature,
+) -> Result<(), ClientError> {
+    let started = Instant::now();
+    loop {
+        sync_wallet(wallet, indexer)?;
+        if wallet
+            .utxos
+            .iter()
+            .any(|utxo| utxo.output_context.hash == utxo_hash)
+        {
+            return Ok(());
+        }
+        if started.elapsed() >= INDEXER_TIMEOUT {
+            return Err(ClientError::DepositNotIndexed {
+                utxo_hash,
+                signature,
+            });
+        }
+        sleep(INDEXER_POLL);
     }
 }
 

--- a/sdk-libs/client/src/actions/deposit.rs
+++ b/sdk-libs/client/src/actions/deposit.rs
@@ -25,8 +25,8 @@ use crate::{error::ClientError, rpc::Rpc, wallet_sync::sync_wallet};
 /// ~34k CU (`program-tests/shielded-pool/CU_BENCHMARK.md`).
 pub const DEFAULT_DEPOSIT_CU_LIMIT: u32 = 40_000;
 
-/// How long [`Deposit::send_and_sync`] waits for the indexer to pick up the
-/// deposited UTXO before giving up.
+/// How long [`Deposit::wait_until_synced`] waits for the indexer to pick up
+/// the deposited UTXO before giving up.
 const INDEXER_TIMEOUT: Duration = Duration::from_secs(120);
 /// Delay between indexer polls.
 const INDEXER_POLL: Duration = Duration::from_millis(500);
@@ -89,6 +89,9 @@ impl Deposit {
         deposit_instruction(tree, depositor, self.spl, &self.data)
     }
 
+    /// Send the deposit. The recipient's wallet sees the deposited UTXO only
+    /// after a sync; a recipient who needs to block until it is visible calls
+    /// [`Deposit::wait_until_synced`].
     pub fn send<R: Rpc>(
         &self,
         rpc: &R,
@@ -99,12 +102,16 @@ impl Deposit {
         deposit(rpc, payer, tree, depositor, self.spl, &self.data)
     }
 
-    /// [`Deposit::send`], then sync `wallet` until the deposited UTXO is
-    /// visible. The indexer lags the chain, so a single sync straight after
-    /// the send can miss the deposit — the next transfer would then select
-    /// stale inputs. Polls up to 120s; on timeout the deposit has still been
-    /// sent and confirmed ([`ClientError::DepositNotIndexed`] carries the
-    /// signature).
+    /// Sync `wallet` until the deposited UTXO is visible: the recipient-side
+    /// read-your-write step after [`Deposit::send`], for callers that spend or
+    /// display the balance immediately.
+    ///
+    /// `wallet` must be the deposit recipient's (a self-deposit, or an
+    /// app-held recipient wallet). A wallet that is not the recipient can
+    /// never see the UTXO: the call waits the full 120s and returns
+    /// [`ClientError::DepositNotIndexed`] even though the deposit succeeded.
+    /// For a deposit to a third party there is nothing to wait for on the
+    /// sender side — the recipient's own sync discovers the UTXO.
     ///
     /// # Examples
     ///
@@ -130,22 +137,18 @@ impl Deposit {
     ///         spl_token_account: None,
     ///         memo: None,
     ///     })?;
-    ///     prepared.send_and_sync(rpc, payer, tree, payer, wallet, indexer)?;
+    ///     let signature = prepared.send(rpc, payer, tree, payer)?;
+    ///     prepared.wait_until_synced(wallet, indexer, signature)?;
     ///     Ok(())
     /// }
     /// ```
-    pub fn send_and_sync<R: Rpc, I: Rpc>(
+    pub fn wait_until_synced<I: Rpc>(
         &self,
-        rpc: &R,
-        payer: &Keypair,
-        tree: Pubkey,
-        depositor: &Keypair,
         wallet: &mut Wallet,
         indexer: &I,
-    ) -> Result<Signature, ClientError> {
-        let signature = self.send(rpc, payer, tree, depositor)?;
-        wait_for_deposited_utxo(wallet, indexer, self.utxo_hash, signature)?;
-        Ok(signature)
+        signature: Signature,
+    ) -> Result<(), ClientError> {
+        wait_for_deposited_utxo(wallet, indexer, self.utxo_hash, signature)
     }
 
     pub fn view_tag(&self) -> [u8; 32] {

--- a/sdk-libs/client/src/actions/deposit.rs
+++ b/sdk-libs/client/src/actions/deposit.rs
@@ -25,51 +25,55 @@ use crate::{error::ClientError, rpc::Rpc, wallet_sync::sync_wallet};
 /// SPL deposit was observed exceeding 40k, so the ceiling leaves headroom.
 pub const DEFAULT_DEPOSIT_CU_LIMIT: u32 = 80_000;
 
-/// How long [`Deposit::wait_until_synced`] waits for the indexer to pick up
-/// the deposited UTXO before giving up.
+/// How long [`CreatedDeposit::wait_until_synced`] waits for the indexer to
+/// pick up the deposited UTXO before giving up.
 const INDEXER_TIMEOUT: Duration = Duration::from_secs(120);
 /// Delay between indexer polls.
 const INDEXER_POLL: Duration = Duration::from_millis(500);
 
-/// Prepared direct proofless SOL shield.
+/// A prepared deposit, ready to send. Deposits enter the pool without a proof.
 ///
 /// This owns the recipient-derived deposit material so callers do not need to
 /// manually coordinate salt, blinding, owner commitment, and UTXO hash rules.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Deposit {
+pub struct CreatedDeposit {
     pub data: DepositIxData,
     pub utxo_hash: [u8; 32],
     pub asset: Address,
     pub spl: Option<DepositSplAccounts>,
 }
 
-pub struct CreateDeposit<'a> {
-    pub recipient: &'a ShieldedAddress,
-    pub asset: Address,
+/// A public-to-private deposit into the pool. No proof is needed to enter;
+/// [`create_deposit`] prepares it, then [`CreatedDeposit::send`] submits.
+pub struct Deposit<'a> {
+    pub destination: &'a ShieldedAddress,
+    /// The asset's mint; [`SOL_MINT`](crate::SOL_MINT) for SOL.
+    pub asset: Pubkey,
     pub amount: u64,
     pub spl_token_account: Option<Pubkey>,
     /// Optional free-form memo emitted in the clear with the deposit.
     pub memo: Option<Vec<u8>>,
 }
 
-impl Deposit {
-    pub fn new(request: CreateDeposit<'_>) -> Result<Self, ClientError> {
+impl CreatedDeposit {
+    pub fn new(request: Deposit<'_>) -> Result<Self, ClientError> {
+        let asset = Address::new_from_array(request.asset.to_bytes());
         // Fresh blinding is sent in the clear; the recipient `owner` commitment
         // is derived from public address material, so a third-party depositor
         // needs no shared secret and the recipient spends the note directly.
-        let owner = request.recipient.owner_hash()?;
+        let owner = request.destination.owner_hash()?;
         let blinding = random_blinding();
-        let view_tag = request.recipient.viewing_pubkey.x();
+        let view_tag = request.destination.viewing_pubkey.x();
         let owner_utxo_hash = owner_utxo_hash(&owner, &blinding)?;
         let utxo_hash = utxo_hash(
-            request.asset,
+            asset,
             request.amount,
             &[0u8; 32],
             &[0u8; 32],
             None,
             &owner_utxo_hash,
         )?;
-        let spl = spl_accounts(request.asset, request.spl_token_account)?;
+        let spl = spl_accounts(asset, request.spl_token_account)?;
         Ok(Self {
             data: DepositIxData {
                 view_tag,
@@ -80,7 +84,7 @@ impl Deposit {
                 memo: request.memo,
             },
             utxo_hash,
-            asset: request.asset,
+            asset,
             spl,
         })
     }
@@ -91,7 +95,7 @@ impl Deposit {
 
     /// Send the deposit. The recipient's wallet sees the deposited UTXO only
     /// after a sync; a recipient who needs to block until it is visible calls
-    /// [`Deposit::wait_until_synced`].
+    /// [`CreatedDeposit::wait_until_synced`].
     pub fn send<R: Rpc>(
         &self,
         rpc: &R,
@@ -103,8 +107,8 @@ impl Deposit {
     }
 
     /// Sync `wallet` until the deposited UTXO is visible: the recipient-side
-    /// read-your-write step after [`Deposit::send`], for callers that spend or
-    /// display the balance immediately.
+    /// read-your-write step after [`CreatedDeposit::send`], for callers that
+    /// spend or display the balance immediately.
     ///
     /// `wallet` must be the deposit recipient's (a self-deposit, or an
     /// app-held recipient wallet). A wallet that is not the recipient can
@@ -118,9 +122,9 @@ impl Deposit {
     /// ```no_run
     /// use solana_pubkey::Pubkey;
     /// use solana_signer::Signer;
-    /// use zolana_client::{create_deposit, ClientError, CreateDeposit, Rpc};
+    /// use zolana_client::{create_deposit, ClientError, Deposit, Rpc, SOL_MINT};
     /// use zolana_keypair::ShieldedAddress;
-    /// use zolana_transaction::{Wallet, SOL_MINT};
+    /// use zolana_transaction::Wallet;
     ///
     /// fn deposit_sol<R: Rpc, I: Rpc>(
     ///     rpc: &R,
@@ -130,8 +134,8 @@ impl Deposit {
     ///     recipient: &ShieldedAddress,
     ///     wallet: &mut Wallet,
     /// ) -> Result<(), ClientError> {
-    ///     let prepared = create_deposit(CreateDeposit {
-    ///         recipient,
+    ///     let prepared = create_deposit(Deposit {
+    ///         destination: recipient,
     ///         asset: SOL_MINT,
     ///         amount: 1_000_000,
     ///         spl_token_account: None,
@@ -184,8 +188,8 @@ fn wait_for_deposited_utxo<I: Rpc>(
     }
 }
 
-pub fn create_deposit(request: CreateDeposit<'_>) -> Result<Deposit, ClientError> {
-    Deposit::new(request)
+pub fn create_deposit(request: Deposit<'_>) -> Result<CreatedDeposit, ClientError> {
+    CreatedDeposit::new(request)
 }
 
 /// Build and send a direct (non-zone) proofless shield: a public deposit
@@ -322,9 +326,9 @@ mod tests {
     fn prepared_sol_deposit_derives_consistent_material() {
         let recipient = ShieldedKeypair::new().unwrap();
         let recipient_address = recipient.shielded_address().unwrap();
-        let prepared = create_deposit(CreateDeposit {
-            recipient: &recipient_address,
-            asset: SOL_MINT,
+        let prepared = create_deposit(Deposit {
+            destination: &recipient_address,
+            asset: crate::SOL_MINT,
             amount: 1_000,
             spl_token_account: None,
             memo: None,
@@ -344,18 +348,17 @@ mod tests {
         let recipient_address = recipient.shielded_address().unwrap();
         let mint = Pubkey::new_unique();
         let user_token = Pubkey::new_unique();
-        let asset = Address::new_from_array(mint.to_bytes());
 
-        let prepared = create_deposit(CreateDeposit {
-            recipient: &recipient_address,
-            asset,
+        let prepared = create_deposit(Deposit {
+            destination: &recipient_address,
+            asset: mint,
             amount: 1_000,
             memo: None,
             spl_token_account: Some(user_token),
         })
         .expect("prepared deposit");
 
-        assert_eq!(prepared.asset, asset);
+        assert_eq!(prepared.asset, Address::new_from_array(mint.to_bytes()));
         assert_eq!(prepared.data.public_amount, Some(1_000));
         assert_eq!(
             prepared.spl,

--- a/sdk-libs/client/src/actions/deposit.rs
+++ b/sdk-libs/client/src/actions/deposit.rs
@@ -21,8 +21,9 @@ use zolana_transaction::{owner_utxo_hash, utxo_hash, Wallet, SOL_MINT};
 use crate::{error::ClientError, rpc::Rpc, wallet_sync::sync_wallet};
 
 /// Compute-unit ceiling [`deposit`] is submitted with. Benchmarked deposits run
-/// ~34k CU (`program-tests/shielded-pool/CU_BENCHMARK.md`).
-pub const DEFAULT_DEPOSIT_CU_LIMIT: u32 = 40_000;
+/// ~34k CU (`program-tests/shielded-pool/CU_BENCHMARK.md`), but a live devnet
+/// SPL deposit was observed exceeding 40k, so the ceiling leaves headroom.
+pub const DEFAULT_DEPOSIT_CU_LIMIT: u32 = 80_000;
 
 /// How long [`Deposit::wait_until_synced`] waits for the indexer to pick up
 /// the deposited UTXO before giving up.

--- a/sdk-libs/client/src/actions/deposit.rs
+++ b/sdk-libs/client/src/actions/deposit.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use solana_address::Address;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_instruction::Instruction;
 use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
@@ -19,6 +20,10 @@ use zolana_keypair::{random_blinding, ShieldedAddress};
 use zolana_transaction::{owner_utxo_hash, utxo_hash, Wallet, SOL_MINT};
 
 use crate::{error::ClientError, rpc::Rpc, wallet_sync::sync_wallet};
+
+/// Compute-unit ceiling [`deposit`] is submitted with. Benchmarked deposits run
+/// ~34k CU (`program-tests/shielded-pool/CU_BENCHMARK.md`).
+pub const DEFAULT_DEPOSIT_CU_LIMIT: u32 = 40_000;
 
 /// How long [`Deposit::send_and_sync`] waits for the indexer to pick up the
 /// deposited UTXO before giving up.
@@ -194,13 +199,14 @@ pub fn deposit<R: Rpc>(
     spl: Option<DepositSplAccounts>,
     data: &DepositIxData,
 ) -> Result<Signature, ClientError> {
+    let cu_ix = ComputeBudgetInstruction::set_compute_unit_limit(DEFAULT_DEPOSIT_CU_LIMIT);
     let ix = deposit_instruction(tree, depositor.pubkey(), spl, data);
     let mut signers: Vec<&Keypair> = vec![payer];
     if depositor.pubkey() != payer.pubkey() {
         signers.push(depositor);
     }
     let payer_address = Address::new_from_array(payer.pubkey().to_bytes());
-    rpc.create_and_send_transaction(&[ix], payer_address, &signers)
+    rpc.create_and_send_transaction(&[cu_ix, ix], payer_address, &signers)
 }
 
 fn deposit_instruction(
@@ -299,8 +305,11 @@ mod tests {
             memo: data.memo.clone(),
         }
         .instruction();
-        assert_eq!(sent.message.instructions.len(), 1);
-        assert_eq!(sent.message.instructions[0].data, expected.data);
+        let cu_expected =
+            ComputeBudgetInstruction::set_compute_unit_limit(DEFAULT_DEPOSIT_CU_LIMIT);
+        assert_eq!(sent.message.instructions.len(), 2);
+        assert_eq!(sent.message.instructions[0].data, cu_expected.data);
+        assert_eq!(sent.message.instructions[1].data, expected.data);
         assert!(sent.message.account_keys.contains(&payer.pubkey()));
         assert!(sent.message.account_keys.contains(&depositor.pubkey()));
     }

--- a/sdk-libs/client/src/actions/deposit.rs
+++ b/sdk-libs/client/src/actions/deposit.rs
@@ -8,7 +8,6 @@ use std::{
 use solana_address::Address;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_instruction::Instruction;
-use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
@@ -95,9 +94,9 @@ impl Deposit {
     pub fn send<R: Rpc>(
         &self,
         rpc: &R,
-        payer: &Keypair,
+        payer: &dyn Signer,
         tree: Pubkey,
-        depositor: &Keypair,
+        depositor: &dyn Signer,
     ) -> Result<Signature, ClientError> {
         deposit(rpc, payer, tree, depositor, self.spl, &self.data)
     }
@@ -116,8 +115,8 @@ impl Deposit {
     /// # Examples
     ///
     /// ```no_run
-    /// use solana_keypair::Keypair;
     /// use solana_pubkey::Pubkey;
+    /// use solana_signer::Signer;
     /// use zolana_client::{create_deposit, ClientError, CreateDeposit, Rpc};
     /// use zolana_keypair::ShieldedAddress;
     /// use zolana_transaction::{Wallet, SOL_MINT};
@@ -125,7 +124,7 @@ impl Deposit {
     /// fn deposit_sol<R: Rpc, I: Rpc>(
     ///     rpc: &R,
     ///     indexer: &I,
-    ///     payer: &Keypair,
+    ///     payer: &dyn Signer,
     ///     tree: Pubkey,
     ///     recipient: &ShieldedAddress,
     ///     wallet: &mut Wallet,
@@ -196,15 +195,15 @@ pub fn create_deposit(request: CreateDeposit<'_>) -> Result<Deposit, ClientError
 /// Returns the transaction signature; event indexing is the caller's concern.
 pub fn deposit<R: Rpc>(
     rpc: &R,
-    payer: &Keypair,
+    payer: &dyn Signer,
     tree: Pubkey,
-    depositor: &Keypair,
+    depositor: &dyn Signer,
     spl: Option<DepositSplAccounts>,
     data: &DepositIxData,
 ) -> Result<Signature, ClientError> {
     let cu_ix = ComputeBudgetInstruction::set_compute_unit_limit(DEFAULT_DEPOSIT_CU_LIMIT);
     let ix = deposit_instruction(tree, depositor.pubkey(), spl, data);
-    let mut signers: Vec<&Keypair> = vec![payer];
+    let mut signers: Vec<&dyn Signer> = vec![payer];
     if depositor.pubkey() != payer.pubkey() {
         signers.push(depositor);
     }
@@ -254,6 +253,7 @@ mod tests {
     use std::cell::RefCell;
 
     use solana_hash::Hash;
+    use solana_keypair::Keypair;
     use solana_transaction::Transaction;
     use zolana_keypair::ShieldedKeypair;
 

--- a/sdk-libs/client/src/actions/mod.rs
+++ b/sdk-libs/client/src/actions/mod.rs
@@ -10,12 +10,14 @@ pub mod submit;
 pub mod transaction;
 
 pub use create_associated_token_account::create_associated_token_account;
-pub use deposit::{create_deposit, deposit, CreateDeposit, Deposit, DEFAULT_DEPOSIT_CU_LIMIT};
+pub use deposit::{create_deposit, deposit, CreatedDeposit, Deposit, DEFAULT_DEPOSIT_CU_LIMIT};
 pub use spl_interface::{fetch_asset_id, register_spl_interface};
 #[cfg(feature = "indexer-api")]
-pub use submit::{Submit, DEFAULT_TRANSACT_CU_LIMIT};
+pub use submit::{Sendable, Submit, DEFAULT_TRANSACT_CU_LIMIT};
 pub use transaction::{
     create_transfer, create_transfer_sync, create_withdrawal, create_withdrawal_sync,
-    sign_transaction, sign_transaction_sync, CreateTransfer, CreateWithdrawal, CreatedTransfer,
-    CreatedWithdrawal, ResolvedAddress, TransferRecipient,
+    sign_transaction, sign_transaction_sync, CreatedTransfer, CreatedWithdrawal, PrivateTransfer,
+    ResolvedAddress, Withdrawal,
 };
+
+pub use crate::user_registry::TransferRecipient;

--- a/sdk-libs/client/src/actions/mod.rs
+++ b/sdk-libs/client/src/actions/mod.rs
@@ -4,12 +4,14 @@
 
 pub mod create_associated_token_account;
 pub mod deposit;
+pub mod spl_interface;
 #[cfg(feature = "indexer-api")]
 pub mod submit;
 pub mod transaction;
 
 pub use create_associated_token_account::create_associated_token_account;
 pub use deposit::{create_deposit, deposit, CreateDeposit, Deposit};
+pub use spl_interface::{fetch_asset_id, register_spl_interface};
 #[cfg(feature = "indexer-api")]
 pub use submit::{Submit, DEFAULT_TRANSACT_CU_LIMIT};
 pub use transaction::{

--- a/sdk-libs/client/src/actions/mod.rs
+++ b/sdk-libs/client/src/actions/mod.rs
@@ -10,7 +10,7 @@ pub mod submit;
 pub mod transaction;
 
 pub use create_associated_token_account::create_associated_token_account;
-pub use deposit::{create_deposit, deposit, CreateDeposit, Deposit};
+pub use deposit::{create_deposit, deposit, CreateDeposit, Deposit, DEFAULT_DEPOSIT_CU_LIMIT};
 pub use spl_interface::{fetch_asset_id, register_spl_interface};
 #[cfg(feature = "indexer-api")]
 pub use submit::{Submit, DEFAULT_TRANSACT_CU_LIMIT};

--- a/sdk-libs/client/src/actions/spl_interface.rs
+++ b/sdk-libs/client/src/actions/spl_interface.rs
@@ -1,0 +1,217 @@
+//! SPL asset interface lookup and registration.
+//!
+//! Every SPL mint used in the shielded pool has a per-mint Asset registry PDA,
+//! written when its interface is created; it is the canonical source of the
+//! mint's `asset_id` on every deployment. SOL is asset id 1 and has no
+//! registry entry.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use solana_keypair::Keypair;
+//! use solana_pubkey::Pubkey;
+//! use zolana_client::{fetch_asset_id, register_spl_interface, ClientError, Rpc};
+//!
+//! fn asset_id<R: Rpc>(
+//!     rpc: &R,
+//!     authority: &Keypair,
+//!     mint: Pubkey,
+//! ) -> Result<u64, ClientError> {
+//!     // Production path: read the canonical per-mint registry PDA.
+//!     match fetch_asset_id(rpc, mint) {
+//!         Err(ClientError::AssetNotRegistered { .. }) => {
+//!             // Devnet / permissionless deployments only (see gating docs).
+//!             register_spl_interface(rpc, authority, mint)
+//!         }
+//!         result => result,
+//!     }
+//! }
+//! ```
+
+use solana_address::Address;
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use zolana_interface::{
+    instruction::{CreateAssetCounter, CreateSplInterface},
+    pda,
+    state::SplAssetRegistry,
+};
+
+use crate::{error::ClientError, rpc::Rpc};
+
+/// Asset id assigned to `mint`, read from the canonical per-mint Asset
+/// registry PDA. Works on every deployment regardless of who registered the
+/// asset. SOL (asset id 1) has no registry entry; this lookup is for SPL
+/// mints (ids >= 2).
+pub fn fetch_asset_id<R: Rpc>(rpc: &R, mint: Pubkey) -> Result<u64, ClientError> {
+    let registry_pda = pda::spl_asset_registry(&mint);
+    let account = rpc
+        .get_account(Address::new_from_array(registry_pda.to_bytes()))?
+        .ok_or(ClientError::AssetNotRegistered { mint })?;
+    let registry = SplAssetRegistry::from_account_bytes(&account.data).map_err(|err| {
+        ClientError::Rpc(format!(
+            "invalid asset registry account for {mint}: {err:?}"
+        ))
+    })?;
+    // The PDA binds the mint; a mismatch means a forged account or program bug.
+    if registry.mint != Address::new_from_array(mint.to_bytes()) {
+        return Err(ClientError::Rpc(format!(
+            "asset registry for {mint} stores a different mint"
+        )));
+    }
+    Ok(registry.asset_id)
+}
+
+/// Create the SPL interface for `mint` and return its asset id; returns the
+/// existing id when the mint is already registered (also when a concurrent
+/// caller wins the registration race).
+///
+/// A devnet / permissionless-deployment tool, not a mainnet user API:
+/// `create_spl_interface` requires `protocol_config.protocol_authority` unless
+/// the deployment sets `spl_interface_creation_is_permissionless` (rejected
+/// on-chain with `UnauthorizedCaller`, code 7003), and the one-time asset
+/// counter bootstrap is always authority-gated. On gated deployments read ids
+/// with [`fetch_asset_id`] instead.
+pub fn register_spl_interface<R: Rpc>(
+    rpc: &R,
+    authority: &Keypair,
+    mint: Pubkey,
+) -> Result<u64, ClientError> {
+    match fetch_asset_id(rpc, mint) {
+        Err(ClientError::AssetNotRegistered { .. }) => {}
+        result => return result,
+    }
+
+    let authority_address = Address::new_from_array(authority.pubkey().to_bytes());
+    let counter = pda::spl_asset_counter();
+    if rpc
+        .get_account(Address::new_from_array(counter.to_bytes()))?
+        .is_none()
+    {
+        let ix = CreateAssetCounter {
+            authority: authority.pubkey(),
+        }
+        .instruction();
+        rpc.create_and_send_transaction(&[ix], authority_address, &[authority])?;
+    }
+
+    let ix = CreateSplInterface {
+        authority: authority.pubkey(),
+        mint,
+    }
+    .instruction();
+    if let Err(err) = rpc.create_and_send_transaction(&[ix], authority_address, &[authority]) {
+        // A concurrent caller may have registered the mint between the lookup
+        // and the send; the id is the outcome that matters.
+        return match fetch_asset_id(rpc, mint) {
+            Ok(asset_id) => Ok(asset_id),
+            Err(_) => Err(ClientError::Rpc(format!(
+                "create_spl_interface for {mint} rejected; interface creation is gated to the \
+                 protocol authority unless the deployment enables permissionless creation: {err}"
+            ))),
+        };
+    }
+    fetch_asset_id(rpc, mint)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, collections::HashMap};
+
+    use solana_account::Account;
+    use solana_hash::Hash;
+    use solana_signature::Signature;
+    use solana_transaction::Transaction;
+    use zolana_interface::SHIELDED_POOL_PROGRAM_ID;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MockRpc {
+        accounts: RefCell<HashMap<Address, Account>>,
+        sent: RefCell<usize>,
+    }
+
+    impl MockRpc {
+        fn with_registry(mint: Pubkey, asset_id: u64) -> Self {
+            let rpc = Self::default();
+            let registry_pda = pda::spl_asset_registry(&mint);
+            rpc.accounts.borrow_mut().insert(
+                Address::new_from_array(registry_pda.to_bytes()),
+                registry_account(mint, asset_id),
+            );
+            rpc
+        }
+    }
+
+    fn registry_account(mint: Pubkey, asset_id: u64) -> Account {
+        Account {
+            lamports: 1,
+            data: SplAssetRegistry::account_bytes(
+                Address::new_from_array(mint.to_bytes()),
+                asset_id,
+            )
+            .to_vec(),
+            owner: Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID),
+            executable: false,
+            rent_epoch: 0,
+        }
+    }
+
+    impl Rpc for MockRpc {
+        fn get_account(&self, address: Address) -> Result<Option<Account>, ClientError> {
+            Ok(self.accounts.borrow().get(&address).cloned())
+        }
+
+        fn get_latest_blockhash(&self) -> Result<(Hash, u64), ClientError> {
+            Ok((Hash::default(), 0))
+        }
+
+        fn send_transaction(&self, _transaction: &Transaction) -> Result<Signature, ClientError> {
+            *self.sent.borrow_mut() += 1;
+            Ok(Signature::default())
+        }
+    }
+
+    #[test]
+    fn fetch_returns_the_registered_id() {
+        let mint = Pubkey::new_unique();
+        let rpc = MockRpc::with_registry(mint, 7);
+        assert_eq!(fetch_asset_id(&rpc, mint).unwrap(), 7);
+    }
+
+    #[test]
+    fn fetch_without_registry_is_asset_not_registered() {
+        let mint = Pubkey::new_unique();
+        let rpc = MockRpc::default();
+        assert!(matches!(
+            fetch_asset_id(&rpc, mint),
+            Err(ClientError::AssetNotRegistered { mint: m }) if m == mint
+        ));
+    }
+
+    #[test]
+    fn fetch_rejects_a_registry_storing_a_different_mint() {
+        let mint = Pubkey::new_unique();
+        let rpc = MockRpc::default();
+        let registry_pda = pda::spl_asset_registry(&mint);
+        rpc.accounts.borrow_mut().insert(
+            Address::new_from_array(registry_pda.to_bytes()),
+            registry_account(Pubkey::new_unique(), 7),
+        );
+        assert!(matches!(
+            fetch_asset_id(&rpc, mint),
+            Err(ClientError::Rpc(message)) if message.contains("different mint")
+        ));
+    }
+
+    #[test]
+    fn register_short_circuits_to_the_existing_id() {
+        let mint = Pubkey::new_unique();
+        let rpc = MockRpc::with_registry(mint, 9);
+        let authority = Keypair::new();
+        assert_eq!(register_spl_interface(&rpc, &authority, mint).unwrap(), 9);
+        assert_eq!(*rpc.sent.borrow(), 0);
+    }
+}

--- a/sdk-libs/client/src/actions/spl_interface.rs
+++ b/sdk-libs/client/src/actions/spl_interface.rs
@@ -8,13 +8,13 @@
 //! # Examples
 //!
 //! ```no_run
-//! use solana_keypair::Keypair;
 //! use solana_pubkey::Pubkey;
+//! use solana_signer::Signer;
 //! use zolana_client::{fetch_asset_id, register_spl_interface, ClientError, Rpc};
 //!
 //! fn asset_id<R: Rpc>(
 //!     rpc: &R,
-//!     authority: &Keypair,
+//!     authority: &dyn Signer,
 //!     mint: Pubkey,
 //! ) -> Result<u64, ClientError> {
 //!     // Production path: read the canonical per-mint registry PDA.
@@ -29,7 +29,6 @@
 //! ```
 
 use solana_address::Address;
-use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use zolana_interface::{
@@ -75,7 +74,7 @@ pub fn fetch_asset_id<R: Rpc>(rpc: &R, mint: Pubkey) -> Result<u64, ClientError>
 /// with [`fetch_asset_id`] instead.
 pub fn register_spl_interface<R: Rpc>(
     rpc: &R,
-    authority: &Keypair,
+    authority: &dyn Signer,
     mint: Pubkey,
 ) -> Result<u64, ClientError> {
     match fetch_asset_id(rpc, mint) {
@@ -121,6 +120,7 @@ mod tests {
 
     use solana_account::Account;
     use solana_hash::Hash;
+    use solana_keypair::Keypair;
     use solana_signature::Signature;
     use solana_transaction::Transaction;
     use zolana_interface::SHIELDED_POOL_PROGRAM_ID;

--- a/sdk-libs/client/src/actions/submit.rs
+++ b/sdk-libs/client/src/actions/submit.rs
@@ -34,9 +34,9 @@ use crate::{
 };
 
 /// Compute-unit ceiling a private transaction is submitted with unless the
-/// caller overrides it. A shielded `Transact` verifies a Groth16 proof on-chain,
-/// which does not fit inside the default per-instruction budget.
-pub const DEFAULT_TRANSACT_CU_LIMIT: u32 = 1_400_000;
+/// caller overrides it. Benchmarked transfers and withdrawals run ~148k-152k CU
+/// (`program-tests/shielded-pool/CU_BENCHMARK.md`).
+pub const DEFAULT_TRANSACT_CU_LIMIT: u32 = 200_000;
 
 /// How long [`Submit::execute`] waits for the indexer to pick up the sent
 /// transaction before giving up.

--- a/sdk-libs/client/src/actions/submit.rs
+++ b/sdk-libs/client/src/actions/submit.rs
@@ -33,9 +33,10 @@ use crate::{
 };
 
 /// Compute-unit ceiling a private transaction is submitted with unless the
-/// caller overrides it. Benchmarked transfers and withdrawals run ~148k-152k CU
-/// (`program-tests/shielded-pool/CU_BENCHMARK.md`).
-pub const DEFAULT_TRANSACT_CU_LIMIT: u32 = 200_000;
+/// caller overrides it. The mollusk benchmark reports ~148k-152k CU
+/// (`program-tests/shielded-pool/CU_BENCHMARK.md`), but live localnet
+/// transfers and withdrawals consume ~290k-296k; 600k leaves headroom.
+pub const DEFAULT_TRANSACT_CU_LIMIT: u32 = 600_000;
 
 /// How long [`Submit::execute`] waits for the indexer to pick up the sent
 /// transaction before giving up.

--- a/sdk-libs/client/src/actions/submit.rs
+++ b/sdk-libs/client/src/actions/submit.rs
@@ -17,6 +17,7 @@ use std::{
 
 use solana_address::Address;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_instruction::Instruction;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
@@ -26,6 +27,7 @@ use zolana_interface::instruction::{
 use zolana_transaction::instructions::{transact::SignedTransaction, types::InputCommitment};
 
 use crate::{
+    actions::transaction::{CreatedTransfer, CreatedWithdrawal},
     error::ClientError,
     prover::{
         transact::witness::{assemble, AssembledTransfer, ProverInputs, SpendProof},
@@ -53,9 +55,8 @@ const INDEXER_POLL: Duration = Duration::from_millis(500);
 /// RPC). [`Submit::execute`] then fetches proofs, proves, sends, and waits for
 /// the transaction to be indexed.
 ///
-/// The three per-transaction pieces (`signed`, `withdrawal`, `wait_tag`) are
-/// passed to [`Submit::execute`]; a caller holds them on the `CreatedTransfer` /
-/// `CreatedWithdrawal` returned by `create_transfer` / `create_withdrawal`.
+/// [`Submit::execute`] takes the created transaction directly: any
+/// [`Sendable`], which [`CreatedTransfer`] and [`CreatedWithdrawal`] implement.
 pub struct Submit<'a, R: Rpc, I: Rpc> {
     /// Answers spend-proof lookups (Photon).
     pub indexer: &'a I,
@@ -78,20 +79,62 @@ impl<R: Rpc, I: Rpc> Submit<'_, R, I> {
         assemble(signed, &spend_proofs)
     }
 
-    /// Prove and submit the transaction, then wait for it to be indexed.
+    /// Prove and submit the created transaction, then wait for it to be
+    /// indexed.
     ///
     /// Fetches the input proofs, assembles, proves on the matching rail,
     /// compresses, builds the `Transact` instruction, sends it under a
     /// compute-unit ceiling, and polls the indexer until the transaction is
     /// visible. Returning after indexing means a caller can `sync_wallet`
-    /// immediately without racing Photon. `wait_tag` is the transfer's
-    /// confidential view tag (on `CreatedTransfer` / `CreatedWithdrawal`).
-    pub fn execute(
+    /// immediately without racing Photon.
+    pub fn execute<T: Sendable>(self, tx: &T) -> Result<Signature, ClientError> {
+        self.execute_inner(tx, &[])
+    }
+
+    /// [`Submit::execute`] with extra instructions spliced into the same
+    /// transaction, atomically: all land or none do. The extras run after the
+    /// `Transact` instruction, and the payer signs everything — spend
+    /// authorization travels inside the proof, so no other signature is
+    /// needed.
+    ///
+    /// Two shared budgets to keep in mind: the extras count against the same
+    /// compute-unit ceiling (override `cu_limit` if they are heavy), and the
+    /// `Transact` instruction is large, so the 1232-byte transaction packet
+    /// leaves limited room for extras.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use solana_compute_budget_interface::ComputeBudgetInstruction;
+    /// use solana_signature::Signature;
+    /// use zolana_client::{ClientError, CreatedTransfer, Rpc, Submit};
+    ///
+    /// fn send_with_priority_fee<R: Rpc, I: Rpc>(
+    ///     submit: Submit<'_, R, I>, // e.g. rpc.send(&payer) on ZolanaClient
+    ///     transfer: &CreatedTransfer,
+    /// ) -> Result<Signature, ClientError> {
+    ///     // A public instruction settled atomically with the private
+    ///     // transfer: here, a priority fee.
+    ///     let priority_fee_ix = ComputeBudgetInstruction::set_compute_unit_price(10_000);
+    ///     submit.execute_with(transfer, &[priority_fee_ix])
+    /// }
+    /// ```
+    pub fn execute_with<T: Sendable>(
         self,
-        signed: SignedTransaction,
-        withdrawal: Option<TransactWithdrawal>,
-        wait_tag: [u8; 32],
+        tx: &T,
+        instructions: &[Instruction],
     ) -> Result<Signature, ClientError> {
+        self.execute_inner(tx, instructions)
+    }
+
+    fn execute_inner<T: Sendable>(
+        self,
+        tx: &T,
+        extra_instructions: &[Instruction],
+    ) -> Result<Signature, ClientError> {
+        let signed = tx.signed().clone();
+        let withdrawal = tx.withdrawal().cloned();
+        let wait_tag = tx.wait_tag();
         let assembled = self.prepare(signed)?;
         let data = prove_assembled(self.prover, assembled)?.data;
 
@@ -102,19 +145,68 @@ impl<R: Rpc, I: Rpc> Submit<'_, R, I> {
             data,
         }
         .instruction();
-        let cu_ix = ComputeBudgetInstruction::set_compute_unit_limit(
-            self.cu_limit.unwrap_or(DEFAULT_TRANSACT_CU_LIMIT),
-        );
+        let instructions = build_instructions(self.cu_limit, transact_ix, extra_instructions);
 
         let payer_address = Address::new_from_array(self.payer.pubkey().to_bytes());
-        let signature = self.rpc.create_and_send_transaction(
-            &[cu_ix, transact_ix],
-            payer_address,
-            &[self.payer],
-        )?;
+        let signature =
+            self.rpc
+                .create_and_send_transaction(&instructions, payer_address, &[self.payer])?;
 
         wait_for_indexed_transaction(self.indexer, wait_tag, signature)?;
         Ok(signature)
+    }
+}
+
+/// Assemble the instruction list a submit sends: the compute-budget ceiling,
+/// the `Transact` instruction, then any caller extras in order.
+fn build_instructions(
+    cu_limit: Option<u32>,
+    transact_ix: Instruction,
+    extras: &[Instruction],
+) -> Vec<Instruction> {
+    let cu_ix = ComputeBudgetInstruction::set_compute_unit_limit(
+        cu_limit.unwrap_or(DEFAULT_TRANSACT_CU_LIMIT),
+    );
+    let mut instructions = vec![cu_ix, transact_ix];
+    instructions.extend_from_slice(extras);
+    instructions
+}
+
+/// A created private transaction [`Submit::execute`] can prove and send: the
+/// signed payload, its optional public-withdrawal routing, and the view tag
+/// to wait for in the indexer. Implemented by [`CreatedTransfer`] and
+/// [`CreatedWithdrawal`].
+pub trait Sendable {
+    fn signed(&self) -> &SignedTransaction;
+    fn withdrawal(&self) -> Option<&TransactWithdrawal>;
+    fn wait_tag(&self) -> [u8; 32];
+}
+
+impl Sendable for CreatedTransfer {
+    fn signed(&self) -> &SignedTransaction {
+        &self.signed
+    }
+
+    fn withdrawal(&self) -> Option<&TransactWithdrawal> {
+        self.withdrawal.as_ref()
+    }
+
+    fn wait_tag(&self) -> [u8; 32] {
+        self.wait_tag
+    }
+}
+
+impl Sendable for CreatedWithdrawal {
+    fn signed(&self) -> &SignedTransaction {
+        &self.signed
+    }
+
+    fn withdrawal(&self) -> Option<&TransactWithdrawal> {
+        Some(&self.withdrawal)
+    }
+
+    fn wait_tag(&self) -> [u8; 32] {
+        self.wait_tag
     }
 }
 
@@ -217,5 +309,45 @@ fn wait_for_indexed_transaction(
             )));
         }
         sleep(INDEXER_POLL);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_ix(marker: u8) -> Instruction {
+        Instruction {
+            program_id: Pubkey::new_unique(),
+            accounts: vec![],
+            data: vec![marker],
+        }
+    }
+
+    #[test]
+    fn execute_orders_cu_transact_then_extras() {
+        let transact_ix = dummy_ix(1);
+        let extras = [dummy_ix(2), dummy_ix(3)];
+
+        let instructions = build_instructions(None, transact_ix.clone(), &extras);
+
+        let cu_expected =
+            ComputeBudgetInstruction::set_compute_unit_limit(DEFAULT_TRANSACT_CU_LIMIT);
+        assert_eq!(instructions.len(), 4);
+        assert_eq!(instructions[0].data, cu_expected.data);
+        assert_eq!(instructions[1], transact_ix);
+        assert_eq!(instructions[2..], extras);
+    }
+
+    #[test]
+    fn execute_without_extras_keeps_the_two_instruction_shape() {
+        let transact_ix = dummy_ix(1);
+
+        let instructions = build_instructions(Some(700_000), transact_ix.clone(), &[]);
+
+        let cu_expected = ComputeBudgetInstruction::set_compute_unit_limit(700_000);
+        assert_eq!(instructions.len(), 2);
+        assert_eq!(instructions[0].data, cu_expected.data);
+        assert_eq!(instructions[1], transact_ix);
     }
 }

--- a/sdk-libs/client/src/actions/submit.rs
+++ b/sdk-libs/client/src/actions/submit.rs
@@ -5,9 +5,10 @@
 //! exposing it as the single [`Submit`] action.
 //!
 //! A private submit needs two backends, not one: spend proofs come from the
-//! Photon indexer ([`ZolanaIndexer`]) and the transaction is sent through a
-//! Solana RPC ([`Rpc`]). [`Submit`] takes them separately so the indexer
-//! dependency is explicit rather than hidden behind a single "rpc".
+//! Photon indexer and the transaction is sent through a Solana RPC. [`Submit`]
+//! takes them as two [`Rpc`] values so the indexer dependency is explicit
+//! rather than hidden behind a single "rpc"; a combined backend (such as
+//! `ZolanaClient`) can fill both fields.
 
 use std::{
     thread::sleep,
@@ -19,12 +20,13 @@ use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
-use zolana_interface::instruction::{Transact, TransactWithdrawal};
+use zolana_interface::instruction::{
+    instruction_data::transact::TransactIxData, Transact, TransactWithdrawal,
+};
 use zolana_transaction::instructions::{transact::SignedTransaction, types::InputCommitment};
 
 use crate::{
     error::ClientError,
-    indexer::ZolanaIndexer,
     prover::{
         transact::witness::{assemble, AssembledTransfer, ProverInputs, SpendProof},
         ProofCompressed, ProverClient,
@@ -46,17 +48,17 @@ const INDEXER_POLL: Duration = Duration::from_millis(500);
 
 /// One-call submit for a signed private transaction.
 ///
-/// Holds the two backends a submit needs plus the fixed parameters: the
-/// [`ZolanaIndexer`] answers spend-proof lookups, the [`Rpc`] sends the
-/// transaction. [`Submit::execute`] then fetches proofs, proves, sends, and
-/// waits for the transaction to be indexed.
+/// Holds the two backends a submit needs plus the fixed parameters: `indexer`
+/// answers spend-proof lookups (Photon), `rpc` sends the transaction (a Solana
+/// RPC). [`Submit::execute`] then fetches proofs, proves, sends, and waits for
+/// the transaction to be indexed.
 ///
 /// The three per-transaction pieces (`signed`, `withdrawal`, `wait_tag`) are
 /// passed to [`Submit::execute`]; a caller holds them on the `CreatedTransfer` /
 /// `CreatedWithdrawal` returned by `create_transfer` / `create_withdrawal`.
-pub struct Submit<'a, R: Rpc> {
+pub struct Submit<'a, R: Rpc, I: Rpc> {
     /// Answers spend-proof lookups (Photon).
-    pub indexer: &'a ZolanaIndexer,
+    pub indexer: &'a I,
     /// Sends the transaction (a Solana RPC).
     pub rpc: &'a R,
     pub prover: &'a ProverClient,
@@ -66,7 +68,7 @@ pub struct Submit<'a, R: Rpc> {
     pub cu_limit: Option<u32>,
 }
 
-impl<R: Rpc> Submit<'_, R> {
+impl<R: Rpc, I: Rpc> Submit<'_, R, I> {
     /// Fetch the input spend proofs for `tree` and assemble the prover witness:
     /// the network-bound, prover-free prefix of [`Submit::execute`].
     fn prepare(&self, signed: SignedTransaction) -> Result<AssembledTransfer, ClientError> {
@@ -91,13 +93,7 @@ impl<R: Rpc> Submit<'_, R> {
         wait_tag: [u8; 32],
     ) -> Result<Signature, ClientError> {
         let assembled = self.prepare(signed)?;
-
-        let proof = match &assembled.prover_inputs {
-            ProverInputs::P256(inputs) => self.prover.prove_transfer_p256(inputs)?,
-            ProverInputs::Eddsa(inputs) => self.prover.prove_transfer(inputs)?,
-        };
-        let proof = ProofCompressed::try_from(proof)?.to_transact_proof();
-        let data = assembled.with_proof(proof);
+        let data = prove_assembled(self.prover, assembled)?.data;
 
         let transact_ix = Transact {
             payer: self.payer.pubkey(),
@@ -122,11 +118,54 @@ impl<R: Rpc> Submit<'_, R> {
     }
 }
 
+/// A proven transaction: the ready-to-send `Transact` instruction data plus the
+/// pieces a caller reporting a bare proof needs (compressed proof, public input
+/// hash, circuit id).
+pub(crate) struct ProvenTransact {
+    pub data: TransactIxData,
+    pub proof: ProofCompressed,
+    pub public_input_hash: [u8; 32],
+    pub circuit_id: u16,
+}
+
+/// Prove an assembled witness on the matching rail and compress the proof:
+/// the prover-bound suffix shared by [`Submit::execute`] and the client-side
+/// [`Rpc::prove`] implementation.
+pub(crate) fn prove_assembled(
+    prover: &ProverClient,
+    assembled: AssembledTransfer,
+) -> Result<ProvenTransact, ClientError> {
+    // circuit_id has no formal registry yet: 1 = P256 rail, 0 = eddsa rail.
+    let (proof, circuit_id) = match &assembled.prover_inputs {
+        ProverInputs::P256(inputs) => (prover.prove_transfer_p256(inputs)?, 1),
+        ProverInputs::Eddsa(inputs) => (prover.prove_transfer(inputs)?, 0),
+    };
+    let proof = ProofCompressed::try_from(proof)?;
+    let public_input_hash = assembled.public_input_hash;
+    let data = assembled.with_proof(proof.to_transact_proof());
+    Ok(ProvenTransact {
+        data,
+        proof,
+        public_input_hash,
+        circuit_id,
+    })
+}
+
+/// Assemble the witness from the fetched spend proofs, then prove and compress:
+/// the full proving pipeline minus the proof fetch.
+pub(crate) fn prove_transact(
+    prover: &ProverClient,
+    signed: SignedTransaction,
+    spend_proofs: &[SpendProof],
+) -> Result<ProvenTransact, ClientError> {
+    prove_assembled(prover, assemble(signed, spend_proofs)?)
+}
+
 /// Resolve the spend proof (state inclusion + nullifier non-inclusion) for each
 /// input commitment on `tree`, in commitment order. Batches both indexer lookups
 /// so a multi-input spend costs two round trips, not two per input.
-fn fetch_spend_proofs(
-    indexer: &ZolanaIndexer,
+pub(crate) fn fetch_spend_proofs(
+    indexer: &impl Rpc,
     tree: Address,
     commitments: &[InputCommitment],
 ) -> Result<Vec<SpendProof>, ClientError> {
@@ -158,7 +197,7 @@ fn fetch_spend_proofs(
 /// [`INDEXER_TIMEOUT`] elapses. The indexer lags the chain, so a plain on-chain
 /// confirmation is not enough for a caller that reads state back immediately.
 fn wait_for_indexed_transaction(
-    indexer: &ZolanaIndexer,
+    indexer: &impl Rpc,
     tag: [u8; 32],
     signature: Signature,
 ) -> Result<(), ClientError> {

--- a/sdk-libs/client/src/actions/submit.rs
+++ b/sdk-libs/client/src/actions/submit.rs
@@ -16,7 +16,6 @@ use std::{
 
 use solana_address::Address;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
-use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
@@ -60,7 +59,7 @@ pub struct Submit<'a, R: Rpc> {
     /// Sends the transaction (a Solana RPC).
     pub rpc: &'a R,
     pub prover: &'a ProverClient,
-    pub payer: &'a Keypair,
+    pub payer: &'a dyn Signer,
     pub tree: Pubkey,
     /// Compute-unit limit; `None` uses [`DEFAULT_TRANSACT_CU_LIMIT`].
     pub cu_limit: Option<u32>,

--- a/sdk-libs/client/src/actions/transaction.rs
+++ b/sdk-libs/client/src/actions/transaction.rs
@@ -9,18 +9,21 @@ use zolana_transaction::{
         transact::{PreparedTransaction, SignedTransaction, Transaction, WithdrawalTarget},
         types::SpendUtxo,
     },
-    Address, AssetRegistry, Wallet, SOL_MINT,
+    Address, AssetRegistry, Wallet,
 };
 
 use crate::{
     error::ClientError,
-    rpc::Rpc,
-    user_registry::try_resolve_registered_address,
+    user_registry::TransferRecipient,
     wallet_authority::{
         ApprovalRequest, ConfidentialRecipientSlot, SyncWalletAuthority, WalletAuthority,
     },
 };
 
+/// A recipient resolved to its registered private wallet: the owner's Solana
+/// pubkey plus the shielded address and view tag a private transfer is built
+/// against. The [`TransferRecipient::Private`] payload of
+/// [`resolve_recipient`](crate::user_registry::resolve_recipient).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ResolvedAddress {
     pub owner: Pubkey,
@@ -28,40 +31,16 @@ pub struct ResolvedAddress {
     pub view_tag: ViewTag,
 }
 
+/// A built and signed private transfer, awaiting its proof. Pass it to
+/// `rpc.send(payer).execute(&transfer)` to prove, send, and wait for indexing.
 #[derive(Clone)]
 pub struct CreatedTransfer {
     pub signed: SignedTransaction,
     pub wait_tag: ViewTag,
     pub recipient: TransferRecipient,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum TransferRecipient {
-    Registered(ResolvedAddress),
-    PublicWithdrawal {
-        recipient: Pubkey,
-        withdrawal: TransactWithdrawal,
-    },
-}
-
-impl TransferRecipient {
-    pub fn pubkey(&self) -> Pubkey {
-        match self {
-            Self::Registered(recipient) => recipient.owner,
-            Self::PublicWithdrawal { recipient, .. } => *recipient,
-        }
-    }
-
-    pub fn is_public_withdrawal(&self) -> bool {
-        matches!(self, Self::PublicWithdrawal { .. })
-    }
-
-    pub fn withdrawal(&self) -> Option<&TransactWithdrawal> {
-        match self {
-            Self::Registered(_) => None,
-            Self::PublicWithdrawal { withdrawal, .. } => Some(withdrawal),
-        }
-    }
+    /// Public settlement routing, present when the recipient resolved to
+    /// [`TransferRecipient::Public`] and the transfer became a withdrawal.
+    pub withdrawal: Option<TransactWithdrawal>,
 }
 
 #[derive(Clone)]
@@ -71,131 +50,185 @@ pub struct CreatedWithdrawal {
     pub withdrawal: TransactWithdrawal,
 }
 
-pub struct CreateTransfer<'a, R: Rpc, A: ?Sized> {
-    pub rpc: &'a R,
-    pub wallet: &'a Wallet,
-    pub authority: &'a A,
-    pub owner_pubkey: Pubkey,
-    pub payer: Address,
-    pub recipient: Pubkey,
-    pub asset: Address,
+/// A private transfer, built and signed locally.
+///
+/// No network happens here: the one chain read a transfer needs is the
+/// explicit [`resolve_recipient`](crate::user_registry::resolve_recipient)
+/// step that produces the `destination` field. A destination that resolved to
+/// [`TransferRecipient::Public`] makes the transfer settle as a
+/// private-to-public withdrawal instead. Finish with
+/// [`PrivateTransfer::create`] (async; custody hosts whose signing crosses a
+/// network boundary) or [`PrivateTransfer::instruction`] (blocking; local
+/// keys and tests).
+pub struct PrivateTransfer<'a, A: ?Sized> {
+    pub source: &'a Wallet,
+    pub destination: TransferRecipient,
+    /// The asset's mint; [`SOL_MINT`](crate::SOL_MINT) for SOL.
+    pub asset: Pubkey,
     pub amount: u64,
+    pub authority: &'a A,
+    pub payer: Pubkey,
     /// Free-form note for the recipient, encrypted into their output
     /// ciphertext and not committed into any hash. It lengthens that
     /// ciphertext, so its presence and byte length are visible onchain; the
-    /// contents are not. Ignored when the transfer falls back to a public
+    /// contents are not. Ignored when the transfer settles as a public
     /// withdrawal (public funds carry no ciphertext).
     pub memo: Option<Vec<u8>>,
 }
 
-pub struct CreateWithdrawal<'a, A: ?Sized> {
-    pub wallet: &'a Wallet,
-    pub authority: &'a A,
-    pub owner_pubkey: Pubkey,
-    pub payer: Address,
-    pub recipient: Pubkey,
-    pub asset: Address,
+/// A private-to-public withdrawal, built and signed locally. Finish with
+/// [`Withdrawal::create`] (async; custody hosts whose signing crosses a
+/// network boundary) or [`Withdrawal::instruction`] (blocking; local keys and
+/// tests).
+pub struct Withdrawal<'a, A: ?Sized> {
+    pub source: &'a Wallet,
+    pub destination: Pubkey,
+    /// The asset's mint; [`SOL_MINT`](crate::SOL_MINT) for SOL.
+    pub asset: Pubkey,
     pub amount: u64,
+    pub authority: &'a A,
+    pub payer: Pubkey,
 }
 
-pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
-    request: CreateTransfer<'_, R, A>,
+impl<A: ?Sized> PrivateTransfer<'_, A> {
+    /// Build and sign the transfer through the async [`WalletAuthority`] —
+    /// the builder for embedded and custody hosts whose signing, encryption,
+    /// or approval crosses a network boundary (enclaves, passkeys, remote
+    /// signers). Hosts managing many users' wallets scope their
+    /// [`MultiWalletAuthority`](crate::wallet_authority::MultiWalletAuthority)
+    /// per user with [`Scoped::new`](crate::wallet_authority::Scoped::new)
+    /// and pass the result as `authority`.
+    ///
+    /// Returns a signed payload awaiting its proof, not a composable Solana
+    /// `Instruction`; pass it to `rpc.send(payer).execute(&transfer)`. No
+    /// network happens here; the chain read lives in `resolve_recipient`.
+    pub async fn create(self) -> Result<CreatedTransfer, ClientError>
+    where
+        A: WalletAuthority,
+    {
+        create_transfer(self).await
+    }
+
+    /// Blocking twin of [`PrivateTransfer::create`] for local-key authorities
+    /// (a [`SyncWalletAuthority`], such as a `ShieldedKeypair`) — the
+    /// convenience for CLI flows and tests.
+    pub fn instruction(self) -> Result<CreatedTransfer, ClientError>
+    where
+        A: SyncWalletAuthority,
+    {
+        create_transfer_sync(self)
+    }
+}
+
+impl<A: ?Sized> Withdrawal<'_, A> {
+    /// Build and sign the withdrawal through the async [`WalletAuthority`] —
+    /// the builder for embedded and custody hosts whose signing, encryption,
+    /// or approval crosses a network boundary (enclaves, passkeys, remote
+    /// signers). Hosts managing many users' wallets scope their
+    /// [`MultiWalletAuthority`](crate::wallet_authority::MultiWalletAuthority)
+    /// per user with [`Scoped::new`](crate::wallet_authority::Scoped::new)
+    /// and pass the result as `authority`.
+    ///
+    /// Returns a signed payload awaiting its proof, not a composable Solana
+    /// `Instruction`; pass it to `rpc.send(payer).execute(&withdrawal)`. No
+    /// network happens here.
+    pub async fn create(self) -> Result<CreatedWithdrawal, ClientError>
+    where
+        A: WalletAuthority,
+    {
+        create_withdrawal(self).await
+    }
+
+    /// Blocking twin of [`Withdrawal::create`] for local-key authorities
+    /// (a [`SyncWalletAuthority`], such as a `ShieldedKeypair`) — the
+    /// convenience for CLI flows and tests.
+    pub fn instruction(self) -> Result<CreatedWithdrawal, ClientError>
+    where
+        A: SyncWalletAuthority,
+    {
+        create_withdrawal_sync(self)
+    }
+}
+
+pub async fn create_transfer<A: WalletAuthority + ?Sized>(
+    request: PrivateTransfer<'_, A>,
 ) -> Result<CreatedTransfer, ClientError> {
-    let Some(recipient) = try_resolve_registered_address(request.rpc, request.recipient)? else {
-        let withdrawal = create_withdrawal(CreateWithdrawal {
-            wallet: request.wallet,
-            authority: request.authority,
-            owner_pubkey: request.owner_pubkey,
-            payer: request.payer,
-            recipient: request.recipient,
-            asset: request.asset,
-            amount: request.amount,
-        })
-        .await?;
-        return Ok(CreatedTransfer {
-            signed: withdrawal.signed,
-            wait_tag: withdrawal.wait_tag,
-            recipient: TransferRecipient::PublicWithdrawal {
-                recipient: request.recipient,
-                withdrawal: withdrawal.withdrawal,
-            },
-        });
+    let recipient = request.destination;
+    let resolved = match recipient {
+        TransferRecipient::Private(resolved) => resolved,
+        // Unregistered recipient: settle publicly. The resolve step already
+        // made the degradation visible; here it is just routing.
+        TransferRecipient::Public(recipient_pubkey) => {
+            let created = create_withdrawal(Withdrawal {
+                source: request.source,
+                destination: recipient_pubkey,
+                asset: request.asset,
+                amount: request.amount,
+                authority: request.authority,
+                payer: request.payer,
+            })
+            .await?;
+            return Ok(CreatedTransfer {
+                signed: created.signed,
+                wait_tag: created.wait_tag,
+                recipient,
+                withdrawal: Some(created.withdrawal),
+            });
+        }
     };
-    let inputs = select_inputs(
-        request.wallet,
-        request.authority,
-        request.owner_pubkey,
-        request.asset,
-        request.amount,
-    )
-    .await?;
-    let address = request
-        .authority
-        .shielded_address(request.owner_pubkey)
-        .await?;
+    let asset = Address::new_from_array(request.asset.to_bytes());
+    let payer = Address::new_from_array(request.payer.to_bytes());
+    let inputs = select_inputs(request.source, request.authority, asset, request.amount).await?;
+    let address = request.authority.shielded_address().await?;
     let wait_tag = address.signing_pubkey.confidential_view_tag()?;
-    let mut tx = Transaction::new(address, inputs, request.payer);
-    tx.send_with_memo(
-        &recipient.address,
-        request.asset,
-        request.amount,
-        request.memo,
-    )?;
-    let prepared = tx.prepare(&request.wallet.registry)?;
+    let mut tx = Transaction::new(address, inputs, payer);
+    tx.send_with_memo(&resolved.address, asset, request.amount, request.memo)?;
+    let prepared = tx.prepare(&request.source.registry)?;
     let signed = sign_prepared(
         prepared,
         &address,
-        request.owner_pubkey,
         request.authority,
-        &request.wallet.registry,
+        &request.source.registry,
         format!(
             "private transfer of {} to {}",
-            request.amount, request.recipient
+            request.amount, resolved.owner
         ),
     )
     .await?;
     Ok(CreatedTransfer {
         signed,
         wait_tag,
-        recipient: TransferRecipient::Registered(recipient),
+        recipient,
+        withdrawal: None,
     })
 }
 
 /// Blocking adapter for CLI and unit-test flows. Async hosts should call
 /// [`create_transfer`] directly.
-pub fn create_transfer_sync<R: Rpc, A: SyncWalletAuthority + ?Sized>(
-    request: CreateTransfer<'_, R, A>,
+pub fn create_transfer_sync<A: SyncWalletAuthority + ?Sized>(
+    request: PrivateTransfer<'_, A>,
 ) -> Result<CreatedTransfer, ClientError> {
     futures::executor::block_on(create_transfer(request))
 }
 
 pub async fn create_withdrawal<A: WalletAuthority + ?Sized>(
-    request: CreateWithdrawal<'_, A>,
+    request: Withdrawal<'_, A>,
 ) -> Result<CreatedWithdrawal, ClientError> {
-    let inputs = select_inputs(
-        request.wallet,
-        request.authority,
-        request.owner_pubkey,
-        request.asset,
-        request.amount,
-    )
-    .await?;
-    let (target, withdrawal) = withdrawal_target(request.recipient, request.asset)?;
-    let address = request
-        .authority
-        .shielded_address(request.owner_pubkey)
-        .await?;
+    let asset = Address::new_from_array(request.asset.to_bytes());
+    let payer = Address::new_from_array(request.payer.to_bytes());
+    let inputs = select_inputs(request.source, request.authority, asset, request.amount).await?;
+    let (target, withdrawal) = withdrawal_target(request.destination, request.asset)?;
+    let address = request.authority.shielded_address().await?;
     let wait_tag = address.signing_pubkey.confidential_view_tag()?;
-    let mut tx = Transaction::new(address, inputs, request.payer);
-    tx.withdraw(request.asset, request.amount, target)?;
-    let prepared = tx.prepare(&request.wallet.registry)?;
+    let mut tx = Transaction::new(address, inputs, payer);
+    tx.withdraw(asset, request.amount, target)?;
+    let prepared = tx.prepare(&request.source.registry)?;
     let signed = sign_prepared(
         prepared,
         &address,
-        request.owner_pubkey,
         request.authority,
-        &request.wallet.registry,
-        format!("withdraw {} to {}", request.amount, request.recipient),
+        &request.source.registry,
+        format!("withdraw {} to {}", request.amount, request.destination),
     )
     .await?;
     Ok(CreatedWithdrawal {
@@ -208,7 +241,7 @@ pub async fn create_withdrawal<A: WalletAuthority + ?Sized>(
 /// Blocking adapter for CLI and unit-test flows. Async hosts should call
 /// [`create_withdrawal`] directly.
 pub fn create_withdrawal_sync<A: SyncWalletAuthority + ?Sized>(
-    request: CreateWithdrawal<'_, A>,
+    request: Withdrawal<'_, A>,
 ) -> Result<CreatedWithdrawal, ClientError> {
     futures::executor::block_on(create_withdrawal(request))
 }
@@ -218,15 +251,13 @@ pub fn create_withdrawal_sync<A: SyncWalletAuthority + ?Sized>(
 pub async fn sign_transaction<A: WalletAuthority + ?Sized>(
     tx: Transaction,
     wallet: &Wallet,
-    owner_pubkey: Pubkey,
     authority: &A,
 ) -> Result<SignedTransaction, ClientError> {
-    let address = authority.shielded_address(owner_pubkey).await?;
+    let address = authority.shielded_address().await?;
     let prepared = tx.prepare(&wallet.registry)?;
     sign_prepared(
         prepared,
         &address,
-        owner_pubkey,
         authority,
         &wallet.registry,
         "private transaction".to_string(),
@@ -239,10 +270,9 @@ pub async fn sign_transaction<A: WalletAuthority + ?Sized>(
 pub fn sign_transaction_sync<A: SyncWalletAuthority + ?Sized>(
     tx: Transaction,
     wallet: &Wallet,
-    owner_pubkey: Pubkey,
     authority: &A,
 ) -> Result<SignedTransaction, ClientError> {
-    futures::executor::block_on(sign_transaction(tx, wallet, owner_pubkey, authority))
+    futures::executor::block_on(sign_transaction(tx, wallet, authority))
 }
 
 fn recipient_slots(prepared: &PreparedTransaction) -> Vec<ConfidentialRecipientSlot> {
@@ -260,7 +290,6 @@ fn recipient_slots(prepared: &PreparedTransaction) -> Vec<ConfidentialRecipientS
 async fn sign_prepared<A: WalletAuthority + ?Sized>(
     prepared: PreparedTransaction,
     address: &ShieldedAddress,
-    owner_pubkey: Pubkey,
     authority: &A,
     assets: &AssetRegistry,
     approval_summary: String,
@@ -268,7 +297,6 @@ async fn sign_prepared<A: WalletAuthority + ?Sized>(
     let sender_tag = address.signing_pubkey.confidential_view_tag()?;
     let encrypted = authority
         .encrypt_confidential_transfer(
-            owner_pubkey,
             &prepared.first_nullifier,
             sender_tag,
             &prepared.sender_plaintext,
@@ -277,7 +305,6 @@ async fn sign_prepared<A: WalletAuthority + ?Sized>(
         .await?;
     authority
         .request_user_approval(ApprovalRequest {
-            owner_pubkey,
             summary: approval_summary,
         })
         .await?;
@@ -289,7 +316,7 @@ async fn sign_prepared<A: WalletAuthority + ?Sized>(
     )?;
     if address.signing_pubkey.signature_type()? == SignatureType::P256 {
         let message_hash = signed.message_hash()?;
-        let sig = authority.sign_p256(owner_pubkey, &message_hash).await?;
+        let sig = authority.sign_p256(&message_hash).await?;
         let mut bytes = [0u8; 64];
         bytes[..32].copy_from_slice(&sig.sig_r);
         bytes[32..].copy_from_slice(&sig.sig_s);
@@ -300,9 +327,9 @@ async fn sign_prepared<A: WalletAuthority + ?Sized>(
 
 fn withdrawal_target(
     recipient: Pubkey,
-    asset: Address,
+    asset: Pubkey,
 ) -> Result<(WithdrawalTarget, TransactWithdrawal), ClientError> {
-    if asset == SOL_MINT {
+    if asset == crate::SOL_MINT {
         return Ok((
             WithdrawalTarget::Sol {
                 user_sol_account: Address::new_from_array(recipient.to_bytes()),
@@ -311,7 +338,7 @@ fn withdrawal_target(
         ));
     }
 
-    let mint = Pubkey::new_from_array(asset.to_bytes());
+    let mint = asset;
     let user_spl_token = pda::associated_token_address(&recipient, &mint);
     let vault = pda::spl_asset_vault(&mint);
     Ok((
@@ -332,11 +359,10 @@ fn withdrawal_target(
 async fn select_inputs<A: WalletAuthority + ?Sized>(
     wallet: &Wallet,
     authority: &A,
-    owner_pubkey: Pubkey,
     asset: Address,
     amount: u64,
 ) -> Result<Vec<SpendUtxo>, ClientError> {
-    let nullifier_key = authority.spend_nullifier_key(owner_pubkey).await?;
+    let nullifier_key = authority.spend_nullifier_key().await?;
     let mut selected = Vec::new();
     let mut total = 0u64;
     for entry in &wallet.utxos {
@@ -370,10 +396,11 @@ mod tests {
     use borsh::to_vec;
     use solana_account::Account;
     use zolana_keypair::ShieldedKeypair;
-    use zolana_transaction::{Data, Utxo, WalletUtxo};
+    use zolana_transaction::{Data, Utxo, WalletUtxo, SOL_MINT};
     use zolana_user_registry_interface::{user_record_pda, user_registry_program_id, UserRecord};
 
     use super::*;
+    use crate::{rpc::Rpc, user_registry::resolve_recipient};
 
     struct MockRpc {
         account: Option<(Address, Account)>,
@@ -434,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn create_transfer_to_registered_recipient_builds_shielded_transfer() {
+    fn private_transfer_to_resolved_recipient_builds_shielded_transfer() {
         let sender = ShieldedKeypair::new().unwrap();
         let recipient = ShieldedKeypair::new().unwrap();
         let owner = Pubkey::new_unique();
@@ -463,92 +490,56 @@ mod tests {
         };
         let wallet = wallet_with_sol(sender.clone(), 10);
 
-        let result = create_transfer_sync(CreateTransfer {
-            rpc: &rpc,
-            wallet: &wallet,
-            authority: &sender,
-            owner_pubkey: Pubkey::default(),
-            payer: Address::default(),
-            recipient: owner,
-            asset: SOL_MINT,
+        let resolved = resolve_recipient(&rpc, owner).expect("resolve");
+        assert!(!resolved.is_public());
+        let result = PrivateTransfer {
+            source: &wallet,
+            destination: resolved,
+            asset: crate::SOL_MINT,
             amount: 1,
+            authority: &sender,
+            payer: Pubkey::default(),
             memo: None,
-        })
+        }
+        .instruction()
         .expect("transfer");
 
-        assert!(matches!(
-            result.recipient,
-            TransferRecipient::Registered(resolved) if resolved.owner == owner
-        ));
-        assert!(result.recipient.withdrawal().is_none());
+        assert_eq!(result.recipient, resolved);
+        assert_eq!(result.recipient.pubkey(), owner);
+        assert!(result.withdrawal.is_none());
     }
 
     #[test]
-    fn create_transfer_to_unregistered_recipient_builds_public_withdrawal() {
+    fn private_transfer_to_unregistered_recipient_settles_as_public_withdrawal() {
         let sender = ShieldedKeypair::new().unwrap();
         let wallet = wallet_with_sol(sender.clone(), 10);
         let recipient = Pubkey::new_unique();
         let rpc = MockRpc { account: None };
 
-        let result = create_transfer_sync(CreateTransfer {
-            rpc: &rpc,
-            wallet: &wallet,
-            authority: &sender,
-            owner_pubkey: Pubkey::default(),
-            payer: Address::default(),
-            recipient,
-            asset: SOL_MINT,
+        let resolved = resolve_recipient(&rpc, recipient).expect("resolve");
+        assert_eq!(resolved, TransferRecipient::Public(recipient));
+
+        let result = PrivateTransfer {
+            source: &wallet,
+            destination: resolved,
+            asset: crate::SOL_MINT,
             amount: 1,
+            authority: &sender,
+            payer: Pubkey::default(),
             memo: None,
-        })
+        }
+        .instruction()
         .expect("public withdrawal fallback");
 
-        assert!(matches!(
-            result.recipient,
-            TransferRecipient::PublicWithdrawal {
-                recipient: pubkey,
-                withdrawal: TransactWithdrawal::Sol(TransactSolWithdrawal { recipient }),
-            } if pubkey == recipient
-        ));
-    }
-
-    #[test]
-    fn create_transfer_to_unregistered_recipient_builds_spl_public_withdrawal() {
-        let sender = ShieldedKeypair::new().unwrap();
-        let mint = Pubkey::new_unique();
-        let asset = Address::new_from_array(mint.to_bytes());
-        let wallet = wallet_with_asset(sender.clone(), asset, 10);
-        let rpc = MockRpc { account: None };
-        let recipient = Pubkey::new_unique();
-        let token_account = pda::associated_token_address(&recipient, &mint);
-
-        let result = create_transfer_sync(CreateTransfer {
-            rpc: &rpc,
-            wallet: &wallet,
-            authority: &sender,
-            owner_pubkey: Pubkey::default(),
-            payer: Address::default(),
-            recipient,
-            asset,
-            amount: 1,
-            memo: None,
-        })
-        .expect("public withdrawal fallback");
-
+        assert!(result.recipient.is_public());
         assert_eq!(
-            result.recipient.withdrawal(),
-            Some(&TransactWithdrawal::Spl(TransactSplWithdrawal {
-                cpi_authority: Some(pda::shielded_pool_cpi_authority()),
-                spl_token_interface: pda::spl_asset_vault(&mint),
-                recipient,
-                user_token_account: token_account,
-                token_program: Pubkey::new_from_array(SPL_TOKEN_PROGRAM_ID),
-            }))
+            result.withdrawal,
+            Some(TransactWithdrawal::Sol(TransactSolWithdrawal { recipient }))
         );
     }
 
     #[test]
-    fn create_withdrawal_builds_spl_settlement_to_recipient_ata() {
+    fn withdrawal_builds_spl_settlement_to_recipient_ata() {
         let sender = ShieldedKeypair::new().unwrap();
         let mint = Pubkey::new_unique();
         let asset = Address::new_from_array(mint.to_bytes());
@@ -556,15 +547,15 @@ mod tests {
         let recipient = Pubkey::new_unique();
         let token_account = pda::associated_token_address(&recipient, &mint);
 
-        let result = create_withdrawal_sync(CreateWithdrawal {
-            wallet: &wallet,
-            authority: &sender,
-            owner_pubkey: Pubkey::default(),
-            payer: Address::default(),
-            recipient,
-            asset,
+        let result = Withdrawal {
+            source: &wallet,
+            destination: recipient,
+            asset: mint,
             amount: 1,
-        })
+            authority: &sender,
+            payer: Pubkey::default(),
+        }
+        .instruction()
         .expect("withdrawal");
 
         assert_eq!(

--- a/sdk-libs/client/src/actions/transaction.rs
+++ b/sdk-libs/client/src/actions/transaction.rs
@@ -77,7 +77,7 @@ pub struct CreateTransfer<'a, R: Rpc, A: ?Sized> {
     pub authority: &'a A,
     pub owner_pubkey: Pubkey,
     pub payer: Address,
-    pub recipient_owner: Pubkey,
+    pub recipient: Pubkey,
     pub asset: Address,
     pub amount: u64,
 }
@@ -95,14 +95,13 @@ pub struct CreateWithdrawal<'a, A: ?Sized> {
 pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
     request: CreateTransfer<'_, R, A>,
 ) -> Result<CreatedTransfer, ClientError> {
-    let Some(recipient) = try_resolve_registered_address(request.rpc, request.recipient_owner)?
-    else {
+    let Some(recipient) = try_resolve_registered_address(request.rpc, request.recipient)? else {
         let withdrawal = create_withdrawal(CreateWithdrawal {
             wallet: request.wallet,
             authority: request.authority,
             owner_pubkey: request.owner_pubkey,
             payer: request.payer,
-            recipient: request.recipient_owner,
+            recipient: request.recipient,
             asset: request.asset,
             amount: request.amount,
         })
@@ -111,7 +110,7 @@ pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
             signed: withdrawal.signed,
             wait_tag: withdrawal.wait_tag,
             recipient: TransferRecipient::PublicWithdrawal {
-                recipient: request.recipient_owner,
+                recipient: request.recipient,
                 withdrawal: withdrawal.withdrawal,
             },
         });
@@ -140,7 +139,7 @@ pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
         &request.wallet.registry,
         format!(
             "private transfer of {} to {}",
-            request.amount, request.recipient_owner
+            request.amount, request.recipient
         ),
     )
     .await?;
@@ -459,7 +458,7 @@ mod tests {
             authority: &sender,
             owner_pubkey: Pubkey::default(),
             payer: Address::default(),
-            recipient_owner: owner,
+            recipient: owner,
             asset: SOL_MINT,
             amount: 1,
         })
@@ -485,7 +484,7 @@ mod tests {
             authority: &sender,
             owner_pubkey: Pubkey::default(),
             payer: Address::default(),
-            recipient_owner: recipient,
+            recipient,
             asset: SOL_MINT,
             amount: 1,
         })
@@ -516,7 +515,7 @@ mod tests {
             authority: &sender,
             owner_pubkey: Pubkey::default(),
             payer: Address::default(),
-            recipient_owner: recipient,
+            recipient,
             asset,
             amount: 1,
         })

--- a/sdk-libs/client/src/actions/transaction.rs
+++ b/sdk-libs/client/src/actions/transaction.rs
@@ -80,6 +80,12 @@ pub struct CreateTransfer<'a, R: Rpc, A: ?Sized> {
     pub recipient: Pubkey,
     pub asset: Address,
     pub amount: u64,
+    /// Free-form note for the recipient, encrypted into their output
+    /// ciphertext and not committed into any hash. It lengthens that
+    /// ciphertext, so its presence and byte length are visible onchain; the
+    /// contents are not. Ignored when the transfer falls back to a public
+    /// withdrawal (public funds carry no ciphertext).
+    pub memo: Option<Vec<u8>>,
 }
 
 pub struct CreateWithdrawal<'a, A: ?Sized> {
@@ -129,7 +135,12 @@ pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
         .await?;
     let wait_tag = address.signing_pubkey.confidential_view_tag()?;
     let mut tx = Transaction::new(address, inputs, request.payer);
-    tx.send(&recipient.address, request.asset, request.amount)?;
+    tx.send_with_memo(
+        &recipient.address,
+        request.asset,
+        request.amount,
+        request.memo,
+    )?;
     let prepared = tx.prepare(&request.wallet.registry)?;
     let signed = sign_prepared(
         prepared,
@@ -461,6 +472,7 @@ mod tests {
             recipient: owner,
             asset: SOL_MINT,
             amount: 1,
+            memo: None,
         })
         .expect("transfer");
 
@@ -487,6 +499,7 @@ mod tests {
             recipient,
             asset: SOL_MINT,
             amount: 1,
+            memo: None,
         })
         .expect("public withdrawal fallback");
 
@@ -518,6 +531,7 @@ mod tests {
             recipient,
             asset,
             amount: 1,
+            memo: None,
         })
         .expect("public withdrawal fallback");
 

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -147,9 +147,10 @@ impl ZolanaClient {
     }
 
     /// A [`Submit`] wired to this client's connections and tree; only the fee
-    /// payer stays caller-owned. Call [`Submit::execute`] on the result, or
+    /// payer stays caller-owned. Call [`Submit::execute`] on the result with a
+    /// created transaction — `rpc.send(&payer).execute(&transfer)` — or
     /// override `cu_limit` first.
-    pub fn submit<'a>(&'a self, payer: &'a dyn Signer) -> Submit<'a, Self, Self> {
+    pub fn send<'a>(&'a self, payer: &'a dyn Signer) -> Submit<'a, Self, Self> {
         Submit {
             indexer: self,
             rpc: self,
@@ -316,7 +317,7 @@ mod tests {
     }
 
     #[test]
-    fn submit_carries_client_tree_and_default_cu_limit() {
+    fn send_carries_client_tree_and_default_cu_limit() {
         let tree = Pubkey::new_unique();
         let client = ZolanaClient::new(ZolanaClientConfig {
             rpc_url: "http://127.0.0.1:9899".to_string(),
@@ -326,7 +327,7 @@ mod tests {
             commitment: None,
         });
         let payer = solana_keypair::Keypair::new();
-        let submit = client.submit(&payer);
+        let submit = client.send(&payer);
         assert_eq!(submit.tree, tree);
         assert_eq!(submit.cu_limit, None);
         assert_eq!(

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -2,7 +2,7 @@
 //! wallet needs, plus the fee payer. Requires both the `indexer-api` and
 //! `solana-rpc` features.
 
-use solana_keypair::Keypair;
+use solana_signer::Signer;
 
 use crate::{
     indexer::{indexer_url, ZolanaIndexer, DEVNET_INDEXER_URL},
@@ -10,26 +10,27 @@ use crate::{
     solana_rpc::{rpc_url, SolanaRpc, HELIUS_DEVNET_RPC_URL},
 };
 
-/// Endpoints and fee payer for [`ZolanaClient`]. The payer is always supplied
-/// by the caller: the SDK never generates keypairs or loads them from disk
-/// (devnet has no faucet). To use an API key, embed it in the URL:
-/// `https://...?api-key=YOUR_KEY`.
+/// Endpoints and fee payer for [`ZolanaClient`]. The payer is any [`Signer`]:
+/// a local keypair on a server, or a wallet-backed signer in an app. It is
+/// always supplied by the caller: the SDK never generates keypairs or loads
+/// them from disk (devnet has no faucet). To use an API key, embed it in the
+/// URL: `https://...?api-key=YOUR_KEY`.
 pub struct ZolanaClientConfig {
     pub rpc_url: String,
     pub indexer_url: String,
     pub prover_url: String,
-    pub payer: Keypair,
+    pub payer: Box<dyn Signer + Send + Sync>,
 }
 
 impl ZolanaClientConfig {
     /// Local defaults, honoring the per-clone `ZOLANA_LOCALNET_URL` /
     /// `ZOLANA_INDEXER_URL` / `ZOLANA_PROVER_URL` overrides.
-    pub fn local(payer: Keypair) -> Self {
+    pub fn local(payer: impl Signer + Send + Sync + 'static) -> Self {
         Self {
             rpc_url: rpc_url(),
             indexer_url: indexer_url(),
             prover_url: server_address(),
-            payer,
+            payer: Box::new(payer),
         }
     }
 
@@ -37,12 +38,12 @@ impl ZolanaClientConfig {
     /// key. The key is embedded in the RPC URL and never read from env or
     /// stored elsewhere. No env overrides: those exist for local port
     /// contention only; set custom URLs on the struct fields instead.
-    pub fn devnet(payer: Keypair, api_key: &str) -> Self {
+    pub fn devnet(payer: impl Signer + Send + Sync + 'static, api_key: &str) -> Self {
         Self {
             rpc_url: format!("{HELIUS_DEVNET_RPC_URL}/?api-key={api_key}"),
             indexer_url: DEVNET_INDEXER_URL.to_string(),
             prover_url: DEVNET_SERVER_ADDRESS.to_string(),
-            payer,
+            payer: Box::new(payer),
         }
     }
 }
@@ -66,7 +67,7 @@ pub struct ZolanaClient {
     rpc: SolanaRpc,
     indexer: ZolanaIndexer,
     prover: ProverClient,
-    payer: Keypair,
+    payer: Box<dyn Signer + Send + Sync>,
 }
 
 impl ZolanaClient {
@@ -79,18 +80,23 @@ impl ZolanaClient {
         }
     }
 
-    pub fn local(payer: Keypair) -> Self {
+    pub fn local(payer: impl Signer + Send + Sync + 'static) -> Self {
         Self::new(ZolanaClientConfig::local(payer))
     }
 
-    pub fn devnet(payer: Keypair, api_key: &str) -> Self {
+    pub fn devnet(payer: impl Signer + Send + Sync + 'static, api_key: &str) -> Self {
         Self::new(ZolanaClientConfig::devnet(payer, api_key))
     }
 
     /// Borrow every connection and the payer at once, as disjoint fields, so
     /// a `&mut` RPC call can take the payer in the same expression.
-    pub fn parts(&mut self) -> (&mut SolanaRpc, &ZolanaIndexer, &ProverClient, &Keypair) {
-        (&mut self.rpc, &self.indexer, &self.prover, &self.payer)
+    pub fn parts(&mut self) -> (&mut SolanaRpc, &ZolanaIndexer, &ProverClient, &dyn Signer) {
+        (
+            &mut self.rpc,
+            &self.indexer,
+            &self.prover,
+            self.payer.as_ref(),
+        )
     }
 
     pub fn rpc(&self) -> &SolanaRpc {
@@ -110,14 +116,17 @@ impl ZolanaClient {
         &self.prover
     }
 
-    pub fn payer(&self) -> &Keypair {
-        &self.payer
+    pub fn payer(&self) -> &dyn Signer {
+        self.payer.as_ref()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use solana_signer::Signer;
+    use solana_keypair::Keypair;
+    use solana_pubkey::Pubkey;
+    use solana_signature::Signature;
+    use solana_signer::SignerError;
 
     use super::*;
 
@@ -164,11 +173,36 @@ mod tests {
             rpc_url: "http://127.0.0.1:9899".to_string(),
             indexer_url: "http://127.0.0.1:9784".to_string(),
             prover_url: "http://127.0.0.1:9001".to_string(),
-            payer,
+            payer: Box::new(payer),
         });
         assert_eq!(client.rpc().client().url(), "http://127.0.0.1:9899");
         assert_eq!(client.indexer().api().base_path(), "http://127.0.0.1:9784");
         assert_eq!(client.prover().server_address(), "http://127.0.0.1:9001");
         assert_eq!(client.payer().pubkey(), payer_pubkey);
+    }
+
+    /// A signer that is not a keypair — the shape a wallet adapter provides.
+    struct StubSigner(Pubkey);
+
+    impl Signer for StubSigner {
+        fn try_pubkey(&self) -> Result<Pubkey, SignerError> {
+            Ok(self.0)
+        }
+
+        fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
+            Ok(Signature::default())
+        }
+
+        fn is_interactive(&self) -> bool {
+            true
+        }
+    }
+
+    // Compiling is the point: the payer needs no secret key on hand.
+    #[test]
+    fn client_accepts_a_non_keypair_signer() {
+        let pubkey = Pubkey::new_unique();
+        let client = ZolanaClient::devnet(StubSigner(pubkey), "test-key");
+        assert_eq!(client.payer().pubkey(), pubkey);
     }
 }

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -1,14 +1,32 @@
 //! Combined client bundling the Solana RPC, indexer, and prover connections a
-//! wallet needs, plus the fee payer. Requires both the `indexer-api` and
-//! `solana-rpc` features.
+//! wallet needs. Requires both the `indexer-api` and `solana-rpc` features.
+//!
+//! The client is the *where* (connections and the state tree), not the *who*:
+//! the fee payer stays a caller-owned [`Signer`] passed to each action.
 
+use solana_account::Account;
+use solana_address::Address;
 use solana_commitment_config::CommitmentConfig;
+use solana_hash::Hash;
 use solana_pubkey::{pubkey, Pubkey};
+use solana_signature::Signature;
+use solana_transaction::Transaction;
+use zolana_transaction::instructions::{transact::SignedTransaction, types::InputCommitment};
+
 use solana_signer::Signer;
 
 use crate::{
+    actions::{
+        submit::{fetch_spend_proofs, prove_transact},
+        Submit,
+    },
+    error::ClientError,
     indexer::{indexer_url, ZolanaIndexer, DEVNET_INDEXER_URL},
-    prover::{server_address, ProverClient, DEVNET_SERVER_ADDRESS},
+    prover::{server_address, transact::witness::SpendProof, ProverClient, DEVNET_SERVER_ADDRESS},
+    rpc::{
+        GetEncryptedUtxosByTagsResponse, GetMerkleProofsResponse, GetNonInclusionProofsResponse,
+        GetShieldedTransactionsByTagsResponse, ProveResult, Rpc, ShieldedTransactionStream,
+    },
     solana_rpc::{rpc_url, SolanaRpc, HELIUS_DEVNET_RPC_URL},
 };
 
@@ -18,16 +36,12 @@ use crate::{
 /// to the deployed tree.
 pub const DEFAULT_TREE: Pubkey = pubkey!("treeYbr45LjxovKvtD46uEphM64kwoFFPYhVNw1A8x8");
 
-/// Endpoints and fee payer for [`ZolanaClient`]. The payer is any [`Signer`]:
-/// a local keypair on a server, or a wallet-backed signer in an app. It is
-/// always supplied by the caller: the SDK never generates keypairs or loads
-/// them from disk (devnet has no faucet). To use an API key, embed it in the
-/// URL: `https://...?api-key=YOUR_KEY`.
+/// Endpoints for [`ZolanaClient`]. To use an API key, embed it in the URL:
+/// `https://...?api-key=YOUR_KEY`.
 pub struct ZolanaClientConfig {
     pub rpc_url: String,
     pub indexer_url: String,
     pub prover_url: String,
-    pub payer: Box<dyn Signer + Send + Sync>,
     /// State tree private transactions write to; the presets fill
     /// [`DEFAULT_TREE`].
     pub tree: Pubkey,
@@ -38,12 +52,11 @@ pub struct ZolanaClientConfig {
 impl ZolanaClientConfig {
     /// Local defaults, honoring the per-clone `ZOLANA_LOCALNET_URL` /
     /// `ZOLANA_INDEXER_URL` / `ZOLANA_PROVER_URL` overrides.
-    pub fn local(payer: impl Signer + Send + Sync + 'static) -> Self {
+    pub fn local() -> Self {
         Self {
             rpc_url: rpc_url(),
             indexer_url: indexer_url(),
             prover_url: server_address(),
-            payer: Box::new(payer),
             tree: DEFAULT_TREE,
             commitment: None,
         }
@@ -53,38 +66,40 @@ impl ZolanaClientConfig {
     /// key. The key is embedded in the RPC URL and never read from env or
     /// stored elsewhere. No env overrides: those exist for local port
     /// contention only; set custom URLs on the struct fields instead.
-    pub fn devnet(payer: impl Signer + Send + Sync + 'static, api_key: &str) -> Self {
+    pub fn devnet(api_key: &str) -> Self {
         Self {
             rpc_url: format!("{HELIUS_DEVNET_RPC_URL}/?api-key={api_key}"),
             indexer_url: DEVNET_INDEXER_URL.to_string(),
             prover_url: DEVNET_SERVER_ADDRESS.to_string(),
-            payer: Box::new(payer),
             tree: DEFAULT_TREE,
             commitment: None,
         }
     }
 }
 
-/// One handle for every connection a wallet needs.
+/// One handle for every connection a wallet needs. The fee payer is not part
+/// of the client; every action takes it as an explicit [`Signer`] argument.
+///
+/// Implements [`Rpc`] end to end: account and transaction methods answer from
+/// the Solana RPC, the indexer queries answer from the indexer, and
+/// [`Rpc::prove`] runs the client-side proving pipeline against the prover
+/// server.
+///
+/// [`Signer`]: solana_signer::Signer
 ///
 /// # Examples
 ///
 /// ```no_run
-/// use solana_keypair::Keypair;
-/// use zolana_client::ZolanaClient;
+/// use zolana_client::{Rpc, ZolanaClient};
 ///
-/// let payer: Keypair = /* your funded keypair */
-/// # Keypair::new();
-/// let mut client = ZolanaClient::devnet(payer, "YOUR_API_KEY");
-/// let (rpc, indexer, prover, payer) = client.parts();
-/// rpc.assert_executable(&solana_pubkey::Pubkey::new_unique())?;
+/// let client = ZolanaClient::devnet("YOUR_API_KEY");
+/// client.rpc().assert_executable(&solana_pubkey::Pubkey::new_unique())?;
 /// # Ok::<(), zolana_client::ClientError>(())
 /// ```
 pub struct ZolanaClient {
     rpc: SolanaRpc,
     indexer: ZolanaIndexer,
     prover: ProverClient,
-    payer: Box<dyn Signer + Send + Sync>,
     tree: Pubkey,
 }
 
@@ -97,28 +112,16 @@ impl ZolanaClient {
             rpc: SolanaRpc::new_with_commitment(config.rpc_url, commitment),
             indexer: ZolanaIndexer::new(config.indexer_url),
             prover: ProverClient::new(config.prover_url),
-            payer: config.payer,
             tree: config.tree,
         }
     }
 
-    pub fn local(payer: impl Signer + Send + Sync + 'static) -> Self {
-        Self::new(ZolanaClientConfig::local(payer))
+    pub fn local() -> Self {
+        Self::new(ZolanaClientConfig::local())
     }
 
-    pub fn devnet(payer: impl Signer + Send + Sync + 'static, api_key: &str) -> Self {
-        Self::new(ZolanaClientConfig::devnet(payer, api_key))
-    }
-
-    /// Borrow every connection and the payer at once, as disjoint fields, so
-    /// a `&mut` RPC call can take the payer in the same expression.
-    pub fn parts(&mut self) -> (&mut SolanaRpc, &ZolanaIndexer, &ProverClient, &dyn Signer) {
-        (
-            &mut self.rpc,
-            &self.indexer,
-            &self.prover,
-            self.payer.as_ref(),
-        )
+    pub fn devnet(api_key: &str) -> Self {
+        Self::new(ZolanaClientConfig::devnet(api_key))
     }
 
     pub fn rpc(&self) -> &SolanaRpc {
@@ -138,23 +141,137 @@ impl ZolanaClient {
         &self.prover
     }
 
-    pub fn payer(&self) -> &dyn Signer {
-        self.payer.as_ref()
-    }
-
     /// State tree private transactions write to.
     pub fn tree(&self) -> Pubkey {
         self.tree
+    }
+
+    /// A [`Submit`] wired to this client's connections and tree; only the fee
+    /// payer stays caller-owned. Call [`Submit::execute`] on the result, or
+    /// override `cu_limit` first.
+    pub fn submit<'a>(&'a self, payer: &'a dyn Signer) -> Submit<'a, Self, Self> {
+        Submit {
+            indexer: self,
+            rpc: self,
+            prover: &self.prover,
+            payer,
+            tree: self.tree,
+            cu_limit: None,
+        }
+    }
+}
+
+impl Rpc for ZolanaClient {
+    // ===== Accounts and transactions (Solana RPC) =====
+
+    fn get_account(&self, address: Address) -> Result<Option<Account>, ClientError> {
+        self.rpc.get_account(address)
+    }
+
+    fn get_program_accounts(
+        &self,
+        program_id: Address,
+    ) -> Result<Vec<(Address, Account)>, ClientError> {
+        self.rpc.get_program_accounts(program_id)
+    }
+
+    fn get_minimum_balance_for_rent_exemption(&self, data_len: usize) -> Result<u64, ClientError> {
+        self.rpc.get_minimum_balance_for_rent_exemption(data_len)
+    }
+
+    fn get_latest_blockhash(&self) -> Result<(Hash, u64), ClientError> {
+        self.rpc.get_latest_blockhash()
+    }
+
+    fn send_transaction(&self, transaction: &Transaction) -> Result<Signature, ClientError> {
+        self.rpc.send_transaction(transaction)
+    }
+
+    // ===== Indexer (SPP) =====
+
+    fn get_encrypted_utxos_by_tags(
+        &self,
+        tags: Vec<[u8; 32]>,
+        cursor: Option<Vec<u8>>,
+        limit: Option<u32>,
+    ) -> Result<GetEncryptedUtxosByTagsResponse, ClientError> {
+        self.indexer
+            .get_encrypted_utxos_by_tags(tags, cursor, limit)
+    }
+
+    fn get_shielded_transactions_by_tags(
+        &self,
+        tags: Vec<[u8; 32]>,
+        cursor: Option<Vec<u8>>,
+        limit: Option<u32>,
+    ) -> Result<GetShieldedTransactionsByTagsResponse, ClientError> {
+        self.indexer
+            .get_shielded_transactions_by_tags(tags, cursor, limit)
+    }
+
+    fn subscribe_to_shielded_transactions_by_tags(
+        &self,
+        tags: Vec<[u8; 32]>,
+    ) -> Result<ShieldedTransactionStream, ClientError> {
+        self.indexer
+            .subscribe_to_shielded_transactions_by_tags(tags)
+    }
+
+    fn get_merkle_proofs(
+        &self,
+        tree_account: Address,
+        leaves: Vec<[u8; 32]>,
+    ) -> Result<GetMerkleProofsResponse, ClientError> {
+        self.indexer.get_merkle_proofs(tree_account, leaves)
+    }
+
+    fn get_non_inclusion_proofs(
+        &self,
+        tree_account: Address,
+        leaves: Vec<[u8; 32]>,
+    ) -> Result<GetNonInclusionProofsResponse, ClientError> {
+        self.indexer.get_non_inclusion_proofs(tree_account, leaves)
+    }
+
+    fn get_input_merkle_proofs(
+        &self,
+        input_utxo_commitments: &[InputCommitment],
+    ) -> Result<Vec<SpendProof>, ClientError> {
+        let tree = Address::new_from_array(self.tree.to_bytes());
+        fetch_spend_proofs(&self.indexer, tree, input_utxo_commitments)
+    }
+
+    // ===== Proving (client-side) =====
+
+    /// Prove a signed transaction client-side: fetch the input proofs from the
+    /// indexer, assemble the witness, and prove on the matching rail via the
+    /// prover server.
+    fn prove(&self, transaction: SignedTransaction) -> Result<ProveResult, ClientError> {
+        let commitments = transaction.input_commitments()?;
+        let spend_proofs = self.get_input_merkle_proofs(&commitments)?;
+        let proven = prove_transact(&self.prover, transaction, &spend_proofs)?;
+        Ok(ProveResult {
+            proof: proven.proof,
+            public_inputs: vec![proven.public_input_hash],
+            circuit_id: proven.circuit_id,
+        })
+    }
+
+    /// Not available client-side: sending needs a fee-payer signature and the
+    /// client holds no signer. Call [`Rpc::prove`], build the `Transact`
+    /// instruction, and send it with the caller's payer — or use
+    /// [`crate::Submit`].
+    fn send_and_prove(&self, _transaction: SignedTransaction) -> Result<Signature, ClientError> {
+        Err(ClientError::Rpc(
+            "send_and_prove needs a fee payer and the client holds no signer; \
+             use prove() and send the Transact instruction with your own payer, or use Submit"
+                .to_string(),
+        ))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use solana_keypair::Keypair;
-    use solana_pubkey::Pubkey;
-    use solana_signature::Signature;
-    use solana_signer::SignerError;
-
     use super::*;
 
     // The env-reading `local()` path is deliberately untested: env is
@@ -164,7 +281,7 @@ mod tests {
 
     #[test]
     fn devnet_config_uses_devnet_endpoints() {
-        let config = ZolanaClientConfig::devnet(Keypair::new(), "test-key");
+        let config = ZolanaClientConfig::devnet("test-key");
         assert_eq!(config.rpc_url, KEYED_DEVNET_RPC_URL);
         assert_eq!(config.indexer_url, DEVNET_INDEXER_URL);
         assert_eq!(config.prover_url, DEVNET_SERVER_ADDRESS);
@@ -172,43 +289,25 @@ mod tests {
 
     #[test]
     fn devnet_preset_wires_devnet_endpoints() {
-        let client = ZolanaClient::devnet(Keypair::new(), "test-key");
+        let client = ZolanaClient::devnet("test-key");
         assert_eq!(client.rpc().client().url(), KEYED_DEVNET_RPC_URL);
         assert_eq!(client.indexer().api().base_path(), DEVNET_INDEXER_URL);
         assert_eq!(client.prover().server_address(), DEVNET_SERVER_ADDRESS);
     }
 
-    // Compiling is the point: `&mut rpc` and `&payer` from one call must not
-    // conflict, which the single accessors (rpc_mut + payer) cannot express.
     #[test]
-    fn parts_returns_disjoint_borrows() {
-        let payer = Keypair::new();
-        let payer_pubkey = payer.pubkey();
-        let mut client = ZolanaClient::devnet(payer, "test-key");
-        let (rpc, indexer, prover, payer) = client.parts();
-        assert_eq!(payer.pubkey(), payer_pubkey);
-        assert_eq!(rpc.client().url(), KEYED_DEVNET_RPC_URL);
-        assert_eq!(indexer.api().base_path(), DEVNET_INDEXER_URL);
-        assert_eq!(prover.server_address(), DEVNET_SERVER_ADDRESS);
-    }
-
-    #[test]
-    fn new_wires_all_connections_and_payer() {
-        let payer = Keypair::new();
-        let payer_pubkey = payer.pubkey();
+    fn new_wires_all_connections() {
         let tree = Pubkey::new_unique();
         let client = ZolanaClient::new(ZolanaClientConfig {
             rpc_url: "http://127.0.0.1:9899".to_string(),
             indexer_url: "http://127.0.0.1:9784".to_string(),
             prover_url: "http://127.0.0.1:9001".to_string(),
-            payer: Box::new(payer),
             tree,
             commitment: Some(CommitmentConfig::processed()),
         });
         assert_eq!(client.rpc().client().url(), "http://127.0.0.1:9899");
         assert_eq!(client.indexer().api().base_path(), "http://127.0.0.1:9784");
         assert_eq!(client.prover().server_address(), "http://127.0.0.1:9001");
-        assert_eq!(client.payer().pubkey(), payer_pubkey);
         assert_eq!(client.tree(), tree);
         assert_eq!(
             client.rpc().client().commitment(),
@@ -217,37 +316,32 @@ mod tests {
     }
 
     #[test]
+    fn submit_carries_client_tree_and_default_cu_limit() {
+        let tree = Pubkey::new_unique();
+        let client = ZolanaClient::new(ZolanaClientConfig {
+            rpc_url: "http://127.0.0.1:9899".to_string(),
+            indexer_url: "http://127.0.0.1:9784".to_string(),
+            prover_url: "http://127.0.0.1:9001".to_string(),
+            tree,
+            commitment: None,
+        });
+        let payer = solana_keypair::Keypair::new();
+        let submit = client.submit(&payer);
+        assert_eq!(submit.tree, tree);
+        assert_eq!(submit.cu_limit, None);
+        assert_eq!(
+            submit.prover.server_address(),
+            client.prover().server_address()
+        );
+    }
+
+    #[test]
     fn presets_fill_default_tree_and_confirmed_commitment() {
-        let client = ZolanaClient::devnet(Keypair::new(), "test-key");
+        let client = ZolanaClient::devnet("test-key");
         assert_eq!(client.tree(), DEFAULT_TREE);
         assert_eq!(
             client.rpc().client().commitment(),
             CommitmentConfig::confirmed()
         );
-    }
-
-    /// A signer that is not a keypair — the shape a wallet adapter provides.
-    struct StubSigner(Pubkey);
-
-    impl Signer for StubSigner {
-        fn try_pubkey(&self) -> Result<Pubkey, SignerError> {
-            Ok(self.0)
-        }
-
-        fn try_sign_message(&self, _message: &[u8]) -> Result<Signature, SignerError> {
-            Ok(Signature::default())
-        }
-
-        fn is_interactive(&self) -> bool {
-            true
-        }
-    }
-
-    // Compiling is the point: the payer needs no secret key on hand.
-    #[test]
-    fn client_accepts_a_non_keypair_signer() {
-        let pubkey = Pubkey::new_unique();
-        let client = ZolanaClient::devnet(StubSigner(pubkey), "test-key");
-        assert_eq!(client.payer().pubkey(), pubkey);
     }
 }

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -2,6 +2,8 @@
 //! wallet needs, plus the fee payer. Requires both the `indexer-api` and
 //! `solana-rpc` features.
 
+use solana_commitment_config::CommitmentConfig;
+use solana_pubkey::{pubkey, Pubkey};
 use solana_signer::Signer;
 
 use crate::{
@@ -9,6 +11,12 @@ use crate::{
     prover::{server_address, ProverClient, DEVNET_SERVER_ADDRESS},
     solana_rpc::{rpc_url, SolanaRpc, HELIUS_DEVNET_RPC_URL},
 };
+
+/// The protocol's state-tree account. One fixed address, created from the same
+/// keypair on localnet and devnet, so the presets fill it in. Verified for
+/// localnet and devnet only; on other networks set [`ZolanaClientConfig::tree`]
+/// to the deployed tree.
+pub const DEFAULT_TREE: Pubkey = pubkey!("treeYbr45LjxovKvtD46uEphM64kwoFFPYhVNw1A8x8");
 
 /// Endpoints and fee payer for [`ZolanaClient`]. The payer is any [`Signer`]:
 /// a local keypair on a server, or a wallet-backed signer in an app. It is
@@ -20,6 +28,11 @@ pub struct ZolanaClientConfig {
     pub indexer_url: String,
     pub prover_url: String,
     pub payer: Box<dyn Signer + Send + Sync>,
+    /// State tree private transactions write to; the presets fill
+    /// [`DEFAULT_TREE`].
+    pub tree: Pubkey,
+    /// Commitment level for every read and send; `None` means `confirmed`.
+    pub commitment: Option<CommitmentConfig>,
 }
 
 impl ZolanaClientConfig {
@@ -31,6 +44,8 @@ impl ZolanaClientConfig {
             indexer_url: indexer_url(),
             prover_url: server_address(),
             payer: Box::new(payer),
+            tree: DEFAULT_TREE,
+            commitment: None,
         }
     }
 
@@ -44,6 +59,8 @@ impl ZolanaClientConfig {
             indexer_url: DEVNET_INDEXER_URL.to_string(),
             prover_url: DEVNET_SERVER_ADDRESS.to_string(),
             payer: Box::new(payer),
+            tree: DEFAULT_TREE,
+            commitment: None,
         }
     }
 }
@@ -68,15 +85,20 @@ pub struct ZolanaClient {
     indexer: ZolanaIndexer,
     prover: ProverClient,
     payer: Box<dyn Signer + Send + Sync>,
+    tree: Pubkey,
 }
 
 impl ZolanaClient {
     pub fn new(config: ZolanaClientConfig) -> Self {
+        let commitment = config
+            .commitment
+            .unwrap_or_else(CommitmentConfig::confirmed);
         Self {
-            rpc: SolanaRpc::new(config.rpc_url),
+            rpc: SolanaRpc::new_with_commitment(config.rpc_url, commitment),
             indexer: ZolanaIndexer::new(config.indexer_url),
             prover: ProverClient::new(config.prover_url),
             payer: config.payer,
+            tree: config.tree,
         }
     }
 
@@ -118,6 +140,11 @@ impl ZolanaClient {
 
     pub fn payer(&self) -> &dyn Signer {
         self.payer.as_ref()
+    }
+
+    /// State tree private transactions write to.
+    pub fn tree(&self) -> Pubkey {
+        self.tree
     }
 }
 
@@ -169,16 +196,34 @@ mod tests {
     fn new_wires_all_connections_and_payer() {
         let payer = Keypair::new();
         let payer_pubkey = payer.pubkey();
+        let tree = Pubkey::new_unique();
         let client = ZolanaClient::new(ZolanaClientConfig {
             rpc_url: "http://127.0.0.1:9899".to_string(),
             indexer_url: "http://127.0.0.1:9784".to_string(),
             prover_url: "http://127.0.0.1:9001".to_string(),
             payer: Box::new(payer),
+            tree,
+            commitment: Some(CommitmentConfig::processed()),
         });
         assert_eq!(client.rpc().client().url(), "http://127.0.0.1:9899");
         assert_eq!(client.indexer().api().base_path(), "http://127.0.0.1:9784");
         assert_eq!(client.prover().server_address(), "http://127.0.0.1:9001");
         assert_eq!(client.payer().pubkey(), payer_pubkey);
+        assert_eq!(client.tree(), tree);
+        assert_eq!(
+            client.rpc().client().commitment(),
+            CommitmentConfig::processed()
+        );
+    }
+
+    #[test]
+    fn presets_fill_default_tree_and_confirmed_commitment() {
+        let client = ZolanaClient::devnet(Keypair::new(), "test-key");
+        assert_eq!(client.tree(), DEFAULT_TREE);
+        assert_eq!(
+            client.rpc().client().commitment(),
+            CommitmentConfig::confirmed()
+        );
     }
 
     /// A signer that is not a keypair — the shape a wallet adapter provides.

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -1,4 +1,5 @@
 use solana_pubkey::Pubkey;
+use solana_signature::Signature;
 use thiserror::Error;
 use zolana_keypair::KeypairError;
 use zolana_transaction::TransactionError;
@@ -99,6 +100,15 @@ pub enum ClientError {
 
     #[error("deposit funding account not found: {address:?}")]
     AccountNotFound { address: [u8; 32] },
+
+    #[error("deposit {signature} confirmed but its UTXO {utxo_hash:?} was not indexed after 120s")]
+    DepositNotIndexed {
+        utxo_hash: [u8; 32],
+        signature: Signature,
+    },
+
+    #[error("asset registry entry not found for mint {mint}; the mint has no SPL interface on this deployment")]
+    AssetNotRegistered { mint: Pubkey },
 
     #[error("SOL deposit funding account {sender:?} must be the signing authority")]
     DepositSenderNotSigner { sender: [u8; 32] },

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -57,8 +57,8 @@ pub use wallet_authority::{
     P256Signature, SyncWalletAuthority, WalletAuthority,
 };
 pub use wallet_sync::{
-    get_private_token_balances, get_private_transactions, sync_wallet, sync_wallet_with_config,
-    SyncWalletConfig,
+    get_private_token_balances, get_private_transactions, refresh_registry_from_chain, sync_wallet,
+    sync_wallet_with_config, SyncWalletConfig,
 };
 pub use zolana_transaction::{
     instructions::{

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -15,9 +15,9 @@ pub mod wallet_sync;
 
 pub use actions::{
     create_associated_token_account, create_deposit, create_transfer, create_transfer_sync,
-    create_withdrawal, create_withdrawal_sync, sign_transaction, sign_transaction_sync,
-    CreateDeposit, CreateTransfer, CreateWithdrawal, CreatedTransfer, CreatedWithdrawal, Deposit,
-    ResolvedAddress, TransferRecipient,
+    create_withdrawal, create_withdrawal_sync, fetch_asset_id, register_spl_interface,
+    sign_transaction, sign_transaction_sync, CreateDeposit, CreateTransfer, CreateWithdrawal,
+    CreatedTransfer, CreatedWithdrawal, Deposit, ResolvedAddress, TransferRecipient,
 };
 #[cfg(feature = "indexer-api")]
 pub use actions::{Submit, DEFAULT_TRANSACT_CU_LIMIT};

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -16,12 +16,12 @@ pub mod wallet_sync;
 pub use actions::{
     create_associated_token_account, create_deposit, create_transfer, create_transfer_sync,
     create_withdrawal, create_withdrawal_sync, fetch_asset_id, register_spl_interface,
-    sign_transaction, sign_transaction_sync, CreateDeposit, CreateTransfer, CreateWithdrawal,
-    CreatedTransfer, CreatedWithdrawal, Deposit, ResolvedAddress, TransferRecipient,
+    sign_transaction, sign_transaction_sync, CreatedDeposit, CreatedTransfer, CreatedWithdrawal,
+    Deposit, PrivateTransfer, ResolvedAddress, TransferRecipient, Withdrawal,
     DEFAULT_DEPOSIT_CU_LIMIT,
 };
 #[cfg(feature = "indexer-api")]
-pub use actions::{Submit, DEFAULT_TRANSACT_CU_LIMIT};
+pub use actions::{Sendable, Submit, DEFAULT_TRANSACT_CU_LIMIT};
 #[cfg(all(feature = "indexer-api", feature = "solana-rpc"))]
 pub use client::{ZolanaClient, ZolanaClientConfig, DEFAULT_TREE};
 pub use error::ClientError;
@@ -50,17 +50,24 @@ pub use rpc::{
 pub use solana_rpc::{ConfirmedInstructionGroups, SolanaRpc};
 pub use user_registry::{
     create_private_wallet, decode_user_record_account, ensure_registered,
-    fetch_user_record_checked, fetch_user_record_optional_checked, resolve_registered_address,
-    resolved_address_from_record, try_resolve_registered_address, validate_registered_keypair,
+    fetch_user_record_checked, fetch_user_record_optional_checked, resolve_recipient,
+    resolve_registered_address, resolved_address_from_record, try_resolve_recipient,
+    try_resolve_registered_address, validate_registered_keypair,
 };
 pub use wallet_authority::{
     AnonymousRecipientSlot, ApprovalRequest, ConfidentialRecipientSlot, EncryptedTransfer,
-    P256Signature, SyncWalletAuthority, WalletAuthority,
+    MultiWalletAuthority, P256Signature, Scoped, SyncWalletAuthority, WalletAuthority,
 };
 pub use wallet_sync::{
     get_private_token_balances, get_private_transactions, refresh_registry_from_chain, sync_wallet,
     sync_wallet_with_config, SyncWalletConfig,
 };
+/// The SOL sentinel mint (all zeros), typed as the [`Pubkey`] the action
+/// structs take for their `asset` field.
+///
+/// [`Pubkey`]: solana_pubkey::Pubkey
+pub const SOL_MINT: solana_pubkey::Pubkey = solana_pubkey::Pubkey::new_from_array([0u8; 32]);
+
 pub use zolana_transaction::{
     instructions::{
         merge::{Merge, PreparedMerge, MERGE_INPUTS},

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -18,6 +18,7 @@ pub use actions::{
     create_withdrawal, create_withdrawal_sync, fetch_asset_id, register_spl_interface,
     sign_transaction, sign_transaction_sync, CreateDeposit, CreateTransfer, CreateWithdrawal,
     CreatedTransfer, CreatedWithdrawal, Deposit, ResolvedAddress, TransferRecipient,
+    DEFAULT_DEPOSIT_CU_LIMIT,
 };
 #[cfg(feature = "indexer-api")]
 pub use actions::{Submit, DEFAULT_TRANSACT_CU_LIMIT};

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -23,7 +23,7 @@ pub use actions::{
 #[cfg(feature = "indexer-api")]
 pub use actions::{Submit, DEFAULT_TRANSACT_CU_LIMIT};
 #[cfg(all(feature = "indexer-api", feature = "solana-rpc"))]
-pub use client::{ZolanaClient, ZolanaClientConfig};
+pub use client::{ZolanaClient, ZolanaClientConfig, DEFAULT_TREE};
 pub use error::ClientError;
 #[cfg(feature = "indexer-api")]
 pub use indexer::ZolanaIndexer;

--- a/sdk-libs/client/src/rpc.rs
+++ b/sdk-libs/client/src/rpc.rs
@@ -6,11 +6,11 @@ use solana_address::Address;
 use solana_clock::Slot;
 use solana_hash::Hash;
 use solana_instruction::Instruction;
-use solana_keypair::Keypair;
 use solana_message::{AddressLookupTableAccount, Message};
 use solana_pubkey::Pubkey;
 use solana_rpc_client_api::config::RpcSendTransactionConfig;
 use solana_signature::Signature;
+use solana_signer::Signer;
 use solana_transaction::{versioned::VersionedTransaction, Transaction};
 use solana_transaction_status_client_types::TransactionStatus;
 use zolana_keypair::P256Pubkey;
@@ -223,7 +223,7 @@ pub trait Rpc {
         &self,
         instructions: &[Instruction],
         payer: Address,
-        signers: &[&Keypair],
+        signers: &[&dyn Signer],
     ) -> Result<Signature, ClientError> {
         let (blockhash, _) = self.get_latest_blockhash()?;
         let payer = Pubkey::new_from_array(payer.to_bytes());
@@ -236,7 +236,7 @@ pub trait Rpc {
         &self,
         instructions: &[Instruction],
         payer: Address,
-        signers: &[&Keypair],
+        signers: &[&dyn Signer],
         address_lookup_tables: &[AddressLookupTableAccount],
     ) -> Result<Signature, ClientError> {
         Err(unsupported("create_and_send_versioned_transaction"))

--- a/sdk-libs/client/src/solana_rpc.rs
+++ b/sdk-libs/client/src/solana_rpc.rs
@@ -53,11 +53,15 @@ pub struct ConfirmedInstructionGroups {
 }
 
 impl SolanaRpc {
+    /// Connect with the `confirmed` commitment level.
     pub fn new(url: impl Into<String>) -> Self {
-        Self::with_client(RpcClient::new_with_commitment(
-            url.into(),
-            CommitmentConfig::confirmed(),
-        ))
+        Self::new_with_commitment(url, CommitmentConfig::confirmed())
+    }
+
+    /// Connect with a caller-chosen commitment level. Every read and send on
+    /// this client uses it.
+    pub fn new_with_commitment(url: impl Into<String>, commitment: CommitmentConfig) -> Self {
+        Self::with_client(RpcClient::new_with_commitment(url.into(), commitment))
     }
 
     pub fn local() -> Self {
@@ -195,7 +199,7 @@ impl SolanaRpc {
         loop {
             let config = RpcTransactionConfig {
                 encoding: Some(UiTransactionEncoding::Json),
-                commitment: Some(CommitmentConfig::confirmed()),
+                commitment: Some(self.client.commitment()),
                 max_supported_transaction_version: Some(0),
             };
             match self.client.get_transaction_with_config(signature, config) {
@@ -315,7 +319,7 @@ impl Rpc for SolanaRpc {
     fn get_account(&self, address: Address) -> Result<Option<Account>, ClientError> {
         let pubkey = pubkey_from_address(&address);
         self.client
-            .get_account_with_commitment(&pubkey, CommitmentConfig::confirmed())
+            .get_account_with_commitment(&pubkey, self.client.commitment())
             .map(|response| response.value)
             .map_err(|err| ClientError::Rpc(format!("get_account {pubkey}: {err}")))
     }

--- a/sdk-libs/client/src/user_registry.rs
+++ b/sdk-libs/client/src/user_registry.rs
@@ -1,5 +1,4 @@
 use solana_address::Address;
-use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
@@ -42,7 +41,7 @@ fn register_fields(keypair: &ShieldedKeypair) -> Result<RegisterData, ClientErro
 /// publish or update it.
 pub fn ensure_registered<R: Rpc>(
     rpc: &R,
-    funding: &Keypair,
+    funding: &dyn Signer,
     keypair: &ShieldedKeypair,
 ) -> Result<Option<Signature>, ClientError> {
     let owner = funding.pubkey();
@@ -95,7 +94,7 @@ pub fn ensure_registered<R: Rpc>(
 /// never reads raw Solana secrets.
 pub fn create_private_wallet<R: Rpc>(
     rpc: &R,
-    owner: &Keypair,
+    owner: &dyn Signer,
     keypair: ShieldedKeypair,
     registry: AssetRegistry,
 ) -> Result<Wallet, ClientError> {
@@ -233,6 +232,7 @@ pub fn resolved_address_from_record(
 mod tests {
     use borsh::to_vec;
     use solana_account::Account;
+    use solana_keypair::Keypair;
     use solana_signer::Signer;
     use zolana_keypair::{ShieldedKeypair, ViewingKey};
     use zolana_user_registry_interface::{user_registry_program_id, SyncDelegateEntry};

--- a/sdk-libs/client/src/user_registry.rs
+++ b/sdk-libs/client/src/user_registry.rs
@@ -11,6 +11,32 @@ use zolana_user_registry_interface::{
 
 use crate::{actions::ResolvedAddress, error::ClientError, rpc::Rpc};
 
+/// Where a transfer to a Solana pubkey lands, decided by one chain read in
+/// [`resolve_recipient`]: privately, to a registered private wallet, or
+/// publicly, as a withdrawal to the pubkey's public account.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TransferRecipient {
+    /// The recipient has a registered private wallet; the transfer stays
+    /// private end to end.
+    Private(ResolvedAddress),
+    /// The recipient has no private wallet; the transfer degrades to a
+    /// private-to-public withdrawal.
+    Public(Pubkey),
+}
+
+impl TransferRecipient {
+    pub fn pubkey(&self) -> Pubkey {
+        match self {
+            Self::Private(resolved) => resolved.owner,
+            Self::Public(pubkey) => *pubkey,
+        }
+    }
+
+    pub fn is_public(&self) -> bool {
+        matches!(self, Self::Public(_))
+    }
+}
+
 /// Derive the on-chain registry record fields from a shielded keypair: the
 /// P256 owner key (only for P256-owned wallets), nullifier pubkey, and viewing
 /// pubkey. Returns the exact `RegisterData` the register/update instructions take.
@@ -194,6 +220,35 @@ pub fn resolve_registered_address<R: Rpc>(
         .map_err(|err| ClientError::AddressResolution(err.to_string()))?;
     resolved_address_from_record(owner, &record)
         .map_err(|err| ClientError::AddressResolution(err.to_string()))
+}
+
+/// Resolve where a transfer to `recipient` lands: one chain read of the
+/// user-record PDA. This is the network step before building a
+/// `PrivateTransfer`; the builder itself does no RPC.
+///
+/// Returns [`TransferRecipient::Private`] when the recipient has a registered
+/// private wallet and [`TransferRecipient::Public`] when it does not (the
+/// transfer then settles as a public withdrawal); errors only when the read
+/// or record decode fails. Callers that must not degrade to a public
+/// withdrawal use [`try_resolve_recipient`] and branch themselves.
+pub fn resolve_recipient<R: Rpc>(
+    rpc: &R,
+    recipient: Pubkey,
+) -> Result<TransferRecipient, ClientError> {
+    Ok(match try_resolve_registered_address(rpc, recipient)? {
+        Some(resolved) => TransferRecipient::Private(resolved),
+        None => TransferRecipient::Public(recipient),
+    })
+}
+
+/// Like [`resolve_recipient`], but returns `Ok(None)` for an unregistered
+/// recipient instead of a `Public` fallback, so the caller decides whether
+/// the transfer may degrade to a public withdrawal.
+pub fn try_resolve_recipient<R: Rpc>(
+    rpc: &R,
+    recipient: Pubkey,
+) -> Result<Option<ResolvedAddress>, ClientError> {
+    try_resolve_registered_address(rpc, recipient)
 }
 
 pub fn try_resolve_registered_address<R: Rpc>(

--- a/sdk-libs/client/src/user_registry.rs
+++ b/sdk-libs/client/src/user_registry.rs
@@ -382,9 +382,8 @@ mod tests {
     #[test]
     fn validate_registered_keypair_accepts_ed25519_owner_records() {
         let owner_keypair = solana_keypair::Keypair::new();
-        let seed: [u8; 32] = *owner_keypair.secret_bytes();
-        let keypair =
-            ShieldedKeypair::from_ed25519(&seed, ViewingKey::new()).expect("ed25519 keypair");
+        let keypair = ShieldedKeypair::from_ed25519(&owner_keypair, ViewingKey::new())
+            .expect("ed25519 keypair");
         let owner = owner_keypair.pubkey();
         let (pda, bump) = user_record_pda(&owner);
         let record = UserRecord {

--- a/sdk-libs/client/src/wallet_authority.rs
+++ b/sdk-libs/client/src/wallet_authority.rs
@@ -31,9 +31,10 @@ pub struct P256Signature {
     pub sig_s: [u8; 32],
 }
 
+/// A human-readable description of the transaction an authority is about to
+/// sign, for hosts that surface an approval step to the user.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ApprovalRequest {
-    pub owner_pubkey: Pubkey,
     pub summary: String,
 }
 
@@ -67,13 +68,18 @@ pub struct EncryptedTransfer {
 
 /// Authority for production wallet hosts where approval, key access, or signing
 /// may cross a process, device, or remote custody boundary.
+///
+/// The trait is scoped to one wallet: no method names an owner. A local
+/// [`ShieldedKeypair`] is inherently scoped. A host managing many users'
+/// wallets keyed by owner pubkey implements [`MultiWalletAuthority`] once and
+/// scopes it per user with [`Scoped::new`], next to where it syncs that user's
+/// wallet.
 #[async_trait(?Send)]
 pub trait WalletAuthority {
-    async fn shielded_address(&self, owner_pubkey: Pubkey) -> Result<ShieldedAddress, ClientError>;
+    async fn shielded_address(&self) -> Result<ShieldedAddress, ClientError>;
 
     async fn encrypt_confidential_transfer(
         &self,
-        owner_pubkey: Pubkey,
         first_nullifier: &[u8; 32],
         sender_tag: ViewTag,
         sender: &TransferSenderPlaintext,
@@ -82,7 +88,6 @@ pub trait WalletAuthority {
 
     async fn encrypt_anonymous_transfer(
         &self,
-        owner_pubkey: Pubkey,
         first_nullifier: &[u8; 32],
         sender_view_tag: ViewTag,
         sender: &AnonymousTransferSenderPlaintext,
@@ -93,22 +98,18 @@ pub trait WalletAuthority {
         Ok(())
     }
 
-    async fn sign_p256(
-        &self,
-        owner_pubkey: Pubkey,
-        message_hash: &[u8; 32],
-    ) -> Result<P256Signature, ClientError>;
+    async fn sign_p256(&self, message_hash: &[u8; 32]) -> Result<P256Signature, ClientError>;
 
-    async fn spend_nullifier_key(&self, owner_pubkey: Pubkey) -> Result<NullifierKey, ClientError>;
+    async fn spend_nullifier_key(&self) -> Result<NullifierKey, ClientError>;
 }
 
 /// Blocking authority for tests, CLI flows, and local direct-key wallets.
+/// Like [`WalletAuthority`], it is scoped to one wallet.
 pub trait SyncWalletAuthority {
-    fn shielded_address(&self, owner_pubkey: Pubkey) -> Result<ShieldedAddress, ClientError>;
+    fn shielded_address(&self) -> Result<ShieldedAddress, ClientError>;
 
     fn encrypt_confidential_transfer(
         &self,
-        owner_pubkey: Pubkey,
         first_nullifier: &[u8; 32],
         sender_tag: ViewTag,
         sender: &TransferSenderPlaintext,
@@ -117,7 +118,6 @@ pub trait SyncWalletAuthority {
 
     fn encrypt_anonymous_transfer(
         &self,
-        owner_pubkey: Pubkey,
         first_nullifier: &[u8; 32],
         sender_view_tag: ViewTag,
         sender: &AnonymousTransferSenderPlaintext,
@@ -128,13 +128,9 @@ pub trait SyncWalletAuthority {
         Ok(())
     }
 
-    fn sign_p256(
-        &self,
-        owner_pubkey: Pubkey,
-        message_hash: &[u8; 32],
-    ) -> Result<P256Signature, ClientError>;
+    fn sign_p256(&self, message_hash: &[u8; 32]) -> Result<P256Signature, ClientError>;
 
-    fn spend_nullifier_key(&self, owner_pubkey: Pubkey) -> Result<NullifierKey, ClientError>;
+    fn spend_nullifier_key(&self) -> Result<NullifierKey, ClientError>;
 }
 
 #[async_trait(?Send)]
@@ -142,13 +138,12 @@ impl<T> WalletAuthority for T
 where
     T: SyncWalletAuthority + ?Sized,
 {
-    async fn shielded_address(&self, owner_pubkey: Pubkey) -> Result<ShieldedAddress, ClientError> {
-        SyncWalletAuthority::shielded_address(self, owner_pubkey)
+    async fn shielded_address(&self) -> Result<ShieldedAddress, ClientError> {
+        SyncWalletAuthority::shielded_address(self)
     }
 
     async fn encrypt_confidential_transfer(
         &self,
-        owner_pubkey: Pubkey,
         first_nullifier: &[u8; 32],
         sender_tag: ViewTag,
         sender: &TransferSenderPlaintext,
@@ -156,7 +151,6 @@ where
     ) -> Result<EncryptedTransfer, ClientError> {
         SyncWalletAuthority::encrypt_confidential_transfer(
             self,
-            owner_pubkey,
             first_nullifier,
             sender_tag,
             sender,
@@ -166,7 +160,6 @@ where
 
     async fn encrypt_anonymous_transfer(
         &self,
-        owner_pubkey: Pubkey,
         first_nullifier: &[u8; 32],
         sender_view_tag: ViewTag,
         sender: &AnonymousTransferSenderPlaintext,
@@ -174,7 +167,6 @@ where
     ) -> Result<EncryptedTransfer, ClientError> {
         SyncWalletAuthority::encrypt_anonymous_transfer(
             self,
-            owner_pubkey,
             first_nullifier,
             sender_view_tag,
             sender,
@@ -186,16 +178,160 @@ where
         SyncWalletAuthority::request_user_approval(self, request)
     }
 
-    async fn sign_p256(
-        &self,
-        owner_pubkey: Pubkey,
-        message_hash: &[u8; 32],
-    ) -> Result<P256Signature, ClientError> {
-        SyncWalletAuthority::sign_p256(self, owner_pubkey, message_hash)
+    async fn sign_p256(&self, message_hash: &[u8; 32]) -> Result<P256Signature, ClientError> {
+        SyncWalletAuthority::sign_p256(self, message_hash)
     }
 
-    async fn spend_nullifier_key(&self, owner_pubkey: Pubkey) -> Result<NullifierKey, ClientError> {
-        SyncWalletAuthority::spend_nullifier_key(self, owner_pubkey)
+    async fn spend_nullifier_key(&self) -> Result<NullifierKey, ClientError> {
+        SyncWalletAuthority::spend_nullifier_key(self)
+    }
+}
+
+/// Authority for custody hosts that manage many users' wallets keyed by the
+/// owner's Solana pubkey — embedded-wallet backends, enclaves, remote signers.
+///
+/// Every method takes the owner explicitly. The action builders do not accept
+/// this trait directly: scope it to one user with [`Scoped::new`] and pass the
+/// result as the action's `authority`.
+#[async_trait(?Send)]
+pub trait MultiWalletAuthority {
+    async fn shielded_address(&self, owner: Pubkey) -> Result<ShieldedAddress, ClientError>;
+
+    async fn encrypt_confidential_transfer(
+        &self,
+        owner: Pubkey,
+        first_nullifier: &[u8; 32],
+        sender_tag: ViewTag,
+        sender: &TransferSenderPlaintext,
+        recipients: &[ConfidentialRecipientSlot],
+    ) -> Result<EncryptedTransfer, ClientError>;
+
+    async fn encrypt_anonymous_transfer(
+        &self,
+        owner: Pubkey,
+        first_nullifier: &[u8; 32],
+        sender_view_tag: ViewTag,
+        sender: &AnonymousTransferSenderPlaintext,
+        recipients: &[AnonymousRecipientSlot],
+    ) -> Result<EncryptedTransfer, ClientError>;
+
+    async fn request_user_approval(
+        &self,
+        _owner: Pubkey,
+        _request: ApprovalRequest,
+    ) -> Result<(), ClientError> {
+        Ok(())
+    }
+
+    async fn sign_p256(
+        &self,
+        owner: Pubkey,
+        message_hash: &[u8; 32],
+    ) -> Result<P256Signature, ClientError>;
+
+    async fn spend_nullifier_key(&self, owner: Pubkey) -> Result<NullifierKey, ClientError>;
+}
+
+/// A [`MultiWalletAuthority`] scoped to one user's wallet. It implements
+/// [`WalletAuthority`] by passing the owner to the host on every call.
+///
+/// # Examples
+///
+/// ```no_run
+/// use solana_pubkey::Pubkey;
+/// use zolana_client::{
+///     ClientError, CreatedTransfer, MultiWalletAuthority, PrivateTransfer, Scoped,
+///     TransferRecipient, SOL_MINT,
+/// };
+/// use zolana_transaction::Wallet;
+///
+/// async fn transfer<H: MultiWalletAuthority>(
+///     host: &H,
+///     owner: Pubkey,
+///     wallet: &Wallet,
+///     destination: TransferRecipient,
+///     payer: Pubkey,
+/// ) -> Result<CreatedTransfer, ClientError> {
+///     let authority = Scoped::new(host, owner);
+///     PrivateTransfer {
+///         source: wallet,
+///         destination,
+///         asset: SOL_MINT,
+///         amount: 1_000,
+///         authority: &authority,
+///         payer,
+///         memo: None,
+///     }
+///     .create()
+///     .await
+/// }
+/// ```
+pub struct Scoped<'a, H: ?Sized> {
+    host: &'a H,
+    owner: Pubkey,
+}
+
+impl<'a, H: ?Sized> Scoped<'a, H> {
+    pub fn new(host: &'a H, owner: Pubkey) -> Self {
+        Self { host, owner }
+    }
+}
+
+#[async_trait(?Send)]
+impl<H> WalletAuthority for Scoped<'_, H>
+where
+    H: MultiWalletAuthority + ?Sized,
+{
+    async fn shielded_address(&self) -> Result<ShieldedAddress, ClientError> {
+        self.host.shielded_address(self.owner).await
+    }
+
+    async fn encrypt_confidential_transfer(
+        &self,
+        first_nullifier: &[u8; 32],
+        sender_tag: ViewTag,
+        sender: &TransferSenderPlaintext,
+        recipients: &[ConfidentialRecipientSlot],
+    ) -> Result<EncryptedTransfer, ClientError> {
+        self.host
+            .encrypt_confidential_transfer(
+                self.owner,
+                first_nullifier,
+                sender_tag,
+                sender,
+                recipients,
+            )
+            .await
+    }
+
+    async fn encrypt_anonymous_transfer(
+        &self,
+        first_nullifier: &[u8; 32],
+        sender_view_tag: ViewTag,
+        sender: &AnonymousTransferSenderPlaintext,
+        recipients: &[AnonymousRecipientSlot],
+    ) -> Result<EncryptedTransfer, ClientError> {
+        self.host
+            .encrypt_anonymous_transfer(
+                self.owner,
+                first_nullifier,
+                sender_view_tag,
+                sender,
+                recipients,
+            )
+            .await
+    }
+
+    async fn request_user_approval(&self, request: ApprovalRequest) -> Result<(), ClientError> {
+        self.host.request_user_approval(self.owner, request).await
+    }
+
+    async fn sign_p256(&self, message_hash: &[u8; 32]) -> Result<P256Signature, ClientError> {
+        self.host.sign_p256(self.owner, message_hash).await
+    }
+
+    async fn spend_nullifier_key(&self) -> Result<NullifierKey, ClientError> {
+        self.host.spend_nullifier_key(self.owner).await
     }
 }
 
@@ -207,13 +343,12 @@ fn recipient_slot_index(i: usize) -> Result<u32, ClientError> {
 }
 
 impl SyncWalletAuthority for ShieldedKeypair {
-    fn shielded_address(&self, _owner_pubkey: Pubkey) -> Result<ShieldedAddress, ClientError> {
-        Ok(self.shielded_address()?)
+    fn shielded_address(&self) -> Result<ShieldedAddress, ClientError> {
+        Ok(ShieldedKeypair::shielded_address(self)?)
     }
 
     fn encrypt_confidential_transfer(
         &self,
-        _owner_pubkey: Pubkey,
         first_nullifier: &[u8; 32],
         sender_tag: ViewTag,
         sender: &TransferSenderPlaintext,
@@ -261,7 +396,6 @@ impl SyncWalletAuthority for ShieldedKeypair {
 
     fn encrypt_anonymous_transfer(
         &self,
-        _owner_pubkey: Pubkey,
         first_nullifier: &[u8; 32],
         sender_view_tag: ViewTag,
         sender: &AnonymousTransferSenderPlaintext,
@@ -310,11 +444,7 @@ impl SyncWalletAuthority for ShieldedKeypair {
         })
     }
 
-    fn sign_p256(
-        &self,
-        _owner_pubkey: Pubkey,
-        message_hash: &[u8; 32],
-    ) -> Result<P256Signature, ClientError> {
+    fn sign_p256(&self, message_hash: &[u8; 32]) -> Result<P256Signature, ClientError> {
         let signer = EcdsaSigningKey::from_slice(self.signing_key.secret_bytes().as_slice())
             .map_err(|e| ClientError::P256Signature(e.to_string()))?;
         let signature: Signature = signer
@@ -332,7 +462,7 @@ impl SyncWalletAuthority for ShieldedKeypair {
         })
     }
 
-    fn spend_nullifier_key(&self, _owner_pubkey: Pubkey) -> Result<NullifierKey, ClientError> {
+    fn spend_nullifier_key(&self) -> Result<NullifierKey, ClientError> {
         Ok(self.nullifier_key.clone())
     }
 }

--- a/sdk-libs/client/src/wallet_sync.rs
+++ b/sdk-libs/client/src/wallet_sync.rs
@@ -41,6 +41,18 @@ impl Default for SyncWalletConfig {
     }
 }
 
+/// Sync the wallet's UTXOs and history from the indexer.
+///
+/// Unknown asset ids are resolved best effort: when decode hits ids the
+/// wallet's registry does not know, sync scans the on-chain `SplAssetRegistry`
+/// accounts via `get_program_accounts` and retries once. On backends without
+/// that method the backfill silently resolves nothing — the stock
+/// `ZolanaIndexer` is such a backend (it implements only the indexer queries),
+/// so with Photon as the sync source the
+/// backfill never fires. Backfill eagerly with a `get_program_accounts`-capable
+/// backend via [`refresh_registry_from_chain`], or insert ids directly with
+/// [`fetch_asset_id`](crate::fetch_asset_id) + `wallet.registry.insert` — the
+/// path that works on every backend.
 pub fn sync_wallet<I>(wallet: &mut Wallet, indexer: &I) -> Result<SyncReport, ClientError>
 where
     I: Rpc,
@@ -111,8 +123,15 @@ where
 /// Fetch every `SplAssetRegistry` account owned by the shielded-pool program and
 /// insert any new `asset_id -> mint` pairs into the wallet's registry. Returns
 /// the number of newly inserted ids. `get_program_accounts` being unsupported on
-/// the RPC is treated as zero new ids (soft miss), not an error.
-fn refresh_registry_from_chain<I>(wallet: &mut Wallet, indexer: &I) -> Result<usize, ClientError>
+/// the backend is treated as zero new ids (soft miss), not an error — which is
+/// why this is public: a wallet synced against Photon (no `get_program_accounts`)
+/// can still backfill eagerly through a capable backend such as
+/// `SolanaRpc`. The guaranteed per-mint path is
+/// [`fetch_asset_id`](crate::fetch_asset_id) + `wallet.registry.insert`.
+pub fn refresh_registry_from_chain<I>(
+    wallet: &mut Wallet,
+    indexer: &I,
+) -> Result<usize, ClientError>
 where
     I: Rpc,
 {

--- a/sdk-libs/client/src/wallet_sync.rs
+++ b/sdk-libs/client/src/wallet_sync.rs
@@ -436,6 +436,46 @@ mod tests {
     const SPL_MINT: Address = Address::new_from_array([2u8; 32]);
 
     #[test]
+    fn transfer_memo_round_trips_to_the_recipient_wallet() {
+        let assets = AssetRegistry::default();
+        let sender = ShieldedKeypair::new().expect("sender");
+        let recipient = ShieldedKeypair::new().expect("recipient");
+
+        let input = SpendUtxo::from_keypair(test_utxo(&sender, SOL_MINT, 100, 1), &sender);
+        let mut tx = Transaction::new(
+            sender.shielded_address().expect("sender address"),
+            vec![input],
+            Address::default(),
+        );
+        tx.send_with_memo(
+            &recipient.shielded_address().expect("recipient address"),
+            SOL_MINT,
+            40,
+            Some(b"gm".to_vec()),
+        )
+        .expect("send");
+        let transfer = signed_to_shielded_tx(tx.sign(&sender, &assets).expect("sign"), 1);
+
+        let mut wallet = Wallet::new(recipient.clone(), assets).expect("wallet");
+        sync_wallet(
+            &mut wallet,
+            &MockIndexer {
+                transactions: vec![transfer],
+                matches: Vec::new(),
+                program_accounts: Vec::new(),
+            },
+        )
+        .expect("sync");
+
+        let received = wallet
+            .utxos
+            .iter()
+            .find(|entry| entry.utxo.amount == 40)
+            .expect("received utxo");
+        assert_eq!(received.utxo.data.memo(), Some(b"gm".as_slice()));
+    }
+
+    #[test]
     fn sync_wallet_records_confidential_transfer_history_without_duplicates() {
         let assets = AssetRegistry::default();
         let alice = ShieldedKeypair::new().expect("alice");

--- a/sdk-libs/client/tests/merge/steps.rs
+++ b/sdk-libs/client/tests/merge/steps.rs
@@ -45,7 +45,8 @@ impl MergeWorld {
         let sender = if self.plan.eddsa {
             let mut seed = [0u8; 32];
             seed[1..].copy_from_slice(&random_blinding());
-            ShieldedKeypair::from_ed25519(&seed, ViewingKey::new()).expect("eddsa sender keypair")
+            let solana = solana_keypair::Keypair::new_from_array(seed);
+            ShieldedKeypair::from_ed25519(&solana, ViewingKey::new()).expect("eddsa sender keypair")
         } else {
             ShieldedKeypair::new().expect("sender keypair")
         };

--- a/sdk-libs/client/tests/merge_zone/steps.rs
+++ b/sdk-libs/client/tests/merge_zone/steps.rs
@@ -52,7 +52,8 @@ impl MergeZoneWorld {
         let sender = if self.plan.eddsa {
             let mut seed = [0u8; 32];
             seed[1..].copy_from_slice(&random_blinding());
-            ShieldedKeypair::from_ed25519(&seed, ViewingKey::new()).expect("eddsa sender keypair")
+            let solana = solana_keypair::Keypair::new_from_array(seed);
+            ShieldedKeypair::from_ed25519(&solana, ViewingKey::new()).expect("eddsa sender keypair")
         } else {
             ShieldedKeypair::new().expect("sender keypair")
         };

--- a/sdk-libs/client/tests/transaction.rs
+++ b/sdk-libs/client/tests/transaction.rs
@@ -17,7 +17,6 @@ use p256::{
 };
 use rand::{rngs::ThreadRng, RngCore};
 use solana_address::Address;
-use solana_pubkey::Pubkey;
 use test_indexer::TestIndexer;
 use zolana_client::{
     sign_transaction, AnonymousRecipientSlot, ApprovalRequest, CircuitType, ClientError,
@@ -75,14 +74,12 @@ struct AsyncTestAuthority {
 impl WalletAuthority for AsyncTestAuthority {
     async fn shielded_address(
         &self,
-        owner_pubkey: Pubkey,
     ) -> Result<zolana_keypair::shielded::ShieldedAddress, ClientError> {
-        SyncWalletAuthority::shielded_address(&self.keypair, owner_pubkey)
+        SyncWalletAuthority::shielded_address(&self.keypair)
     }
 
     async fn encrypt_confidential_transfer(
         &self,
-        owner_pubkey: Pubkey,
         first_nullifier: &[u8; 32],
         sender_tag: [u8; 32],
         sender: &TransferSenderPlaintext,
@@ -90,7 +87,6 @@ impl WalletAuthority for AsyncTestAuthority {
     ) -> Result<zolana_client::EncryptedTransfer, ClientError> {
         SyncWalletAuthority::encrypt_confidential_transfer(
             &self.keypair,
-            owner_pubkey,
             first_nullifier,
             sender_tag,
             sender,
@@ -100,7 +96,6 @@ impl WalletAuthority for AsyncTestAuthority {
 
     async fn encrypt_anonymous_transfer(
         &self,
-        owner_pubkey: Pubkey,
         first_nullifier: &[u8; 32],
         sender_view_tag: [u8; 32],
         sender: &zolana_transaction::serialization::anonymous::AnonymousTransferSenderPlaintext,
@@ -108,7 +103,6 @@ impl WalletAuthority for AsyncTestAuthority {
     ) -> Result<zolana_client::EncryptedTransfer, ClientError> {
         SyncWalletAuthority::encrypt_anonymous_transfer(
             &self.keypair,
-            owner_pubkey,
             first_nullifier,
             sender_view_tag,
             sender,
@@ -117,23 +111,18 @@ impl WalletAuthority for AsyncTestAuthority {
     }
 
     async fn request_user_approval(&self, request: ApprovalRequest) -> Result<(), ClientError> {
-        assert_eq!(request.owner_pubkey, Pubkey::default());
         assert!(request.summary.contains("private transaction"));
         self.approvals.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
 
-    async fn sign_p256(
-        &self,
-        owner_pubkey: Pubkey,
-        message_hash: &[u8; 32],
-    ) -> Result<P256Signature, ClientError> {
+    async fn sign_p256(&self, message_hash: &[u8; 32]) -> Result<P256Signature, ClientError> {
         self.p256_signatures.fetch_add(1, Ordering::SeqCst);
-        SyncWalletAuthority::sign_p256(&self.keypair, owner_pubkey, message_hash)
+        SyncWalletAuthority::sign_p256(&self.keypair, message_hash)
     }
 
-    async fn spend_nullifier_key(&self, owner_pubkey: Pubkey) -> Result<NullifierKey, ClientError> {
-        SyncWalletAuthority::spend_nullifier_key(&self.keypair, owner_pubkey)
+    async fn spend_nullifier_key(&self) -> Result<NullifierKey, ClientError> {
+        SyncWalletAuthority::spend_nullifier_key(&self.keypair)
     }
 }
 
@@ -705,9 +694,7 @@ fn async_authority_signs_p256_and_invokes_approval() {
         .unwrap();
 
     let wallet = Wallet::new(sender.clone(), registry()).expect("wallet");
-    let signed =
-        futures::executor::block_on(sign_transaction(tx, &wallet, Pubkey::default(), &authority))
-            .unwrap();
+    let signed = futures::executor::block_on(sign_transaction(tx, &wallet, &authority)).unwrap();
 
     assert_eq!(authority.approvals.load(Ordering::SeqCst), 1);
     assert_eq!(authority.p256_signatures.load(Ordering::SeqCst), 1);

--- a/sdk-libs/client/tests/zone_authority/steps.rs
+++ b/sdk-libs/client/tests/zone_authority/steps.rs
@@ -347,7 +347,8 @@ fn zone_program() -> Address {
 fn eddsa_keypair() -> ShieldedKeypair {
     let mut seed = [0u8; 32];
     seed[1..].copy_from_slice(&random_blinding());
-    ShieldedKeypair::from_ed25519(&seed, ViewingKey::new()).expect("eddsa keypair")
+    let solana = solana_keypair::Keypair::new_from_array(seed);
+    ShieldedKeypair::from_ed25519(&solana, ViewingKey::new()).expect("eddsa keypair")
 }
 
 fn p256_keypair() -> ShieldedKeypair {

--- a/sdk-libs/client/tests/zone_transfer/steps.rs
+++ b/sdk-libs/client/tests/zone_transfer/steps.rs
@@ -430,7 +430,8 @@ fn zone_program() -> Address {
 fn eddsa_keypair() -> ShieldedKeypair {
     let mut seed = [0u8; 32];
     seed[1..].copy_from_slice(&random_blinding());
-    ShieldedKeypair::from_ed25519(&seed, ViewingKey::new()).expect("eddsa keypair")
+    let solana = solana_keypair::Keypair::new_from_array(seed);
+    ShieldedKeypair::from_ed25519(&solana, ViewingKey::new()).expect("eddsa keypair")
 }
 
 fn p256_keypair() -> ShieldedKeypair {

--- a/sdk-libs/keypair/Cargo.toml
+++ b/sdk-libs/keypair/Cargo.toml
@@ -14,6 +14,7 @@ hkdf = { workspace = true }
 hmac = { workspace = true }
 zeroize = { workspace = true }
 sha2 = { workspace = true }
+solana-keypair = { workspace = true }
 zolana-hasher = { workspace = true, features = ["poseidon", "std"] }
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/sdk-libs/keypair/src/shielded.rs
+++ b/sdk-libs/keypair/src/shielded.rs
@@ -87,10 +87,13 @@ impl ShieldedKeypair {
         )
     }
 
+    /// Wallet keys for a Solana keypair: the signing and nullifier keys derive
+    /// from its ed25519 secret; the viewing key is caller-provided.
     pub fn from_ed25519(
-        signing_secret: &[u8; 32],
+        keypair: &solana_keypair::Keypair,
         viewing_key: ViewingKey,
     ) -> Result<Self, KeypairError> {
+        let signing_secret = keypair.secret_bytes();
         let signing_key = SigningKey::from_ed25519(signing_secret);
         let nullifier_key = NullifierKey::from_signing_secret_key_bytes(signing_secret)?;
         Ok(Self {
@@ -202,5 +205,25 @@ impl ShieldedKeypair {
     ) -> Result<ViewingKey, KeypairError> {
         self.viewing_key
             .get_transaction_viewing_key(first_nullifier)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The keypair-taking constructor must derive the same keys as feeding the
+    /// secret bytes to the key constructors directly.
+    #[test]
+    fn from_ed25519_matches_secret_byte_derivation() {
+        let solana = solana_keypair::Keypair::new();
+        let keypair = ShieldedKeypair::from_ed25519(&solana, ViewingKey::new()).unwrap();
+        let signing = SigningKey::from_ed25519(solana.secret_bytes());
+        let nullifier = NullifierKey::from_signing_secret_key_bytes(solana.secret_bytes()).unwrap();
+        assert_eq!(keypair.signing_pubkey(), signing.pubkey());
+        assert_eq!(
+            keypair.nullifier_key.pubkey().unwrap(),
+            nullifier.pubkey().unwrap()
+        );
     }
 }

--- a/sdk-libs/transaction/src/instructions/transact/builder.rs
+++ b/sdk-libs/transaction/src/instructions/transact/builder.rs
@@ -80,6 +80,7 @@ struct Recipient {
     address: ShieldedAddress,
     asset: Address,
     amount: u64,
+    memo: Option<Vec<u8>>,
 }
 
 pub enum WithdrawalTarget {
@@ -215,10 +216,25 @@ impl Transaction {
         asset: Address,
         amount: u64,
     ) -> Result<&mut Self, TransactionError> {
+        self.send_with_memo(recipient, asset, amount, None)
+    }
+
+    /// [`Self::send`] with a free-form note for the recipient. The memo is
+    /// encrypted into the recipient's output ciphertext and not committed into
+    /// any hash. It lengthens that ciphertext, so its presence and byte length
+    /// are visible onchain; the contents are not.
+    pub fn send_with_memo(
+        &mut self,
+        recipient: &ShieldedAddress,
+        asset: Address,
+        amount: u64,
+        memo: Option<Vec<u8>>,
+    ) -> Result<&mut Self, TransactionError> {
         self.recipients.push(Recipient {
             address: *recipient,
             asset,
             amount,
+            memo,
         });
         Ok(self)
     }
@@ -346,13 +362,16 @@ impl Transaction {
             let position = RECIPIENT_POSITION_BASE + i as u8;
             let blinding = derive_blinding(&self.blinding_seed, position);
             let asset_id = self.asset_id(assets, &recipient.asset)?;
-            outputs.push(OutputUtxo {
+            let mut output = OutputUtxo {
                 owner_address: Some(recipient.address),
                 asset: recipient.asset,
                 amount: recipient.amount,
                 blinding,
                 ..Default::default()
-            });
+            };
+            if let Some(memo) = &recipient.memo {
+                output = output.with_memo(memo.clone());
+            }
             recipient_viewing_pks.push(recipient.address.viewing_pubkey);
             recipients.push(PreparedRecipient {
                 view_tag: recipient.address.signing_pubkey.confidential_view_tag()?,
@@ -362,9 +381,10 @@ impl Transaction {
                     amount: recipient.amount,
                     blinding,
                     zone_program_id: None,
-                    data: Data::default(),
+                    data: output.data.clone(),
                 },
             });
+            outputs.push(output);
         }
 
         for output in &self.custom_outputs {

--- a/sdk-libs/transaction/src/wallet/state.rs
+++ b/sdk-libs/transaction/src/wallet/state.rs
@@ -168,4 +168,20 @@ impl Wallet {
         balances.sort_by_key(|b| b.asset_id);
         Ok(balances)
     }
+
+    /// Per-asset balances of the unspent private UTXOs, without the per-UTXO
+    /// detail: the display-oriented shorthand for `balances(true)`.
+    pub fn private_token_balances(&self) -> Result<Vec<AssetBalance>, TransactionError> {
+        self.balances(true)
+    }
+
+    /// The memo on the most recently synced UTXO that carries one, decoded
+    /// lossily as UTF-8. Memos arrive already decrypted by the wallet sync.
+    pub fn last_memo(&self) -> Option<String> {
+        self.utxos
+            .iter()
+            .rev()
+            .find_map(|entry| entry.utxo.data.memo())
+            .map(|memo| String::from_utf8_lossy(memo).into_owned())
+    }
 }


### PR DESCRIPTION
## Summary
- Builder-style action structs (`PrivateTransfer`, `Withdrawal`, `Deposit`) with `instruction()` (sync/local keys) and `create()` (async/custody signers), fields ordered `source`, `destination`, `asset`, `amount`, `authority`, `payer`, `memo`
- `WalletAuthority`/`SyncWalletAuthority` are now per-wallet (no `owner_pubkey` threading); multi-wallet custody hosts use the new `MultiWalletAuthority` trait with the `Scoped` adapter to bake the owner in once
- One-call submission via `rpc.send(&payer).execute(&transfer)` with the `Sendable` trait, plus `execute_with` for atomically composing extra instructions
- `resolve_recipient` returns a `TransferRecipient` enum; private transfers fall back to a public withdrawal under the hood when the recipient has no private wallet
- Encrypted memo support on transfers, `Wallet` balance/memo helpers, CU-limit fixes, `from_ed25519` keypair-based derivation

## Test plan
- [x] `cargo check/test/clippy -D warnings/fmt` clean across the workspace (incl. cucumber suites and doc-tests)
- [x] All five rust-client examples run green end to end on devnet (deposit, transfer with decrypted memo, withdraw, sync, wallet creation)