### PR TITLE
feat: shielded address codec + pay-by-pubkey wallet flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
@@ -9737,6 +9738,7 @@ name = "zolana-keypair"
 version = "0.1.0"
 dependencies = [
  "aes",
+ "bs58",
  "ctr",
  "cucumber",
  "ed25519-dalek 2.2.0",

--- a/cli/README.md
+++ b/cli/README.md
@@ -24,36 +24,45 @@ Commands:
 
 ```bash
 zolana config get
-zolana config set --keypair ~/.config/zolana/pid.json --rpc-url http://127.0.0.1:8899 --indexer-url http://127.0.0.1:8784 --prover-url http://127.0.0.1:3001
-zolana wallet init --airdrop-lamports 1000000000
+zolana config set --keypair ~/.config/zolana/id.json --rpc-url http://127.0.0.1:8899 --indexer-url http://127.0.0.1:8784 --prover-url http://127.0.0.1:3001
+zolana wallet new
+zolana wallet address
+zolana wallet address --funding
 zolana wallet create-tree --tree-keypair /tmp/zolana-tree.json --airdrop-lamports 20000000000
-zolana wallet sync --indexer-url http://127.0.0.1:8784
 zolana wallet balance --indexer-url http://127.0.0.1:8784
 zolana wallet deposit --amount 1000000000 --mint SOL --airdrop-lamports 2000000000
-zolana wallet transfer --to <RECIPIENT_SOLANA_PUBKEY> --amount 300000000 --mint SOL
+zolana wallet transfer --to <RECIPIENT_SHIELDED_ADDRESS> --amount 300000000 --mint SOL
 zolana wallet withdraw --to <PUBLIC_SOL_PUBKEY> --amount 200000000 --mint SOL
 ```
 
 Wallet commands use the wallet file's Solana funding key for fees/public SOL
-deposits and its shielded keypair for private ownership. `wallet init` creates
-or loads the wallet file and registers its shielded keys in the on-chain
-user-registry program. `deposit` shields public SOL into the local wallet by
-default and requires that wallet to be registered; `deposit --to <PUBKEY>`
-resolves the recipient from the on-chain user registry and never reads the
-recipient's wallet secrets. `transfer --to <PUBKEY>` resolves registered
-recipients from the on-chain user registry; if the registry record is absent,
-the transfer is built as a public SOL withdrawal to that pubkey. `withdraw --to
-<PUBKEY>` always uses a regular public Solana destination.
+deposits and its shielded keypair for private ownership. `wallet new` is an
+offline operation: it creates a fresh shielded identity and a funding key
+without sending a transaction. Pass `--funding-keypair
+~/.config/solana/id.json` to reuse an existing standard Solana keypair as the
+funding/fee-payer key. `wallet address` prints the self-contained shielded
+recipient address; `wallet address --funding` prints the public funding key.
+
+`deposit` shields public assets into the local wallet by default. `deposit --to`
+and `transfer --to` accept either the self-contained shielded address printed by
+`wallet address` (used directly, no registry lookup) or a Solana pubkey (resolved
+through the on-chain user registry). A `transfer` to a Solana pubkey that has no
+registry record silently falls back to a public withdrawal to that pubkey
+(reported as `mode=withdraw`); a `deposit` to an unregistered pubkey errors,
+since a deposit has no public destination. Use `withdraw --to <PUBKEY>` for an
+explicit public Solana destination. Balance and transaction commands synchronize
+wallet state automatically.
 
 CLI-wide defaults live at `~/.config/zolana/config.json`. Explicit flags win
 over config values, and config values win over built-in localnet defaults. The
-`keypair` config field is the path to the wallet file (`pid.json`). `create-tree`
-writes the created tree pubkey into this config file; `deposit`, `transfer`, and
-`withdraw` only require `--tree` when neither the flag nor config has a tree.
+wallet path precedence is `-k/--keypair`, then `config.keypair`, then
+`~/.config/zolana/id.json`. Use `-C/--config <PATH>` to select another config
+file; it takes precedence over `ZOLANA_CONFIG`. `create-tree` writes the created
+tree pubkey into the selected config file; `deposit`, `transfer`, and `withdraw`
+only require `--tree` when neither the flag nor config has a tree.
 
 Optional wallet path:
 
 ```bash
---keypair /path/to/pid.json
+-k /path/to/id.json
 ```
-

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -8,6 +8,15 @@ use crate::config::{
 #[derive(Debug, Parser)]
 #[command(name = "zolana", about = "Local Zolana developer tooling")]
 pub(crate) struct Cli {
+    #[arg(
+        short = 'C',
+        long = "config",
+        global = true,
+        help = "CLI configuration file",
+        value_name = "PATH"
+    )]
+    pub(crate) config_file: Option<String>,
+
     #[command(subcommand)]
     pub(crate) command: Option<CliCommand>,
 }
@@ -90,11 +99,14 @@ pub(crate) struct ConfigAddAssetOptions {
 
 #[derive(Debug, Subcommand, Clone)]
 pub(crate) enum WalletCommand {
+    #[command(name = "new", about = "Create a local wallet keypair")]
+    New(NewWalletOptions),
+
     #[command(
-        name = "init",
-        about = "Create a filesystem private keypair and register it on-chain"
+        name = "address",
+        about = "Print the selected wallet's shielded address"
     )]
-    Init(InitOptions),
+    Address(AddressOptions),
 
     #[command(
         name = "create-tree",
@@ -107,12 +119,6 @@ pub(crate) enum WalletCommand {
         about = "Create a local SPL test mint, fund the wallet, and store its asset mapping"
     )]
     TestMint(TestMintOptions),
-
-    #[command(
-        name = "sync",
-        about = "Sync private wallet state. Transfers run sync automatically."
-    )]
-    Sync(SyncOptions),
 
     #[command(name = "balance", about = "Show private wallet balances")]
     Balance(BalanceOptions),
@@ -316,33 +322,41 @@ pub(crate) struct StartProverOptions {
 #[derive(Args, Debug, Clone)]
 pub(crate) struct WalletKeypairOptions {
     #[arg(
+        short = 'k',
         long = "keypair",
-        help = "Path to private keypair file (default: ~/.config/zolana/pid.json)",
+        help = "Wallet keypair file (default: configured path or ~/.config/zolana/id.json)",
         value_name = "PATH"
     )]
     pub(crate) keypair: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]
-pub(crate) struct InitOptions {
+pub(crate) struct AddressOptions {
+    #[command(flatten)]
+    pub(crate) keypair: WalletKeypairOptions,
+
     #[arg(
-        long = "path",
-        help = "Output path for generated keypair (default: ~/.config/zolana/pid.json)",
+        long,
+        help = "Print the wallet's public funding/fee-payer pubkey instead"
+    )]
+    pub(crate) funding: bool,
+}
+
+#[derive(Args, Debug, Clone)]
+pub(crate) struct NewWalletOptions {
+    #[arg(
+        long = "outfile",
+        help = "Output wallet file (default: configured keypair path or ~/.config/zolana/id.json)",
         value_name = "PATH"
     )]
-    pub(crate) path: Option<String>,
+    pub(crate) outfile: Option<String>,
 
     #[arg(
-        long = "rpc-url",
-        help = "Solana RPC URL used to register the wallet (default: configured value or http://127.0.0.1:8899)"
+        long = "funding-keypair",
+        help = "Use an existing Solana keypair file (e.g. ~/.config/solana/id.json) as the wallet's funding/fee-payer key instead of generating a new one",
+        value_name = "PATH"
     )]
-    pub(crate) rpc_url: Option<String>,
-
-    #[arg(
-        long = "airdrop-lamports",
-        help = "Request a localnet airdrop for the wallet funding key before registering"
-    )]
-    pub(crate) airdrop_lamports: Option<u64>,
+    pub(crate) funding_keypair: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -432,7 +446,8 @@ pub(crate) struct DepositOptions {
 
     #[arg(
         long,
-        help = "Optional registered recipient Solana pubkey (defaults to the --keypair wallet owner)"
+        help = "Optional recipient: a shielded address or a registered Solana pubkey \
+                (defaults to the --keypair wallet)"
     )]
     pub(crate) to: Option<String>,
 
@@ -450,8 +465,9 @@ pub(crate) struct TransferOptions {
 
     #[arg(
         long = "to",
-        help = "Recipient Solana pubkey; registered recipients receive a shielded transfer, unregistered recipients receive a public SOL withdrawal",
-        value_name = "PUBKEY"
+        help = "Recipient: a shielded address (from `zolana wallet address`) or a Solana pubkey \
+                (resolved via the user registry; falls back to a public withdrawal if unregistered)",
+        value_name = "RECIPIENT"
     )]
     pub(crate) to: String,
 
@@ -618,10 +634,10 @@ mod tests {
             ["zolana", "config", "asset-registry", "--help"].as_slice(),
             ["zolana", "config", "add-asset", "--help"].as_slice(),
             ["zolana", "wallet", "--help"].as_slice(),
-            ["zolana", "wallet", "init", "--help"].as_slice(),
+            ["zolana", "wallet", "new", "--help"].as_slice(),
+            ["zolana", "wallet", "address", "--help"].as_slice(),
             ["zolana", "wallet", "create-tree", "--help"].as_slice(),
             ["zolana", "wallet", "test-mint", "--help"].as_slice(),
-            ["zolana", "wallet", "sync", "--help"].as_slice(),
             ["zolana", "wallet", "balance", "--help"].as_slice(),
             ["zolana", "wallet", "deposit", "--help"].as_slice(),
             ["zolana", "wallet", "transfer", "--help"].as_slice(),
@@ -726,21 +742,46 @@ mod tests {
     }
 
     #[test]
-    fn parses_wallet_init_options() {
-        let WalletCommand::Init(opts) = parse_wallet(&[
-            "init",
-            "--path",
-            "/tmp/alice.pid.json",
-            "--rpc-url",
-            "http://127.0.0.1:8900",
-            "--airdrop-lamports",
-            "1000000000",
+    fn parses_wallet_new_and_address_options() {
+        let WalletCommand::New(opts) = parse_wallet(&[
+            "new",
+            "--outfile",
+            "/tmp/alice.json",
+            "--funding-keypair",
+            "/tmp/solana.json",
         ]) else {
-            panic!("expected wallet init command");
+            panic!("expected wallet new command");
         };
-        assert_eq!(opts.path.as_deref(), Some("/tmp/alice.pid.json"));
-        assert_eq!(opts.rpc_url.as_deref(), Some("http://127.0.0.1:8900"));
-        assert_eq!(opts.airdrop_lamports, Some(1_000_000_000));
+        assert_eq!(opts.outfile.as_deref(), Some("/tmp/alice.json"));
+        assert_eq!(opts.funding_keypair.as_deref(), Some("/tmp/solana.json"));
+
+        let WalletCommand::Address(opts) =
+            parse_wallet(&["address", "-k", "/tmp/alice.json", "--funding"])
+        else {
+            panic!("expected wallet address command");
+        };
+        assert_eq!(opts.keypair.keypair.as_deref(), Some("/tmp/alice.json"));
+        assert!(opts.funding);
+    }
+
+    #[test]
+    fn parses_global_config_override() {
+        let cli = Cli::try_parse_from([
+            "zolana",
+            "-C",
+            "/tmp/zolana-config.json",
+            "wallet",
+            "address",
+        ])
+        .expect("parse global config");
+
+        assert_eq!(cli.config_file.as_deref(), Some("/tmp/zolana-config.json"));
+        assert!(matches!(
+            cli.command,
+            Some(CliCommand::Wallet {
+                command: WalletCommand::Address(_)
+            })
+        ));
     }
 
     #[test]
@@ -825,22 +866,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_wallet_sync_and_balance_options() {
-        let WalletCommand::Sync(sync) = parse_wallet(&[
-            "sync",
-            "--keypair",
-            "/tmp/alice.pid.json",
-            "--rpc-url",
-            "http://127.0.0.1:8900",
-            "--indexer-url",
-            "http://127.0.0.1:8785",
-        ]) else {
-            panic!("expected wallet sync command");
-        };
-        assert_eq!(sync.keypair.keypair.as_deref(), Some("/tmp/alice.pid.json"));
-        assert_eq!(sync.rpc_url.as_deref(), Some("http://127.0.0.1:8900"));
-        assert_eq!(sync.indexer_url.as_deref(), Some("http://127.0.0.1:8785"));
-
+    fn parses_wallet_balance_options() {
         let WalletCommand::Balance(balance) = parse_wallet(&[
             "balance",
             "--keypair",

--- a/cli/src/cli_config.rs
+++ b/cli/src/cli_config.rs
@@ -3,6 +3,7 @@ use std::{
     fs::{self, OpenOptions},
     io::Write,
     path::PathBuf,
+    sync::OnceLock,
 };
 
 use anyhow::{Context, Result};
@@ -15,6 +16,7 @@ pub(crate) const DEFAULT_INDEXER_URL: &str = "http://127.0.0.1:8784";
 pub(crate) const DEFAULT_PROVER_URL: &str = "http://127.0.0.1:3001";
 pub(crate) const DEFAULT_TREE: &str = "treeYbr45LjxovKvtD46uEphM64kwoFFPYhVNw1A8x8";
 const CONFIG_VERSION: u8 = 1;
+static CONFIG_FILE_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
 
 #[cfg(test)]
 pub(crate) static CONFIG_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -143,14 +145,23 @@ pub(crate) fn config_dir() -> PathBuf {
 }
 
 pub(crate) fn config_file_path() -> PathBuf {
+    if let Some(path) = CONFIG_FILE_OVERRIDE.get() {
+        return path.clone();
+    }
     if let Ok(path) = env::var("ZOLANA_CONFIG") {
         return PathBuf::from(path);
     }
     config_dir().join("config.json")
 }
 
+pub(crate) fn set_config_file_override(path: impl Into<PathBuf>) -> Result<()> {
+    CONFIG_FILE_OVERRIDE
+        .set(path.into())
+        .map_err(|_| anyhow::anyhow!("CLI config file override was already set"))
+}
+
 pub(crate) fn default_keypair_path() -> PathBuf {
-    config_dir().join("pid.json")
+    config_dir().join("id.json")
 }
 
 pub(crate) fn resolve_keypair_path(cli_override: Option<&str>, config: &CliConfigFile) -> PathBuf {
@@ -252,6 +263,37 @@ mod tests {
         assert_eq!(
             resolve_tree(Some("So11111111111111111111111111111111111111112"), &config),
             "So11111111111111111111111111111111111111112"
+        );
+    }
+
+    #[test]
+    fn resolve_keypair_path_follows_precedence() {
+        let config = CliConfigFile {
+            keypair: Some("/tmp/config.json".to_string()),
+            ..CliConfigFile::default()
+        };
+
+        assert_eq!(
+            resolve_keypair_path(Some("/tmp/flag.json"), &config),
+            PathBuf::from("/tmp/flag.json")
+        );
+        assert_eq!(
+            resolve_keypair_path(None, &config),
+            PathBuf::from("/tmp/config.json")
+        );
+        assert_eq!(
+            resolve_keypair_path(None, &CliConfigFile::default()),
+            default_keypair_path()
+        );
+    }
+
+    #[test]
+    fn built_in_keypair_path_is_id_json() {
+        assert_eq!(
+            default_keypair_path()
+                .file_name()
+                .and_then(|name| name.to_str()),
+            Some("id.json")
         );
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,6 +13,7 @@ use clap::{CommandFactory, Parser};
 
 use crate::{
     args::{Cli, CliCommand},
+    cli_config::set_config_file_override,
     config_cmd::run_config,
     localnet::run_test_validator,
     prover::run_start_prover,
@@ -27,6 +28,9 @@ fn main() {
 }
 
 fn run(cli: Cli) -> Result<()> {
+    if let Some(path) = cli.config_file {
+        set_config_file_override(path)?;
+    }
     match cli.command {
         Some(CliCommand::TestValidator(opts)) => run_test_validator(*opts),
         Some(CliCommand::StartProver(opts)) => run_start_prover(opts),

--- a/cli/src/wallet_cli/deposit.rs
+++ b/cli/src/wallet_cli/deposit.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use solana_signer::Signer;
 use zolana_client::{
     create_deposit, resolve_registered_address, CreateDeposit, SolanaRpc, ZolanaIndexer,
 };
@@ -10,7 +9,8 @@ use super::{
     sync::wait_for_indexed_utxo,
     transaction::maybe_airdrop,
     util::{
-        configured_spl_token_account, ensure_positive, format_address, parse_address, parse_pubkey,
+        configured_spl_token_account, ensure_positive, format_address, parse_address,
+        parse_recipient, RecipientInput,
     },
 };
 use crate::{args::DepositOptions, cli_config::CliConfigFile};
@@ -26,15 +26,17 @@ pub(super) fn run_deposit(opts: DepositOptions) -> Result<()> {
     let material = load_sender_from_resolved_sync(&network.sync)?;
     maybe_airdrop(&mut rpc, &material, network.airdrop_lamports)?;
     let tree = network.tree;
-    let recipient_pubkey = opts
-        .to
-        .as_deref()
-        .map(parse_pubkey)
-        .transpose()?
-        .unwrap_or_else(|| material.funding.pubkey());
-    let recipient = resolve_registered_address(&rpc, recipient_pubkey)?;
+    // A shielded address is used directly; a Solana pubkey must have a user
+    // registry record (a deposit has no public fallback). Defaults to self.
+    let recipient = match opts.to.as_deref() {
+        None => material.keypair.shielded_address()?,
+        Some(to) => match parse_recipient(to)? {
+            RecipientInput::Shielded(address) => address,
+            RecipientInput::Pubkey(owner) => resolve_registered_address(&rpc, owner)?,
+        },
+    };
     let deposit = create_deposit(CreateDeposit {
-        recipient: &recipient.address,
+        recipient: &recipient,
         asset,
         amount: opts.amount,
         spl_token_account,
@@ -46,7 +48,7 @@ pub(super) fn run_deposit(opts: DepositOptions) -> Result<()> {
         "ok deposit amount={} mint={} to={} utxo_hash={} signature={}",
         opts.amount,
         format_address(asset),
-        recipient_pubkey,
+        recipient,
         hex::encode(deposit.utxo_hash),
         signature
     );

--- a/cli/src/wallet_cli/material.rs
+++ b/cli/src/wallet_cli/material.rs
@@ -1,7 +1,7 @@
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::{
-    fs::{self, OpenOptions},
+    fs::{self, File, OpenOptions},
     io::Write,
     path::Path,
 };
@@ -13,7 +13,7 @@ use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use zolana_client::{
     AnonymousRecipientSlot, ApprovalRequest, ClientError, ConfidentialRecipientSlot,
-    EncryptedTransfer, P256Signature, SolanaRpc, SyncWalletAuthority,
+    EncryptedTransfer, P256Signature, SyncWalletAuthority,
 };
 use zolana_keypair::{
     shielded::ShieldedAddress, viewing_key::ViewTag, NullifierKey, ShieldedKeypair, SigningKey,
@@ -23,12 +23,10 @@ use zolana_transaction::serialization::{
     anonymous::AnonymousTransferSenderPlaintext, confidential::TransferSenderPlaintext,
 };
 
-use super::{
-    registry::register_wallet_on_chain, resolve::ResolvedSyncOptions, util::parse_hex_array,
-};
+use super::{resolve::ResolvedSyncOptions, util::parse_hex_array};
 use crate::{
-    args::InitOptions,
-    cli_config::{resolve_keypair_path as config_keypair_path, resolve_rpc_url, CliConfigFile},
+    args::{AddressOptions, NewWalletOptions},
+    cli_config::{resolve_keypair_path, CliConfigFile},
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -142,39 +140,54 @@ impl SyncWalletAuthority for WalletMaterial {
     }
 }
 
-pub(super) fn run_init(opts: InitOptions) -> Result<()> {
-    let config = CliConfigFile::load()?;
-    let keypair_path = config_keypair_path(opts.path.as_deref(), &config);
-    let material = if keypair_path.exists() {
-        load_existing_wallet(&keypair_path)?
-    } else {
-        let keypair = ShieldedKeypair::new()?;
-        let funding = Keypair::new();
-        save_wallet(&keypair_path, &keypair, &funding)?;
-        WalletMaterial { keypair, funding }
+pub(super) fn run_new(opts: NewWalletOptions) -> Result<()> {
+    let path = match opts.outfile.as_deref() {
+        Some(path) => Path::new(path).to_path_buf(),
+        None => resolve_keypair_path(None, &CliConfigFile::load()?),
     };
+    if path.exists() {
+        bail!("wallet already exists at {}", path.display());
+    }
 
-    let mut rpc = SolanaRpc::new(resolve_rpc_url(opts.rpc_url.as_deref(), &config));
-    if let Some(lamports) = opts.airdrop_lamports {
-        let signature = rpc.airdrop(&material.funding.pubkey(), lamports)?;
-        println!("ok airdrop signature={signature}");
-    }
-    if let Some(signature) = register_wallet_on_chain(&rpc, &material)? {
-        println!("ok user_registry signature={signature}");
-    }
+    let keypair = ShieldedKeypair::new()?;
+    let funding = match opts.funding_keypair.as_deref() {
+        Some(path) => load_solana_cli_keypair(Path::new(path))?,
+        None => Keypair::new(),
+    };
+    save_wallet(&path, &keypair, &funding)?;
+    let material = WalletMaterial { keypair, funding };
     println!(
-        "ok keypair {} owner_hash={} funding={}",
-        keypair_path.display(),
-        hex::encode(material.keypair.owner_hash()?),
+        "ok wallet {} address={} funding={}",
+        path.display(),
+        material.keypair.shielded_address()?,
         material.funding.pubkey()
     );
+    Ok(())
+}
+
+pub(super) fn run_address(opts: AddressOptions) -> Result<()> {
+    let path = resolve_keypair_path(opts.keypair.keypair.as_deref(), &CliConfigFile::load()?);
+    if !path.exists() {
+        bail!(
+            "wallet not found at {}; create it with `zolana wallet new --outfile {}`",
+            path.display(),
+            path.display()
+        );
+    }
+    let material = load_existing_wallet(&path)?;
+    if opts.funding {
+        println!("{}", material.owner_pubkey());
+    } else {
+        println!("{}", material.keypair.shielded_address()?);
+    }
     Ok(())
 }
 
 pub(super) fn load_sender_from_resolved_sync(sync: &ResolvedSyncOptions) -> Result<WalletMaterial> {
     if !sync.keypair_path.exists() {
         bail!(
-            "keypair not found at {}; run `zolana wallet init` first",
+            "wallet not found at {}; create it with `zolana wallet new --outfile {}`",
+            sync.keypair_path.display(),
             sync.keypair_path.display()
         );
     }
@@ -186,6 +199,13 @@ pub(super) fn load_existing_wallet(path: &Path) -> Result<WalletMaterial> {
         fs::read(path).with_context(|| format!("failed to read wallet {}", path.display()))?;
     let file: KeypairFile = serde_json::from_slice(&bytes)
         .with_context(|| format!("failed to parse wallet {}", path.display()))?;
+    if file.version != 2 {
+        bail!(
+            "wallet {} has unsupported version {}",
+            path.display(),
+            file.version
+        );
+    }
     let signing_bytes = parse_hex_array::<32>(&file.signing_key_hex)?;
     let viewing_bytes = parse_hex_array::<32>(&file.viewing_key_hex)?;
     let funding_bytes = parse_hex_array::<32>(&file.funding_secret_hex)?;
@@ -207,6 +227,35 @@ pub(super) fn load_existing_wallet(path: &Path) -> Result<WalletMaterial> {
     Ok(WalletMaterial { keypair, funding })
 }
 
+/// Load the JSON byte array written by `solana-keygen`. Both the standard
+/// 64-byte `[secret || pubkey]` form and a bare 32-byte secret are accepted.
+pub(super) fn load_solana_cli_keypair(path: &Path) -> Result<Keypair> {
+    let bytes =
+        fs::read(path).with_context(|| format!("failed to read keypair {}", path.display()))?;
+    let values: Vec<u8> = serde_json::from_slice(&bytes).with_context(|| {
+        format!(
+            "{} is not a Solana keypair file (expected a JSON byte array)",
+            path.display()
+        )
+    })?;
+    let mut secret = [0u8; 32];
+    match values.len() {
+        32 | 64 => secret.copy_from_slice(&values[..32]),
+        length => bail!(
+            "unexpected Solana keypair length {length} in {} (expected 32 or 64 bytes)",
+            path.display()
+        ),
+    }
+    let keypair = Keypair::new_from_array(secret);
+    if values.len() == 64 && keypair.pubkey().to_bytes() != values[32..] {
+        bail!(
+            "keypair {} secret does not match its public key",
+            path.display()
+        );
+    }
+    Ok(keypair)
+}
+
 fn save_wallet(path: &Path, keypair: &ShieldedKeypair, funding: &Keypair) -> Result<()> {
     let file = KeypairFile {
         version: 2,
@@ -216,7 +265,39 @@ fn save_wallet(path: &Path, keypair: &ShieldedKeypair, funding: &Keypair) -> Res
         funding_secret_hex: hex::encode(funding.secret_bytes()),
         funding_pubkey: funding.pubkey().to_string(),
     };
-    write_json_secret(path, &file)
+    write_json_secret_exclusive(path, &file)
+}
+
+fn write_json_secret_exclusive<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    if parent != Path::new(".") {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let bytes = serde_json::to_vec_pretty(value)?;
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    harden_secret_permissions(&file, path)?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn harden_secret_permissions(file: &File, path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    file.set_permissions(fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("failed to set permissions on {}", path.display()))?;
+    #[cfg(not(unix))]
+    let _ = (file, path);
+    Ok(())
 }
 
 pub(super) fn load_or_create_solana_keypair(path: &Path) -> Result<Keypair> {
@@ -311,6 +392,85 @@ mod tests {
         );
         assert_ne!(loaded.funding.pubkey(), Pubkey::default());
         assert_eq!(loaded.funding.pubkey(), funding.pubkey());
+    }
+
+    #[test]
+    fn wallet_file_creation_never_overwrites() {
+        let root = temp_root("zolana-cli-wallet-exclusive");
+        let wallet = root.join("id.json");
+        let first = ShieldedKeypair::new().expect("first shielded keypair");
+        let first_funding = Keypair::new();
+        save_wallet(&wallet, &first, &first_funding).expect("create wallet");
+        let before = fs::read(&wallet).expect("read first wallet");
+
+        assert!(save_wallet(&wallet, &ShieldedKeypair::new().unwrap(), &Keypair::new()).is_err());
+        assert_eq!(fs::read(&wallet).expect("read unchanged wallet"), before);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wallet_file_is_private_when_created() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let wallet = temp_root("zolana-cli-wallet-mode").join("id.json");
+        save_wallet(
+            &wallet,
+            &ShieldedKeypair::new().expect("shielded keypair"),
+            &Keypair::new(),
+        )
+        .expect("create wallet");
+
+        assert_eq!(
+            fs::metadata(wallet)
+                .expect("wallet metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn load_solana_cli_keypair_reads_standard_and_bare_forms() {
+        let root = temp_root("zolana-cli-solana-key");
+        fs::create_dir_all(&root).unwrap();
+        let keypair = Keypair::new();
+
+        let full = root.join("id.json");
+        fs::write(
+            &full,
+            serde_json::to_vec(&keypair.to_bytes().to_vec()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            load_solana_cli_keypair(&full).expect("64-byte").pubkey(),
+            keypair.pubkey()
+        );
+
+        let bare = root.join("id32.json");
+        fs::write(
+            &bare,
+            serde_json::to_vec(&keypair.secret_bytes().to_vec()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            load_solana_cli_keypair(&bare).expect("32-byte").pubkey(),
+            keypair.pubkey()
+        );
+
+        let mut bad = keypair.to_bytes().to_vec();
+        bad[63] ^= 0xff;
+        let bad_path = root.join("bad.json");
+        fs::write(&bad_path, serde_json::to_vec(&bad).unwrap()).unwrap();
+        assert!(load_solana_cli_keypair(&bad_path).is_err());
+
+        let short = root.join("short.json");
+        fs::write(&short, serde_json::to_vec(&vec![0u8; 16]).unwrap()).unwrap();
+        assert!(load_solana_cli_keypair(&short).is_err());
+
+        let invalid = root.join("invalid.json");
+        fs::write(&invalid, b"not json").unwrap();
+        assert!(load_solana_cli_keypair(&invalid).is_err());
     }
 
     #[test]

--- a/cli/src/wallet_cli/mod.rs
+++ b/cli/src/wallet_cli/mod.rs
@@ -21,10 +21,10 @@ const INDEXER_POLL: Duration = Duration::from_millis(500);
 
 pub(crate) fn run_wallet(command: WalletCommand) -> Result<()> {
     match command {
-        WalletCommand::Init(opts) => material::run_init(opts),
+        WalletCommand::New(opts) => material::run_new(opts),
+        WalletCommand::Address(opts) => material::run_address(opts),
         WalletCommand::CreateTree(opts) => tree::run_create_tree(opts),
         WalletCommand::TestMint(opts) => test_mint::run_test_mint(opts),
-        WalletCommand::Sync(opts) => sync::run_sync(opts),
         WalletCommand::Balance(opts) => balance::run_balance(opts),
         WalletCommand::Merge(opts) => registry::run_merge(opts),
         WalletCommand::Deposit(opts) => deposit::run_deposit(opts),

--- a/cli/src/wallet_cli/registry.rs
+++ b/cli/src/wallet_cli/registry.rs
@@ -1,28 +1,14 @@
 use anyhow::{bail, Result};
-use solana_signature::Signature;
 use solana_signer::Signer;
-use zolana_client::{Rpc, SolanaRpc};
+use zolana_client::{
+    ensure_registered, fetch_user_record_optional_checked, validate_registered_keypair, Rpc,
+    SolanaRpc,
+};
 use zolana_transaction::Address;
 use zolana_user_registry_interface::{instruction::set_merging_enabled, user_record_pda};
 
-use super::{
-    material::{load_sender_from_resolved_sync, WalletMaterial},
-    resolve::resolve_sync,
-};
+use super::{material::load_sender_from_resolved_sync, resolve::resolve_sync};
 use crate::args::MergeOptions;
-
-pub(super) fn register_wallet_on_chain(
-    rpc: &SolanaRpc,
-    material: &WalletMaterial,
-) -> Result<Option<Signature>> {
-    // Idempotent register-or-update lives in the SDK; the CLI just supplies its
-    // keypair + funding key.
-    Ok(zolana_client::ensure_registered(
-        rpc,
-        &material.funding,
-        &material.keypair,
-    )?)
-}
 
 pub(super) fn run_merge(opts: MergeOptions) -> Result<()> {
     let sync = resolve_sync(&opts.sync)?;
@@ -35,6 +21,18 @@ pub(super) fn run_merge(opts: MergeOptions) -> Result<()> {
         (false, true) => false,
         _ => bail!("provide exactly one of --enable or --disable"),
     };
+
+    match fetch_user_record_optional_checked(&rpc, owner)? {
+        Some(_) => validate_registered_keypair(&rpc, owner, &material.keypair)?,
+        None if !enabled => {
+            println!("ok merge owner={owner} enabled=false unchanged=true");
+            return Ok(());
+        }
+        None => match ensure_registered(&rpc, &material.funding, &material.keypair)? {
+            Some(signature) => println!("ok user_registry signature={signature}"),
+            None => println!("ok user_registry current=true"),
+        },
+    }
 
     let (user_record, _bump) = user_record_pda(&owner);
     let ix = set_merging_enabled(user_record, owner, enabled);

--- a/cli/src/wallet_cli/sync.rs
+++ b/cli/src/wallet_cli/sync.rs
@@ -19,18 +19,6 @@ pub(super) struct SyncContext {
     pub(super) material: WalletMaterial,
     pub(super) wallet: Wallet,
     pub(super) local_assets: Vec<LocalAssetConfig>,
-    pub(super) report: zolana_transaction::SyncReport,
-}
-
-pub(super) fn run_sync(opts: SyncOptions) -> Result<()> {
-    let ctx = sync_context(&opts)?;
-    println!(
-        "ok sync stored={} unparsed={} undecryptable={}",
-        ctx.report.stored_utxos,
-        ctx.report.unparsed_transactions,
-        ctx.report.undecryptable_candidates
-    );
-    Ok(())
 }
 
 pub(super) fn sync_context(opts: &SyncOptions) -> Result<SyncContext> {
@@ -40,12 +28,11 @@ pub(super) fn sync_context(opts: &SyncOptions) -> Result<SyncContext> {
     let indexer = ZolanaIndexer::new(sync.indexer_url.clone());
     let assets = config.local_asset_registry()?;
     let mut wallet = Wallet::new(clone_keypair(&material.keypair)?, assets)?;
-    let report = client_sync_wallet(&mut wallet, &indexer)?;
+    client_sync_wallet(&mut wallet, &indexer)?;
     Ok(SyncContext {
         material,
         wallet,
         local_assets: config.assets,
-        report,
     })
 }
 

--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -3,20 +3,45 @@ use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_signer::Signer;
 use zolana_client::{
-    create_transfer_sync, prover::transact::assemble, CreateTransfer, InputCommitment,
+    create_transfer_sync, create_withdrawal_sync, prover::transact::assemble,
+    try_resolve_registered_address, CreateTransfer, CreateWithdrawal, InputCommitment,
     ProofCompressed, ProverClient, ProverInputs, Rpc, SignedTransaction, SolanaRpc, SpendProof,
     ZolanaIndexer,
 };
 use zolana_interface::instruction::{Transact, TransactWithdrawal};
+use zolana_keypair::ShieldedAddress;
 use zolana_transaction::Address;
 
 use super::{
     material::WalletMaterial,
     resolve::get_network,
     sync::{sync_context, wait_for_indexed_transaction},
-    util::{ensure_positive, format_address, parse_address, parse_pubkey},
+    util::{ensure_positive, format_address, parse_address, parse_recipient, RecipientInput},
 };
 use crate::args::TransferOptions;
+
+/// A `transfer --to` recipient after resolution.
+enum TransferTarget {
+    /// A self-contained shielded address (shared directly), or a Solana pubkey
+    /// with a user-registry record. Sent as a confidential shielded transfer.
+    Shielded(ShieldedAddress),
+    /// A Solana pubkey with no registry record. The transfer degrades to a
+    /// public withdrawal to that pubkey (spec Single Player, lookup-negative).
+    Public(Pubkey),
+}
+
+/// Resolve `--to`: a shielded address is used directly; a Solana pubkey is
+/// looked up in the user registry, silently falling back to a public withdrawal
+/// when the recipient has no registry record.
+fn resolve_transfer_recipient(rpc: &SolanaRpc, to: &str) -> Result<TransferTarget> {
+    match parse_recipient(to)? {
+        RecipientInput::Shielded(address) => Ok(TransferTarget::Shielded(address)),
+        RecipientInput::Pubkey(owner) => match try_resolve_registered_address(rpc, owner)? {
+            Some(address) => Ok(TransferTarget::Shielded(address)),
+            None => Ok(TransferTarget::Public(owner)),
+        },
+    }
+}
 
 pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
     ensure_positive(opts.amount)?;
@@ -26,44 +51,72 @@ pub(super) fn run_transfer(opts: TransferOptions) -> Result<()> {
     let indexer = ZolanaIndexer::new(network.sync.indexer_url.clone());
     let ctx = sync_context(&opts.network.sync)?;
     maybe_airdrop(&mut rpc, &ctx.material, network.airdrop_lamports)?;
-    let recipient_owner = parse_pubkey(&opts.to)?;
     let tree = network.tree;
+    let owner_pubkey = ctx.material.owner_pubkey();
+    let payer = Address::new_from_array(ctx.material.funding.pubkey().to_bytes());
 
-    let transfer = create_transfer_sync(CreateTransfer {
-        rpc: &rpc,
-        wallet: &ctx.wallet,
-        authority: &ctx.material,
-        owner_pubkey: ctx.material.owner_pubkey(),
-        payer: Address::new_from_array(ctx.material.funding.pubkey().to_bytes()),
-        recipient_owner,
-        asset,
-        amount: opts.amount,
-    })?;
-    let signature = submit_private_transaction(
-        SubmitPrivateTx {
-            rpc: &rpc,
-            indexer: &indexer,
-            material: &ctx.material,
-            tree,
-            prover_url: &network.prover_url,
-            withdrawal: transfer.recipient.withdrawal().cloned(),
-            wait_tag: transfer.wait_tag,
-        },
-        transfer.signed,
-    )?;
-    let mode = if transfer.recipient.is_public_withdrawal() {
-        "withdraw"
-    } else {
-        "shielded"
-    };
-    println!(
-        "ok transfer amount={} mint={} to={} mode={} signature={}",
-        opts.amount,
-        format_address(asset),
-        transfer.recipient.pubkey(),
-        mode,
-        signature
-    );
+    match resolve_transfer_recipient(&rpc, &opts.to)? {
+        TransferTarget::Shielded(recipient) => {
+            let transfer = create_transfer_sync(CreateTransfer {
+                wallet: &ctx.wallet,
+                authority: &ctx.material,
+                owner_pubkey,
+                payer,
+                recipient,
+                asset,
+                amount: opts.amount,
+            })?;
+            let signature = submit_private_transaction(
+                SubmitPrivateTx {
+                    rpc: &rpc,
+                    indexer: &indexer,
+                    material: &ctx.material,
+                    tree,
+                    prover_url: &network.prover_url,
+                    withdrawal: None,
+                    wait_tag: transfer.wait_tag,
+                },
+                transfer.signed,
+            )?;
+            println!(
+                "ok transfer amount={} mint={} to={} mode=shielded signature={}",
+                opts.amount,
+                format_address(asset),
+                transfer.recipient,
+                signature
+            );
+        }
+        TransferTarget::Public(recipient) => {
+            let withdrawal = create_withdrawal_sync(CreateWithdrawal {
+                wallet: &ctx.wallet,
+                authority: &ctx.material,
+                owner_pubkey,
+                payer,
+                recipient,
+                asset,
+                amount: opts.amount,
+            })?;
+            let signature = submit_private_transaction(
+                SubmitPrivateTx {
+                    rpc: &rpc,
+                    indexer: &indexer,
+                    material: &ctx.material,
+                    tree,
+                    prover_url: &network.prover_url,
+                    withdrawal: Some(withdrawal.withdrawal),
+                    wait_tag: withdrawal.wait_tag,
+                },
+                withdrawal.signed,
+            )?;
+            println!(
+                "ok transfer amount={} mint={} to={} mode=withdraw signature={}",
+                opts.amount,
+                format_address(asset),
+                recipient,
+                signature
+            );
+        }
+    }
     Ok(())
 }
 
@@ -158,4 +211,41 @@ pub(super) fn maybe_airdrop(
     let signature = rpc.airdrop(&material.funding.pubkey(), lamports)?;
     println!("ok airdrop signature={signature}");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use zolana_keypair::ShieldedKeypair;
+
+    use super::*;
+
+    // The registry is never queried for a shielded-address string or invalid
+    // input, so these branches resolve without touching the RPC.
+    fn unused_rpc() -> SolanaRpc {
+        SolanaRpc::new("http://127.0.0.1:0".to_string())
+    }
+
+    #[test]
+    fn resolves_shielded_address_string_directly() {
+        let address = ShieldedKeypair::new()
+            .expect("keypair")
+            .shielded_address()
+            .expect("address");
+        match resolve_transfer_recipient(&unused_rpc(), &address.to_string()).expect("resolve") {
+            TransferTarget::Shielded(resolved) => assert_eq!(resolved, address),
+            TransferTarget::Public(_) => {
+                panic!("a shielded address must resolve to a shielded target")
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_input_that_is_neither_address_nor_pubkey() {
+        let err = match resolve_transfer_recipient(&unused_rpc(), "definitely-not-valid") {
+            Ok(_) => panic!("must reject an input that is neither an address nor a pubkey"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("shielded address"));
+        assert!(err.to_string().contains("Solana pubkey"));
+    }
 }

--- a/cli/src/wallet_cli/util.rs
+++ b/cli/src/wallet_cli/util.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Context, Result};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_pubkey::Pubkey;
+use zolana_keypair::ShieldedAddress;
 use zolana_transaction::{Address, SOL_MINT};
 
 use crate::cli_config::CliConfigFile;
@@ -23,6 +24,28 @@ pub(super) fn parse_pubkey(value: &str) -> Result<Pubkey> {
     value
         .parse::<Pubkey>()
         .with_context(|| format!("invalid pubkey `{value}`"))
+}
+
+/// A `--to` recipient: either a self-contained shielded address (shared
+/// directly) or a Solana pubkey (resolved through the user registry).
+pub(super) enum RecipientInput {
+    Shielded(ShieldedAddress),
+    Pubkey(Pubkey),
+}
+
+/// Disambiguate a `--to` value. A versioned Base58Check shielded address parses
+/// as `Shielded`; anything else must be a Solana pubkey. The caller decides how
+/// to resolve a pubkey (registry lookup, public fallback, etc.).
+pub(super) fn parse_recipient(value: &str) -> Result<RecipientInput> {
+    if let Ok(address) = value.parse::<ShieldedAddress>() {
+        return Ok(RecipientInput::Shielded(address));
+    }
+    let owner = value.parse::<Pubkey>().map_err(|_| {
+        anyhow::anyhow!(
+            "invalid recipient `{value}`: expected a shielded address (from `zolana wallet address`) or a Solana pubkey"
+        )
+    })?;
+    Ok(RecipientInput::Pubkey(owner))
 }
 
 pub(super) fn format_address(address: Address) -> String {
@@ -78,5 +101,45 @@ pub(super) fn system_create_account_ix(
             AccountMeta::new(*new_account, true),
         ],
         data,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zolana_keypair::ShieldedKeypair;
+
+    use super::*;
+
+    #[test]
+    fn parse_recipient_accepts_shielded_address() {
+        let address = ShieldedKeypair::new()
+            .expect("keypair")
+            .shielded_address()
+            .expect("address");
+
+        match parse_recipient(&address.to_string()).expect("parse recipient") {
+            RecipientInput::Shielded(parsed) => assert_eq!(parsed, address),
+            RecipientInput::Pubkey(_) => panic!("a shielded address must parse as Shielded"),
+        }
+    }
+
+    #[test]
+    fn parse_recipient_accepts_solana_pubkey() {
+        let pubkey = Pubkey::new_unique();
+
+        match parse_recipient(&pubkey.to_string()).expect("parse recipient") {
+            RecipientInput::Pubkey(parsed) => assert_eq!(parsed, pubkey),
+            RecipientInput::Shielded(_) => panic!("a Solana pubkey must parse as Pubkey"),
+        }
+    }
+
+    #[test]
+    fn parse_recipient_rejects_invalid_input() {
+        let err = match parse_recipient("definitely-not-valid") {
+            Ok(_) => panic!("must reject an input that is neither an address nor a pubkey"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("shielded address"));
+        assert!(err.to_string().contains("Solana pubkey"));
     }
 }

--- a/justfile
+++ b/justfile
@@ -199,7 +199,6 @@ regenerate-photon-fixtures: build-programs build-prover-server build-cli ensure-
     }
     trap cleanup EXIT
     export SHIELDED_POOL_PROGRAM_ID
-    export USER_REGISTRY_PROGRAM_ID
     export ZOLANA_PHOTON_BIN="{{photon-bin}}"
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"

--- a/program-tests/shielded-pool/tests/localnet_wallet_cli_e2e.rs
+++ b/program-tests/shielded-pool/tests/localnet_wallet_cli_e2e.rs
@@ -16,7 +16,8 @@ use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_signer::Signer;
 use zolana_client::{Rpc, SolanaRpc};
-use zolana_interface::{SPL_TOKEN_ACCOUNT_AMOUNT_END, SPL_TOKEN_ACCOUNT_AMOUNT_OFFSET};
+use zolana_interface::{pda, SPL_TOKEN_ACCOUNT_AMOUNT_END, SPL_TOKEN_ACCOUNT_AMOUNT_OFFSET};
+use zolana_keypair::ShieldedAddress;
 use zolana_transaction::Address;
 
 #[path = "common/transact.rs"]
@@ -31,11 +32,6 @@ const PROVER_URL_ENV: &str = "ZOLANA_PROVER_URL";
 const DEFAULT_RPC_URL: &str = "http://127.0.0.1:8899";
 const DEFAULT_INDEXER_URL: &str = "http://127.0.0.1:8784";
 const DEFAULT_PROVER_URL: &str = "http://127.0.0.1:3001";
-
-#[derive(Deserialize)]
-struct WalletFile {
-    funding_pubkey: String,
-}
 
 #[derive(Deserialize)]
 struct WalletFundingKey {
@@ -91,15 +87,17 @@ fn ensure_associated_token_account(
     mint: &Pubkey,
 ) -> Result<Pubkey> {
     let rpc = SolanaRpc::new(rpc_url);
-    let (_sig, ata) = zolana_client::create_associated_token_account(&rpc, payer, owner, mint)?;
-    Ok(ata)
+    let (_signature, account) =
+        zolana_client::create_associated_token_account(&rpc, payer, owner, mint)?;
+    Ok(account)
 }
 
 /// Restart a fresh local validator + Photon through the `zolana` CLI (the same
 /// launcher the other photon e2e tests use; it owns the validator/photon
 /// orchestration and readiness checks). Deploys the shielded-pool and
-/// user-registry programs the wallet CLI needs; `--skip-prover` leaves the
-/// persistent prover server untouched so its proving keys stay loaded.
+/// user-registry programs the wallet CLI needs (the latter backs pay-by-pubkey
+/// recipient resolution); `--skip-prover` leaves the persistent prover server
+/// untouched so its proving keys stay loaded.
 fn restart_localnet() {
     let root = concat!(env!("CARGO_MANIFEST_DIR"), "/../..");
     let cli =
@@ -171,27 +169,53 @@ fn run_cli_with_env(args: &[&str], env: &[(&str, &str)]) -> Result<String> {
     Ok(stdout)
 }
 
-fn wallet_init(path: &Path, rpc_url: &str, cli_env: &[(&str, &str)]) -> Result<()> {
+fn wallet_new(path: &Path, config: &Path, cli_env: &[(&str, &str)]) -> Result<()> {
     run_cli_with_env(
         &[
+            "-C",
+            &config.display().to_string(),
             "wallet",
-            "init",
-            "--path",
+            "new",
+            "--outfile",
             &path.display().to_string(),
-            "--rpc-url",
-            rpc_url,
-            "--airdrop-lamports",
-            "1000000000",
         ],
         cli_env,
     )?;
     Ok(())
 }
 
-fn funding_pubkey(path: &Path) -> Result<String> {
-    let file: WalletFile =
-        serde_json::from_slice(&std::fs::read(path).with_context(|| path.display().to_string())?)?;
-    Ok(file.funding_pubkey)
+fn wallet_address(path: &Path, config: &Path, cli_env: &[(&str, &str)]) -> Result<ShieldedAddress> {
+    run_cli_with_env(
+        &[
+            "-C",
+            &config.display().to_string(),
+            "wallet",
+            "address",
+            "-k",
+            &path.display().to_string(),
+        ],
+        cli_env,
+    )?
+    .trim()
+    .parse::<ShieldedAddress>()
+    .context("parse wallet shielded address")
+}
+
+fn funding_pubkey(path: &Path, config: &Path, cli_env: &[(&str, &str)]) -> Result<String> {
+    Ok(run_cli_with_env(
+        &[
+            "-C",
+            &config.display().to_string(),
+            "wallet",
+            "address",
+            "-k",
+            &path.display().to_string(),
+            "--funding",
+        ],
+        cli_env,
+    )?
+    .trim()
+    .to_string())
 }
 
 fn temp_wallet_dir() -> Result<PathBuf> {
@@ -244,8 +268,10 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
     let config_path_str = config_path.to_string_lossy().into_owned();
     let cli_env = [("ZOLANA_CONFIG", config_path_str.as_str())];
 
-    wallet_init(&alice, &rpc_url, &cli_env)?;
-    wallet_init(&bob, &rpc_url, &cli_env)?;
+    wallet_new(&alice, &config_path, &cli_env)?;
+    wallet_new(&bob, &config_path, &cli_env)?;
+    let alice_address = wallet_address(&alice, &config_path, &cli_env)?;
+    let bob_address = wallet_address(&bob, &config_path, &cli_env)?;
 
     let create_tree_out = run_cli_with_env(
         &[
@@ -284,29 +310,28 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
         &cli_env,
     )?;
     let spl_mint = parse_field(&test_mint_out, "mint")?;
-    let alice_token_account = parse_field(&test_mint_out, "token_account")?;
     let spl_mint_pubkey = spl_mint.parse::<Pubkey>()?;
-    let alice_funding_keypair = load_funding_keypair(&alice)?;
-    let unregistered_recipient = Keypair::new();
-    let bob_funding = funding_pubkey(&bob)?;
+    let public_recipient = Keypair::new();
+    let bob_funding = funding_pubkey(&bob, &config_path, &cli_env)?;
     let bob_owner = bob_funding.parse::<Pubkey>()?;
-    let bob_ata = ensure_associated_token_account(
-        &rpc_url,
-        &alice_funding_keypair,
-        &bob_owner,
-        &spl_mint_pubkey,
-    )?;
-    let unregistered_ata = ensure_associated_token_account(
-        &rpc_url,
-        &alice_funding_keypair,
-        &unregistered_recipient.pubkey(),
-        &spl_mint_pubkey,
-    )?;
-    let rpc = SolanaRpc::new(&rpc_url);
+    let bob_funding_keypair = load_funding_keypair(&bob)?;
+    let bob_ata = pda::associated_token_address(&bob_owner, &spl_mint_pubkey);
+    let public_ata = pda::associated_token_address(&public_recipient.pubkey(), &spl_mint_pubkey);
+    let mut rpc = SolanaRpc::new(&rpc_url);
+    rpc.airdrop(&bob_owner, 2_000_000_000)?;
     assert_eq!(
-        spl_token_account_amount(&rpc, &unregistered_ata)?,
-        0,
-        "unregistered ATA should start empty"
+        ensure_associated_token_account(
+            &rpc_url,
+            &bob_funding_keypair,
+            &bob_owner,
+            &spl_mint_pubkey,
+        )?,
+        bob_ata
+    );
+    assert!(
+        rpc.get_account(Address::new_from_array(public_ata.to_bytes()))?
+            .is_none(),
+        "public recipient ATA should not exist before withdrawal"
     );
 
     let asset_registry_out = run_cli_with_env(&["config", "asset-registry"], &cli_env)?;
@@ -324,7 +349,7 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
                 "--keypair",
                 &alice.display().to_string(),
                 "--to",
-                &bob_funding,
+                &bob_address.to_string(),
                 "--amount",
                 deposit_amount,
                 "--mint",
@@ -339,21 +364,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             &cli_env,
         )?;
     }
-
-    let sync_out = run_cli_with_env(
-        &[
-            "wallet",
-            "sync",
-            "--keypair",
-            &bob.display().to_string(),
-            "--rpc-url",
-            &rpc_url,
-            "--indexer-url",
-            &indexer_url,
-        ],
-        &cli_env,
-    )?;
-    assert!(sync_out.contains("ok sync"), "sync failed: {sync_out}");
 
     let balance_out = run_cli_with_env(
         &[
@@ -384,7 +394,7 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             "--keypair",
             &alice.display().to_string(),
             "--to",
-            &bob_funding,
+            &bob_address.to_string(),
             "--amount",
             "600000",
             "--mint",
@@ -419,7 +429,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
         "expected 600000 SPL balance, got: {spl_balance_out}"
     );
 
-    let alice_funding = funding_pubkey(&alice)?;
     run_cli_with_env(
         &[
             "wallet",
@@ -427,7 +436,7 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             "--keypair",
             &bob.display().to_string(),
             "--to",
-            &alice_funding,
+            &alice_address.to_string(),
             "--amount",
             "400000000",
             "--mint",
@@ -438,8 +447,6 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             &indexer_url,
             "--prover-url",
             &prover_url,
-            "--airdrop-lamports",
-            "2000000000",
         ],
         &cli_env,
     )?;
@@ -451,7 +458,7 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             "--keypair",
             &bob.display().to_string(),
             "--to",
-            &alice_funding,
+            &alice_address.to_string(),
             "--amount",
             "250000",
             "--mint",
@@ -462,25 +469,76 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             &indexer_url,
             "--prover-url",
             &prover_url,
-            "--airdrop-lamports",
-            "2000000000",
         ],
         &cli_env,
     )?;
 
-    let unregistered_transfer_amount = 50_000u64;
-    let alice_token_before_unregistered =
-        spl_token_account_amount(&rpc, &alice_token_account.parse()?)?;
-    run_cli_with_env(
+    // An unregistered Solana pubkey has no user-registry record, so `transfer`
+    // silently falls back to a public withdrawal (spec Single Player,
+    // lookup-negative): the CLI reports mode=withdraw and the lamports land in
+    // the recipient's public account.
+    let fallback_recipient = Keypair::new().pubkey();
+    let fallback_amount = 2_000_000u64;
+    let fallback_before = rpc
+        .get_account(Address::new_from_array(fallback_recipient.to_bytes()))?
+        .map_or(0, |account| account.lamports);
+    let fallback_out = run_cli_with_env(
         &[
             "wallet",
             "transfer",
             "--keypair",
             &bob.display().to_string(),
             "--to",
-            &unregistered_recipient.pubkey().to_string(),
+            &fallback_recipient.to_string(),
             "--amount",
-            &unregistered_transfer_amount.to_string(),
+            &fallback_amount.to_string(),
+            "--mint",
+            "SOL",
+            "--rpc-url",
+            &rpc_url,
+            "--indexer-url",
+            &indexer_url,
+            "--prover-url",
+            &prover_url,
+        ],
+        &cli_env,
+    )?;
+    assert!(
+        fallback_out.contains("mode=withdraw"),
+        "unregistered pubkey transfer must fall back to a public withdrawal: {fallback_out}"
+    );
+    let fallback_after = rpc
+        .get_account(Address::new_from_array(fallback_recipient.to_bytes()))?
+        .map_or(0, |account| account.lamports);
+    assert_eq!(
+        fallback_after,
+        fallback_before + fallback_amount,
+        "silent public fallback should credit the recipient's SOL balance"
+    );
+
+    // Prepare the public SPL recipient used by the explicit `withdraw` below.
+    let public_withdraw_amount = 50_000u64;
+    assert_eq!(
+        ensure_associated_token_account(
+            &rpc_url,
+            &bob_funding_keypair,
+            &public_recipient.pubkey(),
+            &spl_mint_pubkey,
+        )?,
+        public_ata
+    );
+    assert_eq!(spl_token_account_amount(&rpc, &public_ata)?, 0);
+
+    run_cli_with_env(
+        &[
+            "wallet",
+            "withdraw",
+            "--keypair",
+            &bob.display().to_string(),
+            "--to",
+            &public_recipient.pubkey().to_string(),
+            "--amount",
+            &public_withdraw_amount.to_string(),
             "--mint",
             &spl_mint,
             "--rpc-url",
@@ -489,35 +547,14 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
             &indexer_url,
             "--prover-url",
             &prover_url,
-            "--airdrop-lamports",
-            "2000000000",
         ],
         &cli_env,
     )?;
     assert_eq!(
-        spl_token_account_amount(&rpc, &unregistered_ata)?,
-        unregistered_transfer_amount,
-        "unregistered SPL transfer should settle to recipient ATA"
+        spl_token_account_amount(&rpc, &public_ata)?,
+        public_withdraw_amount,
+        "explicit withdrawal should fund the public recipient ATA"
     );
-    assert_eq!(
-        spl_token_account_amount(&rpc, &alice_token_account.parse()?)?,
-        alice_token_before_unregistered,
-        "sender-configured deposit token account must not receive unregistered transfer"
-    );
-
-    run_cli_with_env(
-        &[
-            "wallet",
-            "sync",
-            "--keypair",
-            &alice.display().to_string(),
-            "--rpc-url",
-            &rpc_url,
-            "--indexer-url",
-            &indexer_url,
-        ],
-        &cli_env,
-    )?;
 
     run_cli_with_env(
         &[
@@ -564,11 +601,7 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
     );
 
     let spl_withdraw_amount = 100_000u64;
-    assert_eq!(
-        spl_token_account_amount(&rpc, &bob_ata)?,
-        0,
-        "bob ATA should start empty"
-    );
+    assert_eq!(spl_token_account_amount(&rpc, &bob_ata)?, 0);
     run_cli_with_env(
         &[
             "wallet",
@@ -596,6 +629,50 @@ fn wallet_cli_sol_and_spl_cycle() -> Result<()> {
         spl_token_account_amount(&rpc, &bob_ata)?,
         spl_withdraw_amount,
         "SPL withdraw should settle to recipient ATA"
+    );
+
+    // Pay-by-Solana-pubkey: registering bob (via `merge --enable`) publishes his
+    // shielded keys to the user registry, so `transfer --to <bob pubkey>`
+    // resolves the recipient and stays shielded (mode=shielded) instead of
+    // falling back to a public withdrawal.
+    run_cli_with_env(
+        &[
+            "wallet",
+            "merge",
+            "--enable",
+            "--keypair",
+            &bob.display().to_string(),
+            "--rpc-url",
+            &rpc_url,
+            "--indexer-url",
+            &indexer_url,
+        ],
+        &cli_env,
+    )?;
+    let registered_transfer_out = run_cli_with_env(
+        &[
+            "wallet",
+            "transfer",
+            "--keypair",
+            &alice.display().to_string(),
+            "--to",
+            &bob_funding,
+            "--amount",
+            "1000000",
+            "--mint",
+            "SOL",
+            "--rpc-url",
+            &rpc_url,
+            "--indexer-url",
+            &indexer_url,
+            "--prover-url",
+            &prover_url,
+        ],
+        &cli_env,
+    )?;
+    assert!(
+        registered_transfer_out.contains("mode=shielded"),
+        "transfer to a registered Solana pubkey must resolve via the registry and stay shielded: {registered_transfer_out}"
     );
 
     Ok(())

--- a/sdk-libs/client/src/actions/mod.rs
+++ b/sdk-libs/client/src/actions/mod.rs
@@ -11,5 +11,5 @@ pub use deposit::{create_deposit, deposit, CreateDeposit, Deposit};
 pub use transaction::{
     create_transfer, create_transfer_sync, create_withdrawal, create_withdrawal_sync,
     sign_transaction, sign_transaction_sync, CreateTransfer, CreateWithdrawal, CreatedTransfer,
-    CreatedWithdrawal, ResolvedAddress, TransferRecipient,
+    CreatedWithdrawal,
 };

--- a/sdk-libs/client/src/actions/transaction.rs
+++ b/sdk-libs/client/src/actions/transaction.rs
@@ -14,54 +14,16 @@ use zolana_transaction::{
 
 use crate::{
     error::ClientError,
-    rpc::Rpc,
-    user_registry::try_resolve_registered_address,
     wallet_authority::{
         ApprovalRequest, ConfidentialRecipientSlot, SyncWalletAuthority, WalletAuthority,
     },
 };
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ResolvedAddress {
-    pub owner: Pubkey,
-    pub address: ShieldedAddress,
-    pub view_tag: ViewTag,
-}
-
 #[derive(Clone)]
 pub struct CreatedTransfer {
     pub signed: SignedTransaction,
     pub wait_tag: ViewTag,
-    pub recipient: TransferRecipient,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum TransferRecipient {
-    Registered(ResolvedAddress),
-    PublicWithdrawal {
-        recipient: Pubkey,
-        withdrawal: TransactWithdrawal,
-    },
-}
-
-impl TransferRecipient {
-    pub fn pubkey(&self) -> Pubkey {
-        match self {
-            Self::Registered(recipient) => recipient.owner,
-            Self::PublicWithdrawal { recipient, .. } => *recipient,
-        }
-    }
-
-    pub fn is_public_withdrawal(&self) -> bool {
-        matches!(self, Self::PublicWithdrawal { .. })
-    }
-
-    pub fn withdrawal(&self) -> Option<&TransactWithdrawal> {
-        match self {
-            Self::Registered(_) => None,
-            Self::PublicWithdrawal { withdrawal, .. } => Some(withdrawal),
-        }
-    }
+    pub recipient: ShieldedAddress,
 }
 
 #[derive(Clone)]
@@ -71,13 +33,17 @@ pub struct CreatedWithdrawal {
     pub withdrawal: TransactWithdrawal,
 }
 
-pub struct CreateTransfer<'a, R: Rpc, A: ?Sized> {
-    pub rpc: &'a R,
+/// Build a private transfer to a concrete shielded address.
+///
+/// This action performs no user-registry lookup. Resolve an optional registry
+/// alias before constructing this request, or use [`CreateWithdrawal`] for an
+/// explicit public destination.
+pub struct CreateTransfer<'a, A: ?Sized> {
     pub wallet: &'a Wallet,
     pub authority: &'a A,
     pub owner_pubkey: Pubkey,
     pub payer: Address,
-    pub recipient_owner: Pubkey,
+    pub recipient: ShieldedAddress,
     pub asset: Address,
     pub amount: u64,
 }
@@ -92,30 +58,9 @@ pub struct CreateWithdrawal<'a, A: ?Sized> {
     pub amount: u64,
 }
 
-pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
-    request: CreateTransfer<'_, R, A>,
+pub async fn create_transfer<A: WalletAuthority + ?Sized>(
+    request: CreateTransfer<'_, A>,
 ) -> Result<CreatedTransfer, ClientError> {
-    let Some(recipient) = try_resolve_registered_address(request.rpc, request.recipient_owner)?
-    else {
-        let withdrawal = create_withdrawal(CreateWithdrawal {
-            wallet: request.wallet,
-            authority: request.authority,
-            owner_pubkey: request.owner_pubkey,
-            payer: request.payer,
-            recipient: request.recipient_owner,
-            asset: request.asset,
-            amount: request.amount,
-        })
-        .await?;
-        return Ok(CreatedTransfer {
-            signed: withdrawal.signed,
-            wait_tag: withdrawal.wait_tag,
-            recipient: TransferRecipient::PublicWithdrawal {
-                recipient: request.recipient_owner,
-                withdrawal: withdrawal.withdrawal,
-            },
-        });
-    };
     let inputs = select_inputs(
         request.wallet,
         request.authority,
@@ -130,7 +75,7 @@ pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
         .await?;
     let wait_tag = address.signing_pubkey.confidential_view_tag()?;
     let mut tx = Transaction::new(address, inputs, request.payer);
-    tx.send(&recipient.address, request.asset, request.amount)?;
+    tx.send(&request.recipient, request.asset, request.amount)?;
     let prepared = tx.prepare(&request.wallet.registry)?;
     let signed = sign_prepared(
         prepared,
@@ -140,21 +85,21 @@ pub async fn create_transfer<R: Rpc, A: WalletAuthority + ?Sized>(
         &request.wallet.registry,
         format!(
             "private transfer of {} to {}",
-            request.amount, request.recipient_owner
+            request.amount, request.recipient
         ),
     )
     .await?;
     Ok(CreatedTransfer {
         signed,
         wait_tag,
-        recipient: TransferRecipient::Registered(recipient),
+        recipient: request.recipient,
     })
 }
 
 /// Blocking adapter for CLI and unit-test flows. Async hosts should call
 /// [`create_transfer`] directly.
-pub fn create_transfer_sync<R: Rpc, A: SyncWalletAuthority + ?Sized>(
-    request: CreateTransfer<'_, R, A>,
+pub fn create_transfer_sync<A: SyncWalletAuthority + ?Sized>(
+    request: CreateTransfer<'_, A>,
 ) -> Result<CreatedTransfer, ClientError> {
     futures::executor::block_on(create_transfer(request))
 }
@@ -357,32 +302,10 @@ async fn select_inputs<A: WalletAuthority + ?Sized>(
 
 #[cfg(test)]
 mod tests {
-    use borsh::to_vec;
-    use solana_account::Account;
     use zolana_keypair::ShieldedKeypair;
     use zolana_transaction::{Data, Utxo, WalletUtxo};
-    use zolana_user_registry_interface::{user_record_pda, user_registry_program_id, UserRecord};
 
     use super::*;
-
-    struct MockRpc {
-        account: Option<(Address, Account)>,
-    }
-
-    impl Rpc for MockRpc {
-        fn get_account(&self, address: Address) -> Result<Option<Account>, ClientError> {
-            Ok(self
-                .account
-                .as_ref()
-                .and_then(|(expected, account)| (*expected == address).then(|| account.clone())))
-        }
-    }
-
-    fn account_data(record: &UserRecord) -> Vec<u8> {
-        let mut data = vec![UserRecord::DISCRIMINATOR];
-        data.extend_from_slice(&to_vec(record).expect("serialize user record"));
-        data
-    }
 
     fn wallet_with_sol(keypair: ShieldedKeypair, amount: u64) -> Wallet {
         wallet_with_asset(keypair, SOL_MINT, amount)
@@ -424,114 +347,24 @@ mod tests {
     }
 
     #[test]
-    fn create_transfer_to_registered_recipient_builds_shielded_transfer() {
+    fn create_transfer_uses_the_supplied_shielded_address() {
         let sender = ShieldedKeypair::new().unwrap();
         let recipient = ShieldedKeypair::new().unwrap();
-        let owner = Pubkey::new_unique();
-        let (record_pda, bump) = user_record_pda(&owner);
-        let record = UserRecord {
-            owner: owner.to_bytes().into(),
-            bump,
-            owner_p256: Some(*recipient.signing_pubkey().as_p256().unwrap().as_bytes()),
-            nullifier_pubkey: recipient.nullifier_key.pubkey().unwrap(),
-            viewing_pubkey: *recipient.viewing_pubkey().as_bytes(),
-            sync_delegate: None,
-            entries: Vec::new(),
-            merging_enabled: false,
-        };
-        let rpc = MockRpc {
-            account: Some((
-                Address::new_from_array(record_pda.to_bytes()),
-                Account {
-                    lamports: 1,
-                    data: account_data(&record),
-                    owner: user_registry_program_id(),
-                    executable: false,
-                    rent_epoch: 0,
-                },
-            )),
-        };
+        let recipient = recipient.shielded_address().expect("recipient address");
         let wallet = wallet_with_sol(sender.clone(), 10);
 
         let result = create_transfer_sync(CreateTransfer {
-            rpc: &rpc,
             wallet: &wallet,
             authority: &sender,
             owner_pubkey: Pubkey::default(),
             payer: Address::default(),
-            recipient_owner: owner,
+            recipient,
             asset: SOL_MINT,
             amount: 1,
         })
         .expect("transfer");
 
-        assert!(matches!(
-            result.recipient,
-            TransferRecipient::Registered(resolved) if resolved.owner == owner
-        ));
-        assert!(result.recipient.withdrawal().is_none());
-    }
-
-    #[test]
-    fn create_transfer_to_unregistered_recipient_builds_public_withdrawal() {
-        let sender = ShieldedKeypair::new().unwrap();
-        let wallet = wallet_with_sol(sender.clone(), 10);
-        let recipient = Pubkey::new_unique();
-        let rpc = MockRpc { account: None };
-
-        let result = create_transfer_sync(CreateTransfer {
-            rpc: &rpc,
-            wallet: &wallet,
-            authority: &sender,
-            owner_pubkey: Pubkey::default(),
-            payer: Address::default(),
-            recipient_owner: recipient,
-            asset: SOL_MINT,
-            amount: 1,
-        })
-        .expect("public withdrawal fallback");
-
-        assert!(matches!(
-            result.recipient,
-            TransferRecipient::PublicWithdrawal {
-                recipient: pubkey,
-                withdrawal: TransactWithdrawal::Sol(TransactSolWithdrawal { recipient }),
-            } if pubkey == recipient
-        ));
-    }
-
-    #[test]
-    fn create_transfer_to_unregistered_recipient_builds_spl_public_withdrawal() {
-        let sender = ShieldedKeypair::new().unwrap();
-        let mint = Pubkey::new_unique();
-        let asset = Address::new_from_array(mint.to_bytes());
-        let wallet = wallet_with_asset(sender.clone(), asset, 10);
-        let rpc = MockRpc { account: None };
-        let recipient = Pubkey::new_unique();
-        let token_account = pda::associated_token_address(&recipient, &mint);
-
-        let result = create_transfer_sync(CreateTransfer {
-            rpc: &rpc,
-            wallet: &wallet,
-            authority: &sender,
-            owner_pubkey: Pubkey::default(),
-            payer: Address::default(),
-            recipient_owner: recipient,
-            asset,
-            amount: 1,
-        })
-        .expect("public withdrawal fallback");
-
-        assert_eq!(
-            result.recipient.withdrawal(),
-            Some(&TransactWithdrawal::Spl(TransactSplWithdrawal {
-                cpi_authority: Some(pda::shielded_pool_cpi_authority()),
-                spl_token_interface: pda::spl_asset_vault(&mint),
-                recipient,
-                user_token_account: token_account,
-                token_program: Pubkey::new_from_array(SPL_TOKEN_PROGRAM_ID),
-            }))
-        );
+        assert_eq!(result.recipient, recipient);
     }
 
     #[test]

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -14,7 +14,6 @@ pub use actions::{
     create_associated_token_account, create_deposit, create_transfer, create_transfer_sync,
     create_withdrawal, create_withdrawal_sync, sign_transaction, sign_transaction_sync,
     CreateDeposit, CreateTransfer, CreateWithdrawal, CreatedTransfer, CreatedWithdrawal, Deposit,
-    ResolvedAddress, TransferRecipient,
 };
 pub use error::ClientError;
 #[cfg(feature = "indexer-api")]
@@ -42,8 +41,8 @@ pub use rpc::{
 pub use solana_rpc::{ConfirmedInstructionGroups, SolanaRpc};
 pub use user_registry::{
     decode_user_record_account, ensure_registered, fetch_user_record_checked,
-    fetch_user_record_optional_checked, resolve_registered_address, resolved_address_from_record,
-    try_resolve_registered_address, validate_registered_keypair,
+    fetch_user_record_optional_checked, resolve_registered_address, try_resolve_registered_address,
+    validate_registered_keypair,
 };
 pub use wallet_authority::{
     AnonymousRecipientSlot, ApprovalRequest, ConfidentialRecipientSlot, EncryptedTransfer,

--- a/sdk-libs/client/src/user_registry.rs
+++ b/sdk-libs/client/src/user_registry.rs
@@ -9,7 +9,7 @@ use zolana_user_registry_interface::{
     user_record_pda, user_registry_program_id, UserRecord,
 };
 
-use crate::{actions::ResolvedAddress, error::ClientError, rpc::Rpc};
+use crate::{error::ClientError, rpc::Rpc};
 
 /// Derive the on-chain registry record fields from a shielded keypair: the
 /// P256 owner key (only for P256-owned wallets), nullifier pubkey, and viewing
@@ -27,10 +27,10 @@ fn register_fields(keypair: &ShieldedKeypair) -> Result<RegisterData, ClientErro
 }
 
 /// Publish `keypair`'s shielded keys to the on-chain user-registry directory
-/// under `funding`'s pubkey, so senders who know only that Solana address route
-/// transfers to the shielded path (rather than falling back to a public
-/// withdrawal). Registration is optional for receiving a confidential transfer
-/// to a known shielded address; it is the pubkey-addressability directory.
+/// under `funding`'s pubkey, so senders who know only that Solana address can
+/// resolve its shielded address. Registration is optional for receiving a
+/// confidential transfer to a known shielded address; it is the
+/// pubkey-addressability directory.
 ///
 /// Idempotent: registers if no record exists, updates the record on a key
 /// change, and returns `Ok(None)` if the record already matches (no transaction
@@ -167,7 +167,7 @@ pub fn validate_registered_keypair<R: Rpc>(
 pub fn resolve_registered_address<R: Rpc>(
     rpc: &R,
     owner: Pubkey,
-) -> Result<ResolvedAddress, ClientError> {
+) -> Result<ShieldedAddress, ClientError> {
     let record = fetch_user_record_checked(rpc, owner)
         .map_err(|err| ClientError::AddressResolution(err.to_string()))?;
     resolved_address_from_record(owner, &record)
@@ -177,7 +177,7 @@ pub fn resolve_registered_address<R: Rpc>(
 pub fn try_resolve_registered_address<R: Rpc>(
     rpc: &R,
     owner: Pubkey,
-) -> Result<Option<ResolvedAddress>, ClientError> {
+) -> Result<Option<ShieldedAddress>, ClientError> {
     let Some(record) = fetch_user_record_optional_checked(rpc, owner)? else {
         return Ok(None);
     };
@@ -186,23 +186,19 @@ pub fn try_resolve_registered_address<R: Rpc>(
     )?))
 }
 
-pub fn resolved_address_from_record(
+pub(crate) fn resolved_address_from_record(
     owner: Pubkey,
     record: &UserRecord,
-) -> Result<ResolvedAddress, ClientError> {
+) -> Result<ShieldedAddress, ClientError> {
     let signing_pubkey = match record.owner_p256 {
         Some(owner_p256) => PublicKey::from_p256(&P256Pubkey::from_bytes(owner_p256)?),
         None => PublicKey::from_ed25519(&owner.to_bytes()),
     };
     let viewing_pubkey = P256Pubkey::from_bytes(record.sender_viewing_pubkey())?;
-    Ok(ResolvedAddress {
-        owner,
-        address: ShieldedAddress {
-            signing_pubkey,
-            nullifier_pubkey: record.nullifier_pubkey,
-            viewing_pubkey,
-        },
-        view_tag: viewing_pubkey.x(),
+    Ok(ShieldedAddress {
+        signing_pubkey,
+        nullifier_pubkey: record.nullifier_pubkey,
+        viewing_pubkey,
     })
 }
 
@@ -321,19 +317,17 @@ mod tests {
         let keypair = ShieldedKeypair::new().expect("shielded keypair");
         let record = registered_record(owner, bump, &keypair);
 
-        let resolved = resolved_address_from_record(owner, &record).expect("resolved address");
+        let address = resolved_address_from_record(owner, &record).expect("resolved address");
 
-        assert_eq!(resolved.owner, owner);
-        assert_eq!(resolved.address.signing_pubkey, keypair.signing_pubkey());
+        assert_eq!(address.signing_pubkey, keypair.signing_pubkey());
         assert_eq!(
-            resolved.address.nullifier_pubkey,
+            address.nullifier_pubkey,
             keypair.nullifier_key.pubkey().unwrap()
         );
         assert_eq!(
-            resolved.address.viewing_pubkey.as_bytes(),
+            address.viewing_pubkey.as_bytes(),
             keypair.viewing_pubkey().as_bytes()
         );
-        assert_eq!(resolved.view_tag, keypair.recipient_bootstrap_view_tag());
     }
 
     #[test]
@@ -349,11 +343,31 @@ mod tests {
             )),
         };
 
-        let resolved = resolve_registered_address(&rpc, owner).expect("resolved address");
+        let address = resolve_registered_address(&rpc, owner).expect("resolved address");
 
-        assert_eq!(resolved.owner, owner);
-        assert_eq!(resolved.address.signing_pubkey, keypair.signing_pubkey());
-        assert_eq!(resolved.view_tag, keypair.recipient_bootstrap_view_tag());
+        assert_eq!(address.signing_pubkey, keypair.signing_pubkey());
+        assert_eq!(address.viewing_pubkey, keypair.viewing_pubkey());
+    }
+
+    #[test]
+    fn try_resolve_registered_address_returns_registered_address() {
+        let owner = Pubkey::new_unique();
+        let (pda, bump) = user_record_pda(&owner);
+        let keypair = ShieldedKeypair::new().expect("shielded keypair");
+        let record = registered_record(owner, bump, &keypair);
+        let rpc = MockRpc {
+            account: Some((
+                Address::new_from_array(pda.to_bytes()),
+                account_for(&record),
+            )),
+        };
+
+        let address = try_resolve_registered_address(&rpc, owner)
+            .expect("resolve")
+            .expect("a registered record resolves to Some");
+
+        assert_eq!(address.signing_pubkey, keypair.signing_pubkey());
+        assert_eq!(address.viewing_pubkey, keypair.viewing_pubkey());
     }
 
     #[test]

--- a/sdk-libs/keypair/Cargo.toml
+++ b/sdk-libs/keypair/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 edition.workspace = true
 
 [dependencies]
+bs58 = { workspace = true, features = ["check"] }
 p256 = { workspace = true }
 ed25519-dalek = { workspace = true }
 aes = { workspace = true }

--- a/sdk-libs/keypair/src/error.rs
+++ b/sdk-libs/keypair/src/error.rs
@@ -2,6 +2,18 @@ use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum KeypairError {
+    #[error("invalid shielded address encoding")]
+    InvalidAddressEncoding,
+
+    #[error("invalid shielded address length: expected {expected} bytes, got {actual}")]
+    InvalidAddressLength { expected: usize, actual: usize },
+
+    #[error("unsupported shielded address version: {0}")]
+    UnsupportedAddressVersion(u8),
+
+    #[error("invalid shielded address checksum")]
+    InvalidAddressChecksum,
+
     #[error("invalid public key")]
     InvalidPublicKey,
 

--- a/sdk-libs/keypair/src/lib.rs
+++ b/sdk-libs/keypair/src/lib.rs
@@ -53,7 +53,9 @@ pub mod viewing_key;
 pub use error::KeypairError;
 pub use nullifier_key::NullifierKey;
 pub use pubkey::{P256Pubkey, PublicKey, SignatureType};
-pub use shielded::{CompressedShieldedAddress, ShieldedAddress, ShieldedKeypair};
+pub use shielded::{
+    CompressedShieldedAddress, ShieldedAddress, ShieldedKeypair, SHIELDED_ADDRESS_LEN,
+};
 pub use signing_key::SigningKey;
 pub use traits::{ShieldedKeypairTrait, ViewingKeyTrait};
 pub use viewing_key::{random_blinding, random_salt, ViewingKey};

--- a/sdk-libs/keypair/src/shielded.rs
+++ b/sdk-libs/keypair/src/shielded.rs
@@ -1,5 +1,7 @@
+use std::{fmt, str::FromStr};
+
 use crate::{
-    constants::{BLINDING_LEN, SALT_LEN},
+    constants::{BLINDING_LEN, P256_PUBKEY_LEN, PUBLIC_KEY_LEN, SALT_LEN},
     error::KeypairError,
     hash::owner_hash,
     nullifier_key::NullifierKey,
@@ -7,6 +9,10 @@ use crate::{
     signing_key::SigningKey,
     viewing_key::ViewingKey,
 };
+
+const ADDRESS_VERSION: u8 = 1;
+pub const SHIELDED_ADDRESS_LEN: usize = PUBLIC_KEY_LEN + 32 + P256_PUBKEY_LEN;
+const ADDRESS_PAYLOAD_LEN: usize = 1 + SHIELDED_ADDRESS_LEN;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ShieldedAddress {
@@ -18,6 +24,75 @@ pub struct ShieldedAddress {
 impl ShieldedAddress {
     pub fn owner_hash(&self) -> Result<[u8; 32], KeypairError> {
         owner_hash(&self.signing_pubkey, &self.nullifier_pubkey)
+    }
+
+    pub fn to_bytes(self) -> [u8; SHIELDED_ADDRESS_LEN] {
+        let mut bytes = [0u8; SHIELDED_ADDRESS_LEN];
+        bytes[..PUBLIC_KEY_LEN].copy_from_slice(self.signing_pubkey.as_bytes());
+        bytes[PUBLIC_KEY_LEN..PUBLIC_KEY_LEN + 32].copy_from_slice(&self.nullifier_pubkey);
+        bytes[PUBLIC_KEY_LEN + 32..].copy_from_slice(self.viewing_pubkey.as_bytes());
+        bytes
+    }
+
+    pub fn from_bytes(bytes: [u8; SHIELDED_ADDRESS_LEN]) -> Result<Self, KeypairError> {
+        let signing_pubkey = PublicKey::from_bytes(
+            bytes[..PUBLIC_KEY_LEN]
+                .try_into()
+                .expect("shielded signing key slice has fixed length"),
+        )?;
+        let nullifier_pubkey = bytes[PUBLIC_KEY_LEN..PUBLIC_KEY_LEN + 32]
+            .try_into()
+            .expect("shielded nullifier key slice has fixed length");
+        let viewing_pubkey = P256Pubkey::from_bytes(
+            bytes[PUBLIC_KEY_LEN + 32..]
+                .try_into()
+                .expect("shielded viewing key slice has fixed length"),
+        )?;
+        let address = Self {
+            signing_pubkey,
+            nullifier_pubkey,
+            viewing_pubkey,
+        };
+        address.owner_hash()?;
+        Ok(address)
+    }
+}
+
+/// A versioned Base58Check, self-contained shielded recipient address.
+///
+/// The encoded payload contains the signing, nullifier, and viewing public keys;
+/// no on-chain registry lookup is required to send to it.
+impl fmt::Display for ShieldedAddress {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(
+            &bs58::encode(self.to_bytes())
+                .with_check_version(ADDRESS_VERSION)
+                .into_string(),
+        )
+    }
+}
+
+impl FromStr for ShieldedAddress {
+    type Err = KeypairError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let bytes = bs58::decode(value)
+            .with_check(Some(ADDRESS_VERSION))
+            .into_vec()
+            .map_err(|error| match error {
+                bs58::decode::Error::InvalidChecksum { .. } => KeypairError::InvalidAddressChecksum,
+                bs58::decode::Error::InvalidVersion { ver, .. } => {
+                    KeypairError::UnsupportedAddressVersion(ver)
+                }
+                _ => KeypairError::InvalidAddressEncoding,
+            })?;
+        if bytes.len() != ADDRESS_PAYLOAD_LEN {
+            return Err(KeypairError::InvalidAddressLength {
+                expected: ADDRESS_PAYLOAD_LEN,
+                actual: bytes.len(),
+            });
+        }
+        Self::from_bytes(bytes[1..].try_into().expect("validated address length"))
     }
 }
 
@@ -189,5 +264,97 @@ impl ShieldedKeypair {
     ) -> Result<ViewingKey, KeypairError> {
         self.viewing_key
             .get_transaction_viewing_key(first_nullifier)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shielded_address_string_round_trips() {
+        let address = ShieldedKeypair::new().unwrap().shielded_address().unwrap();
+        let encoded = address.to_string();
+
+        assert_eq!(encoded.parse::<ShieldedAddress>().unwrap(), address);
+    }
+
+    #[test]
+    fn ed25519_shielded_address_string_round_trips() {
+        let keypair = ShieldedKeypair::from_ed25519(&[7u8; 32], ViewingKey::new()).unwrap();
+        let address = keypair.shielded_address().unwrap();
+
+        assert_eq!(
+            address.to_string().parse::<ShieldedAddress>().unwrap(),
+            address
+        );
+    }
+
+    #[test]
+    fn shielded_address_rejects_invalid_base58() {
+        assert_eq!(
+            "not-an-address".parse::<ShieldedAddress>().unwrap_err(),
+            KeypairError::InvalidAddressEncoding
+        );
+    }
+
+    #[test]
+    fn shielded_address_rejects_bad_checksum() {
+        let address = ShieldedKeypair::new().unwrap().shielded_address().unwrap();
+        let encoded = address.to_string();
+        let mut bytes = bs58::decode(encoded).into_vec().unwrap();
+        bytes[1 + PUBLIC_KEY_LEN] ^= 1;
+        let corrupted = bs58::encode(bytes).into_string();
+
+        assert_eq!(
+            corrupted.parse::<ShieldedAddress>().unwrap_err(),
+            KeypairError::InvalidAddressChecksum
+        );
+    }
+
+    #[test]
+    fn shielded_address_rejects_unsupported_version() {
+        let address = ShieldedKeypair::new().unwrap().shielded_address().unwrap();
+        let unsupported = bs58::encode(address.to_bytes())
+            .with_check_version(ADDRESS_VERSION + 1)
+            .into_string();
+
+        assert_eq!(
+            unsupported.parse::<ShieldedAddress>().unwrap_err(),
+            KeypairError::UnsupportedAddressVersion(ADDRESS_VERSION + 1)
+        );
+    }
+
+    #[test]
+    fn shielded_address_rejects_wrong_payload_length() {
+        // Valid Base58Check (correct checksum + supported version) but a payload of
+        // the wrong length must be rejected, not silently truncated.
+        let short = bs58::encode([0u8; 10])
+            .with_check_version(ADDRESS_VERSION)
+            .into_string();
+        assert_eq!(
+            short.parse::<ShieldedAddress>().unwrap_err(),
+            KeypairError::InvalidAddressLength {
+                expected: ADDRESS_PAYLOAD_LEN,
+                actual: 11,
+            }
+        );
+    }
+
+    #[test]
+    fn shielded_address_encoding_is_stable() {
+        let p256 = P256Pubkey::from_bytes(crate::constants::P_CONST_SEC1).unwrap();
+        let address = ShieldedAddress {
+            signing_pubkey: PublicKey::from_p256(&p256),
+            nullifier_pubkey: [1u8; 32],
+            viewing_pubkey: p256,
+        };
+        let encoded = address.to_string();
+
+        assert_eq!(
+            encoded,
+            "FkYvNS9oCrskJGJVc2aXYqkdMErt96rVfudRRQwh3peWnFRdmjcs2ar17jS4ohnmbqdXAKceJUpVJvJrMk18qx3bMRVyudYaCDFdXqMTN7P2YggUxx9t5JtHHMnoLhBtRzhuXsKv55knX"
+        );
+        assert_eq!(encoded.parse::<ShieldedAddress>().unwrap(), address);
     }
 }


### PR DESCRIPTION
Supersedes and collapses #123 and #124.

## Commits
1. `feat(keypair): encode shielded addresses` — versioned Base58Check codec for the full `ShieldedAddress` (signing / nullifier / viewing keys). Required by the confidential recipient slot, which is tagged by and proof-bound to the recipient's signing pubkey (see `docs/spec.md` `RecipientSlot` / default-zone tagging).
2. `feat(cli): shielded-address and pay-by-pubkey wallet flow` — the wallet CLI on a self-contained shielded identity, with `transfer`/`deposit --to` accepting a shielded address (direct) or a Solana pubkey (user-registry lookup); an unregistered pubkey transfer silently falls back to a public withdrawal, a deposit to one errors.

## Why the full address (not the compressed `(owner_hash, viewing_pk)` form)
A default-zone confidential transfer writes the recipient's signing pubkey into the on-chain recipient slot and derives the output owner from it, so the sender needs the full address; `(owner_hash, viewing_pk)` is insufficient. The signing pubkey is published on-chain in every confidential transfer to that recipient anyway, so the address discloses nothing new. The compressed form remains the right primitive for anonymous policy-zone transfers (a separate feature).

## Validation
- `cargo test -p zolana-cli` / `-p zolana-client`; `cargo clippy -- -D warnings`; `cargo fmt --check`.
- Localnet wallet-cli e2e (`just test-localnet-e2e-photon`) deploys the user-registry program and covers the SOL+SPL cycle, direct shielded-address transfers, the public-withdrawal fallback, and registered pay-by-pubkey.
