### PR TITLE
refactor(cli): align command tree with the CLI design (dev grouping, flat wallet commands)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -26,12 +26,12 @@ Commands:
 zolana config get
 zolana config set --keypair ~/.config/zolana/pid.json --rpc-url http://127.0.0.1:8899 --indexer-url http://127.0.0.1:8784 --prover-url http://127.0.0.1:3001
 zolana wallet init --airdrop-lamports 1000000000
-zolana wallet create-tree --tree-keypair /tmp/zolana-tree.json --airdrop-lamports 20000000000
-zolana wallet sync --indexer-url http://127.0.0.1:8784
-zolana wallet balance --indexer-url http://127.0.0.1:8784
-zolana wallet deposit --amount 1000000000 --mint SOL --airdrop-lamports 2000000000
-zolana wallet transfer --to <RECIPIENT_SOLANA_PUBKEY> --amount 300000000 --mint SOL
-zolana wallet withdraw --to <PUBLIC_SOL_PUBKEY> --amount 200000000 --mint SOL
+zolana dev pool create-tree --tree-keypair /tmp/zolana-tree.json --airdrop-lamports 20000000000
+zolana sync --indexer-url http://127.0.0.1:8784
+zolana balance --indexer-url http://127.0.0.1:8784
+zolana deposit --amount 1000000000 --mint SOL --airdrop-lamports 2000000000
+zolana transfer --to <RECIPIENT_SOLANA_PUBKEY> --amount 300000000 --mint SOL
+zolana withdraw --to <PUBLIC_SOL_PUBKEY> --amount 200000000 --mint SOL
 ```
 
 Wallet commands use the wallet file's Solana funding key for fees/public SOL
@@ -47,13 +47,13 @@ the transfer is built as a public SOL withdrawal to that pubkey. `withdraw --to
 
 CLI-wide defaults live at `~/.config/zolana/config.json`. Explicit flags win
 over config values, and config values win over built-in localnet defaults. The
-`keypair` config field is the path to the wallet file (`pid.json`). `create-tree`
-writes the created tree pubkey into this config file; `deposit`, `transfer`, and
-`withdraw` only require `--tree` when neither the flag nor config has a tree.
+`keypair` config field is the path to the wallet file (`pid.json`). `dev pool
+create-tree` writes the created tree pubkey into this config file; `deposit`,
+`transfer`, and `withdraw` only require `--tree` when neither the flag nor config
+has a tree.
 
 Optional wallet path:
 
 ```bash
 --keypair /path/to/pid.json
 ```
-

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -148,7 +148,7 @@ pub(crate) struct ConfigSetOptions {
     pub(crate) tree: Option<String>,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, PartialEq)]
 pub(crate) struct ConfigAddAssetOptions {
     #[arg(long, help = "SPL mint pubkey")]
     pub(crate) mint: String,
@@ -355,7 +355,7 @@ pub(crate) struct StartProverOptions {
     pub(crate) auto_download: bool,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, PartialEq)]
 pub(crate) struct WalletKeypairOptions {
     #[arg(
         long = "keypair",
@@ -365,7 +365,7 @@ pub(crate) struct WalletKeypairOptions {
     pub(crate) keypair: Option<String>,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, PartialEq)]
 pub(crate) struct InitOptions {
     #[arg(
         long = "path",
@@ -387,7 +387,7 @@ pub(crate) struct InitOptions {
     pub(crate) airdrop_lamports: Option<u64>,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, PartialEq)]
 pub(crate) struct SyncOptions {
     #[command(flatten)]
     pub(crate) keypair: WalletKeypairOptions,
@@ -405,7 +405,7 @@ pub(crate) struct SyncOptions {
     pub(crate) indexer_url: Option<String>,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, PartialEq)]
 pub(crate) struct NetworkWalletOptions {
     #[command(flatten)]
     pub(crate) sync: SyncOptions,
@@ -429,7 +429,7 @@ pub(crate) struct NetworkWalletOptions {
     pub(crate) airdrop_lamports: Option<u64>,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, PartialEq)]
 pub(crate) struct CreateTreeOptions {
     #[command(flatten)]
     pub(crate) sync: SyncOptions,
@@ -445,7 +445,7 @@ pub(crate) struct CreateTreeOptions {
     pub(crate) airdrop_lamports: u64,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, PartialEq)]
 pub(crate) struct TestMintOptions {
     #[command(flatten)]
     pub(crate) sync: SyncOptions,
@@ -467,7 +467,7 @@ pub(crate) struct TestMintOptions {
     pub(crate) airdrop_lamports: Option<u64>,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, PartialEq)]
 pub(crate) struct DepositOptions {
     #[command(flatten)]
     pub(crate) network: NetworkWalletOptions,
@@ -485,7 +485,7 @@ pub(crate) struct DepositOptions {
     pub(crate) amount: u64,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, PartialEq)]
 pub(crate) struct TransferOptions {
     #[command(flatten)]
     pub(crate) network: NetworkWalletOptions,
@@ -504,7 +504,7 @@ pub(crate) struct TransferOptions {
     pub(crate) amount: u64,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, PartialEq)]
 pub(crate) struct WithdrawOptions {
     #[command(flatten)]
     pub(crate) network: NetworkWalletOptions,
@@ -519,7 +519,7 @@ pub(crate) struct WithdrawOptions {
     pub(crate) amount: u64,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, PartialEq)]
 pub(crate) struct BalanceOptions {
     #[command(flatten)]
     pub(crate) sync: SyncOptions,
@@ -528,7 +528,7 @@ pub(crate) struct BalanceOptions {
     pub(crate) mint: Option<String>,
 }
 
-#[derive(Args, Debug, Clone)]
+#[derive(Args, Debug, Clone, PartialEq)]
 #[command(group(
     clap::ArgGroup::new("merge_toggle")
         .required(true)
@@ -561,9 +561,12 @@ impl TestValidatorOptions {
     pub(crate) fn sbf_program_specs(&self) -> Vec<ProgramSpec> {
         self.sbf_programs
             .chunks_exact(2)
-            .map(|chunk| ProgramSpec {
-                address: chunk[0].clone(),
-                path: chunk[1].clone(),
+            .filter_map(|chunk| match chunk {
+                [address, path] => Some(ProgramSpec {
+                    address: address.clone(),
+                    path: path.clone(),
+                }),
+                _ => None,
             })
             .collect()
     }
@@ -571,10 +574,13 @@ impl TestValidatorOptions {
     pub(crate) fn upgradeable_program_specs(&self) -> Vec<UpgradeableProgramSpec> {
         self.upgradeable_programs
             .chunks_exact(3)
-            .map(|chunk| UpgradeableProgramSpec {
-                address: chunk[0].clone(),
-                path: chunk[1].clone(),
-                upgrade_authority: chunk[2].clone(),
+            .filter_map(|chunk| match chunk {
+                [address, path, upgrade_authority] => Some(UpgradeableProgramSpec {
+                    address: address.clone(),
+                    path: path.clone(),
+                    upgrade_authority: upgrade_authority.clone(),
+                }),
+                _ => None,
             })
             .collect()
     }
@@ -748,16 +754,43 @@ mod tests {
         assert_eq!(opts.log_dir, "target/localnet/logs");
         let programs = opts.sbf_program_specs();
         assert_eq!(programs.len(), 2);
+        let mut programs = programs.iter();
+        let Some(pool_program) = programs.next() else {
+            panic!("expected pool program");
+        };
         assert_eq!(
-            programs[0].address,
+            pool_program.address,
             "Pool111111111111111111111111111111111111111"
         );
-        assert_eq!(programs[0].path, "target/deploy/pool.so");
+        assert_eq!(pool_program.path, "target/deploy/pool.so");
+        let Some(zone_program) = programs.next() else {
+            panic!("expected zone program");
+        };
         assert_eq!(
-            programs[1].address,
+            zone_program.address,
             "Zone111111111111111111111111111111111111111"
         );
-        assert_eq!(programs[1].path, "target/deploy/zone.so");
+        assert_eq!(zone_program.path, "target/deploy/zone.so");
+        assert!(programs.next().is_none());
+    }
+
+    #[test]
+    fn parses_test_env_alias_options() {
+        let Some(CliCommand::TestEnv(opts)) = parse_cli(&[
+            "test-env",
+            "--skip-prover",
+            "--skip-reset",
+            "--rpc-port",
+            "8901",
+        ])
+        .command
+        else {
+            panic!("expected test-env command");
+        };
+
+        assert!(opts.skip_prover);
+        assert!(opts.skip_reset);
+        assert_eq!(opts.rpc_port, 8901);
     }
 
     #[test]
@@ -823,9 +856,12 @@ mod tests {
             "--airdrop-lamports",
             "1000000000",
         ]);
-        assert_eq!(opts.path.as_deref(), Some("/tmp/alice.pid.json"));
-        assert_eq!(opts.rpc_url.as_deref(), Some("http://127.0.0.1:8900"));
-        assert_eq!(opts.airdrop_lamports, Some(1_000_000_000));
+        let expected = InitOptions {
+            path: Some("/tmp/alice.pid.json".to_string()),
+            rpc_url: Some("http://127.0.0.1:8900".to_string()),
+            airdrop_lamports: Some(1_000_000_000),
+        };
+        assert_eq!(opts, expected);
     }
 
     #[test]
@@ -845,17 +881,18 @@ mod tests {
         ]) else {
             panic!("expected dev pool create-tree command");
         };
-        assert_eq!(
-            opts.sync.keypair.keypair.as_deref(),
-            Some("/tmp/alice.pid.json")
-        );
-        assert_eq!(opts.tree_keypair, "/tmp/tree.json");
-        assert_eq!(opts.sync.rpc_url.as_deref(), Some("http://127.0.0.1:8900"));
-        assert_eq!(
-            opts.sync.indexer_url.as_deref(),
-            Some("http://127.0.0.1:8785")
-        );
-        assert_eq!(opts.airdrop_lamports, 1_000_000_000);
+        let expected = CreateTreeOptions {
+            sync: SyncOptions {
+                keypair: WalletKeypairOptions {
+                    keypair: Some("/tmp/alice.pid.json".to_string()),
+                },
+                rpc_url: Some("http://127.0.0.1:8900".to_string()),
+                indexer_url: Some("http://127.0.0.1:8785".to_string()),
+            },
+            tree_keypair: "/tmp/tree.json".to_string(),
+            airdrop_lamports: 1_000_000_000,
+        };
+        assert_eq!(opts, expected);
     }
 
     #[test]
@@ -881,12 +918,12 @@ mod tests {
         else {
             panic!("expected config asset add command");
         };
-        assert_eq!(opts.asset_id, 2);
-        assert_eq!(opts.mint, "Mint111111111111111111111111111111111111111");
-        assert_eq!(
-            opts.token_account.as_deref(),
-            Some("Token11111111111111111111111111111111111111")
-        );
+        let expected = ConfigAddAssetOptions {
+            mint: "Mint111111111111111111111111111111111111111".to_string(),
+            asset_id: 2,
+            token_account: Some("Token11111111111111111111111111111111111111".to_string()),
+        };
+        assert_eq!(opts, expected);
     }
 
     #[test]
@@ -927,13 +964,19 @@ mod tests {
         ]) else {
             panic!("expected dev pool test-mint command");
         };
-        assert_eq!(
-            opts.sync.keypair.keypair.as_deref(),
-            Some("/tmp/alice.pid.json")
-        );
-        assert_eq!(opts.amount, 1_000_000);
-        assert_eq!(opts.authority_path.as_deref(), Some("/tmp/admin.pid.json"));
-        assert_eq!(opts.airdrop_lamports, Some(1_000_000_000));
+        let expected = TestMintOptions {
+            sync: SyncOptions {
+                keypair: WalletKeypairOptions {
+                    keypair: Some("/tmp/alice.pid.json".to_string()),
+                },
+                rpc_url: None,
+                indexer_url: None,
+            },
+            amount: 1_000_000,
+            authority_path: Some("/tmp/admin.pid.json".to_string()),
+            airdrop_lamports: Some(1_000_000_000),
+        };
+        assert_eq!(opts, expected);
     }
 
     #[test]
@@ -951,9 +994,14 @@ mod tests {
         else {
             panic!("expected sync command");
         };
-        assert_eq!(sync.keypair.keypair.as_deref(), Some("/tmp/alice.pid.json"));
-        assert_eq!(sync.rpc_url.as_deref(), Some("http://127.0.0.1:8900"));
-        assert_eq!(sync.indexer_url.as_deref(), Some("http://127.0.0.1:8785"));
+        let expected = SyncOptions {
+            keypair: WalletKeypairOptions {
+                keypair: Some("/tmp/alice.pid.json".to_string()),
+            },
+            rpc_url: Some("http://127.0.0.1:8900".to_string()),
+            indexer_url: Some("http://127.0.0.1:8785".to_string()),
+        };
+        assert_eq!(sync, expected);
 
         let Some(CliCommand::Balance(balance)) = parse_cli(&[
             "balance",
@@ -966,7 +1014,17 @@ mod tests {
         else {
             panic!("expected balance command");
         };
-        assert_eq!(balance.mint.as_deref(), Some("SOL"));
+        let expected = BalanceOptions {
+            sync: SyncOptions {
+                keypair: WalletKeypairOptions {
+                    keypair: Some("/tmp/alice.pid.json".to_string()),
+                },
+                rpc_url: None,
+                indexer_url: None,
+            },
+            mint: Some("SOL".to_string()),
+        };
+        assert_eq!(balance, expected);
     }
 
     #[test]
@@ -986,17 +1044,18 @@ mod tests {
             panic!("expected merge command");
         };
 
-        assert_eq!(
-            opts.sync.keypair.keypair.as_deref(),
-            Some("/tmp/alice.pid.json")
-        );
-        assert_eq!(opts.sync.rpc_url.as_deref(), Some("http://127.0.0.1:8900"));
-        assert_eq!(
-            opts.sync.indexer_url.as_deref(),
-            Some("http://127.0.0.1:8785")
-        );
-        assert!(opts.enable);
-        assert!(!opts.disable);
+        let expected = MergeOptions {
+            sync: SyncOptions {
+                keypair: WalletKeypairOptions {
+                    keypair: Some("/tmp/alice.pid.json".to_string()),
+                },
+                rpc_url: Some("http://127.0.0.1:8900".to_string()),
+                indexer_url: Some("http://127.0.0.1:8785".to_string()),
+            },
+            enable: true,
+            disable: false,
+        };
+        assert_eq!(opts, expected);
 
         let Some(CliCommand::Merge(opts)) =
             parse_cli(&["merge", "--keypair", "/tmp/alice.pid.json", "--disable"]).command
@@ -1004,8 +1063,18 @@ mod tests {
             panic!("expected merge command");
         };
 
-        assert!(!opts.enable);
-        assert!(opts.disable);
+        let expected = MergeOptions {
+            sync: SyncOptions {
+                keypair: WalletKeypairOptions {
+                    keypair: Some("/tmp/alice.pid.json".to_string()),
+                },
+                rpc_url: None,
+                indexer_url: None,
+            },
+            enable: false,
+            disable: true,
+        };
+        assert_eq!(opts, expected);
     }
 
     #[test]
@@ -1033,16 +1102,24 @@ mod tests {
         else {
             panic!("expected deposit command");
         };
-        assert_eq!(
-            deposit.network.tree.as_deref(),
-            Some("Tree111111111111111111111111111111111111111")
-        );
-        assert_eq!(
-            deposit.to.as_deref(),
-            Some("Recipient1111111111111111111111111111111111")
-        );
-        assert_eq!(deposit.amount, 1_000_000_000);
-        assert_eq!(deposit.network.airdrop_lamports, Some(2_000_000_000));
+        let expected = DepositOptions {
+            network: NetworkWalletOptions {
+                sync: SyncOptions {
+                    keypair: WalletKeypairOptions {
+                        keypair: Some("/tmp/alice.pid.json".to_string()),
+                    },
+                    rpc_url: Some("http://127.0.0.1:8900".to_string()),
+                    indexer_url: Some("http://127.0.0.1:8785".to_string()),
+                },
+                tree: Some("Tree111111111111111111111111111111111111111".to_string()),
+                prover_url: None,
+                airdrop_lamports: Some(2_000_000_000),
+            },
+            to: Some("Recipient1111111111111111111111111111111111".to_string()),
+            mint: "SOL".to_string(),
+            amount: 1_000_000_000,
+        };
+        assert_eq!(deposit, expected);
 
         let Some(CliCommand::Deposit(self_deposit)) = parse_cli(&[
             "deposit",
@@ -1057,7 +1134,24 @@ mod tests {
         else {
             panic!("expected self-deposit command");
         };
-        assert_eq!(self_deposit.to, None);
+        let expected = DepositOptions {
+            network: NetworkWalletOptions {
+                sync: SyncOptions {
+                    keypair: WalletKeypairOptions {
+                        keypair: Some("/tmp/alice.pid.json".to_string()),
+                    },
+                    rpc_url: None,
+                    indexer_url: None,
+                },
+                tree: Some("Tree111111111111111111111111111111111111111".to_string()),
+                prover_url: None,
+                airdrop_lamports: None,
+            },
+            to: None,
+            mint: "SOL".to_string(),
+            amount: 1_000_000_000,
+        };
+        assert_eq!(self_deposit, expected);
 
         let Some(CliCommand::Transfer(transfer)) = parse_cli(&[
             "transfer",
@@ -1078,12 +1172,24 @@ mod tests {
         else {
             panic!("expected transfer command");
         };
-        assert_eq!(transfer.to, "Recipient1111111111111111111111111111111111");
-        assert_eq!(transfer.amount, 400_000_000);
-        assert_eq!(
-            transfer.network.prover_url.as_deref(),
-            Some("http://127.0.0.1:3002")
-        );
+        let expected = TransferOptions {
+            network: NetworkWalletOptions {
+                sync: SyncOptions {
+                    keypair: WalletKeypairOptions {
+                        keypair: Some("/tmp/bob.pid.json".to_string()),
+                    },
+                    rpc_url: None,
+                    indexer_url: None,
+                },
+                tree: Some("Tree111111111111111111111111111111111111111".to_string()),
+                prover_url: Some("http://127.0.0.1:3002".to_string()),
+                airdrop_lamports: None,
+            },
+            to: "Recipient1111111111111111111111111111111111".to_string(),
+            mint: "SOL".to_string(),
+            amount: 400_000_000,
+        };
+        assert_eq!(transfer, expected);
 
         let Some(CliCommand::Withdraw(withdraw)) = parse_cli(&[
             "withdraw",
@@ -1102,7 +1208,23 @@ mod tests {
         else {
             panic!("expected withdraw command");
         };
-        assert_eq!(withdraw.to, "Dest1111111111111111111111111111111111111111");
-        assert_eq!(withdraw.amount, 200_000_000);
+        let expected = WithdrawOptions {
+            network: NetworkWalletOptions {
+                sync: SyncOptions {
+                    keypair: WalletKeypairOptions {
+                        keypair: Some("/tmp/alice.pid.json".to_string()),
+                    },
+                    rpc_url: None,
+                    indexer_url: None,
+                },
+                tree: Some("Tree111111111111111111111111111111111111111".to_string()),
+                prover_url: None,
+                airdrop_lamports: None,
+            },
+            to: "Dest1111111111111111111111111111111111111111".to_string(),
+            mint: "SOL".to_string(),
+            amount: 200_000_000,
+        };
+        assert_eq!(withdraw, expected);
     }
 }

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -14,15 +14,6 @@ pub(crate) struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum CliCommand {
-    #[command(
-        name = "test-validator",
-        about = "Start the local Zolana test validator"
-    )]
-    TestValidator(Box<TestValidatorOptions>),
-
-    #[command(name = "start-prover", about = "Start the local prover server")]
-    StartProver(StartProverOptions),
-
     #[command(name = "config", about = "Show or update CLI configuration")]
     Config {
         #[command(subcommand)]
@@ -34,6 +25,78 @@ pub(crate) enum CliCommand {
         #[command(subcommand)]
         command: WalletCommand,
     },
+
+    #[command(name = "dev", about = "Local development environment commands")]
+    Dev {
+        #[command(subcommand)]
+        command: DevCommand,
+    },
+
+    #[command(
+        name = "test-env",
+        about = "Start the local Zolana test validator (alias for `dev start`)"
+    )]
+    TestEnv(Box<TestValidatorOptions>),
+
+    #[command(
+        name = "sync",
+        about = "Sync private wallet state. Transfers run sync automatically."
+    )]
+    Sync(SyncOptions),
+
+    #[command(name = "balance", about = "Show private wallet balances")]
+    Balance(BalanceOptions),
+
+    #[command(name = "deposit", about = "Deposit into private wallet")]
+    Deposit(DepositOptions),
+
+    #[command(name = "transfer", about = "Send a private transfer")]
+    Transfer(TransferOptions),
+
+    #[command(name = "withdraw", about = "Withdraw to public address")]
+    Withdraw(WithdrawOptions),
+
+    #[command(name = "merge", about = "Enable or disable merging for this wallet")]
+    Merge(MergeOptions),
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum DevCommand {
+    #[command(name = "start", about = "Start the local Zolana test validator")]
+    Start(Box<TestValidatorOptions>),
+
+    #[command(name = "prover", about = "Local prover server commands")]
+    Prover {
+        #[command(subcommand)]
+        command: DevProverCommand,
+    },
+
+    #[command(name = "pool", about = "Local pool setup commands")]
+    Pool {
+        #[command(subcommand)]
+        command: DevPoolCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum DevProverCommand {
+    #[command(name = "start", about = "Start the local prover server")]
+    Start(StartProverOptions),
+}
+
+#[derive(Debug, Subcommand, Clone)]
+pub(crate) enum DevPoolCommand {
+    #[command(
+        name = "create-tree",
+        about = "Initialize protocol config and a pool tree on the configured RPC"
+    )]
+    CreateTree(CreateTreeOptions),
+
+    #[command(
+        name = "test-mint",
+        about = "Create a local SPL test mint, fund the wallet, and store its asset mapping"
+    )]
+    TestMint(TestMintOptions),
 }
 
 #[derive(Debug, Subcommand, Clone)]
@@ -44,11 +107,23 @@ pub(crate) enum ConfigCommand {
     #[command(name = "set", about = "Update the CLI configuration file")]
     Set(ConfigSetOptions),
 
-    #[command(name = "asset-registry", about = "Show locally configured assets")]
-    AssetRegistry,
+    #[command(name = "asset", about = "Manage the local SPL asset registry")]
+    Asset {
+        #[command(subcommand)]
+        command: ConfigAssetCommand,
+    },
+}
 
-    #[command(name = "add-asset", about = "Add or update a local SPL asset mapping")]
-    AddAsset(ConfigAddAssetOptions),
+#[derive(Debug, Subcommand, Clone)]
+pub(crate) enum ConfigAssetCommand {
+    #[command(name = "list", about = "Show locally configured assets")]
+    List,
+
+    #[command(name = "add", about = "Add or update a local SPL asset mapping")]
+    Add(ConfigAddAssetOptions),
+
+    #[command(name = "path", about = "Print the CLI config file path")]
+    Path,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -95,39 +170,6 @@ pub(crate) enum WalletCommand {
         about = "Create a filesystem private keypair and register it on-chain"
     )]
     Init(InitOptions),
-
-    #[command(
-        name = "create-tree",
-        about = "Initialize protocol config and a pool tree on the configured RPC"
-    )]
-    CreateTree(CreateTreeOptions),
-
-    #[command(
-        name = "test-mint",
-        about = "Create a local SPL test mint, fund the wallet, and store its asset mapping"
-    )]
-    TestMint(TestMintOptions),
-
-    #[command(
-        name = "sync",
-        about = "Sync private wallet state. Transfers run sync automatically."
-    )]
-    Sync(SyncOptions),
-
-    #[command(name = "balance", about = "Show private wallet balances")]
-    Balance(BalanceOptions),
-
-    #[command(name = "merge", about = "Enable or disable merging for this wallet")]
-    Merge(MergeOptions),
-
-    #[command(name = "deposit", about = "Deposit into private wallet")]
-    Deposit(DepositOptions),
-
-    #[command(name = "transfer", about = "Send a private transfer")]
-    Transfer(TransferOptions),
-
-    #[command(name = "withdraw", about = "Withdraw to public address")]
-    Withdraw(WithdrawOptions),
 }
 
 #[derive(Debug)]
@@ -556,15 +598,36 @@ pub(crate) fn parse_cli(values: &[&str]) -> Cli {
 #[cfg(test)]
 pub(crate) fn parse_validator(values: &[&str]) -> TestValidatorOptions {
     match parse_cli(
-        &std::iter::once("test-validator")
+        &std::iter::once("dev")
+            .chain(std::iter::once("start"))
             .chain(values.iter().copied())
             .collect::<Vec<_>>(),
     )
     .command
     .expect("command")
     {
-        CliCommand::TestValidator(opts) => *opts,
-        _ => panic!("expected test-validator command"),
+        CliCommand::Dev {
+            command: DevCommand::Start(opts),
+        } => *opts,
+        _ => panic!("expected dev start command"),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn parse_dev_pool(values: &[&str]) -> DevPoolCommand {
+    match parse_cli(
+        &["dev", "pool"]
+            .into_iter()
+            .chain(values.iter().copied())
+            .collect::<Vec<_>>(),
+    )
+    .command
+    .expect("command")
+    {
+        CliCommand::Dev {
+            command: DevCommand::Pool { command },
+        } => command,
+        _ => panic!("expected dev pool command"),
     }
 }
 
@@ -590,11 +653,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_validator_help_documents_localnet_flags() {
+    fn dev_start_help_documents_localnet_flags() {
         let mut command = Cli::command();
         let help = command
-            .find_subcommand_mut("test-validator")
-            .expect("test-validator subcommand")
+            .find_subcommand_mut("dev")
+            .expect("dev subcommand")
+            .find_subcommand_mut("start")
+            .expect("dev start subcommand")
             .render_long_help()
             .to_string();
 
@@ -613,19 +678,27 @@ mod tests {
     fn clap_accepts_top_level_and_command_help() {
         for args in [
             ["zolana", "--help"].as_slice(),
-            ["zolana", "test-validator", "--help"].as_slice(),
-            ["zolana", "start-prover", "--help"].as_slice(),
-            ["zolana", "config", "asset-registry", "--help"].as_slice(),
-            ["zolana", "config", "add-asset", "--help"].as_slice(),
+            ["zolana", "dev", "--help"].as_slice(),
+            ["zolana", "dev", "start", "--help"].as_slice(),
+            ["zolana", "dev", "prover", "--help"].as_slice(),
+            ["zolana", "dev", "prover", "start", "--help"].as_slice(),
+            ["zolana", "dev", "pool", "--help"].as_slice(),
+            ["zolana", "dev", "pool", "create-tree", "--help"].as_slice(),
+            ["zolana", "dev", "pool", "test-mint", "--help"].as_slice(),
+            ["zolana", "test-env", "--help"].as_slice(),
+            ["zolana", "config", "--help"].as_slice(),
+            ["zolana", "config", "asset", "--help"].as_slice(),
+            ["zolana", "config", "asset", "list", "--help"].as_slice(),
+            ["zolana", "config", "asset", "add", "--help"].as_slice(),
+            ["zolana", "config", "asset", "path", "--help"].as_slice(),
             ["zolana", "wallet", "--help"].as_slice(),
             ["zolana", "wallet", "init", "--help"].as_slice(),
-            ["zolana", "wallet", "create-tree", "--help"].as_slice(),
-            ["zolana", "wallet", "test-mint", "--help"].as_slice(),
-            ["zolana", "wallet", "sync", "--help"].as_slice(),
-            ["zolana", "wallet", "balance", "--help"].as_slice(),
-            ["zolana", "wallet", "deposit", "--help"].as_slice(),
-            ["zolana", "wallet", "transfer", "--help"].as_slice(),
-            ["zolana", "wallet", "withdraw", "--help"].as_slice(),
+            ["zolana", "sync", "--help"].as_slice(),
+            ["zolana", "balance", "--help"].as_slice(),
+            ["zolana", "deposit", "--help"].as_slice(),
+            ["zolana", "transfer", "--help"].as_slice(),
+            ["zolana", "withdraw", "--help"].as_slice(),
+            ["zolana", "merge", "--help"].as_slice(),
         ] {
             let error = Cli::try_parse_from(args).expect_err("help exits early");
             assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
@@ -688,9 +761,11 @@ mod tests {
     }
 
     #[test]
-    fn parses_start_prover_options() {
+    fn parses_dev_prover_start_options() {
         let command = parse_cli(&[
-            "start-prover",
+            "dev",
+            "prover",
+            "start",
             "--port",
             "3002",
             "--redis-url",
@@ -698,8 +773,14 @@ mod tests {
         ])
         .command
         .expect("command");
-        let CliCommand::StartProver(opts) = command else {
-            panic!("expected start-prover command");
+        let CliCommand::Dev {
+            command:
+                DevCommand::Prover {
+                    command: DevProverCommand::Start(opts),
+                },
+        } = command
+        else {
+            panic!("expected dev prover start command");
         };
 
         assert_eq!(opts.prover_port, 3002);
@@ -707,12 +788,18 @@ mod tests {
     }
 
     #[test]
-    fn parses_start_prover_auto_download_option() {
-        let command = parse_cli(&["start-prover", "--auto-download", "off"])
+    fn parses_dev_prover_start_auto_download_option() {
+        let command = parse_cli(&["dev", "prover", "start", "--auto-download", "off"])
             .command
             .expect("command");
-        let CliCommand::StartProver(opts) = command else {
-            panic!("expected start-prover command");
+        let CliCommand::Dev {
+            command:
+                DevCommand::Prover {
+                    command: DevProverCommand::Start(opts),
+                },
+        } = command
+        else {
+            panic!("expected dev prover start command");
         };
 
         assert!(!opts.auto_download);
@@ -735,17 +822,15 @@ mod tests {
             "http://127.0.0.1:8900",
             "--airdrop-lamports",
             "1000000000",
-        ]) else {
-            panic!("expected wallet init command");
-        };
+        ]);
         assert_eq!(opts.path.as_deref(), Some("/tmp/alice.pid.json"));
         assert_eq!(opts.rpc_url.as_deref(), Some("http://127.0.0.1:8900"));
         assert_eq!(opts.airdrop_lamports, Some(1_000_000_000));
     }
 
     #[test]
-    fn parses_wallet_create_tree_options() {
-        let WalletCommand::CreateTree(opts) = parse_wallet(&[
+    fn parses_dev_pool_create_tree_options() {
+        let DevPoolCommand::CreateTree(opts) = parse_dev_pool(&[
             "create-tree",
             "--keypair",
             "/tmp/alice.pid.json",
@@ -758,7 +843,7 @@ mod tests {
             "--airdrop-lamports",
             "1000000000",
         ]) else {
-            panic!("expected wallet create-tree command");
+            panic!("expected dev pool create-tree command");
         };
         assert_eq!(
             opts.sync.keypair.keypair.as_deref(),
@@ -777,7 +862,8 @@ mod tests {
     fn parses_config_asset_commands() {
         let Some(CliCommand::Config { command }) = parse_cli(&[
             "config",
-            "add-asset",
+            "asset",
+            "add",
             "--mint",
             "Mint111111111111111111111111111111111111111",
             "--asset-id",
@@ -789,8 +875,11 @@ mod tests {
         else {
             panic!("expected config command");
         };
-        let ConfigCommand::AddAsset(opts) = command else {
-            panic!("expected add-asset command");
+        let ConfigCommand::Asset {
+            command: ConfigAssetCommand::Add(opts),
+        } = command
+        else {
+            panic!("expected config asset add command");
         };
         assert_eq!(opts.asset_id, 2);
         assert_eq!(opts.mint, "Mint111111111111111111111111111111111111111");
@@ -801,8 +890,31 @@ mod tests {
     }
 
     #[test]
-    fn parses_wallet_test_mint_options() {
-        let WalletCommand::TestMint(opts) = parse_wallet(&[
+    fn parses_config_asset_list_and_path() {
+        let Some(CliCommand::Config {
+            command:
+                ConfigCommand::Asset {
+                    command: ConfigAssetCommand::List,
+                },
+        }) = parse_cli(&["config", "asset", "list"]).command
+        else {
+            panic!("expected config asset list command");
+        };
+
+        let Some(CliCommand::Config {
+            command:
+                ConfigCommand::Asset {
+                    command: ConfigAssetCommand::Path,
+                },
+        }) = parse_cli(&["config", "asset", "path"]).command
+        else {
+            panic!("expected config asset path command");
+        };
+    }
+
+    #[test]
+    fn parses_dev_pool_test_mint_options() {
+        let DevPoolCommand::TestMint(opts) = parse_dev_pool(&[
             "test-mint",
             "--keypair",
             "/tmp/alice.pid.json",
@@ -813,7 +925,7 @@ mod tests {
             "--airdrop-lamports",
             "1000000000",
         ]) else {
-            panic!("expected wallet test-mint command");
+            panic!("expected dev pool test-mint command");
         };
         assert_eq!(
             opts.sync.keypair.keypair.as_deref(),
@@ -825,8 +937,8 @@ mod tests {
     }
 
     #[test]
-    fn parses_wallet_sync_and_balance_options() {
-        let WalletCommand::Sync(sync) = parse_wallet(&[
+    fn parses_sync_and_balance_options() {
+        let Some(CliCommand::Sync(sync)) = parse_cli(&[
             "sync",
             "--keypair",
             "/tmp/alice.pid.json",
@@ -834,28 +946,32 @@ mod tests {
             "http://127.0.0.1:8900",
             "--indexer-url",
             "http://127.0.0.1:8785",
-        ]) else {
-            panic!("expected wallet sync command");
+        ])
+        .command
+        else {
+            panic!("expected sync command");
         };
         assert_eq!(sync.keypair.keypair.as_deref(), Some("/tmp/alice.pid.json"));
         assert_eq!(sync.rpc_url.as_deref(), Some("http://127.0.0.1:8900"));
         assert_eq!(sync.indexer_url.as_deref(), Some("http://127.0.0.1:8785"));
 
-        let WalletCommand::Balance(balance) = parse_wallet(&[
+        let Some(CliCommand::Balance(balance)) = parse_cli(&[
             "balance",
             "--keypair",
             "/tmp/alice.pid.json",
             "--mint",
             "SOL",
-        ]) else {
-            panic!("expected wallet balance command");
+        ])
+        .command
+        else {
+            panic!("expected balance command");
         };
         assert_eq!(balance.mint.as_deref(), Some("SOL"));
     }
 
     #[test]
-    fn parses_wallet_merge_options() {
-        let WalletCommand::Merge(opts) = parse_wallet(&[
+    fn parses_merge_options() {
+        let Some(CliCommand::Merge(opts)) = parse_cli(&[
             "merge",
             "--keypair",
             "/tmp/alice.pid.json",
@@ -864,8 +980,10 @@ mod tests {
             "--indexer-url",
             "http://127.0.0.1:8785",
             "--enable",
-        ]) else {
-            panic!("expected wallet merge command");
+        ])
+        .command
+        else {
+            panic!("expected merge command");
         };
 
         assert_eq!(
@@ -880,10 +998,10 @@ mod tests {
         assert!(opts.enable);
         assert!(!opts.disable);
 
-        let WalletCommand::Merge(opts) =
-            parse_wallet(&["merge", "--keypair", "/tmp/alice.pid.json", "--disable"])
+        let Some(CliCommand::Merge(opts)) =
+            parse_cli(&["merge", "--keypair", "/tmp/alice.pid.json", "--disable"]).command
         else {
-            panic!("expected wallet merge command");
+            panic!("expected merge command");
         };
 
         assert!(!opts.enable);
@@ -891,8 +1009,8 @@ mod tests {
     }
 
     #[test]
-    fn parses_wallet_deposit_transfer_and_withdraw_options() {
-        let WalletCommand::Deposit(deposit) = parse_wallet(&[
+    fn parses_deposit_transfer_and_withdraw_options() {
+        let Some(CliCommand::Deposit(deposit)) = parse_cli(&[
             "deposit",
             "--keypair",
             "/tmp/alice.pid.json",
@@ -910,8 +1028,10 @@ mod tests {
             "http://127.0.0.1:8785",
             "--airdrop-lamports",
             "2000000000",
-        ]) else {
-            panic!("expected wallet deposit command");
+        ])
+        .command
+        else {
+            panic!("expected deposit command");
         };
         assert_eq!(
             deposit.network.tree.as_deref(),
@@ -924,7 +1044,7 @@ mod tests {
         assert_eq!(deposit.amount, 1_000_000_000);
         assert_eq!(deposit.network.airdrop_lamports, Some(2_000_000_000));
 
-        let WalletCommand::Deposit(self_deposit) = parse_wallet(&[
+        let Some(CliCommand::Deposit(self_deposit)) = parse_cli(&[
             "deposit",
             "--keypair",
             "/tmp/alice.pid.json",
@@ -932,12 +1052,14 @@ mod tests {
             "Tree111111111111111111111111111111111111111",
             "--amount",
             "1000000000",
-        ]) else {
-            panic!("expected wallet self-deposit command");
+        ])
+        .command
+        else {
+            panic!("expected self-deposit command");
         };
         assert_eq!(self_deposit.to, None);
 
-        let WalletCommand::Transfer(transfer) = parse_wallet(&[
+        let Some(CliCommand::Transfer(transfer)) = parse_cli(&[
             "transfer",
             "--keypair",
             "/tmp/bob.pid.json",
@@ -951,8 +1073,10 @@ mod tests {
             "SOL",
             "--prover-url",
             "http://127.0.0.1:3002",
-        ]) else {
-            panic!("expected wallet transfer command");
+        ])
+        .command
+        else {
+            panic!("expected transfer command");
         };
         assert_eq!(transfer.to, "Recipient1111111111111111111111111111111111");
         assert_eq!(transfer.amount, 400_000_000);
@@ -961,7 +1085,7 @@ mod tests {
             Some("http://127.0.0.1:3002")
         );
 
-        let WalletCommand::Withdraw(withdraw) = parse_wallet(&[
+        let Some(CliCommand::Withdraw(withdraw)) = parse_cli(&[
             "withdraw",
             "--keypair",
             "/tmp/alice.pid.json",
@@ -973,8 +1097,10 @@ mod tests {
             "200000000",
             "--mint",
             "SOL",
-        ]) else {
-            panic!("expected wallet withdraw command");
+        ])
+        .command
+        else {
+            panic!("expected withdraw command");
         };
         assert_eq!(withdraw.to, "Dest1111111111111111111111111111111111111111");
         assert_eq!(withdraw.amount, 200_000_000);

--- a/cli/src/config_cmd.rs
+++ b/cli/src/config_cmd.rs
@@ -19,7 +19,7 @@ pub(crate) fn run_config(command: ConfigCommand) -> Result<()> {
 
 fn run_config_asset(command: ConfigAssetCommand) -> Result<()> {
     match command {
-        ConfigAssetCommand::List => run_asset_registry(),
+        ConfigAssetCommand::List => run_asset_list(),
         ConfigAssetCommand::Add(opts) => run_add_asset(opts),
         ConfigAssetCommand::Path => run_asset_path(),
     }
@@ -95,7 +95,7 @@ fn run_config_set(opts: ConfigSetOptions) -> Result<()> {
     Ok(())
 }
 
-fn run_asset_registry() -> Result<()> {
+fn run_asset_list() -> Result<()> {
     let config = CliConfigFile::load()?;
     print_assets(&config);
     Ok(())

--- a/cli/src/config_cmd.rs
+++ b/cli/src/config_cmd.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use solana_pubkey::Pubkey;
 
 use crate::{
-    args::{ConfigAddAssetOptions, ConfigCommand, ConfigSetOptions},
+    args::{ConfigAddAssetOptions, ConfigAssetCommand, ConfigCommand, ConfigSetOptions},
     cli_config::{
         config_file_path, default_keypair_path, CliConfigFile, DEFAULT_INDEXER_URL,
         DEFAULT_PROVER_URL, DEFAULT_RPC_URL, DEFAULT_TREE,
@@ -13,9 +13,21 @@ pub(crate) fn run_config(command: ConfigCommand) -> Result<()> {
     match command {
         ConfigCommand::Get => run_config_get(),
         ConfigCommand::Set(opts) => run_config_set(opts),
-        ConfigCommand::AssetRegistry => run_asset_registry(),
-        ConfigCommand::AddAsset(opts) => run_add_asset(opts),
+        ConfigCommand::Asset { command } => run_config_asset(command),
     }
+}
+
+fn run_config_asset(command: ConfigAssetCommand) -> Result<()> {
+    match command {
+        ConfigAssetCommand::List => run_asset_registry(),
+        ConfigAssetCommand::Add(opts) => run_add_asset(opts),
+        ConfigAssetCommand::Path => run_asset_path(),
+    }
+}
+
+fn run_asset_path() -> Result<()> {
+    println!("{}", config_file_path().display());
+    Ok(())
 }
 
 fn run_config_get() -> Result<()> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -12,11 +12,14 @@ use anyhow::Result;
 use clap::{CommandFactory, Parser};
 
 use crate::{
-    args::{Cli, CliCommand},
+    args::{Cli, CliCommand, DevCommand, DevPoolCommand, DevProverCommand},
     config_cmd::run_config,
     localnet::run_test_validator,
     prover::run_start_prover,
-    wallet_cli::run_wallet,
+    wallet_cli::{
+        run_balance, run_create_tree, run_deposit, run_merge, run_sync, run_test_mint,
+        run_transfer, run_wallet, run_withdraw,
+    },
 };
 
 fn main() {
@@ -28,14 +31,33 @@ fn main() {
 
 fn run(cli: Cli) -> Result<()> {
     match cli.command {
-        Some(CliCommand::TestValidator(opts)) => run_test_validator(*opts),
-        Some(CliCommand::StartProver(opts)) => run_start_prover(opts),
         Some(CliCommand::Config { command }) => run_config(command),
         Some(CliCommand::Wallet { command }) => run_wallet(command),
+        Some(CliCommand::Dev { command }) => run_dev(command),
+        Some(CliCommand::TestEnv(opts)) => run_test_validator(*opts),
+        Some(CliCommand::Sync(opts)) => run_sync(opts),
+        Some(CliCommand::Balance(opts)) => run_balance(opts),
+        Some(CliCommand::Deposit(opts)) => run_deposit(opts),
+        Some(CliCommand::Transfer(opts)) => run_transfer(opts),
+        Some(CliCommand::Withdraw(opts)) => run_withdraw(opts),
+        Some(CliCommand::Merge(opts)) => run_merge(opts),
         None => {
             Cli::command().print_help()?;
             println!();
             Ok(())
         }
+    }
+}
+
+fn run_dev(command: DevCommand) -> Result<()> {
+    match command {
+        DevCommand::Start(opts) => run_test_validator(*opts),
+        DevCommand::Prover {
+            command: DevProverCommand::Start(opts),
+        } => run_start_prover(opts),
+        DevCommand::Pool { command } => match command {
+            DevPoolCommand::CreateTree(opts) => run_create_tree(opts),
+            DevPoolCommand::TestMint(opts) => run_test_mint(opts),
+        },
     }
 }

--- a/cli/src/wallet_cli/balance.rs
+++ b/cli/src/wallet_cli/balance.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::args::BalanceOptions;
 
-pub(super) fn run_balance(opts: BalanceOptions) -> Result<()> {
+pub(crate) fn run_balance(opts: BalanceOptions) -> Result<()> {
     let ctx = sync_context(&opts.sync)?;
     let balances = ctx.wallet.balances(true)?;
 

--- a/cli/src/wallet_cli/deposit.rs
+++ b/cli/src/wallet_cli/deposit.rs
@@ -15,7 +15,7 @@ use super::{
 };
 use crate::{args::DepositOptions, cli_config::CliConfigFile};
 
-pub(super) fn run_deposit(opts: DepositOptions) -> Result<()> {
+pub(crate) fn run_deposit(opts: DepositOptions) -> Result<()> {
     ensure_positive(opts.amount)?;
     let asset = parse_address(&opts.mint)?;
     let config = CliConfigFile::load()?;

--- a/cli/src/wallet_cli/mod.rs
+++ b/cli/src/wallet_cli/mod.rs
@@ -16,19 +16,23 @@ use anyhow::Result;
 
 use crate::args::WalletCommand;
 
+// Re-export the per-command handlers so `main.rs` can dispatch the day-to-day
+// wallet commands that now live at the top level (sync/balance/merge/deposit/
+// transfer/withdraw) and the pool setup commands under `dev pool`.
+pub(crate) use balance::run_balance;
+pub(crate) use deposit::run_deposit;
+pub(crate) use registry::run_merge;
+pub(crate) use sync::run_sync;
+pub(crate) use test_mint::run_test_mint;
+pub(crate) use transaction::run_transfer;
+pub(crate) use tree::run_create_tree;
+pub(crate) use withdraw::run_withdraw;
+
 const INDEXER_TIMEOUT: Duration = Duration::from_secs(120);
 const INDEXER_POLL: Duration = Duration::from_millis(500);
 
 pub(crate) fn run_wallet(command: WalletCommand) -> Result<()> {
     match command {
         WalletCommand::Init(opts) => material::run_init(opts),
-        WalletCommand::CreateTree(opts) => tree::run_create_tree(opts),
-        WalletCommand::TestMint(opts) => test_mint::run_test_mint(opts),
-        WalletCommand::Sync(opts) => sync::run_sync(opts),
-        WalletCommand::Balance(opts) => balance::run_balance(opts),
-        WalletCommand::Merge(opts) => registry::run_merge(opts),
-        WalletCommand::Deposit(opts) => deposit::run_deposit(opts),
-        WalletCommand::Transfer(opts) => transaction::run_transfer(opts),
-        WalletCommand::Withdraw(opts) => withdraw::run_withdraw(opts),
     }
 }

--- a/cli/src/wallet_cli/registry.rs
+++ b/cli/src/wallet_cli/registry.rs
@@ -24,7 +24,7 @@ pub(super) fn register_wallet_on_chain(
     )?)
 }
 
-pub(super) fn run_merge(opts: MergeOptions) -> Result<()> {
+pub(crate) fn run_merge(opts: MergeOptions) -> Result<()> {
     let sync = resolve_sync(&opts.sync)?;
     let rpc = SolanaRpc::new(sync.rpc_url.clone());
     let material = load_sender_from_resolved_sync(&sync)?;

--- a/cli/src/wallet_cli/sync.rs
+++ b/cli/src/wallet_cli/sync.rs
@@ -22,7 +22,7 @@ pub(super) struct SyncContext {
     pub(super) report: zolana_transaction::SyncReport,
 }
 
-pub(super) fn run_sync(opts: SyncOptions) -> Result<()> {
+pub(crate) fn run_sync(opts: SyncOptions) -> Result<()> {
     let ctx = sync_context(&opts)?;
     println!(
         "ok sync stored={} unparsed={} undecryptable={}",

--- a/cli/src/wallet_cli/test_mint.rs
+++ b/cli/src/wallet_cli/test_mint.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use crate::{args::TestMintOptions, cli_config::CliConfigFile};
 
-pub(super) fn run_test_mint(opts: TestMintOptions) -> Result<()> {
+pub(crate) fn run_test_mint(opts: TestMintOptions) -> Result<()> {
     ensure_positive(opts.amount)?;
     let sync = resolve_sync(&opts.sync)?;
     let material = load_sender_from_resolved_sync(&sync)?;

--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use crate::args::TransferOptions;
 
-pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
+pub(crate) fn run_transfer(opts: TransferOptions) -> Result<()> {
     ensure_positive(opts.amount)?;
     let asset = parse_address(&opts.mint)?;
     let network = get_network(&opts.network)?;

--- a/cli/src/wallet_cli/tree.rs
+++ b/cli/src/wallet_cli/tree.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use crate::{args::CreateTreeOptions, cli_config::CliConfigFile};
 
-pub(super) fn run_create_tree(opts: CreateTreeOptions) -> Result<()> {
+pub(crate) fn run_create_tree(opts: CreateTreeOptions) -> Result<()> {
     let sync = resolve_sync(&opts.sync)?;
     let material = load_sender_from_resolved_sync(&sync)?;
     let mut rpc = SolanaRpc::new(sync.rpc_url);

--- a/cli/src/wallet_cli/util.rs
+++ b/cli/src/wallet_cli/util.rs
@@ -43,7 +43,7 @@ pub(super) fn configured_spl_token_account(
     let mint = Pubkey::new_from_array(asset.to_bytes());
     config
         .token_account_for_mint(mint)?
-        .ok_or_else(|| anyhow::anyhow!("no token account configured for SPL mint {mint}; run `zolana wallet test-mint` or `zolana config add-asset --mint {mint} --asset-id <ID> --token-account <ACCOUNT>`"))
+        .ok_or_else(|| anyhow::anyhow!("no token account configured for SPL mint {mint}; run `zolana dev pool test-mint` or `zolana config asset add --mint {mint} --asset-id <ID> --token-account <ACCOUNT>`"))
         .map(Some)
 }
 

--- a/cli/src/wallet_cli/withdraw.rs
+++ b/cli/src/wallet_cli/withdraw.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::args::WithdrawOptions;
 
-pub(super) fn run_withdraw(opts: WithdrawOptions) -> Result<()> {
+pub(crate) fn run_withdraw(opts: WithdrawOptions) -> Result<()> {
     ensure_positive(opts.amount)?;
     let asset = parse_address(&opts.mint)?;
     let network = get_network(&opts.network)?;

--- a/justfile
+++ b/justfile
@@ -144,7 +144,7 @@ test-localnet-e2e: build-programs build-prover-server build-cli
     #!/usr/bin/env bash
     set -euo pipefail
     eval "$(cargo run -q -p xtask -- program-ids)"
-    cargo run -p zolana-cli -- test-validator --skip-prover --no-use-surfpool --rpc-port {{localnet-rpc-port}} --sbf-program "$SHIELDED_POOL_PROGRAM_ID" target/deploy/shielded_pool_program.so --sbf-program "$USER_REGISTRY_PROGRAM_ID" target/deploy/zolana_user_registry.so --sbf-program "$ZONE_TEST_PROGRAM_ID" target/deploy/zone_test_program.so
+    cargo run -p zolana-cli -- dev start --skip-prover --no-use-surfpool --rpc-port {{localnet-rpc-port}} --sbf-program "$SHIELDED_POOL_PROGRAM_ID" target/deploy/shielded_pool_program.so --sbf-program "$USER_REGISTRY_PROGRAM_ID" target/deploy/zolana_user_registry.so --sbf-program "$ZONE_TEST_PROGRAM_ID" target/deploy/zone_test_program.so
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" cargo test -p shielded-pool-tests --features localnet --test localnet_e2e -- --nocapture
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" cargo test -p shielded-pool-tests --features localnet --test localnet_deposit -- --nocapture
 

--- a/program-tests/shielded-pool/tests/localnet_photon_e2e.rs
+++ b/program-tests/shielded-pool/tests/localnet_photon_e2e.rs
@@ -1446,8 +1446,8 @@ fn restart_localnet() {
             smart_account_account_dir,
         ])
         .status()
-        .expect("run zolana test-validator");
-    assert!(status.success(), "zolana test-validator restart failed");
+        .expect("run zolana dev start");
+    assert!(status.success(), "zolana dev start restart failed");
 }
 
 /// End-to-end encrypted transfer: shield two sender UTXOs, transfer one private

--- a/program-tests/shielded-pool/tests/localnet_photon_e2e.rs
+++ b/program-tests/shielded-pool/tests/localnet_photon_e2e.rs
@@ -1425,7 +1425,8 @@ fn restart_localnet() {
     let status = std::process::Command::new(&cli)
         .current_dir(root)
         .args([
-            "test-validator",
+            "dev",
+            "start",
             "--no-use-surfpool",
             "--with-photon",
             "--skip-prover",

--- a/program-tests/shielded-pool/tests/localnet_wallet_cli_e2e.rs
+++ b/program-tests/shielded-pool/tests/localnet_wallet_cli_e2e.rs
@@ -136,8 +136,8 @@ fn restart_localnet() {
             &user_registry_so,
         ])
         .status()
-        .expect("run zolana test-validator");
-    assert!(status.success(), "zolana test-validator restart failed");
+        .expect("run zolana dev start");
+    assert!(status.success(), "zolana dev start restart failed");
 }
 
 fn cli_bin() -> PathBuf {

--- a/program-tests/shielded-pool/tests/localnet_wallet_cli_e2e.rs
+++ b/program-tests/shielded-pool/tests/localnet_wallet_cli_e2e.rs
@@ -117,7 +117,8 @@ fn restart_localnet() {
     let status = Command::new(&cli)
         .current_dir(root)
         .args([
-            "test-validator",
+            "dev",
+            "start",
             "--no-use-surfpool",
             "--with-photon",
             "--skip-prover",
@@ -249,7 +250,8 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
 
     let create_tree_out = run_cli_with_env(
         &[
-            "wallet",
+            "dev",
+            "pool",
             "create-tree",
             "--keypair",
             &alice.display().to_string(),
@@ -268,7 +270,8 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
 
     let test_mint_out = run_cli_with_env(
         &[
-            "wallet",
+            "dev",
+            "pool",
             "test-mint",
             "--keypair",
             &alice.display().to_string(),
@@ -309,7 +312,7 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
         "unregistered ATA should start empty"
     );
 
-    let asset_registry_out = run_cli_with_env(&["config", "asset-registry"], &cli_env)?;
+    let asset_registry_out = run_cli_with_env(&["config", "asset", "list"], &cli_env)?;
     assert!(
         asset_registry_out.contains(&spl_mint),
         "asset registry missing SPL mint: {asset_registry_out}"
@@ -319,7 +322,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
     for _ in 0..2 {
         run_cli_with_env(
             &[
-                "wallet",
                 "deposit",
                 "--keypair",
                 &alice.display().to_string(),
@@ -342,7 +344,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
 
     let sync_out = run_cli_with_env(
         &[
-            "wallet",
             "sync",
             "--keypair",
             &bob.display().to_string(),
@@ -357,7 +358,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
 
     let balance_out = run_cli_with_env(
         &[
-            "wallet",
             "balance",
             "--keypair",
             &bob.display().to_string(),
@@ -379,7 +379,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
 
     run_cli_with_env(
         &[
-            "wallet",
             "deposit",
             "--keypair",
             &alice.display().to_string(),
@@ -401,7 +400,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
 
     let spl_balance_out = run_cli_with_env(
         &[
-            "wallet",
             "balance",
             "--keypair",
             &bob.display().to_string(),
@@ -422,7 +420,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
     let alice_funding = funding_pubkey(&alice)?;
     run_cli_with_env(
         &[
-            "wallet",
             "transfer",
             "--keypair",
             &bob.display().to_string(),
@@ -446,7 +443,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
 
     run_cli_with_env(
         &[
-            "wallet",
             "transfer",
             "--keypair",
             &bob.display().to_string(),
@@ -473,7 +469,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
         spl_token_account_amount(&rpc, &alice_token_account.parse()?)?;
     run_cli_with_env(
         &[
-            "wallet",
             "transfer",
             "--keypair",
             &bob.display().to_string(),
@@ -507,7 +502,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
 
     run_cli_with_env(
         &[
-            "wallet",
             "sync",
             "--keypair",
             &alice.display().to_string(),
@@ -521,7 +515,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
 
     run_cli_with_env(
         &[
-            "wallet",
             "withdraw",
             "--keypair",
             &alice.display().to_string(),
@@ -545,7 +538,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
 
     let alice_spl_balance_out = run_cli_with_env(
         &[
-            "wallet",
             "balance",
             "--keypair",
             &alice.display().to_string(),
@@ -571,7 +563,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
     );
     run_cli_with_env(
         &[
-            "wallet",
             "withdraw",
             "--keypair",
             &alice.display().to_string(),

--- a/program-tests/spp-test-validator/tests/localnet.rs
+++ b/program-tests/spp-test-validator/tests/localnet.rs
@@ -111,8 +111,8 @@ pub(crate) fn restart_localnet() {
             account_dir,
         ])
         .status()
-        .expect("run zolana test-validator");
-    assert!(status.success(), "zolana test-validator restart failed");
+        .expect("run zolana dev start");
+    assert!(status.success(), "zolana dev start restart failed");
 }
 
 pub(crate) fn send_transaction(

--- a/program-tests/spp-test-validator/tests/localnet.rs
+++ b/program-tests/spp-test-validator/tests/localnet.rs
@@ -87,7 +87,8 @@ pub(crate) fn restart_localnet() {
     let status = std::process::Command::new(&cli)
         .current_dir(root)
         .args([
-            "test-validator",
+            "dev",
+            "start",
             "--no-use-surfpool",
             "--with-photon",
             "--skip-prover",

--- a/program-tests/zone-test-program/tests/localnet.rs
+++ b/program-tests/zone-test-program/tests/localnet.rs
@@ -95,7 +95,8 @@ pub(crate) fn restart_localnet() {
     let status = std::process::Command::new(&cli)
         .current_dir(root)
         .args([
-            "test-validator",
+            "dev",
+            "start",
             "--no-use-surfpool",
             "--with-photon",
             "--skip-prover",

--- a/program-tests/zone-test-program/tests/localnet.rs
+++ b/program-tests/zone-test-program/tests/localnet.rs
@@ -122,8 +122,8 @@ pub(crate) fn restart_localnet() {
             account_dir,
         ])
         .status()
-        .expect("run zolana test-validator");
-    assert!(status.success(), "zolana test-validator restart failed");
+        .expect("run zolana dev start");
+    assert!(status.success(), "zolana dev start restart failed");
 }
 
 pub(crate) fn send_transaction(

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -237,7 +237,7 @@ pub fn spawn_prover() -> Result<(), ClientError> {
     let port = prover_port(&server_address());
     let spawn_result = Command::new("sh")
         .arg("-c")
-        .arg(format!("{cli} start-prover --prover-port {port}"))
+        .arg(format!("{cli} dev prover start --prover-port {port}"))
         .spawn();
 
     let result = match spawn_result {


### PR DESCRIPTION
Aligns the `zolana` CLI command tree with the CLI design doc. Pure command-tree reorganization — handler logic and option structs are unchanged. Keeps the `zolana` name / `~/.config/zolana` / `ZOLANA_*` (no rename) and adds no legacy-name redirects.

### Changes
- **`dev` group** for the local stack: `dev start` (was `test-validator`), `dev prover start` (was `start-prover`), `dev pool create-tree|test-mint` (were under `wallet`). `test-env` kept as a top-level alias for `dev start`.
- **Flattened wallet commands** to the top level (Solana-CLI ergonomics): `sync`, `balance`, `deposit`, `transfer`, `withdraw`, `merge`. `wallet` keeps lifecycle (`init`).
- **`config asset {list,add,path}`** replaces `config asset-registry` / `config add-asset`.

### Out of scope (other PRs / future)
`address`/`utxos`, `split`/`consolidate` (#98), `forester info/run` → `dev forester` (#99/#101), `dev stop/status/logs/reset`, `wallet new/list/use`.

Validated: `cargo check`/`clippy`/`fmt` clean, `cargo test -p zolana-cli` 28 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)