### PR TITLE
refactor(cli): simplify private wallet flow

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -24,36 +24,42 @@ Commands:
 
 ```bash
 zolana config get
-zolana config set --keypair ~/.config/zolana/pid.json --rpc-url http://127.0.0.1:8899 --indexer-url http://127.0.0.1:8784 --prover-url http://127.0.0.1:3001
-zolana wallet init --airdrop-lamports 1000000000
+zolana config set --keypair ~/.config/zolana/id.json --rpc-url http://127.0.0.1:8899 --indexer-url http://127.0.0.1:8784 --prover-url http://127.0.0.1:3001
+zolana wallet new
+zolana wallet address
+zolana wallet address --funding
 zolana wallet create-tree --tree-keypair /tmp/zolana-tree.json --airdrop-lamports 20000000000
-zolana wallet sync --indexer-url http://127.0.0.1:8784
 zolana wallet balance --indexer-url http://127.0.0.1:8784
 zolana wallet deposit --amount 1000000000 --mint SOL --airdrop-lamports 2000000000
-zolana wallet transfer --to <RECIPIENT_SOLANA_PUBKEY> --amount 300000000 --mint SOL
+zolana wallet transfer --to <RECIPIENT_SHIELDED_ADDRESS> --amount 300000000 --mint SOL
 zolana wallet withdraw --to <PUBLIC_SOL_PUBKEY> --amount 200000000 --mint SOL
 ```
 
 Wallet commands use the wallet file's Solana funding key for fees/public SOL
-deposits and its shielded keypair for private ownership. `wallet init` creates
-or loads the wallet file and registers its shielded keys in the on-chain
-user-registry program. `deposit` shields public SOL into the local wallet by
-default and requires that wallet to be registered; `deposit --to <PUBKEY>`
-resolves the recipient from the on-chain user registry and never reads the
-recipient's wallet secrets. `transfer --to <PUBKEY>` resolves registered
-recipients from the on-chain user registry; if the registry record is absent,
-the transfer is built as a public SOL withdrawal to that pubkey. `withdraw --to
-<PUBKEY>` always uses a regular public Solana destination.
+deposits and its shielded keypair for private ownership. `wallet new` is an
+offline operation: it creates a fresh shielded identity and a funding key
+without sending a transaction. Pass `--funding-keypair
+~/.config/solana/id.json` to reuse an existing standard Solana keypair as the
+funding/fee-payer key. `wallet address` prints the self-contained shielded
+recipient address; `wallet address --funding` prints the public funding key.
+
+`deposit` shields public assets into the local wallet by default. `deposit --to
+<SHIELDED_ADDRESS>` and `transfer --to <SHIELDED_ADDRESS>` accept the exact value
+printed by `wallet address`, so receiving private transfers does not require an
+on-chain registry record. Private transfers never fall back to a public
+payment. Use `withdraw --to <PUBKEY>` for an explicit public Solana destination.
+Balance and transaction commands synchronize wallet state automatically.
 
 CLI-wide defaults live at `~/.config/zolana/config.json`. Explicit flags win
 over config values, and config values win over built-in localnet defaults. The
-`keypair` config field is the path to the wallet file (`pid.json`). `create-tree`
-writes the created tree pubkey into this config file; `deposit`, `transfer`, and
-`withdraw` only require `--tree` when neither the flag nor config has a tree.
+wallet path precedence is `-k/--keypair`, then `config.keypair`, then
+`~/.config/zolana/id.json`. Use `-C/--config <PATH>` to select another config
+file; it takes precedence over `ZOLANA_CONFIG`. `create-tree` writes the created
+tree pubkey into the selected config file; `deposit`, `transfer`, and `withdraw`
+only require `--tree` when neither the flag nor config has a tree.
 
 Optional wallet path:
 
 ```bash
---keypair /path/to/pid.json
+-k /path/to/id.json
 ```
-

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -8,6 +8,15 @@ use crate::config::{
 #[derive(Debug, Parser)]
 #[command(name = "zolana", about = "Local Zolana developer tooling")]
 pub(crate) struct Cli {
+    #[arg(
+        short = 'C',
+        long = "config",
+        global = true,
+        help = "CLI configuration file",
+        value_name = "PATH"
+    )]
+    pub(crate) config_file: Option<String>,
+
     #[command(subcommand)]
     pub(crate) command: Option<CliCommand>,
 }
@@ -90,11 +99,14 @@ pub(crate) struct ConfigAddAssetOptions {
 
 #[derive(Debug, Subcommand, Clone)]
 pub(crate) enum WalletCommand {
+    #[command(name = "new", about = "Create a local wallet keypair")]
+    New(NewWalletOptions),
+
     #[command(
-        name = "init",
-        about = "Create a filesystem private keypair and register it on-chain"
+        name = "address",
+        about = "Print the selected wallet's shielded address"
     )]
-    Init(InitOptions),
+    Address(AddressOptions),
 
     #[command(
         name = "create-tree",
@@ -107,12 +119,6 @@ pub(crate) enum WalletCommand {
         about = "Create a local SPL test mint, fund the wallet, and store its asset mapping"
     )]
     TestMint(TestMintOptions),
-
-    #[command(
-        name = "sync",
-        about = "Sync private wallet state. Transfers run sync automatically."
-    )]
-    Sync(SyncOptions),
 
     #[command(name = "balance", about = "Show private wallet balances")]
     Balance(BalanceOptions),
@@ -316,33 +322,41 @@ pub(crate) struct StartProverOptions {
 #[derive(Args, Debug, Clone)]
 pub(crate) struct WalletKeypairOptions {
     #[arg(
+        short = 'k',
         long = "keypair",
-        help = "Path to private keypair file (default: ~/.config/zolana/pid.json)",
+        help = "Wallet keypair file (default: configured path or ~/.config/zolana/id.json)",
         value_name = "PATH"
     )]
     pub(crate) keypair: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]
-pub(crate) struct InitOptions {
+pub(crate) struct AddressOptions {
+    #[command(flatten)]
+    pub(crate) keypair: WalletKeypairOptions,
+
     #[arg(
-        long = "path",
-        help = "Output path for generated keypair (default: ~/.config/zolana/pid.json)",
+        long,
+        help = "Print the wallet's public funding/fee-payer pubkey instead"
+    )]
+    pub(crate) funding: bool,
+}
+
+#[derive(Args, Debug, Clone)]
+pub(crate) struct NewWalletOptions {
+    #[arg(
+        long = "outfile",
+        help = "Output wallet file (default: configured keypair path or ~/.config/zolana/id.json)",
         value_name = "PATH"
     )]
-    pub(crate) path: Option<String>,
+    pub(crate) outfile: Option<String>,
 
     #[arg(
-        long = "rpc-url",
-        help = "Solana RPC URL used to register the wallet (default: configured value or http://127.0.0.1:8899)"
+        long = "funding-keypair",
+        help = "Use an existing Solana keypair file (e.g. ~/.config/solana/id.json) as the wallet's funding/fee-payer key instead of generating a new one",
+        value_name = "PATH"
     )]
-    pub(crate) rpc_url: Option<String>,
-
-    #[arg(
-        long = "airdrop-lamports",
-        help = "Request a localnet airdrop for the wallet funding key before registering"
-    )]
-    pub(crate) airdrop_lamports: Option<u64>,
+    pub(crate) funding_keypair: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -432,7 +446,7 @@ pub(crate) struct DepositOptions {
 
     #[arg(
         long,
-        help = "Optional registered recipient Solana pubkey (defaults to the --keypair wallet owner)"
+        help = "Optional shielded recipient address (defaults to the --keypair wallet)"
     )]
     pub(crate) to: Option<String>,
 
@@ -450,8 +464,8 @@ pub(crate) struct TransferOptions {
 
     #[arg(
         long = "to",
-        help = "Recipient Solana pubkey; registered recipients receive a shielded transfer, unregistered recipients receive a public SOL withdrawal",
-        value_name = "PUBKEY"
+        help = "Shielded recipient address",
+        value_name = "SHIELDED_ADDRESS"
     )]
     pub(crate) to: String,
 
@@ -618,10 +632,10 @@ mod tests {
             ["zolana", "config", "asset-registry", "--help"].as_slice(),
             ["zolana", "config", "add-asset", "--help"].as_slice(),
             ["zolana", "wallet", "--help"].as_slice(),
-            ["zolana", "wallet", "init", "--help"].as_slice(),
+            ["zolana", "wallet", "new", "--help"].as_slice(),
+            ["zolana", "wallet", "address", "--help"].as_slice(),
             ["zolana", "wallet", "create-tree", "--help"].as_slice(),
             ["zolana", "wallet", "test-mint", "--help"].as_slice(),
-            ["zolana", "wallet", "sync", "--help"].as_slice(),
             ["zolana", "wallet", "balance", "--help"].as_slice(),
             ["zolana", "wallet", "deposit", "--help"].as_slice(),
             ["zolana", "wallet", "transfer", "--help"].as_slice(),
@@ -726,21 +740,46 @@ mod tests {
     }
 
     #[test]
-    fn parses_wallet_init_options() {
-        let WalletCommand::Init(opts) = parse_wallet(&[
-            "init",
-            "--path",
-            "/tmp/alice.pid.json",
-            "--rpc-url",
-            "http://127.0.0.1:8900",
-            "--airdrop-lamports",
-            "1000000000",
+    fn parses_wallet_new_and_address_options() {
+        let WalletCommand::New(opts) = parse_wallet(&[
+            "new",
+            "--outfile",
+            "/tmp/alice.json",
+            "--funding-keypair",
+            "/tmp/solana.json",
         ]) else {
-            panic!("expected wallet init command");
+            panic!("expected wallet new command");
         };
-        assert_eq!(opts.path.as_deref(), Some("/tmp/alice.pid.json"));
-        assert_eq!(opts.rpc_url.as_deref(), Some("http://127.0.0.1:8900"));
-        assert_eq!(opts.airdrop_lamports, Some(1_000_000_000));
+        assert_eq!(opts.outfile.as_deref(), Some("/tmp/alice.json"));
+        assert_eq!(opts.funding_keypair.as_deref(), Some("/tmp/solana.json"));
+
+        let WalletCommand::Address(opts) =
+            parse_wallet(&["address", "-k", "/tmp/alice.json", "--funding"])
+        else {
+            panic!("expected wallet address command");
+        };
+        assert_eq!(opts.keypair.keypair.as_deref(), Some("/tmp/alice.json"));
+        assert!(opts.funding);
+    }
+
+    #[test]
+    fn parses_global_config_override() {
+        let cli = Cli::try_parse_from([
+            "zolana",
+            "-C",
+            "/tmp/zolana-config.json",
+            "wallet",
+            "address",
+        ])
+        .expect("parse global config");
+
+        assert_eq!(cli.config_file.as_deref(), Some("/tmp/zolana-config.json"));
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Wallet {
+                command: WalletCommand::Address(_)
+            })
+        ));
     }
 
     #[test]
@@ -825,22 +864,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_wallet_sync_and_balance_options() {
-        let WalletCommand::Sync(sync) = parse_wallet(&[
-            "sync",
-            "--keypair",
-            "/tmp/alice.pid.json",
-            "--rpc-url",
-            "http://127.0.0.1:8900",
-            "--indexer-url",
-            "http://127.0.0.1:8785",
-        ]) else {
-            panic!("expected wallet sync command");
-        };
-        assert_eq!(sync.keypair.keypair.as_deref(), Some("/tmp/alice.pid.json"));
-        assert_eq!(sync.rpc_url.as_deref(), Some("http://127.0.0.1:8900"));
-        assert_eq!(sync.indexer_url.as_deref(), Some("http://127.0.0.1:8785"));
-
+    fn parses_wallet_balance_options() {
         let WalletCommand::Balance(balance) = parse_wallet(&[
             "balance",
             "--keypair",

--- a/cli/src/cli_config.rs
+++ b/cli/src/cli_config.rs
@@ -3,6 +3,7 @@ use std::{
     fs::{self, OpenOptions},
     io::Write,
     path::PathBuf,
+    sync::OnceLock,
 };
 
 use anyhow::{Context, Result};
@@ -15,6 +16,7 @@ pub(crate) const DEFAULT_INDEXER_URL: &str = "http://127.0.0.1:8784";
 pub(crate) const DEFAULT_PROVER_URL: &str = "http://127.0.0.1:3001";
 pub(crate) const DEFAULT_TREE: &str = "treeYbr45LjxovKvtD46uEphM64kwoFFPYhVNw1A8x8";
 const CONFIG_VERSION: u8 = 1;
+static CONFIG_FILE_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
 
 #[cfg(test)]
 pub(crate) static CONFIG_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -143,14 +145,23 @@ pub(crate) fn config_dir() -> PathBuf {
 }
 
 pub(crate) fn config_file_path() -> PathBuf {
+    if let Some(path) = CONFIG_FILE_OVERRIDE.get() {
+        return path.clone();
+    }
     if let Ok(path) = env::var("ZOLANA_CONFIG") {
         return PathBuf::from(path);
     }
     config_dir().join("config.json")
 }
 
+pub(crate) fn set_config_file_override(path: impl Into<PathBuf>) -> Result<()> {
+    CONFIG_FILE_OVERRIDE
+        .set(path.into())
+        .map_err(|_| anyhow::anyhow!("CLI config file override was already set"))
+}
+
 pub(crate) fn default_keypair_path() -> PathBuf {
-    config_dir().join("pid.json")
+    config_dir().join("id.json")
 }
 
 pub(crate) fn resolve_keypair_path(cli_override: Option<&str>, config: &CliConfigFile) -> PathBuf {
@@ -252,6 +263,37 @@ mod tests {
         assert_eq!(
             resolve_tree(Some("So11111111111111111111111111111111111111112"), &config),
             "So11111111111111111111111111111111111111112"
+        );
+    }
+
+    #[test]
+    fn resolve_keypair_path_follows_precedence() {
+        let config = CliConfigFile {
+            keypair: Some("/tmp/config.json".to_string()),
+            ..CliConfigFile::default()
+        };
+
+        assert_eq!(
+            resolve_keypair_path(Some("/tmp/flag.json"), &config),
+            PathBuf::from("/tmp/flag.json")
+        );
+        assert_eq!(
+            resolve_keypair_path(None, &config),
+            PathBuf::from("/tmp/config.json")
+        );
+        assert_eq!(
+            resolve_keypair_path(None, &CliConfigFile::default()),
+            default_keypair_path()
+        );
+    }
+
+    #[test]
+    fn built_in_keypair_path_is_id_json() {
+        assert_eq!(
+            default_keypair_path()
+                .file_name()
+                .and_then(|name| name.to_str()),
+            Some("id.json")
         );
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,6 +13,7 @@ use clap::{CommandFactory, Parser};
 
 use crate::{
     args::{Cli, CliCommand},
+    cli_config::set_config_file_override,
     config_cmd::run_config,
     localnet::run_test_validator,
     prover::run_start_prover,
@@ -27,6 +28,9 @@ fn main() {
 }
 
 fn run(cli: Cli) -> Result<()> {
+    if let Some(path) = cli.config_file {
+        set_config_file_override(path)?;
+    }
     match cli.command {
         Some(CliCommand::TestValidator(opts)) => run_test_validator(*opts),
         Some(CliCommand::StartProver(opts)) => run_start_prover(opts),

--- a/cli/src/wallet_cli/deposit.rs
+++ b/cli/src/wallet_cli/deposit.rs
@@ -1,8 +1,5 @@
 use anyhow::Result;
-use solana_signer::Signer;
-use zolana_client::{
-    create_deposit, resolve_registered_address, CreateDeposit, SolanaRpc, ZolanaIndexer,
-};
+use zolana_client::{create_deposit, CreateDeposit, SolanaRpc, ZolanaIndexer};
 
 use super::{
     material::load_sender_from_resolved_sync,
@@ -10,7 +7,8 @@ use super::{
     sync::wait_for_indexed_utxo,
     transaction::maybe_airdrop,
     util::{
-        configured_spl_token_account, ensure_positive, format_address, parse_address, parse_pubkey,
+        configured_spl_token_account, ensure_positive, format_address, parse_address,
+        parse_shielded_address,
     },
 };
 use crate::{args::DepositOptions, cli_config::CliConfigFile};
@@ -18,6 +16,7 @@ use crate::{args::DepositOptions, cli_config::CliConfigFile};
 pub(super) fn run_deposit(opts: DepositOptions) -> Result<()> {
     ensure_positive(opts.amount)?;
     let asset = parse_address(&opts.mint)?;
+    let recipient_override = opts.to.as_deref().map(parse_shielded_address).transpose()?;
     let config = CliConfigFile::load()?;
     let spl_token_account = configured_spl_token_account(&config, asset)?;
     let network = get_network_with_config(&opts.network, &config)?;
@@ -26,15 +25,12 @@ pub(super) fn run_deposit(opts: DepositOptions) -> Result<()> {
     let material = load_sender_from_resolved_sync(&network.sync)?;
     maybe_airdrop(&mut rpc, &material, network.airdrop_lamports)?;
     let tree = network.tree;
-    let recipient_pubkey = opts
-        .to
-        .as_deref()
-        .map(parse_pubkey)
-        .transpose()?
-        .unwrap_or_else(|| material.funding.pubkey());
-    let recipient = resolve_registered_address(&rpc, recipient_pubkey)?;
+    let recipient = match recipient_override {
+        None => material.keypair.shielded_address()?,
+        Some(recipient) => recipient,
+    };
     let deposit = create_deposit(CreateDeposit {
-        recipient: &recipient.address,
+        recipient: &recipient,
         asset,
         amount: opts.amount,
         spl_token_account,
@@ -46,7 +42,7 @@ pub(super) fn run_deposit(opts: DepositOptions) -> Result<()> {
         "ok deposit amount={} mint={} to={} utxo_hash={} signature={}",
         opts.amount,
         format_address(asset),
-        recipient_pubkey,
+        recipient,
         hex::encode(deposit.utxo_hash),
         signature
     );

--- a/cli/src/wallet_cli/material.rs
+++ b/cli/src/wallet_cli/material.rs
@@ -1,7 +1,7 @@
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::{
-    fs::{self, OpenOptions},
+    fs::{self, File, OpenOptions},
     io::Write,
     path::Path,
 };
@@ -13,7 +13,7 @@ use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use zolana_client::{
     AnonymousRecipientSlot, ApprovalRequest, ClientError, ConfidentialRecipientSlot,
-    EncryptedTransfer, P256Signature, SolanaRpc, SyncWalletAuthority,
+    EncryptedTransfer, P256Signature, SyncWalletAuthority,
 };
 use zolana_keypair::{
     shielded::ShieldedAddress, viewing_key::ViewTag, NullifierKey, ShieldedKeypair, SigningKey,
@@ -23,12 +23,10 @@ use zolana_transaction::serialization::{
     anonymous::AnonymousTransferSenderPlaintext, confidential::TransferSenderPlaintext,
 };
 
-use super::{
-    registry::register_wallet_on_chain, resolve::ResolvedSyncOptions, util::parse_hex_array,
-};
+use super::{resolve::ResolvedSyncOptions, util::parse_hex_array};
 use crate::{
-    args::InitOptions,
-    cli_config::{resolve_keypair_path as config_keypair_path, resolve_rpc_url, CliConfigFile},
+    args::{AddressOptions, NewWalletOptions},
+    cli_config::{resolve_keypair_path, CliConfigFile},
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -142,39 +140,54 @@ impl SyncWalletAuthority for WalletMaterial {
     }
 }
 
-pub(super) fn run_init(opts: InitOptions) -> Result<()> {
-    let config = CliConfigFile::load()?;
-    let keypair_path = config_keypair_path(opts.path.as_deref(), &config);
-    let material = if keypair_path.exists() {
-        load_existing_wallet(&keypair_path)?
-    } else {
-        let keypair = ShieldedKeypair::new()?;
-        let funding = Keypair::new();
-        save_wallet(&keypair_path, &keypair, &funding)?;
-        WalletMaterial { keypair, funding }
+pub(super) fn run_new(opts: NewWalletOptions) -> Result<()> {
+    let path = match opts.outfile.as_deref() {
+        Some(path) => Path::new(path).to_path_buf(),
+        None => resolve_keypair_path(None, &CliConfigFile::load()?),
     };
+    if path.exists() {
+        bail!("wallet already exists at {}", path.display());
+    }
 
-    let mut rpc = SolanaRpc::new(resolve_rpc_url(opts.rpc_url.as_deref(), &config));
-    if let Some(lamports) = opts.airdrop_lamports {
-        let signature = rpc.airdrop(&material.funding.pubkey(), lamports)?;
-        println!("ok airdrop signature={signature}");
-    }
-    if let Some(signature) = register_wallet_on_chain(&rpc, &material)? {
-        println!("ok user_registry signature={signature}");
-    }
+    let keypair = ShieldedKeypair::new()?;
+    let funding = match opts.funding_keypair.as_deref() {
+        Some(path) => load_solana_cli_keypair(Path::new(path))?,
+        None => Keypair::new(),
+    };
+    save_wallet(&path, &keypair, &funding)?;
+    let material = WalletMaterial { keypair, funding };
     println!(
-        "ok keypair {} owner_hash={} funding={}",
-        keypair_path.display(),
-        hex::encode(material.keypair.owner_hash()?),
+        "ok wallet {} address={} funding={}",
+        path.display(),
+        material.keypair.shielded_address()?,
         material.funding.pubkey()
     );
+    Ok(())
+}
+
+pub(super) fn run_address(opts: AddressOptions) -> Result<()> {
+    let path = resolve_keypair_path(opts.keypair.keypair.as_deref(), &CliConfigFile::load()?);
+    if !path.exists() {
+        bail!(
+            "wallet not found at {}; create it with `zolana wallet new --outfile {}`",
+            path.display(),
+            path.display()
+        );
+    }
+    let material = load_existing_wallet(&path)?;
+    if opts.funding {
+        println!("{}", material.owner_pubkey());
+    } else {
+        println!("{}", material.keypair.shielded_address()?);
+    }
     Ok(())
 }
 
 pub(super) fn load_sender_from_resolved_sync(sync: &ResolvedSyncOptions) -> Result<WalletMaterial> {
     if !sync.keypair_path.exists() {
         bail!(
-            "keypair not found at {}; run `zolana wallet init` first",
+            "wallet not found at {}; create it with `zolana wallet new --outfile {}`",
+            sync.keypair_path.display(),
             sync.keypair_path.display()
         );
     }
@@ -186,6 +199,13 @@ pub(super) fn load_existing_wallet(path: &Path) -> Result<WalletMaterial> {
         fs::read(path).with_context(|| format!("failed to read wallet {}", path.display()))?;
     let file: KeypairFile = serde_json::from_slice(&bytes)
         .with_context(|| format!("failed to parse wallet {}", path.display()))?;
+    if file.version != 2 {
+        bail!(
+            "wallet {} has unsupported version {}",
+            path.display(),
+            file.version
+        );
+    }
     let signing_bytes = parse_hex_array::<32>(&file.signing_key_hex)?;
     let viewing_bytes = parse_hex_array::<32>(&file.viewing_key_hex)?;
     let funding_bytes = parse_hex_array::<32>(&file.funding_secret_hex)?;
@@ -207,6 +227,35 @@ pub(super) fn load_existing_wallet(path: &Path) -> Result<WalletMaterial> {
     Ok(WalletMaterial { keypair, funding })
 }
 
+/// Load the JSON byte array written by `solana-keygen`. Both the standard
+/// 64-byte `[secret || pubkey]` form and a bare 32-byte secret are accepted.
+pub(super) fn load_solana_cli_keypair(path: &Path) -> Result<Keypair> {
+    let bytes =
+        fs::read(path).with_context(|| format!("failed to read keypair {}", path.display()))?;
+    let values: Vec<u8> = serde_json::from_slice(&bytes).with_context(|| {
+        format!(
+            "{} is not a Solana keypair file (expected a JSON byte array)",
+            path.display()
+        )
+    })?;
+    let mut secret = [0u8; 32];
+    match values.len() {
+        32 | 64 => secret.copy_from_slice(&values[..32]),
+        length => bail!(
+            "unexpected Solana keypair length {length} in {} (expected 32 or 64 bytes)",
+            path.display()
+        ),
+    }
+    let keypair = Keypair::new_from_array(secret);
+    if values.len() == 64 && keypair.pubkey().to_bytes() != values[32..] {
+        bail!(
+            "keypair {} secret does not match its public key",
+            path.display()
+        );
+    }
+    Ok(keypair)
+}
+
 fn save_wallet(path: &Path, keypair: &ShieldedKeypair, funding: &Keypair) -> Result<()> {
     let file = KeypairFile {
         version: 2,
@@ -216,7 +265,39 @@ fn save_wallet(path: &Path, keypair: &ShieldedKeypair, funding: &Keypair) -> Res
         funding_secret_hex: hex::encode(funding.secret_bytes()),
         funding_pubkey: funding.pubkey().to_string(),
     };
-    write_json_secret(path, &file)
+    write_json_secret_exclusive(path, &file)
+}
+
+fn write_json_secret_exclusive<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    if parent != Path::new(".") {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let bytes = serde_json::to_vec_pretty(value)?;
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    harden_secret_permissions(&file, path)?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn harden_secret_permissions(file: &File, path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    file.set_permissions(fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("failed to set permissions on {}", path.display()))?;
+    #[cfg(not(unix))]
+    let _ = (file, path);
+    Ok(())
 }
 
 pub(super) fn load_or_create_solana_keypair(path: &Path) -> Result<Keypair> {
@@ -311,6 +392,85 @@ mod tests {
         );
         assert_ne!(loaded.funding.pubkey(), Pubkey::default());
         assert_eq!(loaded.funding.pubkey(), funding.pubkey());
+    }
+
+    #[test]
+    fn wallet_file_creation_never_overwrites() {
+        let root = temp_root("zolana-cli-wallet-exclusive");
+        let wallet = root.join("id.json");
+        let first = ShieldedKeypair::new().expect("first shielded keypair");
+        let first_funding = Keypair::new();
+        save_wallet(&wallet, &first, &first_funding).expect("create wallet");
+        let before = fs::read(&wallet).expect("read first wallet");
+
+        assert!(save_wallet(&wallet, &ShieldedKeypair::new().unwrap(), &Keypair::new()).is_err());
+        assert_eq!(fs::read(&wallet).expect("read unchanged wallet"), before);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wallet_file_is_private_when_created() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let wallet = temp_root("zolana-cli-wallet-mode").join("id.json");
+        save_wallet(
+            &wallet,
+            &ShieldedKeypair::new().expect("shielded keypair"),
+            &Keypair::new(),
+        )
+        .expect("create wallet");
+
+        assert_eq!(
+            fs::metadata(wallet)
+                .expect("wallet metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn load_solana_cli_keypair_reads_standard_and_bare_forms() {
+        let root = temp_root("zolana-cli-solana-key");
+        fs::create_dir_all(&root).unwrap();
+        let keypair = Keypair::new();
+
+        let full = root.join("id.json");
+        fs::write(
+            &full,
+            serde_json::to_vec(&keypair.to_bytes().to_vec()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            load_solana_cli_keypair(&full).expect("64-byte").pubkey(),
+            keypair.pubkey()
+        );
+
+        let bare = root.join("id32.json");
+        fs::write(
+            &bare,
+            serde_json::to_vec(&keypair.secret_bytes().to_vec()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            load_solana_cli_keypair(&bare).expect("32-byte").pubkey(),
+            keypair.pubkey()
+        );
+
+        let mut bad = keypair.to_bytes().to_vec();
+        bad[63] ^= 0xff;
+        let bad_path = root.join("bad.json");
+        fs::write(&bad_path, serde_json::to_vec(&bad).unwrap()).unwrap();
+        assert!(load_solana_cli_keypair(&bad_path).is_err());
+
+        let short = root.join("short.json");
+        fs::write(&short, serde_json::to_vec(&vec![0u8; 16]).unwrap()).unwrap();
+        assert!(load_solana_cli_keypair(&short).is_err());
+
+        let invalid = root.join("invalid.json");
+        fs::write(&invalid, b"not json").unwrap();
+        assert!(load_solana_cli_keypair(&invalid).is_err());
     }
 
     #[test]

--- a/cli/src/wallet_cli/mod.rs
+++ b/cli/src/wallet_cli/mod.rs
@@ -21,10 +21,10 @@ const INDEXER_POLL: Duration = Duration::from_millis(500);
 
 pub(crate) fn run_wallet(command: WalletCommand) -> Result<()> {
     match command {
-        WalletCommand::Init(opts) => material::run_init(opts),
+        WalletCommand::New(opts) => material::run_new(opts),
+        WalletCommand::Address(opts) => material::run_address(opts),
         WalletCommand::CreateTree(opts) => tree::run_create_tree(opts),
         WalletCommand::TestMint(opts) => test_mint::run_test_mint(opts),
-        WalletCommand::Sync(opts) => sync::run_sync(opts),
         WalletCommand::Balance(opts) => balance::run_balance(opts),
         WalletCommand::Merge(opts) => registry::run_merge(opts),
         WalletCommand::Deposit(opts) => deposit::run_deposit(opts),

--- a/cli/src/wallet_cli/registry.rs
+++ b/cli/src/wallet_cli/registry.rs
@@ -1,28 +1,14 @@
 use anyhow::{bail, Result};
-use solana_signature::Signature;
 use solana_signer::Signer;
-use zolana_client::{Rpc, SolanaRpc};
+use zolana_client::{
+    ensure_registered, fetch_user_record_optional_checked, validate_registered_keypair, Rpc,
+    SolanaRpc,
+};
 use zolana_transaction::Address;
 use zolana_user_registry_interface::{instruction::set_merging_enabled, user_record_pda};
 
-use super::{
-    material::{load_sender_from_resolved_sync, WalletMaterial},
-    resolve::resolve_sync,
-};
+use super::{material::load_sender_from_resolved_sync, resolve::resolve_sync};
 use crate::args::MergeOptions;
-
-pub(super) fn register_wallet_on_chain(
-    rpc: &SolanaRpc,
-    material: &WalletMaterial,
-) -> Result<Option<Signature>> {
-    // Idempotent register-or-update lives in the SDK; the CLI just supplies its
-    // keypair + funding key.
-    Ok(zolana_client::ensure_registered(
-        rpc,
-        &material.funding,
-        &material.keypair,
-    )?)
-}
 
 pub(super) fn run_merge(opts: MergeOptions) -> Result<()> {
     let sync = resolve_sync(&opts.sync)?;
@@ -35,6 +21,18 @@ pub(super) fn run_merge(opts: MergeOptions) -> Result<()> {
         (false, true) => false,
         _ => bail!("provide exactly one of --enable or --disable"),
     };
+
+    match fetch_user_record_optional_checked(&rpc, owner)? {
+        Some(_) => validate_registered_keypair(&rpc, owner, &material.keypair)?,
+        None if !enabled => {
+            println!("ok merge owner={owner} enabled=false unchanged=true");
+            return Ok(());
+        }
+        None => match ensure_registered(&rpc, &material.funding, &material.keypair)? {
+            Some(signature) => println!("ok user_registry signature={signature}"),
+            None => println!("ok user_registry current=true"),
+        },
+    }
 
     let (user_record, _bump) = user_record_pda(&owner);
     let ix = set_merging_enabled(user_record, owner, enabled);

--- a/cli/src/wallet_cli/sync.rs
+++ b/cli/src/wallet_cli/sync.rs
@@ -19,18 +19,6 @@ pub(super) struct SyncContext {
     pub(super) material: WalletMaterial,
     pub(super) wallet: Wallet,
     pub(super) local_assets: Vec<LocalAssetConfig>,
-    pub(super) report: zolana_transaction::SyncReport,
-}
-
-pub(super) fn run_sync(opts: SyncOptions) -> Result<()> {
-    let ctx = sync_context(&opts)?;
-    println!(
-        "ok sync stored={} unparsed={} undecryptable={}",
-        ctx.report.stored_utxos,
-        ctx.report.unparsed_transactions,
-        ctx.report.undecryptable_candidates
-    );
-    Ok(())
 }
 
 pub(super) fn sync_context(opts: &SyncOptions) -> Result<SyncContext> {
@@ -40,12 +28,11 @@ pub(super) fn sync_context(opts: &SyncOptions) -> Result<SyncContext> {
     let indexer = ZolanaIndexer::new(sync.indexer_url.clone());
     let assets = config.local_asset_registry()?;
     let mut wallet = Wallet::new(clone_keypair(&material.keypair)?, assets)?;
-    let report = client_sync_wallet(&mut wallet, &indexer)?;
+    client_sync_wallet(&mut wallet, &indexer)?;
     Ok(SyncContext {
         material,
         wallet,
         local_assets: config.assets,
-        report,
     })
 }
 

--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -14,28 +14,27 @@ use super::{
     material::WalletMaterial,
     resolve::get_network,
     sync::{sync_context, wait_for_indexed_transaction},
-    util::{ensure_positive, format_address, parse_address, parse_pubkey},
+    util::{ensure_positive, format_address, parse_address, parse_shielded_address},
 };
 use crate::args::TransferOptions;
 
 pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
     ensure_positive(opts.amount)?;
     let asset = parse_address(&opts.mint)?;
+    let recipient = parse_shielded_address(&opts.to)?;
     let network = get_network(&opts.network)?;
     let mut rpc = SolanaRpc::new(network.sync.rpc_url.clone());
     let indexer = ZolanaIndexer::new(network.sync.indexer_url.clone());
     let ctx = sync_context(&opts.network.sync)?;
     maybe_airdrop(&mut rpc, &ctx.material, network.airdrop_lamports)?;
-    let recipient_owner = parse_pubkey(&opts.to)?;
     let tree = network.tree;
 
     let transfer = create_transfer_sync(CreateTransfer {
-        rpc: &rpc,
         wallet: &ctx.wallet,
         authority: &ctx.material,
         owner_pubkey: ctx.material.owner_pubkey(),
         payer: Address::new_from_array(ctx.material.funding.pubkey().to_bytes()),
-        recipient_owner,
+        recipient,
         asset,
         amount: opts.amount,
     })?;
@@ -46,22 +45,16 @@ pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
             material: &ctx.material,
             tree,
             prover_url: &network.prover_url,
-            withdrawal: transfer.recipient.withdrawal().cloned(),
+            withdrawal: None,
             wait_tag: transfer.wait_tag,
         },
         transfer.signed,
     )?;
-    let mode = if transfer.recipient.is_public_withdrawal() {
-        "withdraw"
-    } else {
-        "shielded"
-    };
     println!(
-        "ok transfer amount={} mint={} to={} mode={} signature={}",
+        "ok transfer amount={} mint={} to={} mode=shielded signature={}",
         opts.amount,
         format_address(asset),
-        transfer.recipient.pubkey(),
-        mode,
+        transfer.recipient,
         signature
     );
     Ok(())

--- a/cli/src/wallet_cli/util.rs
+++ b/cli/src/wallet_cli/util.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Context, Result};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_pubkey::Pubkey;
+use zolana_keypair::ShieldedAddress;
 use zolana_transaction::{Address, SOL_MINT};
 
 use crate::cli_config::CliConfigFile;
@@ -23,6 +24,14 @@ pub(super) fn parse_pubkey(value: &str) -> Result<Pubkey> {
     value
         .parse::<Pubkey>()
         .with_context(|| format!("invalid pubkey `{value}`"))
+}
+
+pub(super) fn parse_shielded_address(value: &str) -> Result<ShieldedAddress> {
+    value.parse::<ShieldedAddress>().with_context(|| {
+        format!(
+            "invalid shielded address `{value}`; use the value printed by `zolana wallet address`"
+        )
+    })
 }
 
 pub(super) fn format_address(address: Address) -> String {
@@ -78,5 +87,34 @@ pub(super) fn system_create_account_ix(
             AccountMeta::new(*new_account, true),
         ],
         data,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zolana_keypair::ShieldedKeypair;
+
+    use super::*;
+
+    #[test]
+    fn shielded_address_round_trips_through_cli_parser() {
+        let address = ShieldedKeypair::new()
+            .expect("keypair")
+            .shielded_address()
+            .expect("address");
+
+        assert_eq!(
+            parse_shielded_address(&address.to_string()).expect("parse address"),
+            address
+        );
+    }
+
+    #[test]
+    fn shielded_address_rejects_solana_pubkey_with_actionable_hint() {
+        let pubkey = Pubkey::new_unique().to_string();
+        let err = parse_shielded_address(&pubkey).expect_err("pubkey is not shielded address");
+
+        assert!(err.to_string().contains("invalid shielded address"));
+        assert!(err.to_string().contains("wallet address"));
     }
 }

--- a/justfile
+++ b/justfile
@@ -162,7 +162,6 @@ test-localnet-e2e-photon: build-programs build-prover-server build-cli ensure-ph
     }
     trap cleanup EXIT
     export SHIELDED_POOL_PROGRAM_ID
-    export USER_REGISTRY_PROGRAM_ID
     export ZOLANA_PHOTON_BIN="{{photon-bin}}"
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
@@ -199,7 +198,6 @@ regenerate-photon-fixtures: build-programs build-prover-server build-cli ensure-
     }
     trap cleanup EXIT
     export SHIELDED_POOL_PROGRAM_ID
-    export USER_REGISTRY_PROGRAM_ID
     export ZOLANA_PHOTON_BIN="{{photon-bin}}"
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"

--- a/program-tests/shielded-pool/tests/localnet_wallet_cli_e2e.rs
+++ b/program-tests/shielded-pool/tests/localnet_wallet_cli_e2e.rs
@@ -16,7 +16,8 @@ use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use zolana_client::{Rpc, SolanaRpc};
-use zolana_interface::{SPL_TOKEN_ACCOUNT_AMOUNT_END, SPL_TOKEN_ACCOUNT_AMOUNT_OFFSET};
+use zolana_interface::{pda, SPL_TOKEN_ACCOUNT_AMOUNT_END, SPL_TOKEN_ACCOUNT_AMOUNT_OFFSET};
+use zolana_keypair::ShieldedAddress;
 use zolana_transaction::Address;
 
 #[path = "common/transact.rs"]
@@ -31,11 +32,6 @@ const PROVER_URL_ENV: &str = "ZOLANA_PROVER_URL";
 const DEFAULT_RPC_URL: &str = "http://127.0.0.1:8899";
 const DEFAULT_INDEXER_URL: &str = "http://127.0.0.1:8784";
 const DEFAULT_PROVER_URL: &str = "http://127.0.0.1:3001";
-
-#[derive(Deserialize)]
-struct WalletFile {
-    funding_pubkey: String,
-}
 
 #[derive(Deserialize)]
 struct WalletFundingKey {
@@ -91,28 +87,25 @@ fn ensure_associated_token_account(
     mint: &Pubkey,
 ) -> Result<Pubkey> {
     let rpc = SolanaRpc::new(rpc_url);
-    let (_sig, ata) = zolana_client::create_associated_token_account(&rpc, payer, owner, mint)?;
-    Ok(ata)
+    let (_signature, account) =
+        zolana_client::create_associated_token_account(&rpc, payer, owner, mint)?;
+    Ok(account)
 }
 
 /// Restart a fresh local validator + Photon through the `zolana` CLI (the same
 /// launcher the other photon e2e tests use; it owns the validator/photon
-/// orchestration and readiness checks). Deploys the shielded-pool and
-/// user-registry programs the wallet CLI needs; `--skip-prover` leaves the
-/// persistent prover server untouched so its proving keys stay loaded.
+/// orchestration and readiness checks). `--skip-prover` leaves the persistent
+/// prover server untouched so its proving keys stay loaded.
 fn restart_localnet() {
     let root = concat!(env!("CARGO_MANIFEST_DIR"), "/../..");
     let cli =
         std::env::var("ZOLANA_CLI_BIN").unwrap_or_else(|_| format!("{root}/target/debug/zolana"));
     let program_id =
         std::env::var("SHIELDED_POOL_PROGRAM_ID").expect("SHIELDED_POOL_PROGRAM_ID must be set");
-    let user_registry_program_id =
-        std::env::var("USER_REGISTRY_PROGRAM_ID").expect("USER_REGISTRY_PROGRAM_ID must be set");
     let rpc_port = std::env::var("ZOLANA_LOCALNET_RPC_PORT").unwrap_or_else(|_| "8899".to_string());
     let photon_port =
         std::env::var("ZOLANA_LOCALNET_PHOTON_PORT").unwrap_or_else(|_| "8784".to_string());
     let program_so = format!("{root}/target/deploy/shielded_pool_program.so");
-    let user_registry_so = format!("{root}/target/deploy/zolana_user_registry.so");
 
     let status = Command::new(&cli)
         .current_dir(root)
@@ -130,9 +123,6 @@ fn restart_localnet() {
             "--sbf-program",
             &program_id,
             &program_so,
-            "--sbf-program",
-            &user_registry_program_id,
-            &user_registry_so,
         ])
         .status()
         .expect("run zolana test-validator");
@@ -171,27 +161,72 @@ fn run_cli_with_env(args: &[&str], env: &[(&str, &str)]) -> Result<String> {
     Ok(stdout)
 }
 
-fn wallet_init(path: &Path, rpc_url: &str, cli_env: &[(&str, &str)]) -> Result<()> {
+fn run_cli_expect_failure(args: &[&str], env: &[(&str, &str)]) -> Result<String> {
+    let mut command = Command::new(cli_bin());
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    let output = command
+        .args(args)
+        .output()
+        .with_context(|| format!("spawn zolana {}", args.join(" ")))?;
+    if output.status.success() {
+        bail!("zolana {} unexpectedly succeeded", args.join(" "));
+    }
+    Ok(format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    ))
+}
+
+fn wallet_new(path: &Path, config: &Path, cli_env: &[(&str, &str)]) -> Result<()> {
     run_cli_with_env(
         &[
+            "-C",
+            &config.display().to_string(),
             "wallet",
-            "init",
-            "--path",
+            "new",
+            "--outfile",
             &path.display().to_string(),
-            "--rpc-url",
-            rpc_url,
-            "--airdrop-lamports",
-            "1000000000",
         ],
         cli_env,
     )?;
     Ok(())
 }
 
-fn funding_pubkey(path: &Path) -> Result<String> {
-    let file: WalletFile =
-        serde_json::from_slice(&std::fs::read(path).with_context(|| path.display().to_string())?)?;
-    Ok(file.funding_pubkey)
+fn wallet_address(path: &Path, config: &Path, cli_env: &[(&str, &str)]) -> Result<ShieldedAddress> {
+    run_cli_with_env(
+        &[
+            "-C",
+            &config.display().to_string(),
+            "wallet",
+            "address",
+            "-k",
+            &path.display().to_string(),
+        ],
+        cli_env,
+    )?
+    .trim()
+    .parse::<ShieldedAddress>()
+    .context("parse wallet shielded address")
+}
+
+fn funding_pubkey(path: &Path, config: &Path, cli_env: &[(&str, &str)]) -> Result<String> {
+    Ok(run_cli_with_env(
+        &[
+            "-C",
+            &config.display().to_string(),
+            "wallet",
+            "address",
+            "-k",
+            &path.display().to_string(),
+            "--funding",
+        ],
+        cli_env,
+    )?
+    .trim()
+    .to_string())
 }
 
 fn temp_wallet_dir() -> Result<PathBuf> {
@@ -244,8 +279,10 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
     let config_path_str = config_path.to_string_lossy().into_owned();
     let cli_env = [("ZOLANA_CONFIG", config_path_str.as_str())];
 
-    wallet_init(&alice, &rpc_url, &cli_env)?;
-    wallet_init(&bob, &rpc_url, &cli_env)?;
+    wallet_new(&alice, &config_path, &cli_env)?;
+    wallet_new(&bob, &config_path, &cli_env)?;
+    let alice_address = wallet_address(&alice, &config_path, &cli_env)?;
+    let bob_address = wallet_address(&bob, &config_path, &cli_env)?;
 
     let create_tree_out = run_cli_with_env(
         &[
@@ -286,27 +323,27 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
     let spl_mint = parse_field(&test_mint_out, "mint")?;
     let alice_token_account = parse_field(&test_mint_out, "token_account")?;
     let spl_mint_pubkey = spl_mint.parse::<Pubkey>()?;
-    let alice_funding_keypair = load_funding_keypair(&alice)?;
-    let unregistered_recipient = Keypair::new();
-    let bob_funding = funding_pubkey(&bob)?;
+    let public_recipient = Keypair::new();
+    let bob_funding = funding_pubkey(&bob, &config_path, &cli_env)?;
     let bob_owner = bob_funding.parse::<Pubkey>()?;
-    let bob_ata = ensure_associated_token_account(
-        &rpc_url,
-        &alice_funding_keypair,
-        &bob_owner,
-        &spl_mint_pubkey,
-    )?;
-    let unregistered_ata = ensure_associated_token_account(
-        &rpc_url,
-        &alice_funding_keypair,
-        &unregistered_recipient.pubkey(),
-        &spl_mint_pubkey,
-    )?;
-    let rpc = SolanaRpc::new(&rpc_url);
+    let bob_funding_keypair = load_funding_keypair(&bob)?;
+    let bob_ata = pda::associated_token_address(&bob_owner, &spl_mint_pubkey);
+    let public_ata = pda::associated_token_address(&public_recipient.pubkey(), &spl_mint_pubkey);
+    let mut rpc = SolanaRpc::new(&rpc_url);
+    rpc.airdrop(&bob_owner, 2_000_000_000)?;
     assert_eq!(
-        spl_token_account_amount(&rpc, &unregistered_ata)?,
-        0,
-        "unregistered ATA should start empty"
+        ensure_associated_token_account(
+            &rpc_url,
+            &bob_funding_keypair,
+            &bob_owner,
+            &spl_mint_pubkey,
+        )?,
+        bob_ata
+    );
+    assert!(
+        rpc.get_account(Address::new_from_array(public_ata.to_bytes()))?
+            .is_none(),
+        "public recipient ATA should not exist before withdrawal"
     );
 
     let asset_registry_out = run_cli_with_env(&["config", "asset-registry"], &cli_env)?;
@@ -324,7 +361,7 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
                 "--keypair",
                 &alice.display().to_string(),
                 "--to",
-                &bob_funding,
+                &bob_address.to_string(),
                 "--amount",
                 deposit_amount,
                 "--mint",
@@ -339,21 +376,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             &cli_env,
         )?;
     }
-
-    let sync_out = run_cli_with_env(
-        &[
-            "wallet",
-            "sync",
-            "--keypair",
-            &bob.display().to_string(),
-            "--rpc-url",
-            &rpc_url,
-            "--indexer-url",
-            &indexer_url,
-        ],
-        &cli_env,
-    )?;
-    assert!(sync_out.contains("ok sync"), "sync failed: {sync_out}");
 
     let balance_out = run_cli_with_env(
         &[
@@ -384,7 +406,7 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             "--keypair",
             &alice.display().to_string(),
             "--to",
-            &bob_funding,
+            &bob_address.to_string(),
             "--amount",
             "600000",
             "--mint",
@@ -419,7 +441,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
         "expected 600000 SPL balance, got: {spl_balance_out}"
     );
 
-    let alice_funding = funding_pubkey(&alice)?;
     run_cli_with_env(
         &[
             "wallet",
@@ -427,7 +448,7 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             "--keypair",
             &bob.display().to_string(),
             "--to",
-            &alice_funding,
+            &alice_address.to_string(),
             "--amount",
             "400000000",
             "--mint",
@@ -438,8 +459,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             &indexer_url,
             "--prover-url",
             &prover_url,
-            "--airdrop-lamports",
-            "2000000000",
         ],
         &cli_env,
     )?;
@@ -451,7 +470,7 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             "--keypair",
             &bob.display().to_string(),
             "--to",
-            &alice_funding,
+            &alice_address.to_string(),
             "--amount",
             "250000",
             "--mint",
@@ -462,25 +481,23 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             &indexer_url,
             "--prover-url",
             &prover_url,
-            "--airdrop-lamports",
-            "2000000000",
         ],
         &cli_env,
     )?;
 
-    let unregistered_transfer_amount = 50_000u64;
-    let alice_token_before_unregistered =
+    let public_withdraw_amount = 50_000u64;
+    let alice_token_before_public_attempt =
         spl_token_account_amount(&rpc, &alice_token_account.parse()?)?;
-    run_cli_with_env(
+    let failure = run_cli_expect_failure(
         &[
             "wallet",
             "transfer",
             "--keypair",
             &bob.display().to_string(),
             "--to",
-            &unregistered_recipient.pubkey().to_string(),
+            &public_recipient.pubkey().to_string(),
             "--amount",
-            &unregistered_transfer_amount.to_string(),
+            &public_withdraw_amount.to_string(),
             "--mint",
             &spl_mint,
             "--rpc-url",
@@ -489,35 +506,60 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             &indexer_url,
             "--prover-url",
             &prover_url,
-            "--airdrop-lamports",
-            "2000000000",
         ],
         &cli_env,
     )?;
-    assert_eq!(
-        spl_token_account_amount(&rpc, &unregistered_ata)?,
-        unregistered_transfer_amount,
-        "unregistered SPL transfer should settle to recipient ATA"
+    assert!(
+        failure.contains("invalid shielded address"),
+        "private transfer should reject a Solana pubkey locally: {failure}"
+    );
+    assert!(
+        rpc.get_account(Address::new_from_array(public_ata.to_bytes()))?
+            .is_none(),
+        "failed private transfer must not create the recipient ATA"
     );
     assert_eq!(
         spl_token_account_amount(&rpc, &alice_token_account.parse()?)?,
-        alice_token_before_unregistered,
-        "sender-configured deposit token account must not receive unregistered transfer"
+        alice_token_before_public_attempt,
+        "failed private transfer must not move public tokens"
     );
+    assert_eq!(
+        ensure_associated_token_account(
+            &rpc_url,
+            &bob_funding_keypair,
+            &public_recipient.pubkey(),
+            &spl_mint_pubkey,
+        )?,
+        public_ata
+    );
+    assert_eq!(spl_token_account_amount(&rpc, &public_ata)?, 0);
 
     run_cli_with_env(
         &[
             "wallet",
-            "sync",
+            "withdraw",
             "--keypair",
-            &alice.display().to_string(),
+            &bob.display().to_string(),
+            "--to",
+            &public_recipient.pubkey().to_string(),
+            "--amount",
+            &public_withdraw_amount.to_string(),
+            "--mint",
+            &spl_mint,
             "--rpc-url",
             &rpc_url,
             "--indexer-url",
             &indexer_url,
+            "--prover-url",
+            &prover_url,
         ],
         &cli_env,
     )?;
+    assert_eq!(
+        spl_token_account_amount(&rpc, &public_ata)?,
+        public_withdraw_amount,
+        "explicit withdrawal should fund the public recipient ATA"
+    );
 
     run_cli_with_env(
         &[
@@ -564,11 +606,7 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
     );
 
     let spl_withdraw_amount = 100_000u64;
-    assert_eq!(
-        spl_token_account_amount(&rpc, &bob_ata)?,
-        0,
-        "bob ATA should start empty"
-    );
+    assert_eq!(spl_token_account_amount(&rpc, &bob_ata)?, 0);
     run_cli_with_env(
         &[
             "wallet",

--- a/sdk-libs/client/src/actions/mod.rs
+++ b/sdk-libs/client/src/actions/mod.rs
@@ -11,5 +11,5 @@ pub use deposit::{create_deposit, deposit, CreateDeposit, Deposit};
 pub use transaction::{
     create_transfer, create_transfer_sync, create_withdrawal, create_withdrawal_sync,
     sign_transaction, sign_transaction_sync, CreateTransfer, CreateWithdrawal, CreatedTransfer,
-    CreatedWithdrawal, ResolvedAddress, TransferRecipient,
+    CreatedWithdrawal,
 };

--- a/sdk-libs/client/src/actions/transaction.rs
+++ b/sdk-libs/client/src/actions/transaction.rs
@@ -14,54 +14,16 @@ use zolana_transaction::{
 
 use crate::{
     error::ClientError,
-    rpc::Rpc,
-    user_registry::try_resolve_registered_address,
     wallet_authority::{
         ApprovalRequest, ConfidentialRecipientSlot, SyncWalletAuthority, WalletAuthority,
     },
 };
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ResolvedAddress {
-    pub owner: Pubkey,
-    pub address: ShieldedAddress,
-    pub view_tag: ViewTag,
-}
-
 #[derive(Clone)]
 pub struct CreatedTransfer {
     pub signed: SignedTransaction,
     pub wait_tag: ViewTag,
-    pub recipient: TransferRecipient,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum TransferRecipient {
-    Registered(ResolvedAddress),
-    PublicWithdrawal {
-        recipient: Pubkey,
-        withdrawal: TransactWithdrawal,
-    },
-}
-
-impl TransferRecipient {
-    pub fn pubkey(&self) -> Pubkey {
-        match self {
-            Self::Registered(recipient) => recipient.owner,
-            Self::PublicWithdrawal { recipient, .. } => *recipient,
-        }
-    }
-
-    pub fn is_public_withdrawal(&self) -> bool {
-        matches!(self, Self::PublicWithdrawal { .. })
-    }
-
-    pub fn withdrawal(&self) -> Option<&TransactWithdrawal> {
-        match self {
-            Self::Registered(_) => None,
-            Self::PublicWithdrawal { withdrawal, .. } => Some(withdrawal),
-        }
-    }
+    pub recipient: ShieldedAddress,
 }
 
 #[derive(Clone)]
@@ -71,13 +33,17 @@ pub struct CreatedWithdrawal {
     pub withdrawal: TransactWithdrawal,
 }
 
-pub struct CreateTransfer<'a, R: Rpc, A: ?Sized> {
-    pub rpc: &'a R,
+/// Build a private transfer to a concrete shielded address.
+///
+/// This action performs no user-registry lookup. Resolve an optional registry
+/// alias before constructing this request, or use [`CreateWithdrawal`] for an
+/// explicit public destination.
+pub struct CreateTransfer<'a, A: ?Sized> {
     pub wallet: &'a Wallet,
     pub authority: &'a A,
     pub owner_pubkey: Pubkey,
     pub payer: Address,
-    pub recipient_owner: Pubkey,
+    pub recipient: ShieldedAddress,
     pub asset: Address,
     pub amount: u64,
 }
@@ -92,30 +58,9 @@ pub struct CreateWithdrawal<'a, A: ?Sized> {
     pub amount: u64,
 }
 
-pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
-    request: CreateTransfer<'_, R, A>,
+pub async fn create_transfer<A: WalletAuthority + ?Sized>(
+    request: CreateTransfer<'_, A>,
 ) -> Result<CreatedTransfer, ClientError> {
-    let Some(recipient) = try_resolve_registered_address(request.rpc, request.recipient_owner)?
-    else {
-        let withdrawal = create_withdrawal(CreateWithdrawal {
-            wallet: request.wallet,
-            authority: request.authority,
-            owner_pubkey: request.owner_pubkey,
-            payer: request.payer,
-            recipient: request.recipient_owner,
-            asset: request.asset,
-            amount: request.amount,
-        })
-        .await?;
-        return Ok(CreatedTransfer {
-            signed: withdrawal.signed,
-            wait_tag: withdrawal.wait_tag,
-            recipient: TransferRecipient::PublicWithdrawal {
-                recipient: request.recipient_owner,
-                withdrawal: withdrawal.withdrawal,
-            },
-        });
-    };
     let inputs = select_inputs(
         request.wallet,
         request.authority,
@@ -130,7 +75,7 @@ pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
         .await?;
     let wait_tag = address.signing_pubkey.confidential_view_tag()?;
     let mut tx = Transaction::new(address, inputs, request.payer);
-    tx.send(&recipient.address, request.asset, request.amount)?;
+    tx.send(&request.recipient, request.asset, request.amount)?;
     let prepared = tx.prepare(&request.wallet.registry)?;
     let signed = sign_prepared(
         prepared,
@@ -140,21 +85,21 @@ pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
         &request.wallet.registry,
         format!(
             "private transfer of {} to {}",
-            request.amount, request.recipient_owner
+            request.amount, request.recipient
         ),
     )
     .await?;
     Ok(CreatedTransfer {
         signed,
         wait_tag,
-        recipient: TransferRecipient::Registered(recipient),
+        recipient: request.recipient,
     })
 }
 
 /// Blocking adapter for CLI and unit-test flows. Async hosts should call
 /// [`create_transfer`] directly.
-pub fn create_transfer_sync<R: Rpc, A: SyncWalletAuthority + ?Sized>(
-    request: CreateTransfer<'_, R, A>,
+pub fn create_transfer_sync<A: SyncWalletAuthority + ?Sized>(
+    request: CreateTransfer<'_, A>,
 ) -> Result<CreatedTransfer, ClientError> {
     futures::executor::block_on(create_transfer(request))
 }
@@ -357,32 +302,10 @@ async fn select_inputs<A: WalletAuthority + ?Sized>(
 
 #[cfg(test)]
 mod tests {
-    use borsh::to_vec;
-    use solana_account::Account;
     use zolana_keypair::ShieldedKeypair;
     use zolana_transaction::{Data, Utxo, WalletUtxo};
-    use zolana_user_registry_interface::{user_record_pda, user_registry_program_id, UserRecord};
 
     use super::*;
-
-    struct MockRpc {
-        account: Option<(Address, Account)>,
-    }
-
-    impl Rpc for MockRpc {
-        fn get_account(&self, address: Address) -> Result<Option<Account>, ClientError> {
-            Ok(self
-                .account
-                .as_ref()
-                .and_then(|(expected, account)| (*expected == address).then(|| account.clone())))
-        }
-    }
-
-    fn account_data(record: &UserRecord) -> Vec<u8> {
-        let mut data = vec![UserRecord::DISCRIMINATOR];
-        data.extend_from_slice(&to_vec(record).expect("serialize user record"));
-        data
-    }
 
     fn wallet_with_sol(keypair: ShieldedKeypair, amount: u64) -> Wallet {
         wallet_with_asset(keypair, SOL_MINT, amount)
@@ -424,114 +347,24 @@ mod tests {
     }
 
     #[test]
-    fn create_transfer_to_registered_recipient_builds_shielded_transfer() {
+    fn create_transfer_uses_the_supplied_shielded_address() {
         let sender = ShieldedKeypair::new().unwrap();
         let recipient = ShieldedKeypair::new().unwrap();
-        let owner = Pubkey::new_unique();
-        let (record_pda, bump) = user_record_pda(&owner);
-        let record = UserRecord {
-            owner: owner.to_bytes().into(),
-            bump,
-            owner_p256: Some(*recipient.signing_pubkey().as_p256().unwrap().as_bytes()),
-            nullifier_pubkey: recipient.nullifier_key.pubkey().unwrap(),
-            viewing_pubkey: *recipient.viewing_pubkey().as_bytes(),
-            sync_delegate: None,
-            entries: Vec::new(),
-            merging_enabled: false,
-        };
-        let rpc = MockRpc {
-            account: Some((
-                Address::new_from_array(record_pda.to_bytes()),
-                Account {
-                    lamports: 1,
-                    data: account_data(&record),
-                    owner: user_registry_program_id(),
-                    executable: false,
-                    rent_epoch: 0,
-                },
-            )),
-        };
+        let recipient = recipient.shielded_address().expect("recipient address");
         let wallet = wallet_with_sol(sender.clone(), 10);
 
         let result = create_transfer_sync(CreateTransfer {
-            rpc: &rpc,
             wallet: &wallet,
             authority: &sender,
             owner_pubkey: Pubkey::default(),
             payer: Address::default(),
-            recipient_owner: owner,
+            recipient,
             asset: SOL_MINT,
             amount: 1,
         })
         .expect("transfer");
 
-        assert!(matches!(
-            result.recipient,
-            TransferRecipient::Registered(resolved) if resolved.owner == owner
-        ));
-        assert!(result.recipient.withdrawal().is_none());
-    }
-
-    #[test]
-    fn create_transfer_to_unregistered_recipient_builds_public_withdrawal() {
-        let sender = ShieldedKeypair::new().unwrap();
-        let wallet = wallet_with_sol(sender.clone(), 10);
-        let recipient = Pubkey::new_unique();
-        let rpc = MockRpc { account: None };
-
-        let result = create_transfer_sync(CreateTransfer {
-            rpc: &rpc,
-            wallet: &wallet,
-            authority: &sender,
-            owner_pubkey: Pubkey::default(),
-            payer: Address::default(),
-            recipient_owner: recipient,
-            asset: SOL_MINT,
-            amount: 1,
-        })
-        .expect("public withdrawal fallback");
-
-        assert!(matches!(
-            result.recipient,
-            TransferRecipient::PublicWithdrawal {
-                recipient: pubkey,
-                withdrawal: TransactWithdrawal::Sol(TransactSolWithdrawal { recipient }),
-            } if pubkey == recipient
-        ));
-    }
-
-    #[test]
-    fn create_transfer_to_unregistered_recipient_builds_spl_public_withdrawal() {
-        let sender = ShieldedKeypair::new().unwrap();
-        let mint = Pubkey::new_unique();
-        let asset = Address::new_from_array(mint.to_bytes());
-        let wallet = wallet_with_asset(sender.clone(), asset, 10);
-        let rpc = MockRpc { account: None };
-        let recipient = Pubkey::new_unique();
-        let token_account = pda::associated_token_address(&recipient, &mint);
-
-        let result = create_transfer_sync(CreateTransfer {
-            rpc: &rpc,
-            wallet: &wallet,
-            authority: &sender,
-            owner_pubkey: Pubkey::default(),
-            payer: Address::default(),
-            recipient_owner: recipient,
-            asset,
-            amount: 1,
-        })
-        .expect("public withdrawal fallback");
-
-        assert_eq!(
-            result.recipient.withdrawal(),
-            Some(&TransactWithdrawal::Spl(TransactSplWithdrawal {
-                cpi_authority: Some(pda::shielded_pool_cpi_authority()),
-                spl_token_interface: pda::spl_asset_vault(&mint),
-                recipient,
-                user_token_account: token_account,
-                token_program: Pubkey::new_from_array(SPL_TOKEN_PROGRAM_ID),
-            }))
-        );
+        assert_eq!(result.recipient, recipient);
     }
 
     #[test]

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -14,7 +14,6 @@ pub use actions::{
     create_associated_token_account, create_deposit, create_transfer, create_transfer_sync,
     create_withdrawal, create_withdrawal_sync, sign_transaction, sign_transaction_sync,
     CreateDeposit, CreateTransfer, CreateWithdrawal, CreatedTransfer, CreatedWithdrawal, Deposit,
-    ResolvedAddress, TransferRecipient,
 };
 pub use error::ClientError;
 #[cfg(feature = "indexer-api")]
@@ -42,8 +41,8 @@ pub use rpc::{
 pub use solana_rpc::{ConfirmedInstructionGroups, SolanaRpc};
 pub use user_registry::{
     decode_user_record_account, ensure_registered, fetch_user_record_checked,
-    fetch_user_record_optional_checked, resolve_registered_address, resolved_address_from_record,
-    try_resolve_registered_address, validate_registered_keypair,
+    fetch_user_record_optional_checked, resolve_registered_address, try_resolve_registered_address,
+    validate_registered_keypair,
 };
 pub use wallet_authority::{
     AnonymousRecipientSlot, ApprovalRequest, ConfidentialRecipientSlot, EncryptedTransfer,

--- a/sdk-libs/client/src/user_registry.rs
+++ b/sdk-libs/client/src/user_registry.rs
@@ -9,7 +9,7 @@ use zolana_user_registry_interface::{
     user_record_pda, user_registry_program_id, UserRecord,
 };
 
-use crate::{actions::ResolvedAddress, error::ClientError, rpc::Rpc};
+use crate::{error::ClientError, rpc::Rpc};
 
 /// Derive the on-chain registry record fields from a shielded keypair: the
 /// P256 owner key (only for P256-owned wallets), nullifier pubkey, and viewing
@@ -27,10 +27,10 @@ fn register_fields(keypair: &ShieldedKeypair) -> Result<RegisterData, ClientErro
 }
 
 /// Publish `keypair`'s shielded keys to the on-chain user-registry directory
-/// under `funding`'s pubkey, so senders who know only that Solana address route
-/// transfers to the shielded path (rather than falling back to a public
-/// withdrawal). Registration is optional for receiving a confidential transfer
-/// to a known shielded address; it is the pubkey-addressability directory.
+/// under `funding`'s pubkey, so senders who know only that Solana address can
+/// resolve its shielded address. Registration is optional for receiving a
+/// confidential transfer to a known shielded address; it is the
+/// pubkey-addressability directory.
 ///
 /// Idempotent: registers if no record exists, updates the record on a key
 /// change, and returns `Ok(None)` if the record already matches (no transaction
@@ -167,7 +167,7 @@ pub fn validate_registered_keypair<R: Rpc>(
 pub fn resolve_registered_address<R: Rpc>(
     rpc: &R,
     owner: Pubkey,
-) -> Result<ResolvedAddress, ClientError> {
+) -> Result<ShieldedAddress, ClientError> {
     let record = fetch_user_record_checked(rpc, owner)
         .map_err(|err| ClientError::AddressResolution(err.to_string()))?;
     resolved_address_from_record(owner, &record)
@@ -177,7 +177,7 @@ pub fn resolve_registered_address<R: Rpc>(
 pub fn try_resolve_registered_address<R: Rpc>(
     rpc: &R,
     owner: Pubkey,
-) -> Result<Option<ResolvedAddress>, ClientError> {
+) -> Result<Option<ShieldedAddress>, ClientError> {
     let Some(record) = fetch_user_record_optional_checked(rpc, owner)? else {
         return Ok(None);
     };
@@ -186,23 +186,19 @@ pub fn try_resolve_registered_address<R: Rpc>(
     )?))
 }
 
-pub fn resolved_address_from_record(
+pub(crate) fn resolved_address_from_record(
     owner: Pubkey,
     record: &UserRecord,
-) -> Result<ResolvedAddress, ClientError> {
+) -> Result<ShieldedAddress, ClientError> {
     let signing_pubkey = match record.owner_p256 {
         Some(owner_p256) => PublicKey::from_p256(&P256Pubkey::from_bytes(owner_p256)?),
         None => PublicKey::from_ed25519(&owner.to_bytes()),
     };
     let viewing_pubkey = P256Pubkey::from_bytes(record.sender_viewing_pubkey())?;
-    Ok(ResolvedAddress {
-        owner,
-        address: ShieldedAddress {
-            signing_pubkey,
-            nullifier_pubkey: record.nullifier_pubkey,
-            viewing_pubkey,
-        },
-        view_tag: viewing_pubkey.x(),
+    Ok(ShieldedAddress {
+        signing_pubkey,
+        nullifier_pubkey: record.nullifier_pubkey,
+        viewing_pubkey,
     })
 }
 
@@ -321,19 +317,17 @@ mod tests {
         let keypair = ShieldedKeypair::new().expect("shielded keypair");
         let record = registered_record(owner, bump, &keypair);
 
-        let resolved = resolved_address_from_record(owner, &record).expect("resolved address");
+        let address = resolved_address_from_record(owner, &record).expect("resolved address");
 
-        assert_eq!(resolved.owner, owner);
-        assert_eq!(resolved.address.signing_pubkey, keypair.signing_pubkey());
+        assert_eq!(address.signing_pubkey, keypair.signing_pubkey());
         assert_eq!(
-            resolved.address.nullifier_pubkey,
+            address.nullifier_pubkey,
             keypair.nullifier_key.pubkey().unwrap()
         );
         assert_eq!(
-            resolved.address.viewing_pubkey.as_bytes(),
+            address.viewing_pubkey.as_bytes(),
             keypair.viewing_pubkey().as_bytes()
         );
-        assert_eq!(resolved.view_tag, keypair.recipient_bootstrap_view_tag());
     }
 
     #[test]
@@ -349,11 +343,10 @@ mod tests {
             )),
         };
 
-        let resolved = resolve_registered_address(&rpc, owner).expect("resolved address");
+        let address = resolve_registered_address(&rpc, owner).expect("resolved address");
 
-        assert_eq!(resolved.owner, owner);
-        assert_eq!(resolved.address.signing_pubkey, keypair.signing_pubkey());
-        assert_eq!(resolved.view_tag, keypair.recipient_bootstrap_view_tag());
+        assert_eq!(address.signing_pubkey, keypair.signing_pubkey());
+        assert_eq!(address.viewing_pubkey, keypair.viewing_pubkey());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace network-coupled `wallet init` with offline `wallet new` and `wallet address`
- accept self-contained shielded addresses for deposits and private transfers, with public settlement kept behind explicit `wallet withdraw`
- follow Solana CLI conventions for `-k/--keypair`, `-C/--config`, `id.json`, and importing a funding keypair
- make wallet creation exclusive and private (`create_new`, mode `0600`) and remove the redundant public `wallet sync` command
- keep the user registry optional, using it only when the existing merge-consent command needs it

## Why

The CLI should have one local wallet-selection model and one unambiguous recipient model. Creating a wallet should not require RPC access or registration, and `transfer` should never silently turn an invalid private recipient into a public withdrawal.

This is stacked on #123, which defines the printable shielded-address codec. It deliberately excludes multi-input selection, split/consolidation, and operator-command cleanup.

## Validation

- `cargo test -p zolana-client -p zolana-cli`
- `cargo clippy -p zolana-cli -p zolana-client -- -D warnings`
- `cargo test -p shielded-pool-tests --features localnet --test localnet_wallet_cli_e2e --no-run`
- `cargo fmt --all -- --check`
- manual `-C`/new/address/funding-import/permissions/no-overwrite smoke test
