### PR TITLE
feat(client): add packet-safe note splitting

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -33,6 +33,7 @@ zolana wallet balance --indexer-url http://127.0.0.1:8784
 zolana wallet utxos --mint SOL
 zolana wallet deposit --amount 1000000000 --mint SOL --airdrop-lamports 2000000000
 zolana wallet transfer --to <RECIPIENT_SHIELDED_ADDRESS> --amount 300000000 --mint SOL
+zolana wallet split 4
 zolana wallet withdraw --to <PUBLIC_SOL_PUBKEY> --amount 200000000 --mint SOL
 ```
 
@@ -54,6 +55,8 @@ Balance and transaction commands synchronize wallet state automatically.
 Transfers select the fewest notes by spending largest-first, up to five inputs.
 `wallet utxos` prints each spendable note's hash and amount; pass one of those
 hashes to `transfer --input <HASH>` when a specific note must be spent.
+`wallet split <PARTS>` replaces one SOL note with 2–8 equal self-owned notes;
+it chooses the largest note unless `--input <HASH>` is supplied.
 
 CLI-wide defaults live at `~/.config/zolana/config.json`. Explicit flags win
 over config values, and config values win over built-in localnet defaults. The

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -135,6 +135,12 @@ pub(crate) enum WalletCommand {
     #[command(name = "transfer", about = "Send a private transfer")]
     Transfer(TransferOptions),
 
+    #[command(
+        name = "split",
+        about = "Split one private SOL note into equal self-owned notes"
+    )]
+    Split(SplitOptions),
+
     #[command(name = "withdraw", about = "Withdraw to public address")]
     Withdraw(WithdrawOptions),
 }
@@ -487,6 +493,26 @@ pub(crate) struct TransferOptions {
 }
 
 #[derive(Args, Debug, Clone)]
+pub(crate) struct SplitOptions {
+    #[command(flatten)]
+    pub(crate) network: NetworkWalletOptions,
+
+    #[arg(
+        help = "Number of equal self-owned notes to create (2..=8)",
+        value_name = "PARTS",
+        value_parser = clap::value_parser!(u8).range(2..=8)
+    )]
+    pub(crate) parts: u8,
+
+    #[arg(
+        long = "input",
+        help = "Split this note (hash from `wallet utxos`) instead of the largest",
+        value_name = "UTXO_HASH"
+    )]
+    pub(crate) input: Option<String>,
+}
+
+#[derive(Args, Debug, Clone)]
 pub(crate) struct WithdrawOptions {
     #[command(flatten)]
     pub(crate) network: NetworkWalletOptions,
@@ -659,6 +685,7 @@ mod tests {
             ["zolana", "wallet", "utxos", "--help"].as_slice(),
             ["zolana", "wallet", "deposit", "--help"].as_slice(),
             ["zolana", "wallet", "transfer", "--help"].as_slice(),
+            ["zolana", "wallet", "split", "--help"].as_slice(),
             ["zolana", "wallet", "withdraw", "--help"].as_slice(),
         ] {
             let error = Cli::try_parse_from(args).expect_err("help exits early");
@@ -1036,5 +1063,27 @@ mod tests {
         };
         assert_eq!(utxos.sync.keypair.keypair.as_deref(), Some("/tmp/bob.json"));
         assert_eq!(utxos.mint, "SOL");
+    }
+
+    #[test]
+    fn parses_and_bounds_wallet_split() {
+        let hash = "0707070707070707070707070707070707070707070707070707070707070707";
+        let WalletCommand::Split(split) =
+            parse_wallet(&["split", "8", "-k", "/tmp/alice.json", "--input", hash])
+        else {
+            panic!("expected wallet split command");
+        };
+        assert_eq!(split.parts, 8);
+        assert_eq!(split.input.as_deref(), Some(hash));
+        assert_eq!(
+            split.network.sync.keypair.keypair.as_deref(),
+            Some("/tmp/alice.json")
+        );
+
+        for parts in ["1", "9"] {
+            let err = Cli::try_parse_from(["zolana", "wallet", "split", parts])
+                .expect_err("out-of-range split must fail in clap");
+            assert_eq!(err.kind(), clap::error::ErrorKind::ValueValidation);
+        }
     }
 }

--- a/cli/src/wallet_cli/material.rs
+++ b/cli/src/wallet_cli/material.rs
@@ -13,7 +13,7 @@ use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use zolana_client::{
     AnonymousRecipientSlot, ApprovalRequest, ClientError, ConfidentialRecipientSlot,
-    EncryptedTransfer, P256Signature, SyncWalletAuthority,
+    EncryptedSplit, EncryptedTransfer, P256Signature, SyncWalletAuthority,
 };
 use zolana_keypair::{
     shielded::ShieldedAddress, viewing_key::ViewTag, NullifierKey, ShieldedKeypair, SigningKey,
@@ -21,6 +21,7 @@ use zolana_keypair::{
 };
 use zolana_transaction::serialization::{
     anonymous::AnonymousTransferSenderPlaintext, confidential::TransferSenderPlaintext,
+    split::SplitBundlePlaintext,
 };
 
 use super::{resolve::ResolvedSyncOptions, util::parse_hex_array};
@@ -112,6 +113,23 @@ impl SyncWalletAuthority for WalletMaterial {
             sender_view_tag,
             sender,
             recipients,
+        )
+    }
+
+    fn encrypt_split(
+        &self,
+        owner_pubkey: Pubkey,
+        first_nullifier: &[u8; 32],
+        view_tag: ViewTag,
+        bundle: &SplitBundlePlaintext,
+    ) -> std::result::Result<EncryptedSplit, ClientError> {
+        self.check_owner_pubkey(owner_pubkey)?;
+        SyncWalletAuthority::encrypt_split(
+            &self.keypair,
+            owner_pubkey,
+            first_nullifier,
+            view_tag,
+            bundle,
         )
     }
 

--- a/cli/src/wallet_cli/mod.rs
+++ b/cli/src/wallet_cli/mod.rs
@@ -30,6 +30,7 @@ pub(crate) fn run_wallet(command: WalletCommand) -> Result<()> {
         WalletCommand::Merge(opts) => registry::run_merge(opts),
         WalletCommand::Deposit(opts) => deposit::run_deposit(opts),
         WalletCommand::Transfer(opts) => transaction::run_transfer(opts),
+        WalletCommand::Split(opts) => transaction::run_split(opts),
         WalletCommand::Withdraw(opts) => withdraw::run_withdraw(opts),
     }
 }

--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -1,14 +1,14 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
 use zolana_client::{
-    create_transfer_sync, submit_private_transaction as submit_private_action, CreateTransfer,
-    InputSelection, SignedTransaction, SolanaRpc,
+    create_split_sync, create_transfer_sync, submit_private_transaction as submit_private_action,
+    CreateSplit, CreateTransfer, InputSelection, SignedTransaction, SolanaRpc,
     SubmitPrivateTransaction as ClientSubmitPrivateTransaction, ZolanaIndexer,
 };
 use zolana_interface::instruction::TransactWithdrawal;
-use zolana_transaction::Address;
+use zolana_transaction::{Address, SpendableUtxo, SOL_MINT};
 
 use super::{
     material::WalletMaterial,
@@ -18,7 +18,7 @@ use super::{
         ensure_positive, format_address, parse_address, parse_hex_array, parse_shielded_address,
     },
 };
-use crate::args::{TransferOptions, UtxosOptions};
+use crate::args::{SplitOptions, TransferOptions, UtxosOptions};
 
 pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
     ensure_positive(opts.amount)?;
@@ -72,6 +72,88 @@ fn resolve_transfer_selection(opts: &TransferOptions) -> Result<InputSelection> 
         )?])),
         None => Ok(InputSelection::Auto),
     }
+}
+
+pub(super) fn run_split(opts: SplitOptions) -> Result<()> {
+    let explicit_hash = opts
+        .input
+        .as_deref()
+        .map(parse_hex_array::<32>)
+        .transpose()?;
+    let network = get_network(&opts.network)?;
+    let mut rpc = SolanaRpc::new(network.sync.rpc_url.clone());
+    let indexer = ZolanaIndexer::new(network.sync.indexer_url.clone());
+    let ctx = sync_context(&opts.network.sync)?;
+    let (note, per_output_amount) = split_selection(
+        &ctx.wallet.spendable_utxos(SOL_MINT),
+        opts.parts,
+        explicit_hash,
+    )?;
+
+    let split = create_split_sync(CreateSplit {
+        wallet: &ctx.wallet,
+        authority: &ctx.material,
+        owner_pubkey: ctx.material.owner_pubkey(),
+        payer: Address::new_from_array(ctx.material.funding.pubkey().to_bytes()),
+        asset: SOL_MINT,
+        num_outputs: opts.parts,
+        per_output_amount,
+        selection: InputSelection::Explicit(vec![note.hash]),
+    })?;
+    maybe_airdrop(&mut rpc, &ctx.material, network.airdrop_lamports)?;
+    let (signature, outcome) = submit_private_transaction(
+        SubmitPrivateTx {
+            rpc: &rpc,
+            indexer: &indexer,
+            material: &ctx.material,
+            tree: network.tree,
+            prover_url: &network.prover_url,
+            withdrawal: None,
+            wait_output_hash: split.wait_output_hash,
+        },
+        split.signed,
+    )?;
+    println!(
+        "ok split parts={} amount={} signature={}{}",
+        opts.parts,
+        note.amount,
+        signature,
+        outcome.pending_suffix(),
+    );
+    Ok(())
+}
+
+fn split_selection(
+    notes: &[SpendableUtxo],
+    parts: u8,
+    explicit_hash: Option<[u8; 32]>,
+) -> Result<(SpendableUtxo, u64)> {
+    let note = match explicit_hash {
+        Some(hash) => notes
+            .iter()
+            .find(|note| note.hash == hash)
+            .copied()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "no spendable SOL note with hash {}; run `wallet utxos --mint SOL`",
+                    hex::encode(hash)
+                )
+            })?,
+        None => notes
+            .iter()
+            .max_by_key(|note| note.amount)
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("wallet has no spendable SOL notes to split"))?,
+    };
+    if note.amount % u64::from(parts) != 0 {
+        bail!(
+            "note amount {} does not divide evenly into {parts} parts",
+            note.amount
+        );
+    }
+    let per_output_amount = note.amount / u64::from(parts);
+    ensure_positive(per_output_amount)?;
+    Ok((note, per_output_amount))
 }
 
 pub(super) fn run_utxos(opts: UtxosOptions) -> Result<()> {

--- a/sdk-libs/client/src/actions/mod.rs
+++ b/sdk-libs/client/src/actions/mod.rs
@@ -11,7 +11,8 @@ pub use create_associated_token_account::create_associated_token_account;
 pub use deposit::{create_deposit, deposit, CreateDeposit, Deposit};
 pub use submit::{submit_private_transaction, SubmitPrivateTransaction};
 pub use transaction::{
-    create_transfer, create_transfer_sync, create_withdrawal, create_withdrawal_sync,
-    sign_transaction, sign_transaction_sync, CreateTransfer, CreateWithdrawal, CreatedTransfer,
-    CreatedWithdrawal, InputSelection, MAX_TRANSFER_INPUTS,
+    create_split, create_split_sync, create_transfer, create_transfer_sync, create_withdrawal,
+    create_withdrawal_sync, sign_transaction, sign_transaction_sync, CreateSplit, CreateTransfer,
+    CreateWithdrawal, CreatedSplit, CreatedTransfer, CreatedWithdrawal, InputSelection,
+    MAX_TRANSFER_INPUTS,
 };

--- a/sdk-libs/client/src/actions/transaction.rs
+++ b/sdk-libs/client/src/actions/transaction.rs
@@ -8,10 +8,12 @@ use zolana_interface::{
 use zolana_keypair::{shielded::ShieldedAddress, SignatureType};
 use zolana_transaction::{
     instructions::{
-        transact::{PreparedTransaction, SignedTransaction, Transaction, WithdrawalTarget},
+        transact::{
+            PreparedSplit, PreparedTransaction, SignedTransaction, Transaction, WithdrawalTarget,
+        },
         types::SpendUtxo,
     },
-    Address, AssetRegistry, Wallet, SOL_MINT,
+    Address, AssetRegistry, TransactionError, Wallet, SOL_MINT,
 };
 
 /// How a private spend chooses wallet notes.
@@ -59,6 +61,15 @@ pub struct CreatedWithdrawal {
     pub withdrawal: TransactWithdrawal,
 }
 
+#[derive(Clone)]
+pub struct CreatedSplit {
+    pub signed: SignedTransaction,
+    /// Committed hash of one real self-owned output.
+    pub wait_output_hash: [u8; 32],
+    pub num_outputs: u8,
+    pub per_output_amount: u64,
+}
+
 /// Build a private transfer to a concrete shielded address.
 ///
 /// This action performs no user-registry lookup. Resolve an optional registry
@@ -83,6 +94,19 @@ pub struct CreateWithdrawal<'a, A: ?Sized> {
     pub recipient: Pubkey,
     pub asset: Address,
     pub amount: u64,
+    pub selection: InputSelection,
+}
+
+pub struct CreateSplit<'a, A: ?Sized> {
+    pub wallet: &'a Wallet,
+    pub authority: &'a A,
+    pub owner_pubkey: Pubkey,
+    pub payer: Address,
+    pub asset: Address,
+    pub num_outputs: u8,
+    pub per_output_amount: u64,
+    /// A split spends exactly one note. `Auto` finds an exact-value note;
+    /// `Explicit` must name exactly one note.
     pub selection: InputSelection,
 }
 
@@ -183,6 +207,97 @@ pub fn create_withdrawal_sync<A: SyncWalletAuthority + ?Sized>(
     request: CreateWithdrawal<'_, A>,
 ) -> Result<CreatedWithdrawal, ClientError> {
     futures::executor::block_on(create_withdrawal(request))
+}
+
+/// Split one selected note into 2..=8 equal self-owned notes.
+pub async fn create_split<A: WalletAuthority + ?Sized>(
+    request: CreateSplit<'_, A>,
+) -> Result<CreatedSplit, ClientError> {
+    if !(2..=8).contains(&request.num_outputs) {
+        return Err(TransactionError::InvalidSplitOutputCount(request.num_outputs).into());
+    }
+    if request.per_output_amount == 0 {
+        return Err(ClientError::ZeroAmount);
+    }
+    let total = u64::from(request.num_outputs)
+        .checked_mul(request.per_output_amount)
+        .ok_or(ClientError::SelectedBalanceOverflow)?;
+    let inputs = select_split_inputs(
+        request.wallet,
+        request.authority,
+        request.owner_pubkey,
+        request.asset,
+        total,
+        &request.selection,
+    )
+    .await?;
+    let address = request
+        .authority
+        .shielded_address(request.owner_pubkey)
+        .await?;
+    let mut tx = Transaction::new(address, inputs, request.payer);
+    tx.split(
+        request.asset,
+        request.num_outputs,
+        request.per_output_amount,
+    )?;
+    let prepared = tx.prepare_split(&request.wallet.registry)?;
+    let wait_output_hash = prepared.wait_output_hash()?;
+    let signed = sign_prepared_split(
+        prepared,
+        &address,
+        request.owner_pubkey,
+        request.authority,
+        format!(
+            "split into {} notes of {}",
+            request.num_outputs, request.per_output_amount
+        ),
+    )
+    .await?;
+    Ok(CreatedSplit {
+        signed,
+        wait_output_hash,
+        num_outputs: request.num_outputs,
+        per_output_amount: request.per_output_amount,
+    })
+}
+
+/// Blocking adapter for CLI and unit-test flows.
+pub fn create_split_sync<A: SyncWalletAuthority + ?Sized>(
+    request: CreateSplit<'_, A>,
+) -> Result<CreatedSplit, ClientError> {
+    futures::executor::block_on(create_split(request))
+}
+
+async fn sign_prepared_split<A: WalletAuthority + ?Sized>(
+    prepared: PreparedSplit,
+    address: &ShieldedAddress,
+    owner_pubkey: Pubkey,
+    authority: &A,
+    approval_summary: String,
+) -> Result<SignedTransaction, ClientError> {
+    let view_tag = prepared.view_tag()?;
+    let bundle = prepared.bundle_plaintext()?;
+    let encrypted = authority
+        .encrypt_split(owner_pubkey, &prepared.first_nullifier, view_tag, &bundle)
+        .await?;
+    authority
+        .request_user_approval(ApprovalRequest {
+            owner_pubkey,
+            summary: approval_summary,
+        })
+        .await?;
+    let mut signed =
+        prepared.finalize(encrypted.tx_viewing_pk, encrypted.salt, encrypted.bundle)?;
+    if address.signing_pubkey.signature_type()? == SignatureType::P256 {
+        let message_hash = signed.message_hash()?;
+        let sig = authority.sign_p256(owner_pubkey, &message_hash).await?;
+        let mut bytes = [0u8; 64];
+        bytes[..32].copy_from_slice(&sig.sig_r);
+        bytes[32..].copy_from_slice(&sig.sig_s);
+        signed.p256_owner = Some(bytes);
+    }
+    Ok(signed)
 }
 
 /// Sign a prepared transaction through a wallet authority (encrypt, approve,
@@ -398,6 +513,58 @@ async fn select_inputs<A: WalletAuthority + ?Sized>(
                 });
             }
             Ok(selected)
+        }
+    }
+}
+
+async fn select_split_inputs<A: WalletAuthority + ?Sized>(
+    wallet: &Wallet,
+    authority: &A,
+    owner_pubkey: Pubkey,
+    asset: Address,
+    amount: u64,
+    selection: &InputSelection,
+) -> Result<Vec<SpendUtxo>, ClientError> {
+    match selection {
+        InputSelection::Explicit(hashes) => {
+            if hashes.len() != 1 {
+                return Err(TransactionError::SplitInputCount(hashes.len()).into());
+            }
+            select_inputs(wallet, authority, owner_pubkey, asset, amount, selection).await
+        }
+        InputSelection::Auto => {
+            let nullifier_key = authority.spend_nullifier_key(owner_pubkey).await?;
+            let mut available = 0u64;
+            let mut exact = None;
+            for entry in wallet
+                .utxos
+                .iter()
+                .filter(|entry| !entry.spent && entry.utxo.asset == asset)
+            {
+                available = available
+                    .checked_add(entry.utxo.amount)
+                    .ok_or(ClientError::SelectedBalanceOverflow)?;
+                if entry.utxo.amount == amount {
+                    exact = Some(entry.utxo.clone());
+                    break;
+                }
+            }
+            let utxo = match exact {
+                Some(utxo) => utxo,
+                None if available < amount => {
+                    return Err(ClientError::InsufficientBalance {
+                        requested: amount,
+                        available,
+                    })
+                }
+                None => return Err(ClientError::SplitInputUnavailable { requested: amount }),
+            };
+            Ok(vec![SpendUtxo {
+                utxo,
+                nullifier_key,
+                data_hash: None,
+                zone_data_hash: None,
+            }])
         }
     }
 }
@@ -747,5 +914,60 @@ mod tests {
             ],
         );
         withdraw_auto(&five_sol, &sender, SOL_MINT, 50).expect("five SOL inputs");
+    }
+
+    #[test]
+    fn create_split_uses_one_exact_input_and_one_bundle() {
+        let sender = ShieldedKeypair::new().unwrap();
+        let wallet = wallet_with_notes(sender.clone(), &[(400, [1u8; 31]), (50, [2u8; 31])]);
+        let split = create_split_sync(CreateSplit {
+            wallet: &wallet,
+            authority: &sender,
+            owner_pubkey: Pubkey::default(),
+            payer: Address::default(),
+            asset: SOL_MINT,
+            num_outputs: 4,
+            per_output_amount: 100,
+            selection: InputSelection::Auto,
+        })
+        .expect("split exact note");
+
+        assert_eq!(split.num_outputs, 4);
+        assert_eq!(split.per_output_amount, 100);
+        assert_eq!(
+            (split.signed.shape.n_inputs, split.signed.shape.n_outputs),
+            (1, 8)
+        );
+        assert_eq!(split.signed.external_data.output_ciphertexts.len(), 1);
+        assert_eq!(split.signed.external_data.output_utxo_hashes.len(), 8);
+    }
+
+    #[test]
+    fn create_split_rejects_invalid_arity_and_missing_exact_note() {
+        let sender = ShieldedKeypair::new().unwrap();
+        let wallet = wallet_with_notes(sender.clone(), &[(300, [1u8; 31]), (200, [2u8; 31])]);
+        let request = |num_outputs| CreateSplit {
+            wallet: &wallet,
+            authority: &sender,
+            owner_pubkey: Pubkey::default(),
+            payer: Address::default(),
+            asset: SOL_MINT,
+            num_outputs,
+            per_output_amount: 100,
+            selection: InputSelection::Auto,
+        };
+
+        for count in [0, 1, 9] {
+            assert!(matches!(
+                create_split_sync(request(count)),
+                Err(ClientError::Transaction(
+                    TransactionError::InvalidSplitOutputCount(value)
+                )) if value == count
+            ));
+        }
+        assert!(matches!(
+            create_split_sync(request(4)),
+            Err(ClientError::SplitInputUnavailable { requested: 400 })
+        ));
     }
 }

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -45,6 +45,9 @@ pub enum ClientError {
     #[error("explicit input list contains duplicate note {hash}")]
     DuplicateInputNote { hash: String },
 
+    #[error("no unspent note exactly matches split total {requested}")]
+    SplitInputUnavailable { requested: u64 },
+
     #[error("SPL token account is required for mint {mint}")]
     MissingSplTokenAccount { mint: Pubkey },
 

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -11,9 +11,10 @@ pub mod wallet_authority;
 pub mod wallet_sync;
 
 pub use actions::{
-    create_associated_token_account, create_deposit, create_transfer, create_transfer_sync,
-    create_withdrawal, create_withdrawal_sync, sign_transaction, sign_transaction_sync,
-    submit_private_transaction, CreateDeposit, CreateTransfer, CreateWithdrawal, CreatedTransfer,
+    create_associated_token_account, create_deposit, create_split, create_split_sync,
+    create_transfer, create_transfer_sync, create_withdrawal, create_withdrawal_sync,
+    sign_transaction, sign_transaction_sync, submit_private_transaction, CreateDeposit,
+    CreateSplit, CreateTransfer, CreateWithdrawal, CreatedSplit, CreatedTransfer,
     CreatedWithdrawal, Deposit, InputSelection, SubmitPrivateTransaction, MAX_TRANSFER_INPUTS,
 };
 pub use error::ClientError;
@@ -46,8 +47,8 @@ pub use user_registry::{
     validate_registered_keypair,
 };
 pub use wallet_authority::{
-    AnonymousRecipientSlot, ApprovalRequest, ConfidentialRecipientSlot, EncryptedTransfer,
-    P256Signature, SyncWalletAuthority, WalletAuthority,
+    AnonymousRecipientSlot, ApprovalRequest, ConfidentialRecipientSlot, EncryptedSplit,
+    EncryptedTransfer, P256Signature, SyncWalletAuthority, WalletAuthority,
 };
 pub use wallet_sync::{
     get_private_token_balances, get_private_transactions, sync_wallet, sync_wallet_with_config,

--- a/sdk-libs/client/src/wallet_authority.rs
+++ b/sdk-libs/client/src/wallet_authority.rs
@@ -18,6 +18,7 @@ use zolana_transaction::{
             ConfidentialRecipient, ConfidentialRecipientEncode, ConfidentialSenderBundle,
             ConfidentialSenderEncode, TransferRecipientPlaintext, TransferSenderPlaintext,
         },
+        split::{Split, SplitBundlePlaintext, SplitEncode},
     },
     UtxoSerialization,
 };
@@ -65,6 +66,14 @@ pub struct EncryptedTransfer {
     pub slots: Vec<OutputCiphertext>,
 }
 
+/// The single encrypted bundle carried by a split transaction.
+#[derive(Clone, Debug)]
+pub struct EncryptedSplit {
+    pub tx_viewing_pk: P256Pubkey,
+    pub salt: Salt,
+    pub bundle: OutputCiphertext,
+}
+
 /// Authority for production wallet hosts where approval, key access, or signing
 /// may cross a process, device, or remote custody boundary.
 #[async_trait(?Send)]
@@ -88,6 +97,14 @@ pub trait WalletAuthority {
         sender: &AnonymousTransferSenderPlaintext,
         recipients: &[AnonymousRecipientSlot],
     ) -> Result<EncryptedTransfer, ClientError>;
+
+    async fn encrypt_split(
+        &self,
+        owner_pubkey: Pubkey,
+        first_nullifier: &[u8; 32],
+        view_tag: ViewTag,
+        bundle: &SplitBundlePlaintext,
+    ) -> Result<EncryptedSplit, ClientError>;
 
     async fn request_user_approval(&self, _request: ApprovalRequest) -> Result<(), ClientError> {
         Ok(())
@@ -123,6 +140,14 @@ pub trait SyncWalletAuthority {
         sender: &AnonymousTransferSenderPlaintext,
         recipients: &[AnonymousRecipientSlot],
     ) -> Result<EncryptedTransfer, ClientError>;
+
+    fn encrypt_split(
+        &self,
+        owner_pubkey: Pubkey,
+        first_nullifier: &[u8; 32],
+        view_tag: ViewTag,
+        bundle: &SplitBundlePlaintext,
+    ) -> Result<EncryptedSplit, ClientError>;
 
     fn request_user_approval(&self, _request: ApprovalRequest) -> Result<(), ClientError> {
         Ok(())
@@ -180,6 +205,16 @@ where
             sender,
             recipients,
         )
+    }
+
+    async fn encrypt_split(
+        &self,
+        owner_pubkey: Pubkey,
+        first_nullifier: &[u8; 32],
+        view_tag: ViewTag,
+        bundle: &SplitBundlePlaintext,
+    ) -> Result<EncryptedSplit, ClientError> {
+        SyncWalletAuthority::encrypt_split(self, owner_pubkey, first_nullifier, view_tag, bundle)
     }
 
     async fn request_user_approval(&self, request: ApprovalRequest) -> Result<(), ClientError> {
@@ -307,6 +342,35 @@ impl SyncWalletAuthority for ShieldedKeypair {
             tx_viewing_pk: tx.pubkey(),
             salt,
             slots,
+        })
+    }
+
+    fn encrypt_split(
+        &self,
+        _owner_pubkey: Pubkey,
+        first_nullifier: &[u8; 32],
+        view_tag: ViewTag,
+        bundle: &SplitBundlePlaintext,
+    ) -> Result<EncryptedSplit, ClientError> {
+        let tx = self
+            .viewing_key
+            .get_transaction_viewing_key(first_nullifier)?;
+        let salt = random_salt();
+        let bundle = Split::encode_plaintext(
+            bundle,
+            view_tag,
+            &SplitEncode {
+                tx: tx.clone(),
+                recipient_pubkey: self.viewing_key.pubkey(),
+                salt,
+                slot_index: 0,
+                blinding_seed: bundle.blinding_seed,
+            },
+        )?;
+        Ok(EncryptedSplit {
+            tx_viewing_pk: tx.pubkey(),
+            salt,
+            bundle,
         })
     }
 

--- a/sdk-libs/client/tests/transaction.rs
+++ b/sdk-libs/client/tests/transaction.rs
@@ -121,6 +121,22 @@ impl WalletAuthority for AsyncTestAuthority {
         )
     }
 
+    async fn encrypt_split(
+        &self,
+        owner_pubkey: Pubkey,
+        first_nullifier: &[u8; 32],
+        view_tag: [u8; 32],
+        bundle: &zolana_transaction::serialization::split::SplitBundlePlaintext,
+    ) -> Result<zolana_client::EncryptedSplit, ClientError> {
+        SyncWalletAuthority::encrypt_split(
+            &self.keypair,
+            owner_pubkey,
+            first_nullifier,
+            view_tag,
+            bundle,
+        )
+    }
+
     async fn request_user_approval(&self, request: ApprovalRequest) -> Result<(), ClientError> {
         assert_eq!(request.owner_pubkey, Pubkey::default());
         assert!(request.summary.contains("private transaction"));
@@ -599,6 +615,61 @@ fn withdrawal_packet_boundaries_justify_the_spl_input_cap() {
         sol_five <= PACKET_DATA_SIZE,
         "SOL withdrawal at the regular input cap must fit: {sol_five} bytes"
     );
+}
+
+#[test]
+fn every_split_arity_fits_with_one_bundle_ciphertext() {
+    const PACKET_DATA_SIZE: usize = 1232;
+
+    for parts in 2u8..=8 {
+        let mut rng = rand::thread_rng();
+        let sender = ShieldedKeypair::new().unwrap();
+        let input = p256_input(&sender, u64::from(parts) * 100, &mut rng);
+        let mut split = Transaction::new(
+            sender.shielded_address().unwrap(),
+            vec![input],
+            Address::default(),
+        );
+        split.split(SOL_MINT, parts, 100).unwrap();
+        let signed = sign(split, &sender).unwrap();
+        assert_eq!(signed.external_data.output_ciphertexts.len(), 1);
+
+        let proofs = signed
+            .input_commitments()
+            .unwrap()
+            .iter()
+            .map(|_| fake_spend_proof(5))
+            .collect::<Vec<_>>();
+        let data = zolana_client::assemble(signed, &proofs)
+            .unwrap()
+            .with_proof(TransactProof::P256 {
+                a: [0u8; 32],
+                b: [0u8; 64],
+                c: [0u8; 32],
+                commitment: [0u8; 32],
+                commitment_pok: [0u8; 32],
+            });
+        let payer = Pubkey::new_unique();
+        let instruction = Transact {
+            payer,
+            tree: Pubkey::new_unique(),
+            withdrawal: None,
+            data,
+        }
+        .instruction();
+        let compute_budget =
+            solana_compute_budget_interface::ComputeBudgetInstruction::set_compute_unit_limit(
+                1_400_000,
+            );
+        let message = Message::new(&[compute_budget, instruction], Some(&payer));
+        let tx_size = 1
+            + usize::from(message.header.num_required_signatures) * 64
+            + message.serialize().len();
+        assert!(
+            tx_size <= PACKET_DATA_SIZE,
+            "{parts}-way split serializes to {tx_size} bytes"
+        );
+    }
 }
 
 #[test]

--- a/sdk-libs/transaction/src/error.rs
+++ b/sdk-libs/transaction/src/error.rs
@@ -67,6 +67,24 @@ pub enum TransactionError {
     #[error("withdrawal already set")]
     WithdrawalAlreadySet,
 
+    #[error("split cannot be combined with send, custom output, or withdrawal")]
+    SplitWithOtherActions,
+
+    #[error("split output count must be between 2 and 8; got {0}")]
+    InvalidSplitOutputCount(u8),
+
+    #[error("no split was configured")]
+    SplitNotConfigured,
+
+    #[error("split asset mismatch: input has {input}, split requested {requested}")]
+    SplitAssetMismatch { input: Address, requested: Address },
+
+    #[error("split output amounts sum to {requested} but the selected input holds {available}")]
+    SplitAmountMismatch { requested: u64, available: u64 },
+
+    #[error("a split spends exactly one input; got {0}")]
+    SplitInputCount(usize),
+
     #[error("multiple public spl assets in one transaction")]
     MultiplePublicSplAssets,
 

--- a/sdk-libs/transaction/src/instructions/transact/builder.rs
+++ b/sdk-libs/transaction/src/instructions/transact/builder.rs
@@ -21,6 +21,7 @@ use crate::{
             ConfidentialRecipient, ConfidentialRecipientEncode, ConfidentialSenderBundle,
             ConfidentialSenderEncode, TransferRecipientPlaintext, TransferSenderPlaintext,
         },
+        split::{Split, SplitBundlePlaintext, SplitEncode},
         OwnerCx, UtxoSerialization,
     },
     utxo::{derive_blinding, Utxo},
@@ -50,6 +51,9 @@ pub const SUPPORTED_SHAPES: [Shape; 4] = [
     Shape::new(4, 3),
     Shape::new(5, 3),
 ];
+
+/// Fixed proof shape for splitting one note into 2..=8 equal self-owned notes.
+const SPLIT_SHAPE: Shape = Shape::new(1, 8);
 
 pub struct PreparedRecipient {
     pub view_tag: ViewTag,
@@ -92,6 +96,12 @@ struct Recipient {
     address: ShieldedAddress,
     asset: Address,
     amount: u64,
+}
+
+struct SplitIntent {
+    asset: Address,
+    num_outputs: u8,
+    per_output_amount: u64,
 }
 
 pub enum WithdrawalTarget {
@@ -173,6 +183,7 @@ pub struct Transaction {
     /// verbatim, so the caller controls `data` and the zone/program ids.
     custom_outputs: Vec<OutputUtxo>,
     withdrawal: Option<Withdrawal>,
+    split: Option<SplitIntent>,
     payer_pubkey_hash: [u8; 32],
     blinding_seed: [u8; BLINDING_LEN],
     shape: Option<Shape>,
@@ -187,6 +198,7 @@ impl Transaction {
             recipients: Vec::new(),
             custom_outputs: Vec::new(),
             withdrawal: None,
+            split: None,
             payer_pubkey_hash: sha256_be(payer.as_array()),
             blinding_seed: random_blinding(),
             shape: None,
@@ -200,6 +212,9 @@ impl Transaction {
     /// shape like a [`Self::send`] recipient and is encoded into its own
     /// ciphertext slot. The output must name its recipient via `owner_address`.
     pub fn add_output(&mut self, output: OutputUtxo) -> Result<&mut Self, TransactionError> {
+        if self.split.is_some() {
+            return Err(TransactionError::SplitWithOtherActions);
+        }
         if output.owner_address.is_none() {
             return Err(TransactionError::MissingOutput);
         }
@@ -227,6 +242,9 @@ impl Transaction {
         asset: Address,
         amount: u64,
     ) -> Result<&mut Self, TransactionError> {
+        if self.split.is_some() {
+            return Err(TransactionError::SplitWithOtherActions);
+        }
         self.recipients.push(Recipient {
             address: *recipient,
             asset,
@@ -241,6 +259,9 @@ impl Transaction {
         amount: u64,
         target: WithdrawalTarget,
     ) -> Result<&mut Self, TransactionError> {
+        if self.split.is_some() {
+            return Err(TransactionError::SplitWithOtherActions);
+        }
         if self.withdrawal.is_some() {
             return Err(TransactionError::WithdrawalAlreadySet);
         }
@@ -248,6 +269,30 @@ impl Transaction {
             asset,
             amount,
             target,
+        });
+        Ok(self)
+    }
+
+    /// Split one selected note into 2..=8 equal self-owned notes.
+    pub fn split(
+        &mut self,
+        asset: Address,
+        num_outputs: u8,
+        per_output_amount: u64,
+    ) -> Result<&mut Self, TransactionError> {
+        if !(2..=8).contains(&num_outputs) {
+            return Err(TransactionError::InvalidSplitOutputCount(num_outputs));
+        }
+        if !self.recipients.is_empty()
+            || !self.custom_outputs.is_empty()
+            || self.withdrawal.is_some()
+        {
+            return Err(TransactionError::SplitWithOtherActions);
+        }
+        self.split = Some(SplitIntent {
+            asset,
+            num_outputs,
+            per_output_amount,
         });
         Ok(self)
     }
@@ -261,7 +306,27 @@ impl Transaction {
         keypair: &K,
         assets: &AssetRegistry,
     ) -> Result<SignedTransaction, TransactionError> {
+        if self.split.is_some() {
+            return self.sign_split(keypair, assets);
+        }
         let mut signed = self.assemble(keypair, assets)?;
+        if keypair.curve()? == SignatureType::P256 {
+            let message_hash = signed.message_hash()?;
+            signed.p256_owner = Some(keypair.sign(&message_hash));
+        }
+        Ok(signed)
+    }
+
+    fn sign_split<K: ShieldedKeypairTrait + ViewingKeyTrait>(
+        self,
+        keypair: &K,
+        assets: &AssetRegistry,
+    ) -> Result<SignedTransaction, TransactionError> {
+        let prepared = self.prepare_split(assets)?;
+        let tx = keypair.get_transaction_viewing_key(&prepared.first_nullifier)?;
+        let salt = zolana_keypair::random_salt();
+        let bundle = prepared.encode_bundle(assets, &tx, keypair.viewing_pubkey(), salt, 0)?;
+        let mut signed = prepared.finalize(tx.pubkey(), salt, bundle)?;
         if keypair.curve()? == SignatureType::P256 {
             let message_hash = signed.message_hash()?;
             signed.p256_owner = Some(keypair.sign(&message_hash));
@@ -313,6 +378,9 @@ impl Transaction {
     }
 
     pub fn prepare(self, assets: &AssetRegistry) -> Result<PreparedTransaction, TransactionError> {
+        if self.split.is_some() {
+            return Err(TransactionError::SplitWithOtherActions);
+        }
         let spl_asset = self.spl_asset()?;
         let (public_sol, public_spl) = self.public_amounts();
         let sol_change = self.change(&SOL_MINT, public_sol)?;
@@ -451,6 +519,64 @@ impl Transaction {
             user_sol_account,
             user_spl_token,
             spl_token_interface,
+        })
+    }
+
+    /// Prepare a one-input split for authority-controlled bundle encryption.
+    pub fn prepare_split(self, assets: &AssetRegistry) -> Result<PreparedSplit, TransactionError> {
+        let intent = self
+            .split
+            .as_ref()
+            .ok_or(TransactionError::SplitNotConfigured)?;
+        if !self.recipients.is_empty()
+            || !self.custom_outputs.is_empty()
+            || self.withdrawal.is_some()
+        {
+            return Err(TransactionError::SplitWithOtherActions);
+        }
+        if self.inputs.len() != 1 {
+            return Err(TransactionError::SplitInputCount(self.inputs.len()));
+        }
+
+        let input = &self.inputs.first().ok_or(TransactionError::NoInputs)?.utxo;
+        if input.asset != intent.asset {
+            return Err(TransactionError::SplitAssetMismatch {
+                input: input.asset,
+                requested: intent.asset,
+            });
+        }
+        let requested = u64::from(intent.num_outputs)
+            .checked_mul(intent.per_output_amount)
+            .ok_or(TransactionError::SelectedBalanceOverflow)?;
+        let available = self.input_sum(&intent.asset);
+        if i128::from(requested) != available {
+            return Err(TransactionError::SplitAmountMismatch {
+                requested,
+                available: available.max(0) as u64,
+            });
+        }
+
+        let asset_id = self.asset_id(assets, &intent.asset)?;
+        let outputs = (0..intent.num_outputs)
+            .map(|position| OutputUtxo {
+                owner_address: Some(self.owner),
+                asset: intent.asset,
+                amount: intent.per_output_amount,
+                blinding: derive_blinding(&self.blinding_seed, position),
+                ..Default::default()
+            })
+            .collect();
+        let first_nullifier = self.first_nullifier()?;
+
+        Ok(PreparedSplit {
+            inputs: self.inputs,
+            outputs,
+            owner: self.owner,
+            asset_id,
+            blinding_seed: self.blinding_seed,
+            first_nullifier,
+            payer_pubkey_hash: self.payer_pubkey_hash,
+            expiry_unix_ts: self.expiry_unix_ts,
         })
     }
 
@@ -670,6 +796,136 @@ impl PreparedTransaction {
             external_data,
             payer_pubkey_hash,
             shape,
+            p256_owner: None,
+        })
+    }
+}
+
+/// A split prepared for one bundle ciphertext and a fixed `{1,8}` proof shape.
+pub struct PreparedSplit {
+    pub inputs: Vec<SpendUtxo>,
+    pub outputs: Vec<OutputUtxo>,
+    pub owner: ShieldedAddress,
+    pub asset_id: u64,
+    pub blinding_seed: [u8; BLINDING_LEN],
+    pub first_nullifier: [u8; 32],
+    pub payer_pubkey_hash: [u8; 32],
+    pub expiry_unix_ts: u64,
+}
+
+impl PreparedSplit {
+    pub fn bundle_plaintext(&self) -> Result<SplitBundlePlaintext, TransactionError> {
+        let num_outputs =
+            u8::try_from(self.outputs.len()).map_err(|_| TransactionError::TooManyOutputs)?;
+        Ok(SplitBundlePlaintext {
+            owner_pubkey: self.owner.signing_pubkey,
+            num_outputs,
+            asset_id: self.asset_id,
+            asset_amount: self
+                .outputs
+                .first()
+                .map(|output| output.amount)
+                .unwrap_or(0),
+            blinding_seed: self.blinding_seed,
+            data: Data::default(),
+        })
+    }
+
+    pub fn wait_output_hash(&self) -> Result<[u8; 32], TransactionError> {
+        self.outputs
+            .first()
+            .ok_or(TransactionError::MissingOutput)?
+            .hash()
+    }
+
+    pub fn view_tag(&self) -> Result<ViewTag, TransactionError> {
+        Ok(self.owner.signing_pubkey.confidential_view_tag()?)
+    }
+
+    fn encode_bundle(
+        &self,
+        assets: &AssetRegistry,
+        tx: &zolana_keypair::ViewingKey,
+        recipient_pubkey: P256Pubkey,
+        salt: [u8; zolana_keypair::constants::SALT_LEN],
+        slot_index: u32,
+    ) -> Result<OutputCiphertext, TransactionError> {
+        let owner_cx = OwnerCx {
+            owner: self.owner.signing_pubkey,
+            assets,
+            zone_program_id: None,
+        };
+        Split::encode(
+            &self.bundle_plaintext()?.into_utxos(assets, None)?,
+            &owner_cx,
+            self.view_tag()?,
+            &SplitEncode {
+                tx: tx.clone(),
+                recipient_pubkey,
+                salt,
+                slot_index,
+                blinding_seed: self.blinding_seed,
+            },
+        )
+    }
+
+    /// Finalize the fixed `{1,8}` split. Real outputs are padded to eight
+    /// commitments, while the single encrypted bundle remains the only
+    /// ciphertext. The program therefore maps every output position to the
+    /// bundle view tag.
+    pub fn finalize(
+        self,
+        tx_viewing_pk: P256Pubkey,
+        salt: [u8; zolana_keypair::constants::SALT_LEN],
+        bundle: OutputCiphertext,
+    ) -> Result<SignedTransaction, TransactionError> {
+        let PreparedSplit {
+            inputs,
+            mut outputs,
+            payer_pubkey_hash,
+            expiry_unix_ts,
+            ..
+        } = self;
+
+        while outputs.len() < SPLIT_SHAPE.n_outputs {
+            outputs.push(OutputUtxo {
+                blinding: random_blinding(),
+                owner_tag: Some(bundle.view_tag),
+                ..Default::default()
+            });
+        }
+        let output_utxo_hashes = outputs
+            .iter()
+            .map(OutputUtxo::hash)
+            .collect::<Result<Vec<_>, _>>()?;
+        let external_data = ExternalData {
+            instruction_discriminator: TRANSACT_DISCRIMINATOR,
+            expiry_unix_ts,
+            relayer_fee: 0,
+            public_sol_amount: None,
+            public_spl_amount: None,
+            user_sol_account: Address::default(),
+            user_spl_token: Address::default(),
+            spl_token_interface: Address::default(),
+            data_hash: None,
+            zone_data_hash: None,
+            tx_viewing_pk: *tx_viewing_pk.as_bytes(),
+            salt,
+            output_utxo_hashes,
+            output_ciphertexts: vec![bundle],
+        };
+
+        Ok(SignedTransaction {
+            inputs,
+            outputs,
+            public_amounts: PublicAmounts {
+                sol: [0u8; 32],
+                spl: [0u8; 32],
+                asset: [0u8; 32],
+            },
+            external_data,
+            payer_pubkey_hash,
+            shape: SPLIT_SHAPE,
             p256_owner: None,
         })
     }

--- a/sdk-libs/transaction/src/instructions/transact/mod.rs
+++ b/sdk-libs/transaction/src/instructions/transact/mod.rs
@@ -8,7 +8,8 @@ pub mod signed_transaction;
 pub mod types;
 
 pub use builder::{
-    PreparedRecipient, PreparedTransaction, Shape, Transaction, WithdrawalTarget, SENDER_SLOT_COUNT,
+    PreparedRecipient, PreparedSplit, PreparedTransaction, Shape, Transaction, WithdrawalTarget,
+    SENDER_SLOT_COUNT,
 };
 pub use external_data::ExternalData;
 pub use signed_transaction::{PublicAmounts, SignedTransaction};

--- a/sdk-libs/transaction/tests/split_builder.rs
+++ b/sdk-libs/transaction/tests/split_builder.rs
@@ -1,0 +1,250 @@
+use zolana_keypair::ShieldedKeypair;
+use zolana_transaction::{
+    instructions::{
+        transact::{
+            OutputContext, OutputSlot, OutputUtxo, ShieldedTransaction, SignedTransaction,
+            Transaction, WithdrawalTarget,
+        },
+        types::SpendUtxo,
+    },
+    wallet::{PrivateTransactionKind, Wallet, WalletUtxo},
+    Address, AssetRegistry, Data, TransactionError, Utxo, SOL_MINT,
+};
+
+fn sol_utxo(keypair: &ShieldedKeypair, amount: u64, blinding: [u8; 31]) -> Utxo {
+    Utxo {
+        owner: keypair.signing_pubkey(),
+        asset: SOL_MINT,
+        amount,
+        blinding,
+        zone_program_id: None,
+        data: Data::default(),
+    }
+}
+
+fn transaction(keypair: &ShieldedKeypair, inputs: Vec<Utxo>) -> Transaction {
+    Transaction::new(
+        keypair.shielded_address().unwrap(),
+        inputs
+            .into_iter()
+            .map(|utxo| SpendUtxo::from_keypair(utxo, keypair))
+            .collect(),
+        Address::default(),
+    )
+}
+
+fn to_shielded_transaction(signed: &SignedTransaction) -> ShieldedTransaction {
+    let external = &signed.external_data;
+    let bundle = external.output_ciphertexts.first().expect("split bundle");
+    let output_slots = external
+        .output_utxo_hashes
+        .iter()
+        .enumerate()
+        .map(|(index, hash)| OutputSlot {
+            view_tag: if index == 0 {
+                bundle.view_tag
+            } else {
+                [0u8; 32]
+            },
+            output_context: OutputContext {
+                hash: *hash,
+                tree: Address::default(),
+                leaf_index: index as u64,
+            },
+            payload: if index == 0 {
+                bundle.data.clone()
+            } else {
+                Vec::new()
+            },
+        })
+        .collect();
+    ShieldedTransaction {
+        slot: 0,
+        tx_signature: solana_signature::Signature::default(),
+        tx_viewing_pk: Some(
+            zolana_keypair::P256Pubkey::from_bytes(external.tx_viewing_pk).unwrap(),
+        ),
+        salt: Some(external.salt),
+        output_slots,
+        nullifiers: signed
+            .input_commitments()
+            .unwrap()
+            .into_iter()
+            .map(|commitment| commitment.nullifier)
+            .collect(),
+        proofless: false,
+    }
+}
+
+fn wallet_holding(keypair: ShieldedKeypair, input: &Utxo) -> Wallet {
+    let mut wallet = Wallet::new(keypair, AssetRegistry::default()).unwrap();
+    let nullifier_pk = wallet.keypair.nullifier_key.pubkey().unwrap();
+    let hash = input.hash(&nullifier_pk, &[0u8; 32], &[0u8; 32]).unwrap();
+    wallet.utxos.push(WalletUtxo {
+        utxo: input.clone(),
+        output_context: OutputContext {
+            hash,
+            tree: Address::default(),
+            leaf_index: 0,
+        },
+        nullifier: input
+            .nullifier(&hash, &wallet.keypair.nullifier_key)
+            .unwrap(),
+        spent: false,
+    });
+    wallet
+}
+
+fn build_and_recover(num_outputs: u8, per_output_amount: u64) -> (Wallet, SignedTransaction) {
+    let keypair = ShieldedKeypair::new().unwrap();
+    let input = sol_utxo(
+        &keypair,
+        u64::from(num_outputs) * per_output_amount,
+        [9u8; 31],
+    );
+    let mut tx = transaction(&keypair, vec![input.clone()]);
+    tx.split(SOL_MINT, num_outputs, per_output_amount).unwrap();
+    let signed = tx.sign(&keypair, &AssetRegistry::default()).unwrap();
+
+    assert_eq!(signed.shape.n_inputs, 1);
+    assert_eq!(signed.shape.n_outputs, 8);
+    assert_eq!(signed.external_data.output_utxo_hashes.len(), 8);
+    assert_eq!(
+        signed.external_data.output_ciphertexts.len(),
+        1,
+        "N={num_outputs}: a split always emits one bundle"
+    );
+    let bundle_tag = signed.external_data.output_ciphertexts[0].view_tag;
+    for output in signed.outputs.iter().skip(usize::from(num_outputs)) {
+        assert_eq!(output.owner_tag, Some(bundle_tag));
+    }
+
+    let mut wallet = wallet_holding(keypair, &input);
+    let report = wallet
+        .sync(&[to_shielded_transaction(&signed)], 1_700_000_000, 8)
+        .unwrap();
+    assert_eq!(report.unparsed_transactions, 0);
+    (wallet, signed)
+}
+
+#[test]
+fn every_split_arity_round_trips_with_one_packet_safe_bundle() {
+    for num_outputs in 2u8..=8 {
+        let (wallet, signed) = build_and_recover(num_outputs, 10);
+        let balance = wallet
+            .balances(false)
+            .unwrap()
+            .into_iter()
+            .find(|balance| balance.mint == SOL_MINT)
+            .expect("SOL balance");
+        assert_eq!(balance.amount, u64::from(num_outputs) * 10);
+        assert_eq!(balance.utxos.len(), usize::from(num_outputs));
+        assert!(balance.utxos.iter().all(|utxo| utxo.amount == 10));
+        assert!(wallet
+            .private_transactions()
+            .iter()
+            .any(|tx| tx.kind == PrivateTransactionKind::Split));
+
+        let nullifier_pk = wallet.keypair.nullifier_key.pubkey().unwrap();
+        for utxo in &balance.utxos {
+            let hash = utxo.hash(&nullifier_pk, &[0u8; 32], &[0u8; 32]).unwrap();
+            assert!(signed.external_data.output_utxo_hashes.contains(&hash));
+        }
+    }
+}
+
+#[test]
+fn split_rejects_every_out_of_range_arity_at_configuration() {
+    let keypair = ShieldedKeypair::new().unwrap();
+    for parts in [0, 1, 9] {
+        let mut tx = transaction(&keypair, vec![sol_utxo(&keypair, 90, [parts; 31])]);
+        let err = tx
+            .split(SOL_MINT, parts, 10)
+            .err()
+            .expect("invalid split arity");
+        assert_eq!(err, TransactionError::InvalidSplitOutputCount(parts));
+    }
+}
+
+#[test]
+fn split_is_mutually_exclusive_with_other_actions() {
+    let keypair = ShieldedKeypair::new().unwrap();
+    let recipient = ShieldedKeypair::new().unwrap();
+
+    let mut sent = transaction(&keypair, vec![sol_utxo(&keypair, 100, [1u8; 31])]);
+    sent.send(&recipient.shielded_address().unwrap(), SOL_MINT, 10)
+        .unwrap();
+    assert_eq!(
+        sent.split(SOL_MINT, 2, 50).err().unwrap(),
+        TransactionError::SplitWithOtherActions
+    );
+
+    let mut withdrawn = transaction(&keypair, vec![sol_utxo(&keypair, 100, [2u8; 31])]);
+    withdrawn
+        .withdraw(
+            SOL_MINT,
+            10,
+            WithdrawalTarget::Sol {
+                user_sol_account: Address::default(),
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        withdrawn.split(SOL_MINT, 2, 50).err().unwrap(),
+        TransactionError::SplitWithOtherActions
+    );
+
+    let mut split = transaction(&keypair, vec![sol_utxo(&keypair, 100, [3u8; 31])]);
+    split.split(SOL_MINT, 2, 50).unwrap();
+    assert_eq!(
+        split
+            .add_output(OutputUtxo {
+                owner_address: Some(recipient.shielded_address().unwrap()),
+                amount: 1,
+                ..Default::default()
+            })
+            .err()
+            .unwrap(),
+        TransactionError::SplitWithOtherActions
+    );
+}
+
+#[test]
+fn split_rejects_value_input_and_asset_mismatches() {
+    let keypair = ShieldedKeypair::new().unwrap();
+    let assets = AssetRegistry::default();
+
+    let mut value = transaction(&keypair, vec![sol_utxo(&keypair, 100, [4u8; 31])]);
+    value.split(SOL_MINT, 3, 40).unwrap();
+    assert_eq!(
+        value.prepare_split(&assets).err().unwrap(),
+        TransactionError::SplitAmountMismatch {
+            requested: 120,
+            available: 100,
+        }
+    );
+
+    let mut multiple = transaction(
+        &keypair,
+        vec![
+            sol_utxo(&keypair, 50, [5u8; 31]),
+            sol_utxo(&keypair, 50, [6u8; 31]),
+        ],
+    );
+    multiple.split(SOL_MINT, 2, 50).unwrap();
+    assert_eq!(
+        multiple.prepare_split(&assets).err().unwrap(),
+        TransactionError::SplitInputCount(2)
+    );
+
+    let requested = Address::new_from_array([7u8; 32]);
+    let mut asset = transaction(&keypair, vec![sol_utxo(&keypair, 100, [7u8; 31])]);
+    asset.split(requested, 2, 50).unwrap();
+    assert_eq!(
+        asset.prepare_split(&assets).err().unwrap(),
+        TransactionError::SplitAssetMismatch {
+            input: SOL_MINT,
+            requested,
+        }
+    );
+}


### PR DESCRIPTION
## Summary
- add SDK and CLI support for splitting one private SOL note into 2 through 8 equal self-owned notes
- encode all real split outputs in one encrypted bundle and pad only commitments to the fixed 1x8 proof shape
- validate exact-note selection and CLI arity before proving or submitting
- cover every arity with wallet recovery and full Solana packet serialization tests

## Why this is separate
The original PR #98 implementation padded missing outputs with recipient-sized ciphertexts. Splits into 2 through 5 parts then exceeded Solana's 1232-byte packet limit. This branch keeps the protocol's single split bundle and makes every accepted arity packet-safe.

Stacked on #125. Merge/consolidation and operator/e2e changes are intentionally excluded.

## Validation
- `cargo test -p zolana-transaction -p zolana-client -p zolana-cli`
- `cargo clippy -p zolana-transaction -p zolana-client -p zolana-cli --all-targets -- -D warnings`
- `cargo test -p shielded-pool-tests --features localnet --test localnet_wallet_cli_e2e --no-run`
- `cargo fmt --all -- --check`