### PR TITLE
Reject transact with both public amounts (C-01)

### DIFF
--- a/program-libs/interface/src/error.rs
+++ b/program-libs/interface/src/error.rs
@@ -67,6 +67,8 @@ pub enum ShieldedPoolError {
     MismatchedTransactProofRail = 7021,
     #[error("zone_authority_transact is disabled for this zone")]
     ZoneAuthorityTransactDisabled = 7022,
+    #[error("transact sets both public_sol_amount and public_spl_amount; at most one is allowed")]
+    BothPublicAmountsSet = 7023,
 }
 
 impl From<ShieldedPoolError> for ProgramError {
@@ -126,6 +128,7 @@ mod tests {
             (InvalidMergeOutputScheme as u32, 7020),
             (MismatchedTransactProofRail as u32, 7021),
             (ZoneAuthorityTransactDisabled as u32, 7022),
+            (BothPublicAmountsSet as u32, 7023),
         ];
         for (got, want) in table {
             assert_eq!(got, want, "error code drifted");

--- a/program-tests/shielded-pool/Cargo.toml
+++ b/program-tests/shielded-pool/Cargo.toml
@@ -88,3 +88,7 @@ path = "tests/transact/shield_withdraw.rs"
 [[test]]
 name = "p256"
 path = "tests/transact/p256.rs"
+
+[[test]]
+name = "both_amounts"
+path = "tests/transact/both_amounts.rs"

--- a/program-tests/shielded-pool/tests/transact/both_amounts.rs
+++ b/program-tests/shielded-pool/tests/transact/both_amounts.rs
@@ -8,23 +8,46 @@
 
 #[path = "../common/setup.rs"]
 mod common;
-#[path = "../common/transact.rs"]
-mod transact_common;
 
 use solana_keypair::Keypair;
 use solana_message::Message;
 use solana_signer::Signer;
 use solana_transaction::Transaction;
 use zolana_interface::{
-    instruction::{Transact, TransactSplWithdrawal, TransactWithdrawal},
+    instruction::{
+        instruction_data::transact::{InputUtxo, OutputCiphertext, TransactIxData, TransactProof},
+        Transact, TransactSplWithdrawal, TransactWithdrawal,
+    },
     pda,
 };
 use zolana_program_test::ZolanaProgramTest;
 
-use crate::transact_common::{eddsa_input_utxo, fe, ix_output_ciphertext, new_transact_ix_data};
-
 /// Error code for `ShieldedPoolError::BothPublicAmountsSet`.
 const BOTH_PUBLIC_AMOUNTS_SET: u32 = 7023;
+
+/// A field element holding `value` in its low 8 bytes (big-endian).
+fn fe(value: u64) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[24..].copy_from_slice(&value.to_be_bytes());
+    out
+}
+
+fn input(nullifier_hash: [u8; 32]) -> InputUtxo {
+    InputUtxo {
+        nullifier_hash,
+        nullifier_tree_root_index: 0,
+        utxo_tree_root_index: 0,
+        tree_index: 0,
+        eddsa_signer_index: 0,
+    }
+}
+
+fn ciphertext(view_tag: [u8; 32]) -> OutputCiphertext {
+    OutputCiphertext {
+        view_tag,
+        data: Vec::new(),
+    }
+}
 
 fn send_raw(
     rpc: &mut ZolanaProgramTest,
@@ -66,18 +89,26 @@ fn both_public_amounts_are_rejected() {
     rpc.mint_to(&mint, &attacker_ata, 1_000).expect("mint dust");
 
     // Both amounts set: +1 SOL and +1000 SPL.
-    let mut ix_data = new_transact_ix_data(
-        vec![eddsa_input_utxo(fe(101), 0), eddsa_input_utxo(fe(102), 0)],
-        Some(1_000_000_000),
-        vec![[1u8; 32], [2u8; 32], [3u8; 32]],
-        vec![
-            ix_output_ciphertext([1u8; 32]),
-            ix_output_ciphertext([2u8; 32]),
-            ix_output_ciphertext([3u8; 32]),
+    let ix_data = TransactIxData {
+        proof: TransactProof::zeroed_eddsa(),
+        expiry_unix_ts: u64::MAX,
+        relayer_fee: 0,
+        private_tx_hash: [0u8; 32],
+        p256_signing_pk_field: None,
+        tx_viewing_pk: [0u8; 33],
+        salt: [0u8; 16],
+        inputs: vec![input(fe(101)), input(fe(102))],
+        public_sol_amount: Some(1_000_000_000),
+        public_spl_amount: Some(1_000),
+        data_hash: None,
+        zone_data_hash: None,
+        output_utxo_hashes: vec![[1u8; 32], [2u8; 32], [3u8; 32]],
+        output_ciphertexts: vec![
+            ciphertext([1u8; 32]),
+            ciphertext([2u8; 32]),
+            ciphertext([3u8; 32]),
         ],
-        None,
-    );
-    ix_data.public_spl_amount = Some(1_000);
+    };
 
     let ix = Transact {
         payer: attacker.pubkey(),

--- a/program-tests/shielded-pool/tests/transact/both_amounts.rs
+++ b/program-tests/shielded-pool/tests/transact/both_amounts.rs
@@ -1,0 +1,123 @@
+//! C-01 regression: a both-amounts `transact` used to mint an unbacked note,
+//! because the parser settles one asset (SPL when `public_spl_amount` is set)
+//! while the proven SOL leg never moved. The fix rejects both-present up front.
+//!
+//! Asserts the program returns `BothPublicAmountsSet` (7023) and moves no tokens.
+//! The reject precedes proof verification, so no real proof is needed. Skips when
+//! the program `.so` is missing.
+
+#[path = "../common/setup.rs"]
+mod common;
+#[path = "../common/transact.rs"]
+mod transact_common;
+
+use solana_keypair::Keypair;
+use solana_message::Message;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+use zolana_interface::{
+    instruction::{Transact, TransactSplWithdrawal, TransactWithdrawal},
+    pda,
+};
+use zolana_program_test::ZolanaProgramTest;
+
+use crate::transact_common::{eddsa_input_utxo, fe, ix_output_ciphertext, new_transact_ix_data};
+
+/// Error code for `ShieldedPoolError::BothPublicAmountsSet`.
+const BOTH_PUBLIC_AMOUNTS_SET: u32 = 7023;
+
+fn send_raw(
+    rpc: &mut ZolanaProgramTest,
+    ix: solana_instruction::Instruction,
+    payer: &Keypair,
+) -> Result<(), String> {
+    let blockhash = rpc.svm.latest_blockhash();
+    let msg = Message::new(&[ix], Some(&payer.pubkey()));
+    let tx = Transaction::new(&[payer], msg, blockhash);
+    rpc.svm
+        .send_transaction(tx)
+        .map(|_| ())
+        .map_err(|e| format!("{e:?}"))
+}
+
+#[test]
+fn both_public_amounts_are_rejected() {
+    let Some(mut rpc) = common::program_test() else {
+        return;
+    };
+    let authority = Keypair::new();
+    rpc.create_protocol_config(&authority)
+        .expect("create protocol config");
+    let tree = rpc
+        .create_tree(common::tree_account_size(), &authority)
+        .expect("create tree");
+
+    let attacker = rpc.payer.insecure_clone();
+
+    // Valid SPL accounts, so the tx reaches the guard, not an earlier account error.
+    let mint = rpc.create_mint().expect("create mint");
+    rpc.ensure_asset_counter(&authority).expect("asset counter");
+    let (_registry, vault) = rpc
+        .create_spl_interface(&authority, &mint)
+        .expect("create spl interface");
+    let attacker_ata = rpc
+        .create_token_account(&mint, &attacker.pubkey())
+        .expect("attacker ata");
+    rpc.mint_to(&mint, &attacker_ata, 1_000).expect("mint dust");
+
+    // Both amounts set: +1 SOL and +1000 SPL.
+    let mut ix_data = new_transact_ix_data(
+        vec![eddsa_input_utxo(fe(101), 0), eddsa_input_utxo(fe(102), 0)],
+        Some(1_000_000_000),
+        vec![[1u8; 32], [2u8; 32], [3u8; 32]],
+        vec![
+            ix_output_ciphertext([1u8; 32]),
+            ix_output_ciphertext([2u8; 32]),
+            ix_output_ciphertext([3u8; 32]),
+        ],
+        None,
+    );
+    ix_data.public_spl_amount = Some(1_000);
+
+    let ix = Transact {
+        payer: attacker.pubkey(),
+        tree: tree.pubkey(),
+        withdrawal: Some(TransactWithdrawal::Spl(TransactSplWithdrawal {
+            cpi_authority: None,
+            spl_token_interface: vault,
+            recipient: attacker.pubkey(),
+            user_token_account: attacker_ata,
+            token_program: ZolanaProgramTest::token_program_id(),
+        })),
+        data: ix_data,
+    }
+    .instruction();
+
+    let ata_before = rpc.token_balance(&attacker_ata).unwrap_or(0);
+    let vault_before = rpc.token_balance(&vault).unwrap_or(0);
+    let sol_vault_before = rpc.svm.get_balance(&pda::sol_interface()).unwrap_or(0);
+
+    let err =
+        send_raw(&mut rpc, ix, &attacker).expect_err("both-amounts transact must be rejected");
+    assert!(
+        err.contains(&format!("Custom({BOTH_PUBLIC_AMOUNTS_SET})")),
+        "expected BothPublicAmountsSet ({BOTH_PUBLIC_AMOUNTS_SET}), got: {err}"
+    );
+
+    // The guard fires before settlement, so nothing moved.
+    assert_eq!(
+        rpc.token_balance(&attacker_ata).unwrap_or(0),
+        ata_before,
+        "no SPL debited"
+    );
+    assert_eq!(
+        rpc.token_balance(&vault).unwrap_or(0),
+        vault_before,
+        "no SPL credited"
+    );
+    assert_eq!(
+        rpc.svm.get_balance(&pda::sol_interface()).unwrap_or(0),
+        sol_vault_before,
+        "no SOL moved"
+    );
+}

--- a/programs/shielded-pool/src/instructions/transact/processor.rs
+++ b/programs/shielded-pool/src/instructions/transact/processor.rs
@@ -93,6 +93,12 @@ pub(crate) fn process_transact_core<const IS_ZONE: bool, const IS_AUTHORITY: boo
     current_slot: u64,
     discriminator: u8,
 ) -> ProgramResult {
+    // The parser picks one settlement branch, so both amounts set would move only
+    // SPL while the proven SOL leg never settles: an unbacked note. Reject first.
+    if ix.public_sol_amount.is_some() && ix.public_spl_amount.is_some() {
+        return Err(ShieldedPoolError::BothPublicAmountsSet.into());
+    }
+
     let tree_write = {
         let output_tree = transact_accounts.tree.address().to_bytes();
         // Note currently only one tree is supported for the entire protocol

--- a/prover/server/circuits/spp_transaction/balance_test.go
+++ b/prover/server/circuits/spp_transaction/balance_test.go
@@ -281,6 +281,40 @@ func TestCircuitAcceptsPublicSplWithdraw(t *testing.T) {
 	assert.SolvingSucceeded(circuit, assignment, test.WithCurves(ecc.BN254))
 }
 
+// C-01: the balance circuit conserves SOL and the public SPL asset on independent
+// per-asset equations with no mutual-exclusion constraint, so one proof may carry
+// both a positive publicSolAmount and a positive publicSplAmount and mint value in
+// both assets at once. This is the enabling condition for the on-chain settlement
+// bug (the program settles only the SPL leg, leaving the SOL leg unbacked). A
+// mutual-exclusion constraint here would make this witness unsatisfiable.
+func TestCircuitAcceptsSimultaneousSolAndSplDeposit(t *testing.T) {
+	assert := test.NewAssert(t)
+	shape := protocol.Shape{NInputs: 2, NOutputs: 2}
+	circuit := MustNewCircuit(Shape(shape))
+	solAsset := protocol.SolAsset()
+	splAsset := spptest.Fe(77)
+
+	// No prior value: both inputs are zero-amount; the two outputs are funded
+	// entirely by the two simultaneous public deposits (25 SOL and 25 SPL).
+	assignment := buildCircuitAssignmentFromUtxos(
+		t,
+		shape,
+		[]protocol.Utxo{
+			sampleUtxoWithAssetAndAmount(10, solAsset, spptest.Fe(0)),
+			sampleUtxoWithAssetAndAmount(20, splAsset, spptest.Fe(0)),
+		},
+		[]protocol.Utxo{
+			sampleUtxoWithAssetAndAmount(100, solAsset, spptest.Fe(25)),
+			sampleUtxoWithAssetAndAmount(110, splAsset, spptest.Fe(25)),
+		},
+		big.NewInt(25),
+		big.NewInt(25),
+		splAsset,
+	)
+
+	assert.SolvingSucceeded(circuit, assignment, test.WithCurves(ecc.BN254))
+}
+
 // The public SPL mint id must be 0 when no SPL amount moves: a balanced,
 // otherwise-valid transfer carrying a stray publicSplAssetPubkey is rejected,
 // so a no-public-SPL transaction cannot leak a mint id into the transcript.


### PR DESCRIPTION
A transact that set both public_sol_amount and public_spl_amount settled only the SPL leg - the account parser picks a single settlement branch while the proven SOL leg never moved, minting an unbacked SOL note.