### PR TITLE
ci: pin workspace Rust 1.97

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,15 +1,11 @@
 name: Setup Rust
-description: Install the stable Rust toolchain, warm the Cargo cache, and (optionally) install `just`. Run after actions/checkout.
+description: Install the workspace Rust toolchain, warm the Cargo cache, and (optionally) install `just`. Run after actions/checkout.
 
 inputs:
-  components:
-    description: Comma-separated Rust toolchain components (e.g. "rustfmt,clippy")
-    required: false
-    default: ""
   shared-key:
     description: Swatinem rust-cache shared-key for cross-workflow cache reuse.
     required: false
-    default: rust-stable
+    default: rust-workspace
   install-just:
     description: Install the `just` task runner via taiki-e/install-action.
     required: false
@@ -33,9 +29,9 @@ runs:
         TOKEN: ${{ inputs.private-libs-token }}
       run: |
         git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        components: ${{ inputs.components }}
+    - name: Install workspace Rust toolchain
+      shell: bash
+      run: rustup show active-toolchain
     - uses: Swatinem/rust-cache@v2
       with:
         shared-key: ${{ inputs.shared-key }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,9 +38,8 @@ jobs:
           TOKEN: ${{ secrets.PRIVATE_LIBS_TOKEN }}
         run: |
           git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - name: Install workspace Rust toolchain
+        run: rustup show active-toolchain
       - run: cargo fmt --all -- --check
 
   machete:
@@ -67,7 +66,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
         with:
-          components: clippy
           private-libs-token: ${{ secrets.PRIVATE_LIBS_TOKEN }}
       - run: just clippy
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.97.0"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
## Summary

- pin the workspace toolchain to Rust 1.97.0
- install Clippy and rustfmt from the same `rust-toolchain.toml`
- make CI use the workspace toolchain instead of floating `stable`
- key Rust caches by the workspace toolchain rather than a moving stable label

## Why

CI currently installs the latest stable Rust while local development uses whichever stable version happens to be installed. This caused PR #99 to pass Clippy locally on Rust 1.95 but fail in CI on Rust 1.97.

`rust-toolchain.toml` is now the single source of truth for local development and CI.

## Validation

- `rustup show active-toolchain`
- `rustc --version`
- `cargo clippy --version`
- `cargo fmt --version`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `actionlint` on affected workflows
