### PR TITLE
Fix justfile compatibility with older just

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,10 +9,10 @@ surfpool-version := env_var_or_default("SURFPOOL_VERSION", "1.1.1")
 # (auto-loaded above) to shift every service port by a fixed amount so concurrent
 # checkouts never contend. Each individual port/URL var can still be overridden
 # explicitly. See .env.example.
-port-offset := env_var_or_default("ZOLANA_PORT_OFFSET", "0")
-localnet-rpc-port := env_var_or_default("ZOLANA_LOCALNET_RPC_PORT", shell('echo $((8899 + ${1:-0}))', port-offset))
-localnet-photon-port := env_var_or_default("ZOLANA_LOCALNET_PHOTON_PORT", shell('echo $((8784 + ${1:-0}))', port-offset))
-localnet-prover-port := env_var_or_default("ZOLANA_LOCALNET_PROVER_PORT", shell('echo $((3001 + ${1:-0}))', port-offset))
+export ZOLANA_PORT_OFFSET := env_var_or_default("ZOLANA_PORT_OFFSET", "0")
+localnet-rpc-port := env_var_or_default("ZOLANA_LOCALNET_RPC_PORT", `echo $((8899 + ${ZOLANA_PORT_OFFSET:-0}))`)
+localnet-photon-port := env_var_or_default("ZOLANA_LOCALNET_PHOTON_PORT", `echo $((8784 + ${ZOLANA_PORT_OFFSET:-0}))`)
+localnet-prover-port := env_var_or_default("ZOLANA_LOCALNET_PROVER_PORT", `echo $((3001 + ${ZOLANA_PORT_OFFSET:-0}))`)
 localnet-rpc-url := env_var_or_default("ZOLANA_LOCALNET_URL", "http://127.0.0.1:" + localnet-rpc-port)
 localnet-photon-url := env_var_or_default("ZOLANA_LOCALNET_PHOTON_URL", "http://127.0.0.1:" + localnet-photon-port)
 localnet-prover-url := env_var_or_default("ZOLANA_PROVER_URL", "http://127.0.0.1:" + localnet-prover-port)
@@ -25,11 +25,16 @@ spp-keys-dir := env_var_or_default("ZOLANA_SPP_KEYS_DIR", "prover/server/proving
 # this single var is the source of truth for the prover.
 export ZOLANA_PROVER_URL := localnet-prover-url
 
-mod forester 'forester'
-mod prover 'prover/server'
-
 default:
     @just --list
+
+# Preserve module-like subcommands without requiring unstable module support in
+# older `just` versions.
+forester *args:
+    just --justfile forester/justfile {{args}}
+
+prover *args:
+    just --justfile prover/server/justfile {{args}}
 
 # === Rust workspace ===
 


### PR DESCRIPTION
## Summary

- replace the `shell()` port arithmetic with backtick evaluation using an exported `ZOLANA_PORT_OFFSET`
- replace unstable `mod` declarations with forwarding recipes for the existing forester and prover justfiles
- preserve `just forester …` and `just prover …` command syntax

## Root cause

The workspace justfile used `shell()`, which is unavailable in `just 1.21`, and module declarations that require unstable support in that version. As a result, plain `just` could not parse or list workspace recipes on systems shipping that release.

## Impact

Plain `just` now works with `just 1.21` while retaining port-offset behavior, explicit per-port overrides, and the existing nested command interface.

## Validation

- `just --no-dotenv`
- default port evaluation: `8899`
- `ZOLANA_PORT_OFFSET=100`: RPC `8999`, Photon `8884`, prover `3101`
- explicit `ZOLANA_LOCALNET_RPC_PORT=9999` override
- `just --no-dotenv forester`
- `just --no-dotenv prover`
- dry-run forwarding for `forester check` and `prover bench-spp 2x`
- `git diff --check`

`just 1.21`'s formatter proposes repository-wide formatting changes unrelated to this fix, so those were intentionally excluded.
