### PR TITLE
feat: LLM pipeline that keeps docs/spec.md honest against the code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Edit(docs/spec-review/**)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git status:*)",
+      "Bash(just spec-gate:*)",
+      "Bash(cargo run -q -p xtask -- spec-gate:*)"
+    ]
+  }
+}

--- a/.claude/skills/spec-review/SKILL.md
+++ b/.claude/skills/spec-review/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: spec-review
+description: Audit docs/spec.md against the code (the code is the more recent truth) and against the SPEC_GUIDE production checklist, recording gaps as actionable findings; the fix mode rewrites the spec to production grade. Use for spec-vs-code drift, spec security audits, and bringing a spec to release quality. Runs interactively or headless (claude -p).
+argument-hint: "[full | diff [base] | fix]"
+---
+
+# Spec Review
+
+`docs/spec.md` is the protocol source of truth, but code moves faster and a spec
+can also be structurally incomplete. This skill measures the spec on two axes and
+records every gap in the operator-reviewed ledger `docs/spec-review/findings.md`:
+
+1. **Correctness** — does every claim match the code? (`spec-gap`, `code-bug`)
+2. **Completeness** — does the spec satisfy the `docs/SPEC_GUIDE.md` production
+   checklist? (`spec-quality`)
+
+`just spec-gate` fails CI while any finding is `status: open`.
+
+The default modes (`full`, `diff`) AUDIT only: the sole file they change is the
+ledger. The `fix` mode is a separate, operator-triggered pass that rewrites
+`docs/spec.md` to close the findings and lift the spec to production grade — see
+the `fix` section at the end. CI and the pre-commit hook never invoke `fix`.
+
+## Operating rules
+
+- **Code is newer than the spec.** A disagreement is presumed spec drift unless
+  the code looks wrong. Audit modes never touch code or `docs/spec.md`.
+- **Audit modes edit only** `docs/spec-review/findings.md` (append entries;
+  grammar in `references/findings-format.md`, new IDs = max existing + 1).
+- **Never change an existing ledger entry** in an audit mode. Only the operator,
+  or `fix` mode for findings it resolves, flips status.
+- **Write findings the way you would write the spec:** maximum information
+  density, no filler, no hedging. `references/spec-style.md` governs every word
+  you write, in findings and in the summary.
+- **Every finding is actionable.** It names the spec claim, the code truth with
+  a `file:line`, and the reader/implementer consequence. Every `spec-gap` and
+  `spec-quality` finding carries a `fix:` line stating the concrete correction —
+  that line is what `yolo-fix-spec` applies, so make it precise enough to act on
+  without re-reading the code.
+
+## What counts as a finding (relevance bar)
+
+Record a gap only when it changes what a reader would believe or build, or when
+it leaves the spec short of the production checklist. Rank by consequence
+(severity definitions in `references/findings-format.md`).
+
+Report:
+
+- A spec claim the code contradicts (wrong size, field name, order, derivation,
+  authority, tag, constant) → `spec-gap`.
+- A specified interface/instruction/field with no implementation, or an
+  implemented one the spec omits, when it affects how the protocol is used →
+  `spec-gap`.
+- A security-relevant divergence (`references/security-checklist.md`): missing
+  check, unbound input, broken invariant, over-broad authority, overclaimed
+  privacy → `spec-gap` (or `design-weakness` if the design itself is at fault).
+- A `SPEC_GUIDE` structural element the spec lacks (Trust Assumptions, Constants
+  table, Permission Matrix, a wire struct's visibility table, a named-error
+  table, an upgrade/versioning story, a recovery path) → `spec-quality`.
+- Code that contradicts the spec and looks wrong → `code-bug` (never patch the
+  spec to a bug).
+- Spec code-block comments that fail the justification test in
+  `references/spec-style.md` — comments that narrate a field, restate an
+  encoding/size/derivation already given by the type or a linked definition, or
+  were copied verbatim from the implementation → `spec-quality`. Report these
+  together as one finding per section, not one per comment.
+
+Do NOT report, and do NOT let these inflate the output:
+
+- Cosmetic prose wording or ordering that misleads no one.
+- Struct-field representation differences that yield the same on-chain bytes and
+  the same reader understanding (mention once, briefly, only if load-bearing).
+- Anything already in the ledger, at any status.
+- Implementation detail the spec deliberately abstracts (per `docs/CLAUDE.md`,
+  the spec links derivations instead of restating them — absence is not a gap).
+- Speculation. If you cannot cite the code, do not raise it.
+
+Merge findings that share a root cause into one entry. Ten load-bearing findings
+beat fifty that bury them — but never drop a real gap to hit a number.
+
+## Procedure
+
+### Phase 0 — Setup
+
+Read `docs/SPEC_GUIDE.md` (the house production checklist),
+`references/spec-best-practices.md` (RFC / standards conventions),
+`docs/CLAUDE.md`, `references/spec-style.md`, `references/security-checklist.md`,
+`references/section-map.md`, and the current ledger (existing IDs and claims —
+never re-report). `diff` mode: `git diff <base>...HEAD --name-only` (base
+defaults to `origin/main`), map changed files to section groups via the section
+map, restrict the audit to those groups; if no mapped code changed, report "no
+spec-relevant changes" and stop after the self-check.
+
+### Phase 1 — Correctness fan-out
+
+Launch one read-only subagent per in-scope section group (six in `full` mode;
+groups in `references/section-map.md`). Each subagent's contract:
+
+- Extract the section's verifiable claims (constants, layouts, derivations, hash
+  domains, account lists, validation rules, error conditions, state transitions,
+  privacy assertions).
+- Verify each against its code directories and return a row `claim | code
+  citation (file:line) | verdict | corrected wording`, verdict ∈ `match`,
+  `spec-stale`, `code-suspect`, `unclear`. Every non-`match` carries a
+  `file:line`; every `spec-stale` carries a one-sentence corrected wording (this
+  becomes the finding's `fix:` line).
+- Note any `SPEC_GUIDE` structural element the section should have but lacks.
+- Report a `MATCH_COUNT` and the list of what it verified as matching, so
+  coverage is attestable. Subagents report; they do not edit.
+
+### Phase 2 — Completeness sweep (orchestrator)
+
+Walk both checklists — `docs/SPEC_GUIDE.md` (house structure) and
+`references/spec-best-practices.md` (RFC / standards conventions) — against the
+whole spec and open a `spec-quality` finding for each production element absent
+or partial:
+
+- SPEC_GUIDE structure: Trust Assumptions, Constants table, Permission Matrix,
+  per-struct visibility tables, a named-error table, entry-point
+  validate-and-execute lists, the upgrade/versioning story, extended-downtime
+  recovery, failure-path diagrams, default-deny allow-lists.
+- Standards conventions: a Conventions section stating RFC 2119/8174 keyword use;
+  a Security Considerations section (RFC 3552 — threat model, what each mechanism
+  protects, residual risks, out-of-scope, documented open weaknesses); explicit
+  cryptographic-construction identification (proving system, BN254 field modulus,
+  per-circuit public-input vector, trusted-setup assumption, every KDF/hash named
+  with its label); a labeled-derivation registry; a References list of the
+  external standards used; test-vector coverage (or a link to where vectors live)
+  for the core derivations.
+
+Each finding's `fix:` names the section to add and the code (or standard) the
+content comes from. A documented residual risk is not bulk: prefer folding an
+open `design-weakness` into Security Considerations over a standalone caveat. Also check cross-cutting consistency and record
+as findings:
+
+- A constant/size/field stated inconsistently in two places in the spec.
+- A glossary term the code removed or renamed.
+- Mechanical link/vocabulary defects: run `just spec-lint`. It is deterministic
+  and authoritative for dead anchors, unresolvable relative links, and banned
+  vocabulary — never hand-derive slug rules or grep for links yourself.
+  Consolidate its violations into one finding. Judge its warnings: a TODO/TBD in
+  a normative section is a finding; an external link is a finding when it
+  duplicates in-repo content or points outside `docs/` for a protocol fact.
+
+### Phase 3 — Triage and ledger update
+
+Apply the relevance bar. Drop cosmetic and representation-only items. Merge by
+root cause. Run `references/security-checklist.md` against the confirmed claims
+and citations; each real weakness is a finding. Append the survivors to the
+ledger per the grammar, each with `type`, severity by consequence, and a `fix:`
+line for every `spec-gap`/`spec-quality`. Do not soften a finding to keep the
+gate green. Run `just spec-gate --syntax-only`; it must exit 0.
+
+Final terminal output, and nothing more:
+
+1. **Coverage** — per section group, the `MATCH_COUNT` and the `SPEC_GUIDE`
+   items confirmed present, so the operator can trust what was checked.
+2. **Findings opened** — ID, severity, type, one-line claim-vs-code.
+3. **Dropped at triage** — one line, so coverage shows without noise.
+
+In headless mode this summary is the entire visible result. Keep it dense.
+
+## `fix` mode (operator-triggered spec autofix)
+
+Invoked manually via `just yolo-fix-spec` (`claude -p "/spec-review fix"`), never
+by CI or the hook. The only mode that edits `docs/spec.md`. It closes the ledger
+findings the spec can settle and lifts the spec to production grade.
+
+Scope:
+
+- Edit `docs/spec.md` and `docs/spec-review/findings.md` only. Never touch code.
+- **`spec-gap`** — rewrite the spec text to the code's actual behavior, applying
+  the finding's `fix:` line. Minimal, local edits; restructure a section only
+  when a claim is unfixable in place.
+- **`spec-quality`** — add the missing element (Trust Assumptions, Constants,
+  Permission Matrix, visibility/error tables, Conventions, Security
+  Considerations, cryptographic-assumptions/labels, References, …) built from the
+  cited code and `references/spec-best-practices.md`, following
+  `docs/SPEC_GUIDE.md` layout and `references/spec-style.md`. Wire it into the
+  table of contents. For test vectors, do NOT fabricate values — add the section
+  with a pointer to where vectors are generated from code, or leave the finding
+  open if none exist.
+- **`design-weakness` / `code-bug`** — do NOT rewrite the spec to hide these;
+  they need a code change or a human decision. Leave them `open`. You MAY add a
+  neutral normative note where the spec would mislead (e.g. state the actual
+  privacy boundary), but never invent a guarantee the code does not provide.
+- Dead anchors / broken links — fix the link, or add the missing section/anchor
+  when the target content genuinely belongs.
+- The spec references only files under `./docs/`. If a fix would link elsewhere,
+  inline the fact instead.
+- Unimplemented-but-specified interfaces get a one-line **Status:** marker
+  (`interface specification; not implemented in this repository`), not deletion,
+  unless the finding says to remove them.
+
+Discipline for production quality:
+
+- **Definition-site rule.** Never write a number, size, field name, order, tag,
+  or derivation into the spec without having read its definition site in the
+  code during THIS run. A `fix:` line is direction, not evidence — cite-check it
+  before applying. If code and `fix:` disagree, the code wins; note the
+  discrepancy in the report.
+- **Net-line discipline.** A correction replaces text; it does not append beside
+  it. Target zero net prose growth for corrections. A new section earns each
+  line: every sentence and table row must carry a fact stated nowhere else. When
+  a rewrite lets you delete a now-redundant passage elsewhere, delete it.
+- Preserve the normative voice: MUST/SHOULD/MAY (RFC 2119), define-once-and-link,
+  no restated derivations, no review-process language in the spec.
+- Comment justification pass: over every code block you touch (and, in `full`
+  scope, every code block in the spec), apply the justification test in
+  `references/spec-style.md` — delete any comment that narrates a field, restates
+  an encoding/size/derivation already given by the type or a linked definition,
+  or was copied from the implementation. A comment present in the source code is
+  not thereby justified in the spec.
+- Change-justification annotations: every passage this mode edits or adds gets
+  one adjacent markdown comment, `<!-- ZSR-NNNN: why -->` — a single brief
+  sentence stating why the change appeared (the code truth or checklist gap
+  behind it), so the commit diff reviews itself. Invisible when rendered; the
+  operator may strip them after review. One comment per contiguous edit site,
+  not per line; never restate the finding body — compress it to its point.
+  Coverage is over the whole working diff: run `git diff HEAD -- docs/spec.md`
+  and annotate every un-annotated change site left by prior runs too, matching
+  each site to its ledger finding (skip the TOC and pure link-slug repairs —
+  those justify themselves). Place comments outside code fences and separated
+  from tables by a blank line; correct any existing annotation that misstates
+  its site.
+- Table cells hold at most two short sentences. Longer rationale moves to a
+  notes list after the table (SPEC_GUIDE pattern 30); a cell that needs a
+  paragraph is a section, not a row.
+- Every new number is named with a unit and a source; every new struct that
+  crosses a trust boundary gets a visibility note.
+
+Self-review before finishing (adversarial, on your own diff):
+
+1. Run `just spec-lint` — it must exit 0. Never hand-check links; the lint is
+   authoritative.
+2. Check no edit contradicts another section (a constant you changed in one
+   place is consistent everywhere — grep the old value).
+3. Re-read each edited passage against `references/spec-style.md` — no filler,
+   copula over inflated verbs, comments justified, dense table cells.
+4. **Independent verification.** For every heavy rewrite (a layout, a byte-size
+   arithmetic, a public-input list, a permission row), launch one read-only
+   subagent with ONLY the edited spec text and the code paths, asking it to
+   refute each concrete claim. Fix what it refutes; do not argue with it. Your
+   own re-read is not verification — a fresh context is.
+
+Then, for every finding you fully closed in the spec, set `status: auto-resolved`
+and add `resolved: <YYYY-MM-DD> spec updated`. Use `auto-resolved`, never
+`resolved`: these edits are machine-applied and unverified, so the status must
+record that provenance while still passing the gate (the fix ships through a
+reviewed PR). Leave `design-weakness` and `code-bug` findings `open`. Run
+`just spec-gate`; it passes once no finding is `open` — the auto-resolved ones do
+not trip it. Report the sections edited (with the finding ID each closes) and the
+findings left open with why.
+
+`--permission-mode acceptEdits` means this mode does not stop to ask — it does
+not mean the edits skip human review. Review `git diff docs/spec.md` before
+committing.

--- a/.claude/skills/spec-review/references/findings-format.md
+++ b/.claude/skills/spec-review/references/findings-format.md
@@ -1,0 +1,91 @@
+# Findings Ledger Format
+
+Single source of truth for the grammar of `docs/spec-review/findings.md`.
+Enforced by `xtask spec-gate` (`xtask/src/spec_gate.rs`); change them together.
+
+## File layout
+
+A free-form preamble (the `# Spec Review Findings Ledger` heading and prose),
+followed by zero or more entries. Every `## ` heading in the file must be an
+entry heading.
+
+## Entry grammar
+
+```markdown
+## ZSR-0001: <short title>
+- status: open
+- severity: high
+- type: design-weakness
+- code: programs/shielded-pool/src/instructions/transact/processor.rs:128
+- spec: docs/spec.md#merge
+- opened: 2026-07-17
+- fix: <one line: the concrete correction, so the fix pass need not re-derive it>
+- resolved: 2026-08-01 fixed by #241
+
+Free-form prose: what the spec claims, what the code does (with the citation),
+and the reader/implementer consequence. Bullet lines whose key is not a field
+name are treated as prose.
+```
+
+Rules:
+
+- Entry heading must match `## ZSR-NNNN: <title>` (exactly four digits,
+  non-empty title). IDs must be unique; new entries use max existing ID + 1.
+- Required fields, each exactly once per entry, non-empty:
+  - `status`: `open` | `acknowledged` | `resolved` | `auto-resolved`
+  - `severity`: `critical` | `high` | `medium` | `low` | `info`
+  - `type`: `design-weakness` | `spec-gap` | `code-bug` | `spec-quality`
+  - `code`: `path[:line]` of the most relevant code location (for a
+    `spec-quality` structural gap, cite the code the missing section would
+    document, or `docs/SPEC_GUIDE.md:<line>` for the requirement)
+  - `spec`: `docs/spec.md#<anchor>` of the affected (or missing) spec section
+  - `opened`: `YYYY-MM-DD`
+- Optional fields:
+  - `fix`: one line stating the concrete correction. Strongly recommended for
+    every `spec-gap` / `spec-quality` finding — it is what `yolo-fix-spec`
+    applies, so a precise `fix` line makes the autofix deterministic.
+  - `resolved`: date plus short note; set when status becomes `resolved`.
+- A trailing ` # comment` on a field line is stripped before validation.
+- Entries are never deleted; the operator (or `yolo-fix-spec`) flips `status`
+  and fills `resolved`.
+
+## Lifecycle
+
+- `open` — recorded by the skill, unreviewed. Fails `spec-gate` (and CI). The
+  only status that fails the gate.
+- `acknowledged` — operator has reviewed; accepted risk or tracked elsewhere.
+  Passes the gate.
+- `auto-resolved` — closed in the spec by `yolo-fix-spec`, machine-applied and
+  not yet human-verified. Passes the gate (the fix landed and ships through a
+  reviewed PR), but stays distinct from `resolved` so an operator can spot-check
+  the autofix. Only `yolo-fix-spec` sets this.
+- `resolved` — addressed and human-verified (operator confirmed the spec edit,
+  or the code fix for a `code-bug`/`design-weakness` landed). Passes the gate;
+  kept as history.
+
+## Types
+
+- `design-weakness` — the protocol design itself has a weakness (security,
+  liveness, privacy); fixing it means changing the design, not the prose.
+- `spec-gap` — the spec disagrees with the code, is silent about implemented
+  behavior, or overclaims (privacy, restrictions). The correction is a spec
+  rewrite (`yolo-fix-spec` handles these).
+- `code-bug` — the code contradicts the spec and the code looks wrong; the
+  spec was deliberately NOT patched to match the bug. Needs a code change.
+- `spec-quality` — the spec is missing a structural element required for a
+  production-grade spec by `docs/SPEC_GUIDE.md` (Trust Assumptions, Constants
+  table, Permission Matrix, a wire struct's visibility table, a named-error
+  table, an entry-point validate-and-execute list, an upgrade/versioning
+  story, a recovery path, a failure-path diagram). Not a code disagreement;
+  a completeness gap. `yolo-fix-spec` fills these.
+
+Severity reflects reader/implementer consequence, not tone:
+
+- `critical` — a reader acting on the spec loses funds or privacy, or an
+  implementer ships an exploitable bug.
+- `high` — an implementer builds the wrong behavior, or a real security
+  weakness is undocumented.
+- `medium` — a reader forms a materially wrong belief about the protocol.
+- `low` — a precise reader is briefly misled or inconvenienced (stale number,
+  dead link, missing minor field).
+- `info` — worth recording, no reader is misled today.

--- a/.claude/skills/spec-review/references/section-map.md
+++ b/.claude/skills/spec-review/references/section-map.md
@@ -1,0 +1,65 @@
+# Spec Section → Code Map
+
+Maps `docs/spec.md` top-level sections to the code that implements them. Used
+for the verification fan-out (one subagent per group) and for scoping `diff`
+mode (a changed file selects every group that lists its directory).
+
+## Group 1 — Keys & addresses
+
+Sections: `# Shielded Address`, `# Signing Key`, `# Nullifier Key`,
+`# ViewingKey`
+
+Code: `sdk-libs/keypair/`, `sdk-libs/transaction/` (key derivation, view tags,
+encryption key handling), `prover/server/circuits/` (ownership/derivation
+constraints)
+
+## Group 2 — UTXO model & serialization
+
+Sections: `# UTXO` (hash, nullifier, empty UTXO),
+`# Output UTXO Serialization` (AES key derivation, UTXO data, Transfer,
+Plaintext Transfer, UTXO Split, Merge)
+
+Code: `sdk-libs/transaction/` (UTXO, wincode layouts, encryption),
+`program-libs/interface/src/instruction/instruction_data/`,
+`services/photon/` (decode side)
+
+## Group 3 — Proof systems
+
+Sections: `# SPP Proof - Solana Privacy ZK Proof`,
+`# Merge Proof - Merge ZK Proof`
+
+Code: `prover/server/circuits/spp_transaction/`, `prover/server/` (shapes,
+lazy key manager), `prover/client/`, `sdk-libs/client/src/shape.rs`,
+`program-libs/interface/src/verifying_keys/`
+
+## Group 4 — SPP program
+
+Sections: `# SPP - Solana Privacy Program` (Accounts, Instructions)
+
+Code: `programs/shielded-pool/src/`, `program-libs/interface/src/`
+(tags, builders, instruction data, state, error), `program-libs/` support
+crates (tree, event, account-checks)
+
+## Group 5 — Zone & ZK program interfaces
+
+Sections: `# Zone Program Interface`, `# ZK Program Interface`, the zone
+subsections of Architecture (`## Default Zone`, `## Policy Zones`)
+
+Code: `programs/shielded-pool/src/` (zone/CPI paths),
+`program-libs/interface/`, `sdk-tests/` zone/swap test programs
+
+## Group 6 — RPC & services
+
+Sections: `# RPC` (Indexer, Prover, Relayer, Zone RPC, Merge Service,
+Registry, Sync Delegate)
+
+Code: `services/photon/`, `prover/server/`, `prover/client/`, `forester/`,
+`sdk-libs/client/`, `sdk-libs/program-test/` (local harness behavior)
+
+## Cross-cutting (checked by the orchestrator, not fanned out)
+
+Sections: `# Architecture`, `# Glossary`, `# User Flows`, and any
+Constants / Trust Assumptions / Permission Matrix sections
+
+Code: whole workspace; constants live in `program-libs/interface/src/`
+(`constants`, tree parameters) and `prover/server/`

--- a/.claude/skills/spec-review/references/security-checklist.md
+++ b/.claude/skills/spec-review/references/security-checklist.md
@@ -1,0 +1,79 @@
+# Security Audit Checklist (Phase 4)
+
+Audit the *design as specified and implemented*, not code style. For each item,
+either confirm the property with a code citation or open a ledger finding.
+Weaknesses in the general design are `type: design-weakness`; the skill never
+fixes code.
+
+## Double-spend & nullifiers
+
+- Nullifier uniqueness across the full queue/tree window: can a nullifier be
+  inserted twice across queue rotation, batch boundaries, or forester lag?
+- Bloom filter false-positive policy: what happens to an honest transaction on
+  a false positive, and can an attacker grind one to censor a victim?
+- Nullifier domain separation: are nullifiers, padding/reserved nullifiers,
+  and merge tags in disjoint namespaces? Can any instruction pin or reserve a
+  value another user would legitimately produce?
+- Padding inputs/outputs: are padding UTXOs and their nullifiers bound to the
+  proof so they cannot be substituted or replayed?
+
+## Proof binding
+
+- Is every user-controlled instruction field bound into the proof's public
+  inputs (amounts, recipients, hashes such as `private_tx_hash`, `data_hash`,
+  `zone_data_hash`, fee fields, payer binding)? List any unbound field.
+- Public input hash construction: any malleability (length extension, field
+  overflow, ambiguous concatenation) in how public inputs are hashed?
+- Root freshness: which historical roots are accepted, and can a stale root
+  enable spending pruned or reorged state?
+
+## Rails (EdDSA vs P256)
+
+- Are the two rails' proofs, verifying keys, and BSB22 commitment handling
+  strictly separated (a proof for one rail can never verify under the other)?
+- Signer binding per rail: eddsa signer index vs P256 ownership — can a UTXO
+  owned under one rail be spent via the other?
+
+## Zones & CPI
+
+- Zone authority checks: can a zone program be impersonated, or a
+  zone-authority instruction be invoked outside the intended CPI context?
+- Are zone data hashes bound to the proof and to the executing zone program id?
+
+## Value conservation
+
+- Sum checks across inputs, outputs, public deposit/withdraw amounts, and
+  fees — including edge shapes (all-padding inputs, zero-amount outputs) and
+  both-public-amounts cases.
+
+## Privacy claims
+
+- For every "Private"/"Visible" claim in the spec (sender, recipient, amount,
+  zone), does the implementation actually deliver it (e.g. payer binding on
+  withdraw reveals sender unless relayed)? Overclaims are findings.
+- View tags, encrypted UTXO layout, and sender slots: any metadata leak
+  (lengths, orderings, deterministic ephemerals) that links transactions?
+
+## Keys & derivation
+
+- Key hierarchy: does compromise of a viewing/transaction key stay contained
+  (no escalation to spend authority)?
+- Deterministic derivations: can any derived key or ephemeral repeat across
+  transactions in a way that links or leaks (see spec TODO on viewing-key
+  repetition)?
+
+## Liveness & operators
+
+- Forester: single-authority liveness dependency; what stalls (nullifier
+  queue, batches) if it halts or censors, and is that documented in Trust
+  Assumptions?
+- Relayer fee griefing: can a relayer front-run, censor, or extract value from
+  a queued transaction beyond the agreed fee?
+- Prover and indexer trust: confirm they are untrusted for safety (only
+  liveness/privacy), and that the spec's trust table matches reality.
+
+## Upgrade & governance
+
+- Who can change protocol config, trees, verifying keys, or authorities, and
+  is every privileged instruction listed in the Permission Matrix with the
+  correct signer?

--- a/.claude/skills/spec-review/references/spec-best-practices.md
+++ b/.claude/skills/spec-review/references/spec-best-practices.md
@@ -1,0 +1,96 @@
+# Spec Best Practices (RFC / standards conventions)
+
+Authoritative conventions for a production cryptographic-protocol spec, distilled
+to what `docs/spec.md` (a ZK confidential-transfer protocol on Solana) must
+satisfy. `docs/SPEC_GUIDE.md` covers house structure; this file covers the
+standards-body conventions on top of it. Each item states the rule, its source,
+and what the audit flags (`spec-quality` unless noted). Apply the same
+density discipline as everywhere else — these add rigor, not bulk.
+
+## Normative language (RFC 2119 + RFC 8174)
+
+- The spec MUST carry a Conventions section stating that MUST / MUST NOT /
+  REQUIRED / SHALL / SHOULD / SHOULD NOT / MAY / OPTIONAL are RFC 2119 keywords,
+  and — per RFC 8174 — are normative ONLY when in uppercase. A lowercase "must"
+  is prose, not a requirement.
+- Each normative statement is atomic and testable: one assertion, verifiable by
+  inspection or a test. "The verifier MUST reject X and SHOULD log Y" is two
+  requirements; split them.
+- Audit: flag a missing Conventions section; flag a normative-sounding lowercase
+  keyword in a checks/validation list (an implementer could miss the
+  requirement).
+
+## Security Considerations (RFC 3552 / BCP 72)
+
+A cryptographic protocol spec MUST have a Security Considerations section that
+states, concisely:
+
+- The threat model: which parties are adversarial and their capabilities (ties
+  to [Trust Assumptions](../../../docs/spec.md); do not duplicate the table,
+  reference it).
+- What each mechanism protects and against whom (double-spend, forgery,
+  linkability, front-running).
+- Residual risks and explicitly out-of-scope threats (RFC 3552 requires stating
+  what is NOT protected — e.g. metadata timing, RPC-operator tag linkage,
+  server-side-prover disclosure).
+- Known unresolved weaknesses. Open `design-weakness` findings belong here as
+  documented residual risk, not hidden.
+
+Audit: absence is a `spec-quality` finding (medium — a crypto spec without it is
+not review-ready). A design weakness that exists in code but is undocumented in
+Security Considerations is a `spec-gap`.
+
+## Cryptographic assumptions and construction identification
+
+State once, explicitly (norm from RFC 9180 §9, ZK review practice):
+
+- Proving system, curve, and field: Groth16 over BN254, with the field modulus
+  named. For each circuit: the ordered public-input vector, the trusted-setup
+  assumption (per-shape structured reference string), and that security rests on
+  knowledge-soundness plus a correctly-run setup ceremony.
+- Every KDF/hash is identified with its primitive and domain-separation label:
+  HKDF-SHA256 (RFC 5869) with the exact `info`/label string; hash-to-curve is
+  `P256_XMD:SHA-256_SSWU_RO_` (RFC 9380); SHA-256 is FIPS 180-4; P-256/SEC1 for
+  point encoding. Tabulate every label and context string once (a labeled-
+  derivation registry), so an implementer reproduces bytes exactly.
+- Audit: an unnamed primitive, an underivable label, or a missing field modulus
+  is a `spec-gap`.
+
+## Wire format and encoding
+
+- State endianness once and apply it uniformly; every multi-byte integer's
+  encoding must be unambiguous (RFC 8446 presentation-language discipline).
+- Every serialized struct that crosses a trust boundary has a visibility table
+  (SPEC_GUIDE 10) and a fixed field order matching the code.
+- Length prefixes, presence bytes, and discriminators are specified exactly (a
+  decoder built from the spec must round-trip the code's bytes).
+
+## Interoperability: test vectors (RFC 9180 §A style)
+
+Cryptographic derivations SHOULD ship known-answer test vectors (or link to
+where they live in the repo) for: `owner_hash`, `nullifier`, each view-tag
+family, the transaction-viewing-key derivation, and the HPKE/merge encryption.
+A vector fixes inputs → expected output so independent implementations agree.
+Audit: absence is a low-severity `spec-quality` finding; do not fabricate
+vectors — flag them for generation from code.
+
+## Versioning and downgrade (RFC 8446 / RFC 9000 discipline)
+
+- State how verifying keys and circuits rotate, how a client selects the version
+  in force, and the behavior when parts of the stack are stale.
+- Every extensible wire object carries a version/type discriminator, and every
+  hash domain over it folds the discriminator in (SPEC_GUIDE 21). Default-deny
+  unknown discriminators (SPEC_GUIDE 20).
+
+## References
+
+A production spec cites the external standards it depends on (RFC 7322): list
+RFC 2119, RFC 8174, RFC 5869, RFC 9380, RFC 9180, FIPS 180-4, SEC1, and the
+proving-system / BN254 references. Cite the standard, not a tutorial; keep the
+list to what the protocol actually uses.
+
+## Informative vs normative
+
+Mark examples, diagrams, and size tables as informative; the normative text is
+the source of truth. An example that contradicts the normative text is a defect
+in the example, not the rule.

--- a/.claude/skills/spec-review/references/spec-style.md
+++ b/.claude/skills/spec-review/references/spec-style.md
@@ -1,0 +1,113 @@
+# Spec Prose Style
+
+Rules for any text written into `docs/spec.md`. Derived from `docs/SPEC_GUIDE.md`,
+`docs/CLAUDE.md`, and the avoid-ai-writing skill (docs/technical profile).
+Violations in existing spec text are fair game to fix during an edit pass, but
+never rewrite prose that carries no defect.
+
+## Worked examples (imitate these)
+
+The single most useful calibration. Each pair is a real defect class → its fix.
+
+Restated size (delete the comment; the type/constant already says it):
+- Before: `encrypted_utxo: Vec<u8>, // single ciphertext bundle, exactly 110 B`
+- After:  `encrypted_utxo: Vec<u8>,` — with the 110 B named once, in [Constants].
+
+Field narration (delete; the field name already says it):
+- Before: `blinding: [u8; 31], // random blinding for the output`
+- After:  `blinding: [u8; 31],`
+
+Copula avoidance → plain copula:
+- Before: "The nullifier serves as the double-spend guard and features a
+  per-owner secret."
+- After:  "The nullifier is the double-spend guard; it binds the owner's
+  `nullifier_secret`."
+
+Correction that appends instead of replaces (rewrite in place, no growth):
+- Before: "The proof is 192 bytes. (Note: the eddsa rail is 128 bytes.)"
+- After:  "The proof is 128 bytes on the eddsa rail, 192 on the P256 rail."
+
+Overloaded table cell → row plus a note:
+- Before: one cell with four sentences of caveats.
+- After:  a two-clause cell, and the caveats in a notes list under the table.
+
+## Information density
+
+- Every sentence states a fact, constraint, or rationale. If a sentence
+  restates the previous one in fresh words, cut it.
+- Prefer "X is Y" and "X has Y" over "X serves as Y", "X features Y",
+  "X represents Y".
+- No filler: "it's worth noting", "importantly", "note that", "in order to",
+  "at its core", "comprehensive", "robust", "leverage", "seamless", "delve".
+- No hedge stacks ("could potentially", "may eventually"). Normative text uses
+  RFC 2119 keywords; descriptive text states what the code does.
+- No significance inflation. State the mechanism; the reader judges importance.
+- One idea per sentence. Imperative mood for procedures. Numbered steps for
+  entry-point checks.
+- Repeat the precise term instead of cycling synonyms. If the word is
+  `nullifier`, write `nullifier` every time.
+- Bold sparingly; never bold-label bullet lists that restate their own label.
+- Tables for enumerable facts only. A cell holds at most two short sentences;
+  longer rationale goes in a notes list after the table. A cell that needs a
+  paragraph is a section, not a row.
+- Correcting text replaces it in place. Never leave the stale claim beside a
+  parenthetical fix; a corrected passage should not be longer than the original
+  unless the added length is new fact.
+
+## Banned vocabulary (docs/CLAUDE.md)
+
+- "the wire" (write: instruction data, transaction data, serialized form)
+- "written by" for chain data (transactions are sent, not written)
+- "wall time"
+- "folded into"
+
+## Definitions and links
+
+- Define every type, constant, and derivation exactly once; link `[term](#anchor)`
+  everywhere else. Never restate an encoding, size, or derivation that a type,
+  the glossary, or a linked definition already states.
+- Links target anchors inside `docs/spec.md` or files under `docs/` only.
+  Never link repository code, the findings ledger, review tooling, or external
+  URLs that duplicate in-repo content.
+- The spec describes the protocol. It never mentions the review process, its
+  own revision history, open findings, or implementation-status caveats framed
+  as review output. Behavior that exists is specified; behavior that does not
+  exist is absent or marked as a plain normative requirement.
+
+## Implementation-status markers
+
+A production spec may describe an interface that is designed but not yet built.
+Mark it once, at the top of its section, as a plain fact:
+
+> **Status.** Interface specification; not implemented in this repository.
+
+Do not scatter "not yet", "TODO", or "will be" through the prose, and never
+frame the marker as review output. An interface with no status marker is
+asserted to exist and match the code. Remove a marker only when the code lands.
+
+## Comments in spec code blocks
+
+Every comment must justify its existence by adding protocol understanding a
+reader cannot get from the code itself. The test: delete the comment — if the
+struct field, type, glossary entry, or linked definition already conveys it, the
+comment was noise and stays deleted. A comment earns its line ONLY by stating a
+protocol invariant, a security constraint, a role/purpose, or a non-obvious
+layout decision.
+
+Markdown comments (`<!-- ... -->`) are exempt from the no-review-process rule:
+the fix mode annotates each edit site with one — `<!-- ZSR-NNNN: why -->` — so
+the commit diff carries its own justification. They never render; keep each to
+one sentence.
+
+Strip, even when the same comment exists in the implementation code:
+
+- Narration of the field it sits on (`// the user's pubkey` on `user_pubkey`).
+- Restatement of an encoding, size, or derivation the type or a linked
+  definition already gives (`// 32 bytes` on `[u8; 32]`, `// SHA-256 of ...`
+  next to a field whose derivation is defined elsewhere — link instead).
+- Comments carried over from source that describe the implementation rather than
+  the protocol.
+
+The spec is not the code with prose around it; a comment that survives into the
+spec must teach the protocol. Code-block comments obey the same
+banned-vocabulary rules as prose.

--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,9 @@ ZOLANA_PORT_OFFSET=0
 # ZOLANA_LOCALNET_PHOTON_URL=http://127.0.0.1:8784
 # ZOLANA_INDEXER_URL=http://127.0.0.1:8784
 # ZOLANA_PROVER_URL=http://127.0.0.1:3001
+
+# Anthropic API key for the headless spec review recipes (`just spec-review`,
+# `just spec-review-diff`). `set dotenv-load` exports it to the `claude` CLI.
+# Not needed when your local `claude` is already logged in; in CI the
+# spec-review.yml analysis job takes it from the ANTHROPIC_API_KEY repo secret.
+# ANTHROPIC_API_KEY=sk-ant-...

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Spec-review findings gate. Opt-in: enable with `just install-hooks`
+# (sets core.hooksPath .githooks); bypass a single commit with --no-verify.
+set -euo pipefail
+
+just spec-gate
+just spec-lint
+
+# Optional deep check: SPEC_REVIEW_PRECOMMIT=full additionally runs a
+# diff-scoped headless spec review (slow, requires the `claude` CLI).
+if [[ "${SPEC_REVIEW_PRECOMMIT:-}" == "full" ]]; then
+    just spec-review-diff HEAD
+    just spec-gate
+fi

--- a/.github/workflows/spec-review.yml
+++ b/.github/workflows/spec-review.yml
@@ -1,0 +1,95 @@
+name: spec-review
+
+# Separate from rust.yml because that workflow ignores "**/*.md" paths and
+# would skip exactly the spec/ledger changes this must gate.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: Spec review scope for the headless analysis job
+        type: choice
+        options: [full, diff]
+        default: full
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  # Deterministic ledger gate: fails while docs/spec-review/findings.md has any
+  # `status: open` entry. Runs on every PR; needs no API key.
+  gate:
+    name: findings ledger gate
+    runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/setup-rust
+        with:
+          shared-key: spec-gate
+          private-libs-token: ${{ secrets.PRIVATE_LIBS_TOKEN }}
+      - run: just spec-gate
+      - run: just spec-lint
+
+  # Headless spec refinement: runs the spec-review skill via `claude -p`,
+  # then uploads any resulting spec/ledger edits as a patch artifact and fails
+  # so an operator applies them through a normal PR (this workflow never
+  # writes to the repository; see enforce-pr-only.yml).
+  analysis:
+    name: headless spec review (${{ inputs.scope }})
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-rust
+        with:
+          shared-key: spec-gate
+          private-libs-token: ${{ secrets.PRIVATE_LIBS_TOKEN }}
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+      - name: Run spec review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [[ "${{ inputs.scope }}" == "diff" ]]; then
+            just spec-review-diff origin/main
+          else
+            just spec-review
+          fi
+      - name: Collect spec edits
+        id: collect
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git diff > spec-review.patch
+            echo "dirty=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "dirty=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Upload spec review patch
+        if: steps.collect.outputs.dirty == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: spec-review-patch
+          path: spec-review.patch
+      - name: Report ledger state
+        run: just spec-gate || true
+      - name: Require operator follow-up
+        if: steps.collect.outputs.dirty == 'true'
+        run: |
+          echo "The spec review produced edits. Download the spec-review-patch" >&2
+          echo "artifact, apply it on a branch (git apply spec-review.patch)," >&2
+          echo "and open a PR. This job fails so the result is not lost." >&2
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,15 @@
 test-ledger
 .DS_Store
 /.idea
-.claude
-docs
+# Ignore local Claude Code state but track the shared config and skills.
+/.claude/*
+!/.claude/settings.json
+!/.claude/skills/
+# Ignore stray docs by default; track the spec-review directory except the
+# findings ledger, which is local review state.
+/docs/*
+!/docs/spec-review/
+/docs/spec-review/findings.md
 experiments
 docs/api/
 docs/docs.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,26 @@
 implementation cleanup unless that is the explicit task. If code, tests, and the
 spec disagree, treat the code or tests as suspect first.
 
+## Spec Maintenance
+
+Spec refreshes run through the `spec-review` skill
+(`.claude/skills/spec-review/SKILL.md`): it compares `docs/spec.md` with the
+code, fixes stale spec text, security-audits the design, and appends findings
+to `docs/spec-review/findings.md` (gitignored local review state). `just
+spec-gate` (CI: `spec-review.yml`) fails while any finding is `status: open`
+and passes when no ledger exists; `yolo-fix-spec` marks the findings it
+closes `auto-resolved` (passes CI, distinct from operator `resolved`), and a
+human operator flips the rest to `acknowledged`/`resolved`. `just spec-lint` is
+the deterministic spec check (dead anchors, broken links, banned vocabulary) run
+by the gate job, the hook, and the skill's self-review. Headless audit runs:
+`just spec-review` / `just spec-review-diff` (these never edit the spec).
+`just yolo-fix-spec` is the operator-only autofix: it rewrites `docs/spec.md` to
+match the code for recorded drift and to production grade, then auto-resolves
+those findings — review `git diff docs/spec.md` before committing. Every fix
+edit carries an adjacent `<!-- ZSR-NNNN: why -->` markdown comment, so the diff
+justifies itself; strip them after review at will. The optional
+pre-commit gate (`spec-gate` + `spec-lint`) is enabled with `just install-hooks`.
+
 ## Repo Structure
 
 program-libs

--- a/docs/spec-review/README.md
+++ b/docs/spec-review/README.md
@@ -1,0 +1,44 @@
+# Spec Review Pipeline
+
+Keeps `docs/spec.md` truthful against the code and at production grade. The
+code moves faster than the spec; this pipeline measures the gap, records every
+divergence as an operator-reviewed finding, and can rewrite the spec to close
+it. CI stays red while a finding is unhandled, so drift cannot land silently.
+
+## Parts
+
+| Part | Role |
+| --- | --- |
+| `findings.md` (this directory) | The ledger: one entry per divergence, machine-parsed. Gitignored local review state — a clone without one gates nothing until an audit writes it. Grammar in `.claude/skills/spec-review/references/findings-format.md` |
+| `.claude/skills/spec-review/` | The review skill: audit modes compare spec vs code and append findings; fix mode rewrites the spec |
+| `xtask spec-gate` | Deterministic gate: exit 1 while any finding is `status: open` |
+| `xtask spec-lint` | Deterministic lint: dead anchors, unresolvable links, banned vocabulary |
+| `.github/workflows/spec-review.yml` | Runs gate + lint on every PR (no API key). A manual dispatch runs the headless review and uploads its edits as a patch artifact — it never writes to the repository |
+| `.githooks/pre-commit` | Opt-in local gate (`just install-hooks`); bypass once with `--no-verify` |
+
+## Use
+
+```bash
+just spec-gate            # fails while any finding is open
+just spec-lint            # anchors, links, vocabulary; warnings don't fail
+just spec-review          # headless audit: appends findings, never edits the spec
+just spec-review-diff     # audit only sections whose mapped code changed since origin/main
+just yolo-fix-spec        # operator-only: rewrite the spec to code truth, auto-resolve
+just install-hooks        # enable the pre-commit gate
+```
+
+The audit recipes need the `claude` CLI (logged in, or `ANTHROPIC_API_KEY` —
+see `.env.example`).
+
+## Finding lifecycle
+
+`open` trips the gate until someone acts. An operator flips it to
+`acknowledged` (risk accepted) or `resolved` (verified fixed).
+`yolo-fix-spec` flips the findings it settles to `auto-resolved` — passes the
+gate, but records that the edit is machine-applied and unverified, so it still
+ships through a reviewed PR. `design-weakness` and `code-bug` findings are
+never auto-resolved: they need a code change or a human decision.
+
+Every fix edit carries an adjacent `<!-- ZSR-NNNN: why -->` markdown comment —
+invisible when rendered — so `git diff docs/spec.md` justifies itself row by
+row. Strip them after review at will.

--- a/justfile
+++ b/justfile
@@ -563,6 +563,46 @@ xtask-create-verifying-keys-smoke:
     fi
     cargo run -p xtask -- create-verifying-keys --limit 1
 
+# === Spec review ===
+
+# Tools the headless skill needs, granted on the command line so they apply even
+# when the workspace has not been trust-dialog-accepted (the .claude/settings.json
+# allowlist is ignored in an untrusted headless workspace).
+spec-review-tools := "Read Grep Glob Task " + \
+    '"Bash(git diff:*)" "Bash(git log:*)" "Bash(git show:*)" "Bash(grep:*)" ' + \
+    '"Bash(just spec-gate:*)" "Bash(cargo run -q -p xtask -- spec-gate:*)" ' + \
+    '"Bash(just spec-lint:*)" "Bash(cargo run -q -p xtask -- spec-lint:*)" ' + \
+    '"Edit(docs/spec-review/**)"'
+
+# No API key needed; runs in CI on every PR.
+# Deterministic gate: fails while docs/spec-review/findings.md has open findings.
+spec-gate *args:
+    cargo run -q -p xtask -- spec-gate {{args}}
+
+# Deterministic spec lint: dead anchors, unresolvable links, banned vocabulary.
+spec-lint *args:
+    cargo run -q -p xtask -- spec-lint {{args}}
+
+# Requires the `claude` CLI; in CI additionally ANTHROPIC_API_KEY.
+# Headless spec-vs-code audit: appends findings to the ledger; never edits the spec.
+spec-review:
+    claude -p "/spec-review full" --output-format text --allowedTools {{spec-review-tools}}
+
+# Diff-scoped review of spec sections whose mapped code changed since `base`.
+spec-review-diff base="origin/main":
+    claude -p "/spec-review diff {{base}}" --output-format text --allowedTools {{spec-review-tools}}
+
+# Never run by CI or the hook. Review `git diff docs/spec.md` before committing.
+# Operator-only autofix: rewrites docs/spec.md to match code for recorded spec drift.
+# Adds Edit(docs/spec.md) to the audit tool set — the only recipe that may edit the spec.
+yolo-fix-spec:
+    claude -p "/spec-review fix" --output-format text \
+      --allowedTools {{spec-review-tools}} "Edit(docs/spec.md)"
+
+# Enable the repo git hooks (pre-commit spec gate). Opt-in; off by default.
+install-hooks:
+    git config core.hooksPath .githooks
+
 # === Maintenance ===
 
 metadata:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,9 @@ use std::{
 use sha2::{Digest, Sha256};
 
 mod init_protocol;
+mod spec_gate;
+mod spec_lint;
+mod term;
 mod update_protocol_config;
 
 fn main() {
@@ -64,6 +67,14 @@ fn main() {
                 eprintln!("update-protocol-config failed: {error:?}");
                 std::process::exit(1);
             }
+        }
+        Some("spec-gate") => {
+            let code = spec_gate::run(spec_gate::Options::parse(args.collect()));
+            std::process::exit(code);
+        }
+        Some("spec-lint") => {
+            let code = spec_lint::run(spec_lint::Options::parse(args.collect()));
+            std::process::exit(code);
         }
         Some("tx-size") => tx_size(args.collect()),
         Some("--help") | Some("-h") | None => print_help(),
@@ -302,6 +313,12 @@ fn print_help() {
     println!("  init-protocol            Initialize the protocol on a cluster (see --help)");
     println!("  update-protocol-config   Update protocol config flags on a cluster (see --help)");
     println!("  tx-size [N:M ...]        Compute serialized transaction sizes per circuit shape");
+    println!(
+        "  spec-gate                Fail while the spec-review findings ledger has open entries"
+    );
+    println!(
+        "  spec-lint                Check docs/spec.md for dead anchors, broken links, banned terms"
+    );
 }
 
 fn print_create_verifying_keys_help() {

--- a/xtask/src/spec_gate.rs
+++ b/xtask/src/spec_gate.rs
@@ -1,0 +1,456 @@
+//! Deterministic gate over the spec-review findings ledger.
+//!
+//! Parses `docs/spec-review/findings.md` and fails while any finding is
+//! `status: open`. The ledger grammar is specified in
+//! `.claude/skills/spec-review/references/findings-format.md`; this parser is
+//! the enforcement of that grammar. The ledger is gitignored local review
+//! state, so a missing file is clean: the gate binds wherever a ledger exists.
+//!
+//! Exit codes: 0 = clean (or no ledger), 1 = open findings, 2 = grammar violation.
+
+use std::{fs, path::PathBuf};
+
+const DEFAULT_LEDGER: &str = "docs/spec-review/findings.md";
+
+// Only `open` trips the gate. `auto-resolved` is set by `yolo-fix-spec` when it
+// closes a finding in the spec: it passes CI (the fix landed) but stays distinct
+// from operator-verified `resolved`.
+const STATUS_VALUES: [&str; 4] = ["open", "acknowledged", "resolved", "auto-resolved"];
+const SEVERITY_VALUES: [&str; 5] = ["critical", "high", "medium", "low", "info"];
+const TYPE_VALUES: [&str; 4] = ["design-weakness", "spec-gap", "code-bug", "spec-quality"];
+const REQUIRED_FIELDS: [&str; 6] = ["status", "severity", "type", "code", "spec", "opened"];
+const OPTIONAL_FIELDS: [&str; 2] = ["resolved", "fix"];
+
+#[derive(Debug)]
+pub struct Options {
+    ledger: PathBuf,
+    syntax_only: bool,
+}
+
+impl Options {
+    pub fn parse(args: Vec<String>) -> Self {
+        let mut ledger = PathBuf::from(DEFAULT_LEDGER);
+        let mut syntax_only = false;
+
+        let mut args = args.into_iter();
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--ledger" => {
+                    ledger = args.next().map(PathBuf::from).unwrap_or_else(|| {
+                        eprintln!("spec-gate: --ledger requires a path");
+                        std::process::exit(2);
+                    });
+                }
+                "--syntax-only" => syntax_only = true,
+                "--help" | "-h" => {
+                    print_spec_gate_help();
+                    std::process::exit(0);
+                }
+                other => {
+                    eprintln!("spec-gate: unknown argument {other:?}");
+                    print_spec_gate_help();
+                    std::process::exit(2);
+                }
+            }
+        }
+
+        Self {
+            ledger,
+            syntax_only,
+        }
+    }
+}
+
+fn print_spec_gate_help() {
+    println!("xtask spec-gate [--ledger <path>] [--syntax-only]");
+    println!();
+    println!("Parses the spec-review findings ledger and exits non-zero while any");
+    println!("finding is `status: open`.");
+    println!();
+    println!("Defaults:");
+    println!("  --ledger {DEFAULT_LEDGER}");
+    println!();
+    println!("Flags:");
+    println!("  --syntax-only   Validate the ledger grammar only; open findings do not fail");
+    println!();
+    println!("Exit codes: 0 clean, 1 open findings, 2 grammar violation");
+}
+
+pub fn run(options: Options) -> i32 {
+    let out = crate::term::Style::stdout();
+    let err = crate::term::Style::stderr();
+    let path = &options.ledger;
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            println!(
+                "spec-gate: {}: no ledger at {}, nothing to gate",
+                out.green("pass"),
+                path.display()
+            );
+            return 0;
+        }
+        Err(error) => {
+            eprintln!("spec-gate: cannot read {}: {error}", path.display());
+            return 2;
+        }
+    };
+
+    let findings = match parse_ledger(&text) {
+        Ok(findings) => findings,
+        Err(errors) => {
+            eprintln!(
+                "spec-gate: {}: ledger grammar violations in {}:",
+                err.red("fail"),
+                path.display()
+            );
+            for error in errors {
+                eprintln!("  {error}");
+            }
+            return 2;
+        }
+    };
+
+    let open: Vec<&Finding> = findings.iter().filter(|f| f.status == "open").collect();
+    let count = |status: &str| findings.iter().filter(|f| f.status == status).count();
+    let acknowledged = count("acknowledged");
+    let resolved = count("resolved");
+    let auto_resolved = count("auto-resolved");
+
+    let passing = options.syntax_only || open.is_empty();
+    let verdict = if passing {
+        out.green("pass")
+    } else {
+        out.red("fail")
+    };
+    let mode = if options.syntax_only {
+        " (syntax only)"
+    } else {
+        ""
+    };
+    println!(
+        "spec-gate: {verdict}{mode}: {} open, {acknowledged} acknowledged, {resolved} resolved, \
+         {auto_resolved} auto-resolved ({})",
+        open.len(),
+        path.display()
+    );
+
+    if options.syntax_only {
+        return 0;
+    }
+
+    if !open.is_empty() {
+        eprintln!("spec-gate: open findings require operator review:");
+        for finding in &open {
+            let severity = match finding.severity.as_str() {
+                "critical" | "high" => err.red(&finding.severity),
+                "medium" => err.yellow(&finding.severity),
+                other => other.to_string(),
+            };
+            eprintln!("  ZSR-{:04} [{severity}] {}", finding.id, finding.title);
+        }
+        return 1;
+    }
+
+    0
+}
+
+#[derive(Debug)]
+struct Finding {
+    id: u32,
+    title: String,
+    status: String,
+    severity: String,
+}
+
+struct PartialFinding {
+    id: u32,
+    title: String,
+    header_line: usize,
+    fields: Vec<(String, String, usize)>,
+}
+
+fn parse_ledger(text: &str) -> Result<Vec<Finding>, Vec<String>> {
+    let mut findings: Vec<Finding> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+    let mut current: Option<PartialFinding> = None;
+
+    for (index, line) in text.lines().enumerate() {
+        let lineno = index + 1;
+        if let Some(header) = line.strip_prefix("## ") {
+            if let Some(finding) = current.take() {
+                finalize_entry(finding, &mut findings, &mut errors);
+            }
+            match parse_header(header) {
+                Ok((id, title)) => {
+                    current = Some(PartialFinding {
+                        id,
+                        title,
+                        header_line: lineno,
+                        fields: Vec::new(),
+                    });
+                }
+                Err(reason) => {
+                    errors.push(format!("line {lineno}: {reason}"));
+                    current = None;
+                }
+            }
+        } else if let Some(finding) = current.as_mut() {
+            if let Some((key, value)) = parse_field_line(line) {
+                finding.fields.push((key, value, lineno));
+            }
+        }
+    }
+    if let Some(finding) = current.take() {
+        finalize_entry(finding, &mut findings, &mut errors);
+    }
+
+    let mut seen = std::collections::BTreeSet::new();
+    for finding in &findings {
+        if !seen.insert(finding.id) {
+            errors.push(format!("duplicate finding id ZSR-{:04}", finding.id));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(findings)
+    } else {
+        Err(errors)
+    }
+}
+
+fn parse_header(header: &str) -> Result<(u32, String), String> {
+    let rest = header.strip_prefix("ZSR-").ok_or_else(|| {
+        format!("entry heading must match `## ZSR-NNNN: <title>`, got {header:?}")
+    })?;
+    let (digits, title) = rest
+        .split_once(": ")
+        .ok_or_else(|| format!("entry heading missing `: <title>` separator: {header:?}"))?;
+    if digits.len() != 4 || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(format!("finding id must be four digits, got ZSR-{digits}"));
+    }
+    let title = title.trim();
+    if title.is_empty() {
+        return Err(format!("entry ZSR-{digits} has an empty title"));
+    }
+    Ok((digits.parse().expect("checked digits"), title.to_string()))
+}
+
+/// Field lines are `- key: value`; bullet lines whose key is not a known field
+/// name are treated as prose and ignored. A trailing ` # ...` comment on the
+/// value is stripped (so `spec: docs/spec.md#anchor` keeps its anchor).
+fn parse_field_line(line: &str) -> Option<(String, String)> {
+    let rest = line.strip_prefix("- ")?;
+    let (key, value) = rest.split_once(':')?;
+    let key = key.trim();
+    if !REQUIRED_FIELDS.contains(&key) && !OPTIONAL_FIELDS.contains(&key) {
+        return None;
+    }
+    let value = value.split(" #").next().unwrap_or("").trim();
+    Some((key.to_string(), value.to_string()))
+}
+
+fn finalize_entry(entry: PartialFinding, findings: &mut Vec<Finding>, errors: &mut Vec<String>) {
+    let status = required_field(&entry, "status", errors);
+    let severity = required_field(&entry, "severity", errors);
+    let kind = required_field(&entry, "type", errors);
+    required_field(&entry, "code", errors);
+    required_field(&entry, "spec", errors);
+    let opened = required_field(&entry, "opened", errors);
+    lookup_field(&entry, "resolved", errors);
+
+    let id = entry.id;
+    check_enum(id, "status", &status, &STATUS_VALUES, errors);
+    check_enum(id, "severity", &severity, &SEVERITY_VALUES, errors);
+    check_enum(id, "type", &kind, &TYPE_VALUES, errors);
+
+    if !opened.is_empty() && !is_iso_date(&opened) {
+        errors.push(format!(
+            "ZSR-{id:04}: `opened: {opened}` must be a YYYY-MM-DD date"
+        ));
+    }
+
+    findings.push(Finding {
+        id,
+        title: entry.title,
+        status,
+        severity,
+    });
+}
+
+/// Returns the single value for `name`, recording a grammar error when the
+/// field is repeated within one entry.
+fn lookup_field(entry: &PartialFinding, name: &str, errors: &mut Vec<String>) -> Option<String> {
+    let matches: Vec<&(String, String, usize)> = entry
+        .fields
+        .iter()
+        .filter(|(key, _, _)| key == name)
+        .collect();
+    match matches.as_slice() {
+        [] => None,
+        [(_, value, _)] => Some(value.clone()),
+        [_, (_, _, lineno), ..] => {
+            errors.push(format!(
+                "line {lineno}: ZSR-{:04} repeats field `{name}`",
+                entry.id
+            ));
+            None
+        }
+    }
+}
+
+fn required_field(entry: &PartialFinding, name: &str, errors: &mut Vec<String>) -> String {
+    match lookup_field(entry, name, errors) {
+        Some(value) if !value.is_empty() => value,
+        Some(_) => {
+            errors.push(format!(
+                "ZSR-{:04} (line {}): field `{name}` is empty",
+                entry.id, entry.header_line
+            ));
+            String::new()
+        }
+        None => {
+            errors.push(format!(
+                "ZSR-{:04} (line {}): missing required field `{name}`",
+                entry.id, entry.header_line
+            ));
+            String::new()
+        }
+    }
+}
+
+fn check_enum(id: u32, name: &str, value: &str, allowed: &[&str], errors: &mut Vec<String>) {
+    if !value.is_empty() && !allowed.contains(&value) {
+        errors.push(format!(
+            "ZSR-{id:04}: `{name}: {value}` is not one of {allowed:?}"
+        ));
+    }
+}
+
+fn is_iso_date(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes
+            .iter()
+            .enumerate()
+            .all(|(i, b)| matches!(i, 4 | 7) || b.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HEADER: &str = "# Spec Review Findings Ledger\n\nProse preamble.\n\n";
+
+    fn entry(id: &str, status: &str) -> String {
+        format!(
+            "## ZSR-{id}: Example finding title\n\
+             - status: {status}\n\
+             - severity: high\n\
+             - type: design-weakness\n\
+             - code: programs/shielded-pool/src/lib.rs:1\n\
+             - spec: docs/spec.md#example\n\
+             - opened: 2026-07-17\n\n\
+             Prose description with a bullet:\n\
+             - not a field, just prose\n\n"
+        )
+    }
+
+    #[test]
+    fn empty_ledger_is_clean() {
+        let findings = parse_ledger(HEADER).unwrap();
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn spec_quality_type_and_fix_field_accepted() {
+        let text = format!(
+            "{HEADER}## ZSR-0001: Missing constants table\n\
+             - status: open\n\
+             - severity: low\n\
+             - type: spec-quality\n\
+             - code: program-libs/interface/src/constants.rs:1\n\
+             - spec: docs/spec.md#constants\n\
+             - opened: 2026-07-17\n\
+             - fix: add a Constants section per SPEC_GUIDE item 25\n\n\
+             Prose.\n"
+        );
+        let findings = parse_ledger(&text).unwrap();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].status, "open");
+    }
+
+    #[test]
+    fn valid_ledger_parses_statuses() {
+        let text = format!(
+            "{HEADER}{}{}{}",
+            entry("0001", "resolved"),
+            entry("0002", "acknowledged"),
+            entry("0003", "open")
+        );
+        let findings = parse_ledger(&text).unwrap();
+        assert_eq!(findings.len(), 3);
+        assert_eq!(findings.iter().filter(|f| f.status == "open").count(), 1);
+        assert_eq!(findings[2].id, 3);
+        assert_eq!(findings[2].title, "Example finding title");
+        assert_eq!(findings[2].severity, "high");
+    }
+
+    #[test]
+    fn missing_field_is_grammar_error() {
+        let text = format!("{HEADER}## ZSR-0001: Broken entry\n- status: open\n- severity: high\n");
+        let errors = parse_ledger(&text).unwrap_err();
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("missing required field `type`")));
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("missing required field `code`")));
+    }
+
+    #[test]
+    fn invalid_enum_is_grammar_error() {
+        let text = format!("{HEADER}{}", entry("0001", "pending"));
+        let errors = parse_ledger(&text).unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("`status: pending`")));
+    }
+
+    #[test]
+    fn auto_resolved_is_valid_and_not_open() {
+        let text = format!("{HEADER}{}", entry("0001", "auto-resolved"));
+        let findings = parse_ledger(&text).unwrap();
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].status, "auto-resolved");
+        // A gate run over only auto-resolved findings has zero open, so it passes.
+        assert_eq!(findings.iter().filter(|f| f.status == "open").count(), 0);
+    }
+
+    #[test]
+    fn duplicate_id_is_grammar_error() {
+        let text = format!(
+            "{HEADER}{}{}",
+            entry("0001", "resolved"),
+            entry("0001", "open")
+        );
+        let errors = parse_ledger(&text).unwrap_err();
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("duplicate finding id ZSR-0001")));
+    }
+
+    #[test]
+    fn malformed_header_is_grammar_error() {
+        let text = format!("{HEADER}## Finding without id\n- status: open\n");
+        let errors = parse_ledger(&text).unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("must match `## ZSR-NNNN")));
+    }
+
+    #[test]
+    fn spec_anchor_survives_comment_stripping() {
+        let (key, value) = parse_field_line("- spec: docs/spec.md#merge # trailing note").unwrap();
+        assert_eq!(key, "spec");
+        assert_eq!(value, "docs/spec.md#merge");
+    }
+}

--- a/xtask/src/spec_lint.rs
+++ b/xtask/src/spec_lint.rs
@@ -1,0 +1,286 @@
+//! Deterministic lint for `docs/spec.md`.
+//!
+//! Catches the mechanical spec defects an LLM pass should never spend judgment
+//! on: dead intra-document anchors, relative links that do not resolve, and
+//! vocabulary banned by `docs/CLAUDE.md`. `TODO`/`TBD` markers are reported as
+//! warnings (SPEC_GUIDE forbids them in normative sections, but converting one
+//! is a review judgment, not a lint fix).
+//!
+//! Exit codes: 0 = clean (warnings allowed), 1 = violations, 2 = cannot read.
+
+use std::{collections::BTreeSet, fs, path::PathBuf};
+
+const DEFAULT_SPEC: &str = "docs/spec.md";
+
+/// Banned by docs/CLAUDE.md ("Language"). Case-insensitive substring match.
+const BANNED_PHRASES: [&str; 3] = ["the wire", "wall time", "folded into"];
+
+#[derive(Debug)]
+pub struct Options {
+    spec: PathBuf,
+}
+
+impl Options {
+    pub fn parse(args: Vec<String>) -> Self {
+        let mut spec = PathBuf::from(DEFAULT_SPEC);
+        let mut args = args.into_iter();
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--spec" => {
+                    spec = args.next().map(PathBuf::from).unwrap_or_else(|| {
+                        eprintln!("spec-lint: --spec requires a path");
+                        std::process::exit(2);
+                    });
+                }
+                "--help" | "-h" => {
+                    println!("xtask spec-lint [--spec <path>]");
+                    println!();
+                    println!("Checks {DEFAULT_SPEC} for dead intra-doc anchors, unresolvable");
+                    println!("relative links, and banned vocabulary. TODO/TBD are warnings.");
+                    println!();
+                    println!("Exit codes: 0 clean, 1 violations, 2 cannot read");
+                    std::process::exit(0);
+                }
+                other => {
+                    eprintln!("spec-lint: unknown argument {other:?}");
+                    std::process::exit(2);
+                }
+            }
+        }
+        Self { spec }
+    }
+}
+
+pub fn run(options: Options) -> i32 {
+    let path = &options.spec;
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(error) => {
+            eprintln!("spec-lint: cannot read {}: {error}", path.display());
+            return 2;
+        }
+    };
+    let base_dir = path.parent().map(PathBuf::from).unwrap_or_default();
+
+    let report = lint(&text, &base_dir);
+
+    let out = crate::term::Style::stdout();
+    let err = crate::term::Style::stderr();
+    for warning in &report.warnings {
+        println!("spec-lint: {}: {warning}", out.yellow("warning"));
+    }
+    if report.violations.is_empty() {
+        println!(
+            "spec-lint: {}: {} anchors, {} intra-doc links, {} warnings ({})",
+            out.green("pass"),
+            report.anchor_count,
+            report.link_count,
+            report.warnings.len(),
+            path.display()
+        );
+        0
+    } else {
+        eprintln!(
+            "spec-lint: {}: {} violations in {}:",
+            err.red("fail"),
+            report.violations.len(),
+            path.display()
+        );
+        for violation in &report.violations {
+            eprintln!("  {violation}");
+        }
+        1
+    }
+}
+
+struct Report {
+    violations: Vec<String>,
+    warnings: Vec<String>,
+    anchor_count: usize,
+    link_count: usize,
+}
+
+/// GitHub heading slug: lowercase; keep alphanumerics, `-`, `_`, spaces; drop
+/// the rest; spaces become `-`. Repeated slugs get `-1`, `-2`, ... suffixes in
+/// document order.
+fn github_slug(heading: &str) -> String {
+    let mut out = String::new();
+    let mut text = String::new();
+    // Strip HTML tags from the heading text before slugging.
+    let mut in_tag = false;
+    for ch in heading.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            c if !in_tag => text.push(c),
+            _ => {}
+        }
+    }
+    for ch in text.trim().chars() {
+        match ch {
+            c if c.is_alphanumeric() => out.extend(c.to_lowercase()),
+            ' ' | '-' => out.push('-'),
+            '_' => out.push('_'),
+            _ => {}
+        }
+    }
+    out
+}
+
+fn lint(text: &str, base_dir: &std::path::Path) -> Report {
+    let mut violations = Vec::new();
+    let mut warnings = Vec::new();
+
+    // Pass 1: collect anchors (headings outside code fences, plus <a id="...">).
+    let mut anchors: BTreeSet<String> = BTreeSet::new();
+    let mut slug_counts: std::collections::BTreeMap<String, usize> = Default::default();
+    let mut in_fence = false;
+    for line in text.lines() {
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        if let Some(heading) = line.strip_prefix('#') {
+            let heading = heading.trim_start_matches('#');
+            if let Some(title) = heading.strip_prefix(' ') {
+                let slug = github_slug(title);
+                let n = *slug_counts
+                    .entry(slug.clone())
+                    .and_modify(|n| *n += 1)
+                    .or_insert(0);
+                anchors.insert(if n == 0 { slug } else { format!("{slug}-{n}") });
+            }
+        }
+        let mut rest = line;
+        while let Some(idx) = rest.find("<a id=\"") {
+            let tail = &rest[idx + 7..];
+            if let Some(end) = tail.find('"') {
+                anchors.insert(tail[..end].to_string());
+                rest = &tail[end..];
+            } else {
+                break;
+            }
+        }
+    }
+
+    // Pass 2: check links and vocabulary, skipping code fences.
+    let mut link_count = 0usize;
+    let mut in_fence = false;
+    for (index, line) in text.lines().enumerate() {
+        let lineno = index + 1;
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+
+        let mut rest = line;
+        while let Some(idx) = rest.find("](") {
+            let tail = &rest[idx + 2..];
+            let Some(end) = tail.find(')') else { break };
+            let target = &tail[..end];
+            if let Some(anchor) = target.strip_prefix('#') {
+                link_count += 1;
+                if !anchors.contains(anchor) {
+                    violations.push(format!("line {lineno}: dead anchor #{anchor}"));
+                }
+            } else if target.starts_with("http://") || target.starts_with("https://") {
+                warnings.push(format!(
+                    "line {lineno}: external link {target} (spec should reference docs/ only)"
+                ));
+            } else {
+                // Relative link; must resolve from the spec's directory.
+                let path_part = target.split('#').next().unwrap_or("");
+                if !path_part.is_empty() && !base_dir.join(path_part).exists() {
+                    violations.push(format!(
+                        "line {lineno}: relative link {path_part} does not resolve"
+                    ));
+                }
+            }
+            rest = &tail[end..];
+        }
+
+        let lower = line.to_lowercase();
+        for phrase in BANNED_PHRASES {
+            if lower.contains(phrase) {
+                violations.push(format!(
+                    "line {lineno}: banned phrase {phrase:?} (docs/CLAUDE.md Language rules)"
+                ));
+            }
+        }
+        if lower.contains("todo") || lower.contains("tbd") {
+            warnings.push(format!("line {lineno}: TODO/TBD marker"));
+        }
+    }
+
+    Report {
+        violations,
+        warnings,
+        anchor_count: anchors.len(),
+        link_count,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn slugs_match_github_rules() {
+        assert_eq!(
+            github_slug("SPP Proof - Solana Privacy ZK Proof"),
+            "spp-proof---solana-privacy-zk-proof"
+        );
+        assert_eq!(github_slug("Versioning & Upgrades"), "versioning--upgrades");
+        assert_eq!(github_slug("`zone_transact`"), "zone_transact");
+        assert_eq!(
+            github_slug("Concurrency & Balance Fragmentation"),
+            "concurrency--balance-fragmentation"
+        );
+    }
+
+    #[test]
+    fn duplicate_headings_dedup_in_order() {
+        let text = "# Transfer\n\n## Transfer\n\n### Transfer\n\n[a](#transfer)[b](#transfer-1)[c](#transfer-2)\n";
+        let report = lint(text, Path::new("."));
+        assert!(report.violations.is_empty(), "{:?}", report.violations);
+    }
+
+    #[test]
+    fn dead_anchor_and_html_id_anchor() {
+        let text = "# Title\n\n<a id=\"custom\"></a>\n\n[ok](#custom) [bad](#missing)\n";
+        let report = lint(text, Path::new("."));
+        assert_eq!(report.violations.len(), 1);
+        assert!(report.violations[0].contains("#missing"));
+    }
+
+    #[test]
+    fn links_inside_code_fences_ignored() {
+        let text = "# T\n\n```rust\n// [not a link](#nope)\n```\n";
+        let report = lint(text, Path::new("."));
+        assert!(report.violations.is_empty());
+    }
+
+    #[test]
+    fn banned_phrase_fails_todo_warns() {
+        let text = "# T\n\nSent over the wire.\n\nTODO: later.\n";
+        let report = lint(text, Path::new("."));
+        assert_eq!(report.violations.len(), 1);
+        assert!(report.violations[0].contains("the wire"));
+        assert_eq!(report.warnings.len(), 1);
+    }
+
+    #[test]
+    fn unresolvable_relative_link_fails() {
+        let text = "# T\n\n[x](no-such-dir/missing.md)\n";
+        let report = lint(text, Path::new("/nonexistent-base"));
+        assert_eq!(report.violations.len(), 1);
+        assert!(report.violations[0].contains("does not resolve"));
+    }
+}

--- a/xtask/src/term.rs
+++ b/xtask/src/term.rs
@@ -1,0 +1,45 @@
+//! Minimal ANSI colour for gate summaries. Colour only when the stream is a
+//! terminal and NO_COLOR is unset, so CI logs and pipes stay plain.
+
+use std::io::IsTerminal;
+
+#[derive(Clone, Copy)]
+pub struct Style {
+    enabled: bool,
+}
+
+impl Style {
+    pub fn stdout() -> Self {
+        Self::for_terminal(std::io::stdout().is_terminal())
+    }
+
+    pub fn stderr() -> Self {
+        Self::for_terminal(std::io::stderr().is_terminal())
+    }
+
+    fn for_terminal(is_terminal: bool) -> Self {
+        Self {
+            enabled: is_terminal && std::env::var_os("NO_COLOR").is_none(),
+        }
+    }
+
+    fn wrap(&self, code: &str, text: &str) -> String {
+        if self.enabled {
+            format!("\x1b[{code}m{text}\x1b[0m")
+        } else {
+            text.to_string()
+        }
+    }
+
+    pub fn green(&self, text: &str) -> String {
+        self.wrap("32", text)
+    }
+
+    pub fn red(&self, text: &str) -> String {
+        self.wrap("31", text)
+    }
+
+    pub fn yellow(&self, text: &str) -> String {
+        self.wrap("33", text)
+    }
+}


### PR DESCRIPTION
The skill audits the spec against the code and records divergences in a gitignored local findings ledger. just spec-gate fails while any finding is open. just spec-lint checks anchors, links, and vocabulary. just yolo-fix-spec rewrites the spec to code truth and annotates each edit with its finding. CI gates every PR. A manual dispatch returns headless review edits as a patch artifact. Pre-commit hook is opt-in. See docs/spec-review/README.md.