### PR TITLE
feat(keypair): encode shielded addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
@@ -9737,6 +9738,7 @@ name = "zolana-keypair"
 version = "0.1.0"
 dependencies = [
  "aes",
+ "bs58",
  "ctr",
  "cucumber",
  "ed25519-dalek 2.2.0",

--- a/sdk-libs/keypair/Cargo.toml
+++ b/sdk-libs/keypair/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 edition.workspace = true
 
 [dependencies]
+bs58 = { workspace = true, features = ["check"] }
 p256 = { workspace = true }
 ed25519-dalek = { workspace = true }
 aes = { workspace = true }

--- a/sdk-libs/keypair/src/error.rs
+++ b/sdk-libs/keypair/src/error.rs
@@ -2,6 +2,18 @@ use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum KeypairError {
+    #[error("invalid shielded address encoding")]
+    InvalidAddressEncoding,
+
+    #[error("invalid shielded address length: expected {expected} bytes, got {actual}")]
+    InvalidAddressLength { expected: usize, actual: usize },
+
+    #[error("unsupported shielded address version: {0}")]
+    UnsupportedAddressVersion(u8),
+
+    #[error("invalid shielded address checksum")]
+    InvalidAddressChecksum,
+
     #[error("invalid public key")]
     InvalidPublicKey,
 

--- a/sdk-libs/keypair/src/lib.rs
+++ b/sdk-libs/keypair/src/lib.rs
@@ -53,7 +53,9 @@ pub mod viewing_key;
 pub use error::KeypairError;
 pub use nullifier_key::NullifierKey;
 pub use pubkey::{P256Pubkey, PublicKey, SignatureType};
-pub use shielded::{CompressedShieldedAddress, ShieldedAddress, ShieldedKeypair};
+pub use shielded::{
+    CompressedShieldedAddress, ShieldedAddress, ShieldedKeypair, SHIELDED_ADDRESS_LEN,
+};
 pub use signing_key::SigningKey;
 pub use traits::{ShieldedKeypairTrait, ViewingKeyTrait};
 pub use viewing_key::{random_blinding, random_salt, ViewingKey};

--- a/sdk-libs/keypair/src/shielded.rs
+++ b/sdk-libs/keypair/src/shielded.rs
@@ -1,5 +1,7 @@
+use std::{fmt, str::FromStr};
+
 use crate::{
-    constants::{BLINDING_LEN, SALT_LEN},
+    constants::{BLINDING_LEN, P256_PUBKEY_LEN, PUBLIC_KEY_LEN, SALT_LEN},
     error::KeypairError,
     hash::owner_hash,
     nullifier_key::NullifierKey,
@@ -7,6 +9,10 @@ use crate::{
     signing_key::SigningKey,
     viewing_key::ViewingKey,
 };
+
+const ADDRESS_VERSION: u8 = 1;
+pub const SHIELDED_ADDRESS_LEN: usize = PUBLIC_KEY_LEN + 32 + P256_PUBKEY_LEN;
+const ADDRESS_PAYLOAD_LEN: usize = 1 + SHIELDED_ADDRESS_LEN;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ShieldedAddress {
@@ -18,6 +24,75 @@ pub struct ShieldedAddress {
 impl ShieldedAddress {
     pub fn owner_hash(&self) -> Result<[u8; 32], KeypairError> {
         owner_hash(&self.signing_pubkey, &self.nullifier_pubkey)
+    }
+
+    pub fn to_bytes(self) -> [u8; SHIELDED_ADDRESS_LEN] {
+        let mut bytes = [0u8; SHIELDED_ADDRESS_LEN];
+        bytes[..PUBLIC_KEY_LEN].copy_from_slice(self.signing_pubkey.as_bytes());
+        bytes[PUBLIC_KEY_LEN..PUBLIC_KEY_LEN + 32].copy_from_slice(&self.nullifier_pubkey);
+        bytes[PUBLIC_KEY_LEN + 32..].copy_from_slice(self.viewing_pubkey.as_bytes());
+        bytes
+    }
+
+    pub fn from_bytes(bytes: [u8; SHIELDED_ADDRESS_LEN]) -> Result<Self, KeypairError> {
+        let signing_pubkey = PublicKey::from_bytes(
+            bytes[..PUBLIC_KEY_LEN]
+                .try_into()
+                .expect("shielded signing key slice has fixed length"),
+        )?;
+        let nullifier_pubkey = bytes[PUBLIC_KEY_LEN..PUBLIC_KEY_LEN + 32]
+            .try_into()
+            .expect("shielded nullifier key slice has fixed length");
+        let viewing_pubkey = P256Pubkey::from_bytes(
+            bytes[PUBLIC_KEY_LEN + 32..]
+                .try_into()
+                .expect("shielded viewing key slice has fixed length"),
+        )?;
+        let address = Self {
+            signing_pubkey,
+            nullifier_pubkey,
+            viewing_pubkey,
+        };
+        address.owner_hash()?;
+        Ok(address)
+    }
+}
+
+/// A versioned Base58Check, self-contained shielded recipient address.
+///
+/// The encoded payload contains the signing, nullifier, and viewing public keys;
+/// no on-chain registry lookup is required to send to it.
+impl fmt::Display for ShieldedAddress {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(
+            &bs58::encode(self.to_bytes())
+                .with_check_version(ADDRESS_VERSION)
+                .into_string(),
+        )
+    }
+}
+
+impl FromStr for ShieldedAddress {
+    type Err = KeypairError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let bytes = bs58::decode(value)
+            .with_check(Some(ADDRESS_VERSION))
+            .into_vec()
+            .map_err(|error| match error {
+                bs58::decode::Error::InvalidChecksum { .. } => KeypairError::InvalidAddressChecksum,
+                bs58::decode::Error::InvalidVersion { ver, .. } => {
+                    KeypairError::UnsupportedAddressVersion(ver)
+                }
+                _ => KeypairError::InvalidAddressEncoding,
+            })?;
+        if bytes.len() != ADDRESS_PAYLOAD_LEN {
+            return Err(KeypairError::InvalidAddressLength {
+                expected: ADDRESS_PAYLOAD_LEN,
+                actual: bytes.len(),
+            });
+        }
+        Self::from_bytes(bytes[1..].try_into().expect("validated address length"))
     }
 }
 
@@ -189,5 +264,97 @@ impl ShieldedKeypair {
     ) -> Result<ViewingKey, KeypairError> {
         self.viewing_key
             .get_transaction_viewing_key(first_nullifier)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shielded_address_string_round_trips() {
+        let address = ShieldedKeypair::new().unwrap().shielded_address().unwrap();
+        let encoded = address.to_string();
+
+        assert_eq!(encoded.parse::<ShieldedAddress>().unwrap(), address);
+    }
+
+    #[test]
+    fn ed25519_shielded_address_string_round_trips() {
+        let keypair = ShieldedKeypair::from_ed25519(&[7u8; 32], ViewingKey::new()).unwrap();
+        let address = keypair.shielded_address().unwrap();
+
+        assert_eq!(
+            address.to_string().parse::<ShieldedAddress>().unwrap(),
+            address
+        );
+    }
+
+    #[test]
+    fn shielded_address_rejects_invalid_base58() {
+        assert_eq!(
+            "not-an-address".parse::<ShieldedAddress>().unwrap_err(),
+            KeypairError::InvalidAddressEncoding
+        );
+    }
+
+    #[test]
+    fn shielded_address_rejects_bad_checksum() {
+        let address = ShieldedKeypair::new().unwrap().shielded_address().unwrap();
+        let encoded = address.to_string();
+        let mut bytes = bs58::decode(encoded).into_vec().unwrap();
+        bytes[1 + PUBLIC_KEY_LEN] ^= 1;
+        let corrupted = bs58::encode(bytes).into_string();
+
+        assert_eq!(
+            corrupted.parse::<ShieldedAddress>().unwrap_err(),
+            KeypairError::InvalidAddressChecksum
+        );
+    }
+
+    #[test]
+    fn shielded_address_rejects_unsupported_version() {
+        let address = ShieldedKeypair::new().unwrap().shielded_address().unwrap();
+        let unsupported = bs58::encode(address.to_bytes())
+            .with_check_version(ADDRESS_VERSION + 1)
+            .into_string();
+
+        assert_eq!(
+            unsupported.parse::<ShieldedAddress>().unwrap_err(),
+            KeypairError::UnsupportedAddressVersion(ADDRESS_VERSION + 1)
+        );
+    }
+
+    #[test]
+    fn shielded_address_rejects_wrong_payload_length() {
+        // Valid Base58Check (correct checksum + supported version) but a payload of
+        // the wrong length must be rejected, not silently truncated.
+        let short = bs58::encode([0u8; 10])
+            .with_check_version(ADDRESS_VERSION)
+            .into_string();
+        assert_eq!(
+            short.parse::<ShieldedAddress>().unwrap_err(),
+            KeypairError::InvalidAddressLength {
+                expected: ADDRESS_PAYLOAD_LEN,
+                actual: 11,
+            }
+        );
+    }
+
+    #[test]
+    fn shielded_address_encoding_is_stable() {
+        let p256 = P256Pubkey::from_bytes(crate::constants::P_CONST_SEC1).unwrap();
+        let address = ShieldedAddress {
+            signing_pubkey: PublicKey::from_p256(&p256),
+            nullifier_pubkey: [1u8; 32],
+            viewing_pubkey: p256,
+        };
+        let encoded = address.to_string();
+
+        assert_eq!(
+            encoded,
+            "FkYvNS9oCrskJGJVc2aXYqkdMErt96rVfudRRQwh3peWnFRdmjcs2ar17jS4ohnmbqdXAKceJUpVJvJrMk18qx3bMRVyudYaCDFdXqMTN7P2YggUxx9t5JtHHMnoLhBtRzhuXsKv55knX"
+        );
+        assert_eq!(encoded.parse::<ShieldedAddress>().unwrap(), address);
     }
 }


### PR DESCRIPTION
## Summary

- define a fixed 99-byte `ShieldedAddress` binary layout
- add versioned Base58Check `Display` and `FromStr` implementations
- validate embedded keys, checksum, version, and length, with a pinned golden vector

## Why

Private recipients need a self-contained printable representation before CLI and SDK flows can stop relying on mutable registry lookup. This PR only defines the codec; it does not change wallet or transfer behavior.

## Validation

- `cargo test -p zolana-keypair`
- `cargo clippy -p zolana-keypair --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
