### PR TITLE
feat(sdk): full shape set, arbitrary-shape submit, shape-aware selector

### DIFF
--- a/sdk-libs/client/src/actions/mod.rs
+++ b/sdk-libs/client/src/actions/mod.rs
@@ -13,11 +13,11 @@ pub use create_associated_token_account::create_associated_token_account;
 pub use deposit::{create_deposit, deposit, CreatedDeposit, Deposit, DEFAULT_DEPOSIT_CU_LIMIT};
 pub use spl_interface::{fetch_asset_id, register_spl_interface};
 #[cfg(feature = "indexer-api")]
-pub use submit::{Sendable, Submit, DEFAULT_TRANSACT_CU_LIMIT};
+pub use submit::{PreparedSubmit, Sendable, Submit, DEFAULT_TRANSACT_CU_LIMIT};
 pub use transaction::{
     create_transfer, create_transfer_sync, create_withdrawal, create_withdrawal_sync,
-    sign_transaction, sign_transaction_sync, CreatedTransfer, CreatedWithdrawal, PrivateTransfer,
-    ResolvedAddress, Withdrawal,
+    select_inputs_for_shape, sign_transaction, sign_transaction_sync, CreatedTransfer,
+    CreatedWithdrawal, PrivateTransfer, ResolvedAddress, Withdrawal, MAX_SELECTABLE_INPUTS,
 };
 
 pub use crate::user_registry::TransferRecipient;

--- a/sdk-libs/client/src/actions/submit.rs
+++ b/sdk-libs/client/src/actions/submit.rs
@@ -210,6 +210,61 @@ impl Sendable for CreatedWithdrawal {
     }
 }
 
+/// A hand-built [`SignedTransaction`] paired with the submit metadata a bare
+/// transaction cannot carry, so it can go through [`Submit::execute`] like a
+/// [`CreatedTransfer`] or [`CreatedWithdrawal`].
+///
+/// [`PrivateTransfer`](crate::PrivateTransfer) and
+/// [`Withdrawal`](crate::Withdrawal) are the ordinary path and already produce a
+/// [`Sendable`]. Reach for this only when the transaction was assembled directly
+/// through the [`Transaction`](zolana_transaction::instructions::transact::Transaction)
+/// builder — preselected/locked inputs or a non-default shape the high-level
+/// actions cannot express.
+///
+/// [`Sendable`] is deliberately not implemented for [`SignedTransaction`] on its
+/// own: the payload cannot recover an SPL withdrawal's routing accounts, and
+/// which party's view tag to poll the indexer for is caller context. This
+/// wrapper supplies both explicitly.
+#[derive(Clone)]
+pub struct PreparedSubmit {
+    signed: SignedTransaction,
+    wait_tag: [u8; 32],
+    withdrawal: Option<TransactWithdrawal>,
+}
+
+impl PreparedSubmit {
+    /// Wrap `signed` with the view `wait_tag` [`Submit::execute`] polls the
+    /// indexer for (typically the sender's or recipient's confidential view
+    /// tag). Pass `withdrawal` when the transaction settles a private-to-public
+    /// withdrawal — its routing accounts are not recoverable from `signed` —
+    /// or `None` for a purely private transfer.
+    pub fn new(
+        signed: SignedTransaction,
+        wait_tag: [u8; 32],
+        withdrawal: Option<TransactWithdrawal>,
+    ) -> Self {
+        Self {
+            signed,
+            wait_tag,
+            withdrawal,
+        }
+    }
+}
+
+impl Sendable for PreparedSubmit {
+    fn signed(&self) -> &SignedTransaction {
+        &self.signed
+    }
+
+    fn withdrawal(&self) -> Option<&TransactWithdrawal> {
+        self.withdrawal.as_ref()
+    }
+
+    fn wait_tag(&self) -> [u8; 32] {
+        self.wait_tag
+    }
+}
+
 /// A proven transaction: the ready-to-send `Transact` instruction data plus the
 /// pieces a caller reporting a bare proof needs (compressed proof, public input
 /// hash, circuit id).
@@ -349,5 +404,49 @@ mod tests {
         assert_eq!(instructions.len(), 2);
         assert_eq!(instructions[0].data, cu_expected.data);
         assert_eq!(instructions[1], transact_ix);
+    }
+
+    fn signed_transfer() -> SignedTransaction {
+        use zolana_keypair::ShieldedKeypair;
+        use zolana_transaction::{
+            instructions::{transact::Transaction, types::SpendUtxo},
+            AssetRegistry, Data, Utxo, SOL_MINT,
+        };
+
+        let sender = ShieldedKeypair::new().unwrap();
+        let utxo = Utxo {
+            owner: sender.signing_pubkey(),
+            asset: SOL_MINT,
+            amount: 100,
+            blinding: [7u8; 31],
+            zone_program_id: None,
+            data: Data::default(),
+        };
+        let tx = Transaction::new(
+            sender.shielded_address().unwrap(),
+            vec![SpendUtxo::from_keypair(utxo, &sender)],
+            Address::default(),
+        );
+        tx.sign(&sender, &AssetRegistry::default()).unwrap()
+    }
+
+    #[test]
+    fn prepared_submit_preserves_wait_tag_and_withdrawal_metadata() {
+        use zolana_interface::instruction::{TransactSolWithdrawal, TransactWithdrawal};
+
+        let signed = signed_transfer();
+        let tag = [9u8; 32];
+
+        let transfer = PreparedSubmit::new(signed.clone(), tag, None);
+        assert_eq!(transfer.wait_tag(), tag);
+        assert!(transfer.withdrawal().is_none());
+        assert_eq!(transfer.signed().shape, signed.shape);
+        assert_eq!(transfer.signed().inputs.len(), signed.inputs.len());
+
+        let withdrawal = TransactWithdrawal::Sol(TransactSolWithdrawal {
+            recipient: Pubkey::new_unique(),
+        });
+        let settlement = PreparedSubmit::new(signed, tag, Some(withdrawal));
+        assert_eq!(settlement.withdrawal(), Some(&withdrawal));
     }
 }

--- a/sdk-libs/client/src/actions/submit.rs
+++ b/sdk-libs/client/src/actions/submit.rs
@@ -359,9 +359,10 @@ fn wait_for_indexed_transaction(
             return Ok(());
         }
         if started.elapsed() >= INDEXER_TIMEOUT {
-            return Err(ClientError::Rpc(format!(
-                "timed out after {INDEXER_TIMEOUT:?} waiting for the indexer to pick up {signature}"
-            )));
+            return Err(ClientError::TransactionNotIndexed {
+                signature,
+                timeout_seconds: INDEXER_TIMEOUT.as_secs(),
+            });
         }
         sleep(INDEXER_POLL);
     }

--- a/sdk-libs/client/src/actions/transaction.rs
+++ b/sdk-libs/client/src/actions/transaction.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use solana_pubkey::Pubkey;
 use zolana_interface::{
     instruction::{TransactSolWithdrawal, TransactSplWithdrawal, TransactWithdrawal},
@@ -6,13 +8,17 @@ use zolana_interface::{
 use zolana_keypair::{shielded::ShieldedAddress, viewing_key::ViewTag, SignatureType};
 use zolana_transaction::{
     instructions::{
-        transact::{PreparedTransaction, SignedTransaction, Transaction, WithdrawalTarget},
+        transact::{
+            PreparedTransaction, SignedTransaction, Transaction, WithdrawalTarget,
+            SENDER_SLOT_COUNT,
+        },
         types::SpendUtxo,
     },
-    Address, AssetRegistry, Wallet,
+    Address, AssetRegistry, Wallet, WalletUtxo,
 };
 
 use crate::{
+    canonical_shape,
     error::ClientError,
     user_registry::TransferRecipient,
     wallet_authority::{
@@ -391,6 +397,91 @@ async fn select_inputs<A: WalletAuthority + ?Sized>(
     Ok(selected)
 }
 
+/// UTXO count ceiling for a single shaped transaction: the largest input arity
+/// any supported transfer shape provides.
+pub const MAX_SELECTABLE_INPUTS: usize = 5;
+
+/// Select the fewest unlocked UTXOs of `asset` whose combined value covers
+/// `amount`, such that the resulting transaction — `selected` inputs against
+/// [`SENDER_SLOT_COUNT`] sender-change slots plus `output_count` recipient
+/// outputs — fits a [supported shape](crate::SUPPORTED_SHAPES) within
+/// [`MAX_SELECTABLE_INPUTS`].
+///
+/// Unlike the greedy [`select_inputs`] behind the high-level transfer, this is
+/// shape- and lock-aware: `output_count` is the number of recipient outputs the
+/// caller intends to add (the builder always reserves [`SENDER_SLOT_COUNT`]
+/// change slots on top), and `excluded` holds the commitment hashes
+/// (`WalletUtxo::output_context.hash`) of UTXOs already locked in flight, which
+/// are skipped so concurrent transactions spend disjoint sets.
+///
+/// Picks largest-first to reach `amount` in the fewest inputs, and separates two
+/// failures a caller handles differently:
+/// - [`ClientError::InsufficientBalance`] — the total unlocked balance is below
+///   `amount`; the wallet simply lacks the funds.
+/// - [`ClientError::ShapeExceeded`] — the balance covers `amount` but is too
+///   fragmented (or `output_count` is too large) for any subset of at most
+///   [`MAX_SELECTABLE_INPUTS`] UTXOs to fit a supported shape; the caller should
+///   consolidate/denominate before retrying.
+pub async fn select_inputs_for_shape<A: WalletAuthority + ?Sized>(
+    wallet: &Wallet,
+    authority: &A,
+    asset: Address,
+    amount: u64,
+    output_count: usize,
+    excluded: &HashSet<[u8; 32]>,
+) -> Result<Vec<SpendUtxo>, ClientError> {
+    let nullifier_key = authority.spend_nullifier_key().await?;
+    let required_outputs = SENDER_SLOT_COUNT + output_count;
+
+    // Spendable UTXOs of this asset, largest first, so the running sum reaches
+    // `amount` in the fewest inputs.
+    let mut available: Vec<&WalletUtxo> = wallet
+        .utxos
+        .iter()
+        .filter(|entry| {
+            !entry.spent
+                && entry.utxo.asset == asset
+                && !excluded.contains(&entry.output_context.hash)
+        })
+        .collect();
+    available.sort_by_key(|entry| std::cmp::Reverse(entry.utxo.amount));
+
+    let mut total = 0u64;
+    for entry in &available {
+        total = total
+            .checked_add(entry.utxo.amount)
+            .ok_or(ClientError::SelectedBalanceOverflow)?;
+    }
+    if total < amount {
+        return Err(ClientError::InsufficientBalance {
+            requested: amount,
+            available: total,
+        });
+    }
+
+    let mut selected = Vec::new();
+    let mut running = 0u64;
+    for entry in available.iter().take(MAX_SELECTABLE_INPUTS) {
+        selected.push(SpendUtxo {
+            utxo: entry.utxo.clone(),
+            nullifier_key: nullifier_key.clone(),
+            data_hash: None,
+            zone_data_hash: None,
+        });
+        // Bounded by `total`, which was overflow-checked above.
+        running += entry.utxo.amount;
+        if running >= amount && canonical_shape(selected.len(), required_outputs).is_ok() {
+            return Ok(selected);
+        }
+    }
+
+    Err(ClientError::ShapeExceeded {
+        requested: amount,
+        available: total,
+        max_inputs: MAX_SELECTABLE_INPUTS,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use borsh::to_vec;
@@ -536,6 +627,145 @@ mod tests {
             result.withdrawal,
             Some(TransactWithdrawal::Sol(TransactSolWithdrawal { recipient }))
         );
+    }
+
+    fn wallet_with_amounts(keypair: ShieldedKeypair, asset: Address, amounts: &[u64]) -> Wallet {
+        let registry = if asset == SOL_MINT {
+            AssetRegistry::default()
+        } else {
+            AssetRegistry::new([(2, asset)]).expect("asset registry")
+        };
+        let mut wallet = Wallet::new(keypair.clone(), registry).expect("wallet");
+        let nullifier_pk = keypair.nullifier_key.pubkey().expect("nullifier pubkey");
+        for (i, &amount) in amounts.iter().enumerate() {
+            let utxo = Utxo {
+                owner: keypair.signing_pubkey(),
+                asset,
+                amount,
+                blinding: [(i + 1) as u8; 31],
+                zone_program_id: None,
+                data: Data::default(),
+            };
+            let hash = utxo
+                .hash(&nullifier_pk, &[0u8; 32], &[0u8; 32])
+                .expect("utxo hash");
+            let nullifier = utxo
+                .nullifier(&hash, &keypair.nullifier_key)
+                .expect("nullifier");
+            wallet.utxos.push(WalletUtxo {
+                utxo,
+                output_context: zolana_transaction::instructions::transact::types::OutputContext {
+                    hash,
+                    tree: Address::default(),
+                    leaf_index: i as u64,
+                },
+                nullifier,
+                spent: false,
+            });
+        }
+        wallet
+    }
+
+    fn select(
+        wallet: &Wallet,
+        keypair: &ShieldedKeypair,
+        amount: u64,
+        output_count: usize,
+        excluded: &HashSet<[u8; 32]>,
+    ) -> Result<Vec<SpendUtxo>, ClientError> {
+        futures::executor::block_on(select_inputs_for_shape(
+            wallet,
+            keypair,
+            SOL_MINT,
+            amount,
+            output_count,
+            excluded,
+        ))
+    }
+
+    fn selected_amounts(selected: &[SpendUtxo]) -> Vec<u64> {
+        selected.iter().map(|s| s.utxo.amount).collect()
+    }
+
+    #[test]
+    fn shape_selector_picks_fewest_inputs_largest_first() {
+        let keypair = ShieldedKeypair::new().unwrap();
+        let wallet = wallet_with_amounts(keypair.clone(), SOL_MINT, &[100, 50, 30]);
+
+        let selected = select(&wallet, &keypair, 120, 1, &HashSet::new()).expect("selection");
+
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected_amounts(&selected), vec![100, 50]);
+    }
+
+    #[test]
+    fn shape_selector_skips_locked_utxos() {
+        let keypair = ShieldedKeypair::new().unwrap();
+        let wallet = wallet_with_amounts(keypair.clone(), SOL_MINT, &[100, 50, 30]);
+        let locked_hash = wallet.utxos[0].output_context.hash;
+        let excluded = HashSet::from([locked_hash]);
+
+        let selected = select(&wallet, &keypair, 60, 1, &excluded).expect("selection");
+
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected_amounts(&selected), vec![50, 30]);
+        assert!(selected.iter().all(|s| s.utxo.amount != 100));
+    }
+
+    #[test]
+    fn shape_selector_reports_insufficient_balance() {
+        let keypair = ShieldedKeypair::new().unwrap();
+        let wallet = wallet_with_amounts(keypair.clone(), SOL_MINT, &[10, 10]);
+
+        match select(&wallet, &keypair, 100, 1, &HashSet::new())
+            .err()
+            .expect("should fail")
+        {
+            ClientError::InsufficientBalance {
+                requested,
+                available,
+            } => assert_eq!((requested, available), (100, 20)),
+            other => panic!("expected InsufficientBalance, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shape_selector_reports_shape_exceeded_when_fragmented() {
+        let keypair = ShieldedKeypair::new().unwrap();
+        // Six UTXOs of 10 cover 60, but no <= 5-input subset does.
+        let wallet = wallet_with_amounts(keypair.clone(), SOL_MINT, &[10, 10, 10, 10, 10, 10]);
+
+        match select(&wallet, &keypair, 60, 1, &HashSet::new())
+            .err()
+            .expect("should fail")
+        {
+            ClientError::ShapeExceeded {
+                requested,
+                available,
+                max_inputs,
+            } => assert_eq!((requested, available, max_inputs), (60, 60, 5)),
+            other => panic!("expected ShapeExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn shape_selector_reports_shape_exceeded_when_output_count_caps_inputs() {
+        let keypair = ShieldedKeypair::new().unwrap();
+        // Balance is ample, but six recipient outputs force the (1,8) shape, so
+        // only a single input is admissible and one 50 UTXO cannot cover 60.
+        let wallet = wallet_with_amounts(keypair.clone(), SOL_MINT, &[50, 50]);
+
+        match select(&wallet, &keypair, 60, 6, &HashSet::new())
+            .err()
+            .expect("should fail")
+        {
+            ClientError::ShapeExceeded {
+                requested,
+                available,
+                max_inputs,
+            } => assert_eq!((requested, available, max_inputs), (60, 100, 5)),
+            other => panic!("expected ShapeExceeded, got {other:?}"),
+        }
     }
 
     #[test]

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -27,6 +27,13 @@ pub enum ClientError {
     #[error("insufficient balance for asset: requested {requested}, available {available}")]
     InsufficientBalance { requested: u64, available: u64 },
 
+    #[error("balance of {available} covers {requested} but is too fragmented: no subset of at most {max_inputs} UTXO(s) fits a supported shape")]
+    ShapeExceeded {
+        requested: u64,
+        available: u64,
+        max_inputs: usize,
+    },
+
     #[error("selected balance overflow")]
     SelectedBalanceOverflow,
 

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -114,6 +114,14 @@ pub enum ClientError {
         signature: Signature,
     },
 
+    #[error(
+        "transaction {signature} confirmed but was not indexed after {timeout_seconds} seconds"
+    )]
+    TransactionNotIndexed {
+        signature: Signature,
+        timeout_seconds: u64,
+    },
+
     #[error("asset registry entry not found for mint {mint}; the mint has no SPL interface on this deployment")]
     AssetNotRegistered { mint: Pubkey },
 

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -16,12 +16,12 @@ pub mod wallet_sync;
 pub use actions::{
     create_associated_token_account, create_deposit, create_transfer, create_transfer_sync,
     create_withdrawal, create_withdrawal_sync, fetch_asset_id, register_spl_interface,
-    sign_transaction, sign_transaction_sync, CreatedDeposit, CreatedTransfer, CreatedWithdrawal,
-    Deposit, PrivateTransfer, ResolvedAddress, TransferRecipient, Withdrawal,
-    DEFAULT_DEPOSIT_CU_LIMIT,
+    select_inputs_for_shape, sign_transaction, sign_transaction_sync, CreatedDeposit,
+    CreatedTransfer, CreatedWithdrawal, Deposit, PrivateTransfer, ResolvedAddress,
+    TransferRecipient, Withdrawal, DEFAULT_DEPOSIT_CU_LIMIT, MAX_SELECTABLE_INPUTS,
 };
 #[cfg(feature = "indexer-api")]
-pub use actions::{Sendable, Submit, DEFAULT_TRANSACT_CU_LIMIT};
+pub use actions::{PreparedSubmit, Sendable, Submit, DEFAULT_TRANSACT_CU_LIMIT};
 #[cfg(all(feature = "indexer-api", feature = "solana-rpc"))]
 pub use client::{ZolanaClient, ZolanaClientConfig, DEFAULT_TREE};
 pub use error::ClientError;

--- a/sdk-libs/client/tests/steps/transfer.rs
+++ b/sdk-libs/client/tests/steps/transfer.rs
@@ -13,7 +13,10 @@ use zolana_client::{CircuitType, PublicAmounts, Rpc, SpendUtxo, Transaction, Wit
 use zolana_event::OutputData;
 use zolana_keypair::{shielded::ShieldedKeypair, NullifierKey, P256Pubkey, PublicKey};
 use zolana_transaction::{
-    instructions::transact::signed_transaction::{asset_field, signed_to_field},
+    instructions::transact::{
+        signed_transaction::{asset_field, signed_to_field},
+        SENDER_SLOT_COUNT,
+    },
     serialization::{
         confidential::{
             ConfidentialRecipient, ConfidentialSenderBundle, TransferRecipientPlaintext,
@@ -99,14 +102,14 @@ impl TransferWorld {
             .map(|_| ShieldedKeypair::new().expect("recipient keypair"))
             .collect();
 
+        // These feature files are the established (2,3) proof baseline. The
+        // dedicated shape sweep covers every other prover/verifier shape.
         let mut tx = Transaction::new(
             sender.shielded_address().expect("sender address"),
             inputs,
             Address::default(),
-        );
-        if plan.declared_shape {
-            tx = tx.with_shape(zolana_transaction::instructions::transact::Shape::new(2, 3));
-        }
+        )
+        .with_shape(zolana_transaction::instructions::transact::Shape::new(2, 3));
         for (recipient, send) in recipients.iter().zip(&plan.sends) {
             tx.send(
                 &recipient.shielded_address().expect("recipient address"),
@@ -130,6 +133,13 @@ impl TransferWorld {
         }
 
         let signed = tx.sign(&sender, &assets).expect("sign");
+        if plan.declared_shape {
+            assert_eq!(
+                signed.shape,
+                zolana_transaction::instructions::transact::Shape::new(2, 3)
+            );
+        }
+        let max_recipients = signed.shape.n_outputs - SENDER_SLOT_COUNT;
 
         let commitments = signed.input_commitments().expect("input commitments");
         let first_nullifier = commitments.first().expect("at least one input").nullifier;
@@ -154,6 +164,7 @@ impl TransferWorld {
                     &sender,
                     &recipients,
                     &first_nullifier,
+                    max_recipients,
                 );
                 prove_and_verify_p256(&prover.build().expect("build"));
             }
@@ -166,6 +177,7 @@ impl TransferWorld {
                     &sender,
                     &recipients,
                     &first_nullifier,
+                    max_recipients,
                 );
                 prove_and_verify_eddsa(&prover.build().expect("build"));
             }
@@ -185,6 +197,7 @@ fn assert_outputs(
     sender: &ShieldedKeypair,
     recipients: &[ShieldedKeypair],
     first_nullifier: &[u8; 32],
+    max_recipients: usize,
 ) {
     let net_public = |asset: Asset| -> i128 {
         match &plan.withdraw {
@@ -304,7 +317,7 @@ fn assert_outputs(
             ..Default::default()
         });
     }
-    // The builder pads to the fixed (2,3) shape: the real outputs are the prefix,
+    // The builder pads to the resolved shape: the real outputs are the prefix,
     // and any trailing slots are dummy padding (owner = 0, amount = 0, random
     // blinding), which cannot be asserted by value.
     let real = outputs
@@ -382,13 +395,12 @@ fn assert_outputs(
             spl_amount: change(Asset::Spl),
             sol_amount: change(Asset::Sol),
             blinding_seed: seed,
-            // Padded to MAX_RECIPIENTS (1 for the (2,3) shape) with the sender's own
-            // viewing key so the bundle is fixed-size and hides the recipient count.
+            // Padded to the resolved shape's recipient capacity with the sender's
+            // own viewing key so the bundle hides the real recipient count.
             recipient_viewing_pks: {
-                const MAX_RECIPIENTS: usize = 1;
                 let mut pks: Vec<P256Pubkey> =
                     recipients.iter().map(|r| r.viewing_pubkey()).collect();
-                while pks.len() < MAX_RECIPIENTS {
+                while pks.len() < max_recipients {
                     pks.push(sender.viewing_pubkey());
                 }
                 pks

--- a/sdk-libs/client/tests/transaction.rs
+++ b/sdk-libs/client/tests/transaction.rs
@@ -377,6 +377,11 @@ fn dummy_output_ciphertexts_are_indistinguishable_from_real() {
             tx.send(&recipient.shielded_address().unwrap(), SOL_MINT, 60)
                 .unwrap();
         }
+        // Pin the (2,3) shape so the change-only and one-recipient builds share
+        // one shape: indistinguishability is a within-shape property, and with
+        // the full supported set a change-only transfer would otherwise resolve
+        // to the smaller (1,2) shape.
+        let tx = tx.with_shape(zolana_transaction::instructions::transact::Shape::new(2, 3));
         let signed = sign(tx, &sender).unwrap();
         let commitments = signed.input_commitments().unwrap();
         let proofs: Vec<SpendProof> = commitments.iter().map(|_| fake_spend_proof(5)).collect();
@@ -535,6 +540,10 @@ fn withdrawal_sets_external_data_and_change() {
         },
     )
     .unwrap();
+    // Pin (2,3): with the full supported set this lone-input, no-recipient
+    // withdrawal would resolve to (1,2); the test exercises the dummy padding
+    // slot the larger shape produces.
+    let tx = tx.with_shape(zolana_transaction::instructions::transact::Shape::new(2, 3));
 
     let signed = sign(tx, &sender).unwrap();
     let first_nullifier = signed

--- a/sdk-libs/transaction/src/instructions/transact/builder.rs
+++ b/sdk-libs/transaction/src/instructions/transact/builder.rs
@@ -37,7 +37,29 @@ const RECIPIENT_POSITION_BASE: u8 = 2;
 /// always start at slot 2.
 pub const SENDER_SLOT_COUNT: usize = 2;
 
-pub const SUPPORTED_SHAPES: [Shape; 1] = [Shape::new(2, 3)];
+/// The transfer proof shapes the prover and on-chain verifier serve, in
+/// ascending fit order so [`canonical_shape`] resolves a request to the
+/// smallest shape that holds it. Mirrors the client-side prover set
+/// (`zolana-client`'s `prover::shape::SUPPORTED_SHAPES`).
+///
+/// The `(1, 1)` shape is a valid prover/verifier shape but is unreachable
+/// through this builder: [`Transaction::prepare`] always emits
+/// [`SENDER_SLOT_COUNT`] leading sender-change slots, so the builder never
+/// produces fewer than two outputs. It is listed so [`resolve_shape`] agrees
+/// with the prover on the full supported set; [`canonical_shape`] simply never
+/// selects it for a builder-produced (>= 2 output) transaction.
+pub const SUPPORTED_SHAPES: [Shape; 10] = [
+    Shape::new(1, 1),
+    Shape::new(1, 2),
+    Shape::new(2, 2),
+    Shape::new(2, 3),
+    Shape::new(3, 3),
+    Shape::new(4, 3),
+    Shape::new(4, 4),
+    Shape::new(5, 3),
+    Shape::new(5, 4),
+    Shape::new(1, 8),
+];
 
 pub struct PreparedRecipient {
     pub view_tag: ViewTag,

--- a/sdk-libs/transaction/src/instructions/transact/mod.rs
+++ b/sdk-libs/transaction/src/instructions/transact/mod.rs
@@ -8,7 +8,8 @@ pub mod signed_transaction;
 pub mod types;
 
 pub use builder::{
-    PreparedRecipient, PreparedTransaction, Shape, Transaction, WithdrawalTarget, SENDER_SLOT_COUNT,
+    canonical_shape, resolve_shape, PreparedRecipient, PreparedTransaction, Shape, Transaction,
+    WithdrawalTarget, SENDER_SLOT_COUNT, SUPPORTED_SHAPES,
 };
 pub use external_data::ExternalData;
 pub use signed_transaction::{PublicAmounts, SignedTransaction};

--- a/sdk-libs/transaction/tests/builder_shapes.rs
+++ b/sdk-libs/transaction/tests/builder_shapes.rs
@@ -1,0 +1,138 @@
+//! Every builder-reachable proof shape builds and signs.
+//!
+//! The prover and on-chain verifier serve the ten shapes listed in
+//! [`SUPPORTED_SHAPES`]; `sdk-libs/client/tests/transfer_dummy.rs` proves each
+//! against its committed verifying key. This is the cheaper builder-side
+//! counterpart: it drives a real [`Transaction`] through assembly + signing for
+//! every shape (no prover server), padding a single real input and the
+//! sender-change slots up to the target dimensions, and asserts the resulting
+//! [`SignedTransaction`] has the expected `(n_inputs, n_outputs)`.
+//!
+//! Run with: `cargo test -p zolana-transaction --test builder_shapes`
+
+use zolana_keypair::ShieldedKeypair;
+use zolana_transaction::{
+    error::TransactionError,
+    instructions::{
+        transact::{
+            canonical_shape, Shape, SignedTransaction, Transaction, SENDER_SLOT_COUNT,
+            SUPPORTED_SHAPES,
+        },
+        types::SpendUtxo,
+    },
+    AssetRegistry, Data, Utxo, SOL_MINT,
+};
+
+/// A single Solana-owned input the signing keypair can spend, with a distinct
+/// blinding so repeated inputs carry distinct nullifiers.
+fn real_input(keypair: &ShieldedKeypair, amount: u64, seed: u8) -> SpendUtxo {
+    let utxo = Utxo {
+        owner: keypair.signing_pubkey(),
+        asset: SOL_MINT,
+        amount,
+        blinding: [seed; 31],
+        zone_program_id: None,
+        data: Data::default(),
+    };
+    SpendUtxo::from_keypair(utxo, keypair)
+}
+
+/// Sign a change-only transfer with `n_in` real inputs and no recipients,
+/// declaring `shape` so the builder pads inputs and sender-change slots up to
+/// its dimensions.
+fn sign_padded(shape: Shape, n_in: usize) -> Result<SignedTransaction, TransactionError> {
+    let sender = ShieldedKeypair::new().unwrap();
+    let inputs = (0..n_in)
+        .map(|i| real_input(&sender, 1_000, (i + 1) as u8))
+        .collect();
+    let tx = Transaction::new(
+        sender.shielded_address().unwrap(),
+        inputs,
+        Default::default(),
+    )
+    .with_shape(shape);
+    tx.sign(&sender, &AssetRegistry::default())
+}
+
+/// The `(1, 1)` prover shape the builder cannot emit; every other supported
+/// shape has at least [`SENDER_SLOT_COUNT`] outputs.
+fn is_builder_reachable(shape: &Shape) -> bool {
+    shape.n_outputs >= SENDER_SLOT_COUNT
+}
+
+/// Each builder-reachable shape: one real input padded up to the shape, signed,
+/// with the padded input and output counts matching the declared dimensions.
+#[test]
+fn each_supported_shape_pads_and_signs() {
+    for shape in SUPPORTED_SHAPES.iter().filter(|s| is_builder_reachable(s)) {
+        let signed = sign_padded(*shape, 1)
+            .unwrap_or_else(|e| panic!("shape {shape:?} should build and sign: {e:?}"));
+        assert_eq!(signed.shape, *shape, "recorded shape for {shape:?}");
+        assert_eq!(
+            signed.inputs.len(),
+            shape.n_inputs,
+            "inputs padded to n_inputs for {shape:?}"
+        );
+        assert_eq!(
+            signed.outputs.len(),
+            shape.n_outputs,
+            "outputs padded to n_outputs for {shape:?}"
+        );
+    }
+}
+
+/// Each builder-reachable shape built from `n_inputs` real inputs plus
+/// `n_outputs - SENDER_SLOT_COUNT` real recipients resolves (undeclared) to
+/// exactly that shape, exercising [`canonical_shape`]'s smallest-fit selection
+/// and the real recipient-encoding path across shapes.
+#[test]
+fn canonical_shape_selects_smallest_fit_and_signs() {
+    for shape in SUPPORTED_SHAPES.iter().filter(|s| is_builder_reachable(s)) {
+        let sender = ShieldedKeypair::new().unwrap();
+        let inputs = (0..shape.n_inputs)
+            .map(|i| real_input(&sender, 1_000, (i + 1) as u8))
+            .collect();
+        let mut tx = Transaction::new(
+            sender.shielded_address().unwrap(),
+            inputs,
+            Default::default(),
+        );
+        let recipients: Vec<ShieldedKeypair> = (0..shape.n_outputs - SENDER_SLOT_COUNT)
+            .map(|_| ShieldedKeypair::new().unwrap())
+            .collect();
+        for recipient in &recipients {
+            tx.send(&recipient.shielded_address().unwrap(), SOL_MINT, 10)
+                .unwrap();
+        }
+
+        let signed = tx
+            .sign(&sender, &AssetRegistry::default())
+            .unwrap_or_else(|e| panic!("shape {shape:?} should build and sign: {e:?}"));
+        assert_eq!(
+            signed.shape, *shape,
+            "canonical shape resolves to smallest fit for {shape:?}"
+        );
+        assert_eq!(signed.inputs.len(), shape.n_inputs);
+        assert_eq!(signed.outputs.len(), shape.n_outputs);
+    }
+}
+
+/// The `(1, 1)` shape is a real prover shape (`canonical_shape` names it for a
+/// single-output request) but is unreachable through the builder: a lone-input
+/// change-only transfer keeps both sender-change slots and resolves to `(1, 2)`,
+/// and declaring `(1, 1)` explicitly is rejected because two outputs exceed it.
+#[test]
+fn one_by_one_shape_is_unreachable_through_builder() {
+    assert_eq!(canonical_shape(1, 1).unwrap(), Shape::new(1, 1));
+
+    let resolved = sign_padded(canonical_shape(1, 2).unwrap(), 1).expect("change-only transfer");
+    assert_eq!(resolved.shape, Shape::new(1, 2));
+
+    match sign_padded(Shape::new(1, 1), 1) {
+        Err(TransactionError::TooManyOutputsForShape { got, max }) => {
+            assert_eq!((got, max), (2, 1));
+        }
+        Err(other) => panic!("declaring (1, 1) rejected with wrong error: {other:?}"),
+        Ok(_) => panic!("declaring (1, 1) must be rejected"),
+    }
+}


### PR DESCRIPTION
Stacked on #117 (base: `feat/sdk-client-dx`). This supplies the SDK surface used by the private on/off-ramp reference implementation.

## Summary

- Expand the transaction builder to the full prover/verifier shape set: `(1,1)`, `(1,2)`, `(2,2)`, `(2,3)`, `(3,3)`, `(4,3)`, `(4,4)`, `(5,3)`, `(5,4)`, `(1,8)`.
- Add `PreparedSubmit`, which pairs an arbitrary shaped `SignedTransaction` with explicit wait-tag and withdrawal metadata for `rpc.send().execute()`.
- Add shape-aware, exclusion-aware fewest-input selection with a five-input cap and distinct `ShapeExceeded` reporting.
- Preserve confirmed transaction signatures when indexing times out through `ClientError::TransactionNotIndexed`, allowing settlement callers to confirm chain state instead of losing the signature.
- Keep transfer BDD fixtures pinned to their established `(2,3)` proof baseline while using resolved-shape recipient capacity.

## Public API

- `zolana_transaction::instructions::transact::{SUPPORTED_SHAPES, canonical_shape, resolve_shape}`
- `zolana_client::PreparedSubmit::new(signed, wait_tag, withdrawal)`
- `zolana_client::select_inputs_for_shape(...)`
- `zolana_client::MAX_SELECTABLE_INPUTS`
- `ClientError::ShapeExceeded`
- `ClientError::TransactionNotIndexed`

`(1,1)` remains part of the prover set but is not builder-reachable because the builder always reserves two sender slots.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p zolana-transaction`
- [x] `cargo test -p zolana-client --lib actions::transaction`
- [x] `cargo test -p zolana-client --test transaction`
- [x] `cargo test -p zolana-client --features indexer-api --lib actions::submit`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`