### PR TITLE
refactor(prover): remove the Light zk-compression proving surface

### DIFF
--- a/prover/server/main.go
+++ b/prover/server/main.go
@@ -39,23 +39,15 @@ func runCli() {
 			{
 				Name: "setup",
 				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "circuit", Usage: "Type of circuit (\"inclusion\" / \"non-inclusion\" / \"combined\" / \"append\" / \"update\" / \"address-append\" )", Required: true},
+					&cli.StringFlag{Name: "circuit", Usage: "Type of circuit (\"address-append\")", Required: true},
 					&cli.StringFlag{Name: "output", Usage: "Output file", Required: true},
 					&cli.StringFlag{Name: "output-vkey", Usage: "Output file", Required: true},
-					&cli.UintFlag{Name: "inclusion-tree-height", Usage: "[Inclusion]: Merkle tree height", Required: false},
-					&cli.UintFlag{Name: "inclusion-compressed-accounts", Usage: "[Inclusion]: Number of compressed accounts", Required: false},
-					&cli.UintFlag{Name: "non-inclusion-tree-height", Usage: "[Non-inclusion]: merkle tree height", Required: false},
-					&cli.UintFlag{Name: "non-inclusion-compressed-accounts", Usage: "[Non-inclusion]: number of compressed accounts", Required: false},
-					&cli.UintFlag{Name: "append-tree-height", Usage: "[Batch append]: tree height", Required: false},
-					&cli.UintFlag{Name: "append-batch-size", Usage: "[Batch append]: batch size", Required: false},
-					&cli.UintFlag{Name: "update-tree-height", Usage: "[Batch update]: tree height", Required: false},
-					&cli.UintFlag{Name: "update-batch-size", Usage: "[Batch update]: batch size", Required: false},
 					&cli.UintFlag{Name: "address-append-tree-height", Usage: "[Batch address append]: tree height", Required: false},
 					&cli.UintFlag{Name: "address-append-batch-size", Usage: "[Batch address append]: batch size", Required: false},
 				},
 				Action: func(context *cli.Context) error {
 					circuit := common.CircuitType(context.String("circuit"))
-					if circuit != common.InclusionCircuitType && circuit != common.NonInclusionCircuitType && circuit != common.CombinedCircuitType && circuit != common.BatchUpdateCircuitType && circuit != common.BatchAppendCircuitType && circuit != common.BatchAddressAppendCircuitType {
+					if circuit != common.BatchAddressAppendCircuitType {
 						return fmt.Errorf("invalid circuit type %s", circuit)
 					}
 
@@ -193,26 +185,13 @@ func runCli() {
 				Name: "r1cs",
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "output", Usage: "Output file", Required: true},
-					&cli.StringFlag{Name: "circuit", Usage: "Type of circuit (\"inclusion\" / \"non-inclusion\" / \"combined\" / \"append\" / \"update\" / \"address-append\")", Required: true},
-					&cli.UintFlag{Name: "inclusion-tree-height", Usage: "[Inclusion]: merkle tree height", Required: false},
-					&cli.UintFlag{Name: "inclusion-compressed-accounts", Usage: "[Inclusion]: number of compressed accounts", Required: false},
-					&cli.UintFlag{Name: "non-inclusion-tree-height", Usage: "[Non-inclusion]: merkle tree height", Required: false},
-					&cli.UintFlag{Name: "non-inclusion-compressed-accounts", Usage: "[Non-inclusion]: number of compressed accounts", Required: false},
-					&cli.UintFlag{Name: "append-tree-height", Usage: "[Batch append]: merkle tree height", Required: false},
-					&cli.UintFlag{Name: "append-batch-size", Usage: "[Batch append]: batch size", Required: false},
-					&cli.UintFlag{Name: "update-tree-height", Usage: "[Batch update]: merkle tree height", Required: false},
-					&cli.UintFlag{Name: "update-batch-size", Usage: "[Batch update]: batch size", Required: false},
+					&cli.StringFlag{Name: "circuit", Usage: "Type of circuit (\"address-append\")", Required: true},
 					&cli.UintFlag{Name: "address-append-tree-height", Usage: "[Batch address append]: tree height", Required: false},
 					&cli.UintFlag{Name: "address-append-batch-size", Usage: "[Batch address append]: batch size", Required: false},
 				},
 				Action: func(context *cli.Context) error {
 					circuit := common.CircuitType(context.String("circuit"))
-					if circuit != common.InclusionCircuitType &&
-						circuit != common.NonInclusionCircuitType &&
-						circuit != common.CombinedCircuitType &&
-						circuit != common.BatchUpdateCircuitType &&
-						circuit != common.BatchAppendCircuitType &&
-						circuit != common.BatchAddressAppendCircuitType {
+					if circuit != common.BatchAddressAppendCircuitType {
 						return fmt.Errorf("invalid circuit type %s", circuit)
 					}
 
@@ -259,20 +238,12 @@ func runCli() {
 			{
 				Name: "import-setup",
 				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "circuit", Usage: "Type of circuit (\"inclusion\" / \"non-inclusion\" / \"combined\")", Required: true},
+					&cli.StringFlag{Name: "circuit", Usage: "Type of circuit (\"address-append\")", Required: true},
 					&cli.StringFlag{Name: "output", Usage: "Output file", Required: true},
 					&cli.StringFlag{Name: "vkey-output", Usage: "Verifying key output file (optional)", Required: false},
 					&cli.StringFlag{Name: "pk", Usage: "Proving key", Required: true},
 					&cli.StringFlag{Name: "vk", Usage: "Verifying key", Required: true},
 					&cli.StringFlag{Name: "r1cs", Usage: "R1CS file", Required: false},
-					&cli.UintFlag{Name: "inclusion-tree-height", Usage: "[Inclusion]: merkle tree height", Required: false},
-					&cli.UintFlag{Name: "inclusion-compressed-accounts", Usage: "[Inclusion]: number of compressed accounts", Required: false},
-					&cli.UintFlag{Name: "non-inclusion-tree-height", Usage: "[Non-inclusion]: merkle tree height", Required: false},
-					&cli.UintFlag{Name: "non-inclusion-compressed-accounts", Usage: "[Non-inclusion]: number of compressed accounts", Required: false},
-					&cli.UintFlag{Name: "append-tree-height", Usage: "[Batch append]: merkle tree height", Required: false},
-					&cli.UintFlag{Name: "append-batch-size", Usage: "[Batch append]: batch size", Required: false},
-					&cli.UintFlag{Name: "update-tree-height", Usage: "[Batch update]: merkle tree height", Required: false},
-					&cli.UintFlag{Name: "update-batch-size", Usage: "[Batch update]: batch size", Required: false},
 					&cli.UintFlag{Name: "address-append-tree-height", Usage: "[Batch address append]: tree height", Required: false},
 					&cli.UintFlag{Name: "address-append-batch-size", Usage: "[Batch address append]: batch size", Required: false},
 				},
@@ -335,8 +306,6 @@ func runCli() {
 
 					var buf bytes.Buffer
 					switch s := system.(type) {
-					case *common.MerkleProofSystem:
-						_, err = s.VerifyingKey.WriteTo(&buf)
 					case *common.BatchProofSystem:
 						_, err = s.VerifyingKey.WriteRawTo(&buf)
 					case *common.TransferProofSystem:
@@ -406,7 +375,7 @@ func runCli() {
 					},
 					&cli.StringSliceFlag{
 						Name:  "circuit",
-						Usage: "Download keys for specific circuits (inclusion, non-inclusion, combined, append, update, append-test, update-test, address-append, address-append-test)",
+						Usage: "Download keys for specific circuits (address-append, address-append-test)",
 					},
 					&cli.StringFlag{
 						Name:  "keys-dir",
@@ -484,7 +453,7 @@ func runCli() {
 					&cli.StringFlag{Name: "keys-dir", Usage: "Directory where key files are stored", Value: "./proving-keys/", Required: false},
 					&cli.StringSliceFlag{
 						Name:  "circuit",
-						Usage: "Specify the circuits to enable (inclusion, non-inclusion, combined, append, update, append-test, update-test, address-append, address-append-test)",
+						Usage: "Specify the circuits to enable (address-append, address-append-test, transfer)",
 					},
 					&cli.StringFlag{
 						Name:  "preload-keys",
@@ -717,17 +686,13 @@ func runCli() {
 			{
 				Name: "prove",
 				Flags: []cli.Flag{
-					&cli.BoolFlag{Name: "inclusion", Usage: "Run inclusion circuit", Required: true},
-					&cli.BoolFlag{Name: "non-inclusion", Usage: "Run non-inclusion circuit", Required: false},
-					&cli.BoolFlag{Name: "append", Usage: "Run batch append circuit", Required: false},
-					&cli.BoolFlag{Name: "update", Usage: "Run batch update circuit", Required: false},
 					&cli.BoolFlag{Name: "address-append", Usage: "Run batch address append circuit", Required: false},
 					&cli.StringFlag{Name: "keys-dir", Usage: "Directory where circuit key files are stored", Value: "./proving-keys/", Required: false},
 					&cli.StringSliceFlag{Name: "keys-file", Aliases: []string{"k"}, Value: cli.NewStringSlice(), Usage: "Proving system file"},
 					&cli.StringSliceFlag{
 						Name:  "circuit",
-						Usage: "Specify the circuits to enable (inclusion, non-inclusion, combined, append, update, append-test, update-test, address-append, address-append-test)",
-						Value: cli.NewStringSlice("inclusion", "non-inclusion", "combined", "append", "update", "append-test", "update-test", "address-append", "address-append-test"),
+						Usage: "Specify the circuits to enable (address-append, address-append-test)",
+						Value: cli.NewStringSlice("address-append", "address-append-test"),
 					},
 					&cli.StringFlag{
 						Name:  "run-mode",
@@ -744,12 +709,12 @@ func runCli() {
 					}
 					var keysDirPath = context.String("keys-dir")
 
-					psv1, psv2, err := common.LoadKeys(keysDirPath, runMode, circuits)
+					psv2, err := common.LoadKeys(keysDirPath, runMode, circuits)
 					if err != nil {
 						return err
 					}
 
-					if len(psv1) == 0 && len(psv2) == 0 {
+					if len(psv2) == 0 {
 						return fmt.Errorf("no proving systems loaded")
 					}
 

--- a/prover/server/prover/common/circuit_utils.go
+++ b/prover/server/prover/common/circuit_utils.go
@@ -15,17 +15,6 @@ type ProofWithTiming struct {
 	ProofDurationMs int64  `json:"proof_duration_ms"`
 }
 
-type MerkleProofSystem struct {
-	InclusionTreeHeight                    uint32
-	InclusionNumberOfCompressedAccounts    uint32
-	NonInclusionTreeHeight                 uint32
-	NonInclusionNumberOfCompressedAccounts uint32
-	Version                                uint32
-	ProvingKey                             groth16.ProvingKey
-	VerifyingKey                           groth16.VerifyingKey
-	ConstraintSystem                       constraint.ConstraintSystem
-}
-
 type BatchProofSystem struct {
 	CircuitType      CircuitType
 	TreeHeight       uint32

--- a/prover/server/prover/common/lazy_key_manager.go
+++ b/prover/server/prover/common/lazy_key_manager.go
@@ -10,7 +10,6 @@ import (
 
 type LazyKeyManager struct {
 	mu                sync.RWMutex
-	merkleSystems     map[string]*MerkleProofSystem
 	batchSystems      map[string]*BatchProofSystem
 	transferSystems   map[string]*TransferProofSystem
 	keysDir           string
@@ -23,44 +22,12 @@ func NewLazyKeyManager(keysDir string, downloadConfig *DownloadConfig) *LazyKeyM
 		downloadConfig = DefaultDownloadConfig()
 	}
 	return &LazyKeyManager{
-		merkleSystems:     make(map[string]*MerkleProofSystem),
 		batchSystems:      make(map[string]*BatchProofSystem),
 		transferSystems:   make(map[string]*TransferProofSystem),
 		keysDir:           keysDir,
 		downloadConfig:    downloadConfig,
 		loadingInProgress: make(map[string]chan struct{}),
 	}
-}
-
-func (m *LazyKeyManager) GetMerkleSystem(
-	inclusionTreeHeight uint32,
-	inclusionCompressedAccounts uint32,
-	nonInclusionTreeHeight uint32,
-	nonInclusionCompressedAccounts uint32,
-	version uint32,
-) (*MerkleProofSystem, error) {
-	var key string
-	if inclusionCompressedAccounts > 0 && nonInclusionCompressedAccounts > 0 {
-		key = fmt.Sprintf("comb_%d_%d_%d_%d_v%d", inclusionTreeHeight, inclusionCompressedAccounts, nonInclusionTreeHeight, nonInclusionCompressedAccounts, version)
-	} else if inclusionCompressedAccounts > 0 {
-		key = fmt.Sprintf("inc_%d_%d_v%d", inclusionTreeHeight, inclusionCompressedAccounts, version)
-	} else if nonInclusionCompressedAccounts > 0 {
-		key = fmt.Sprintf("non_%d_%d_v%d", nonInclusionTreeHeight, nonInclusionCompressedAccounts, version)
-	} else {
-		return nil, fmt.Errorf("invalid parameters: must specify either inclusion or non-inclusion accounts")
-	}
-
-	m.mu.RLock()
-	if ps, exists := m.merkleSystems[key]; exists {
-		m.mu.RUnlock()
-		logging.Logger().Debug().
-			Str("key", key).
-			Msg("Found cached MerkleProofSystem")
-		return ps, nil
-	}
-	m.mu.RUnlock()
-
-	return m.loadMerkleSystem(key, inclusionTreeHeight, inclusionCompressedAccounts, nonInclusionTreeHeight, nonInclusionCompressedAccounts, version)
 }
 
 func (m *LazyKeyManager) GetBatchSystem(circuitType CircuitType, treeHeight uint32, batchSize uint32) (*BatchProofSystem, error) {
@@ -93,67 +60,6 @@ func (m *LazyKeyManager) GetTransferSystem(circuitType CircuitType, nInputs uint
 	m.mu.RUnlock()
 
 	return m.loadTransferSystem(key, circuitType, nInputs, nOutputs)
-}
-
-func (m *LazyKeyManager) loadMerkleSystem(
-	key string,
-	inclusionTreeHeight uint32,
-	inclusionCompressedAccounts uint32,
-	nonInclusionTreeHeight uint32,
-	nonInclusionCompressedAccounts uint32,
-	version uint32,
-) (*MerkleProofSystem, error) {
-	loadChan := m.acquireLoadingLock(key)
-	if loadChan == nil {
-		m.waitForLoading(key)
-		m.mu.RLock()
-		ps, exists := m.merkleSystems[key]
-		m.mu.RUnlock()
-		if exists {
-			return ps, nil
-		}
-		return nil, fmt.Errorf("loading completed but system not found in cache")
-	}
-	defer m.releaseLoadingLock(key, loadChan)
-
-	keyPath := m.determineMerkleKeyPath(inclusionTreeHeight, inclusionCompressedAccounts, nonInclusionTreeHeight, nonInclusionCompressedAccounts, version)
-	if keyPath == "" {
-		return nil, fmt.Errorf("no key file mapping for parameters: inc(%d,%d) non(%d,%d) v%d",
-			inclusionTreeHeight, inclusionCompressedAccounts, nonInclusionTreeHeight, nonInclusionCompressedAccounts, version)
-	}
-
-	logging.Logger().Info().
-		Str("key_path", keyPath).
-		Str("cache_key", key).
-		Msg("Loading MerkleProofSystem")
-
-	if err := EnsureProvingKey(keyPath, m.downloadConfig.AutoDownload, m.downloadConfig); err != nil {
-		return nil, fmt.Errorf("failed to download key %s: %w", keyPath, err)
-	}
-
-	system, err := ReadSystemFromFile(keyPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load key %s: %w", keyPath, err)
-	}
-
-	ps, ok := system.(*MerkleProofSystem)
-	if !ok {
-		return nil, fmt.Errorf("expected MerkleProofSystem but got different type")
-	}
-
-	m.mu.Lock()
-	m.merkleSystems[key] = ps
-	m.mu.Unlock()
-
-	logging.Logger().Info().
-		Str("cache_key", key).
-		Uint32("inc_height", ps.InclusionTreeHeight).
-		Uint32("inc_accounts", ps.InclusionNumberOfCompressedAccounts).
-		Uint32("non_height", ps.NonInclusionTreeHeight).
-		Uint32("non_accounts", ps.NonInclusionNumberOfCompressedAccounts).
-		Msg("MerkleProofSystem loaded and cached successfully")
-
-	return ps, nil
 }
 
 func (m *LazyKeyManager) loadBatchSystem(key string, circuitType CircuitType, treeHeight uint32, batchSize uint32) (*BatchProofSystem, error) {
@@ -295,50 +201,8 @@ func (m *LazyKeyManager) keyPath(filename string) string {
 	return filepath.Join(m.keysDir, filename)
 }
 
-func (m *LazyKeyManager) determineMerkleKeyPath(
-	inclusionTreeHeight uint32,
-	inclusionCompressedAccounts uint32,
-	nonInclusionTreeHeight uint32,
-	nonInclusionCompressedAccounts uint32,
-	version uint32,
-) string {
-	if inclusionCompressedAccounts > 0 && nonInclusionCompressedAccounts > 0 {
-		if version == 1 && inclusionTreeHeight == 26 && nonInclusionTreeHeight == 26 {
-			return m.keyPath(fmt.Sprintf("v1_combined_26_26_%d_%d.key", inclusionCompressedAccounts, nonInclusionCompressedAccounts))
-		} else if version == 2 && inclusionTreeHeight == 32 && nonInclusionTreeHeight == 40 {
-			return m.keyPath(fmt.Sprintf("v2_combined_32_40_%d_%d.key", inclusionCompressedAccounts, nonInclusionCompressedAccounts))
-		}
-	} else if inclusionCompressedAccounts > 0 {
-		if version == 1 && inclusionTreeHeight == 26 {
-			return m.keyPath(fmt.Sprintf("v1_inclusion_26_%d.key", inclusionCompressedAccounts))
-		} else if version == 2 && inclusionTreeHeight == 32 {
-			return m.keyPath(fmt.Sprintf("v2_inclusion_32_%d.key", inclusionCompressedAccounts))
-		}
-	} else if nonInclusionCompressedAccounts > 0 {
-		if version == 1 && nonInclusionTreeHeight == 26 {
-			return m.keyPath(fmt.Sprintf("v1_non-inclusion_26_%d.key", nonInclusionCompressedAccounts))
-		} else if version == 2 && nonInclusionTreeHeight == 40 {
-			return m.keyPath(fmt.Sprintf("v2_non-inclusion_40_%d.key", nonInclusionCompressedAccounts))
-		}
-	}
-
-	return ""
-}
-
 func (m *LazyKeyManager) determineBatchKeyPath(circuitType CircuitType, treeHeight uint32, batchSize uint32) string {
 	switch circuitType {
-	case BatchAppendCircuitType:
-		if treeHeight == 32 && batchSize == 500 {
-			return m.keyPath("batch_append_32_500.key")
-		} else if treeHeight == 32 && batchSize == 10 {
-			return m.keyPath("batch_append_32_10.key")
-		}
-	case BatchUpdateCircuitType:
-		if treeHeight == 32 && batchSize == 500 {
-			return m.keyPath("batch_update_32_500.key")
-		} else if treeHeight == 32 && batchSize == 10 {
-			return m.keyPath("batch_update_32_10.key")
-		}
 	case BatchAddressAppendCircuitType:
 		if treeHeight == 40 && batchSize == 250 {
 			return m.keyPath("batch_address-append_40_250.key")
@@ -408,7 +272,6 @@ func (m *LazyKeyManager) GetStats() map[string]interface{} {
 	defer m.mu.RUnlock()
 
 	return map[string]interface{}{
-		"merkle_systems_loaded":   len(m.merkleSystems),
 		"batch_systems_loaded":    len(m.batchSystems),
 		"transfer_systems_loaded": len(m.transferSystems),
 		"keys_loading":            len(m.loadingInProgress),
@@ -474,9 +337,7 @@ func (m *LazyKeyManager) PreloadCircuits(circuits []string) error {
 }
 
 func (m *LazyKeyManager) tryParseSpecificConfig(config string) string {
-	if strings.HasPrefix(config, "batch_") ||
-		strings.HasPrefix(config, "v1_") ||
-		strings.HasPrefix(config, "v2_") {
+	if strings.HasPrefix(config, "batch_") {
 		return m.keyPath(fmt.Sprintf("%s.key", config))
 	}
 	return ""
@@ -525,34 +386,6 @@ func (m *LazyKeyManager) cacheSystem(system interface{}) error {
 	defer m.mu.Unlock()
 
 	switch ps := system.(type) {
-	case *MerkleProofSystem:
-		var key string
-		if ps.InclusionNumberOfCompressedAccounts > 0 && ps.NonInclusionNumberOfCompressedAccounts > 0 {
-			key = fmt.Sprintf("comb_%d_%d_%d_%d_v%d",
-				ps.InclusionTreeHeight,
-				ps.InclusionNumberOfCompressedAccounts,
-				ps.NonInclusionTreeHeight,
-				ps.NonInclusionNumberOfCompressedAccounts,
-				ps.Version)
-		} else if ps.InclusionNumberOfCompressedAccounts > 0 {
-			key = fmt.Sprintf("inc_%d_%d_v%d",
-				ps.InclusionTreeHeight,
-				ps.InclusionNumberOfCompressedAccounts,
-				ps.Version)
-		} else if ps.NonInclusionNumberOfCompressedAccounts > 0 {
-			key = fmt.Sprintf("non_%d_%d_v%d",
-				ps.NonInclusionTreeHeight,
-				ps.NonInclusionNumberOfCompressedAccounts,
-				ps.Version)
-		} else {
-			return fmt.Errorf("invalid MerkleProofSystem: no compressed accounts specified")
-		}
-
-		m.merkleSystems[key] = ps
-		logging.Logger().Debug().
-			Str("cache_key", key).
-			Msg("Cached MerkleProofSystem")
-
 	case *BatchProofSystem:
 		key := fmt.Sprintf("%s_%d_%d", ps.CircuitType, ps.TreeHeight, ps.BatchSize)
 		m.batchSystems[key] = ps

--- a/prover/server/prover/common/marshal.go
+++ b/prover/server/prover/common/marshal.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"math/big"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/consensys/gnark-crypto/ecc"
@@ -137,90 +136,6 @@ func (p *Proof) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return nil
-}
-
-func (ps *MerkleProofSystem) WriteTo(w io.Writer) (int64, error) {
-	var totalWritten int64 = 0
-	var intBuf [4]byte
-
-	fieldsToWrite := []uint32{
-		ps.InclusionTreeHeight,
-		ps.InclusionNumberOfCompressedAccounts,
-		ps.NonInclusionTreeHeight,
-		ps.NonInclusionNumberOfCompressedAccounts,
-	}
-
-	for _, field := range fieldsToWrite {
-		binary.BigEndian.PutUint32(intBuf[:], field)
-		written, err := w.Write(intBuf[:])
-		totalWritten += int64(written)
-		if err != nil {
-			return totalWritten, err
-		}
-	}
-
-	keyWritten, err := ps.ProvingKey.WriteTo(w)
-	totalWritten += keyWritten
-	if err != nil {
-		return totalWritten, err
-	}
-
-	keyWritten, err = ps.VerifyingKey.WriteTo(w)
-	totalWritten += keyWritten
-	if err != nil {
-		return totalWritten, err
-	}
-
-	keyWritten, err = ps.ConstraintSystem.WriteTo(w)
-	totalWritten += keyWritten
-	if err != nil {
-		return totalWritten, err
-	}
-	return totalWritten, nil
-}
-
-func (ps *MerkleProofSystem) UnsafeReadFrom(r io.Reader) (int64, error) {
-	var totalRead int64 = 0
-	var intBuf [4]byte
-
-	fieldsToRead := []*uint32{
-		&ps.InclusionTreeHeight,
-		&ps.InclusionNumberOfCompressedAccounts,
-		&ps.NonInclusionTreeHeight,
-		&ps.NonInclusionNumberOfCompressedAccounts,
-	}
-
-	for _, field := range fieldsToRead {
-		read, err := io.ReadFull(r, intBuf[:])
-		totalRead += int64(read)
-		if err != nil {
-			return totalRead, err
-		}
-		*field = binary.BigEndian.Uint32(intBuf[:])
-	}
-
-	ps.ProvingKey = groth16.NewProvingKey(ecc.BN254)
-	keyRead, err := ps.ProvingKey.UnsafeReadFrom(r)
-	totalRead += keyRead
-	if err != nil {
-		return totalRead, err
-	}
-
-	ps.VerifyingKey = groth16.NewVerifyingKey(ecc.BN254)
-	keyRead, err = ps.VerifyingKey.UnsafeReadFrom(r)
-	totalRead += keyRead
-	if err != nil {
-		return totalRead, err
-	}
-
-	ps.ConstraintSystem = groth16.NewCS(ecc.BN254)
-	keyRead, err = ps.ConstraintSystem.ReadFrom(r)
-	totalRead += keyRead
-	if err != nil {
-		return totalRead, err
-	}
-
-	return totalRead, nil
 }
 
 func (ps *TransferProofSystem) WriteTo(w io.Writer) (int64, error) {
@@ -353,7 +268,7 @@ func ReadSystemFromFile(path string) (interface{}, error) {
 	} else if strings.Contains(strings.ToLower(path), "merge") {
 		// Merge reuses TransferProofSystem (generic Groth16 holder); the file name
 		// (merge_8_1.key) carries no "transfer" substring, so it needs its own
-		// branch or it would be misread as a MerkleProofSystem.
+		// branch or it would fall through to the unrecognized-file error.
 		ps := new(TransferProofSystem)
 		file, err := os.Open(path)
 		if err != nil {
@@ -386,56 +301,8 @@ func ReadSystemFromFile(path string) (interface{}, error) {
 			return nil, err
 		}
 		return ps, nil
-	} else if strings.Contains(strings.ToLower(path), "append") {
-		ps := new(BatchProofSystem)
-		ps.CircuitType = BatchAppendCircuitType
-		file, err := os.Open(path)
-		if err != nil {
-			return nil, err
-		}
-		defer file.Close()
-		_, err = ps.UnsafeReadFrom(file)
-		if err != nil {
-			return nil, err
-		}
-		return ps, nil
-	} else if strings.Contains(strings.ToLower(path), "update") {
-		ps := new(BatchProofSystem)
-		ps.CircuitType = BatchUpdateCircuitType
-		file, err := os.Open(path)
-		if err != nil {
-			return nil, err
-		}
-		defer file.Close()
-
-		_, err = ps.UnsafeReadFrom(file)
-		if err != nil {
-			return nil, err
-		}
-		return ps, nil
 	} else {
-		ps := new(MerkleProofSystem)
-		filename := strings.ToLower(filepath.Base(path))
-		if strings.HasPrefix(filename, "v2_") {
-			ps.Version = 2
-		} else if strings.HasPrefix(filename, "v1_") {
-			ps.Version = 1
-		} else if strings.Contains(filename, "mainnet") {
-			ps.Version = 1
-		} else {
-			ps.Version = 1
-		}
-		file, err := os.Open(path)
-		if err != nil {
-			return nil, err
-		}
-		defer file.Close()
-
-		_, err = ps.UnsafeReadFrom(file)
-		if err != nil {
-			return nil, err
-		}
-		return ps, nil
+		return nil, fmt.Errorf("unrecognized proving key file: %s", path)
 	}
 }
 

--- a/prover/server/prover/common/proving_keys_utils.go
+++ b/prover/server/prover/common/proving_keys_utils.go
@@ -150,35 +150,26 @@ func GetKeys(keysDir string, runMode RunMode, circuits []string) []string {
 	return uniqueKeys
 }
 
-func LoadKeys(keysDirPath string, runMode RunMode, circuits []string) ([]*MerkleProofSystem, []*BatchProofSystem, error) {
+func LoadKeys(keysDirPath string, runMode RunMode, circuits []string) ([]*BatchProofSystem, error) {
 	return LoadKeysWithConfig(keysDirPath, runMode, circuits, DefaultDownloadConfig())
 }
 
-func LoadKeysWithConfig(keysDirPath string, runMode RunMode, circuits []string, config *DownloadConfig) ([]*MerkleProofSystem, []*BatchProofSystem, error) {
-	var pssv1 []*MerkleProofSystem
+func LoadKeysWithConfig(keysDirPath string, runMode RunMode, circuits []string, config *DownloadConfig) ([]*BatchProofSystem, error) {
 	var pssv2 []*BatchProofSystem
 	keys := GetKeys(keysDirPath, runMode, circuits)
 
 	// Ensure all required keys exist (download if necessary)
 	if err := EnsureKeysExist(keys, config); err != nil {
-		return nil, nil, fmt.Errorf("failed to ensure keys exist: %w", err)
+		return nil, fmt.Errorf("failed to ensure keys exist: %w", err)
 	}
 
 	for _, key := range keys {
 		logging.Logger().Info().Msg("Reading proving system from file " + key + "...")
 		system, err := ReadSystemFromFile(key)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		switch s := system.(type) {
-		case *MerkleProofSystem:
-			pssv1 = append(pssv1, s)
-			logging.Logger().Info().
-				Uint32("inclusionTreeHeight", s.InclusionTreeHeight).
-				Uint32("inclusionCompressedAccounts", s.InclusionNumberOfCompressedAccounts).
-				Uint32("nonInclusionTreeHeight", s.NonInclusionTreeHeight).
-				Uint32("nonInclusionCompressedAccounts", s.NonInclusionNumberOfCompressedAccounts).
-				Msg("Read MerkleProofSystem")
 		case *BatchProofSystem:
 			pssv2 = append(pssv2, s)
 			logging.Logger().Info().
@@ -186,10 +177,10 @@ func LoadKeysWithConfig(keysDirPath string, runMode RunMode, circuits []string, 
 				Uint32("batchSize", s.BatchSize).
 				Msg("Read BatchProofSystem")
 		default:
-			return nil, nil, fmt.Errorf("unknown proving system type")
+			return nil, fmt.Errorf("unknown proving system type")
 		}
 	}
-	return pssv1, pssv2, nil
+	return pssv2, nil
 }
 
 func createFileAndWriteBytes(filePath string, data []byte) error {
@@ -222,8 +213,6 @@ func WriteProvingSystem(system interface{}, path string, pathVkey string) error 
 
 	var written int64
 	switch s := system.(type) {
-	case *MerkleProofSystem:
-		written, err = s.WriteTo(file)
 	case *BatchProofSystem:
 		written, err = s.WriteTo(file)
 	case *TransferProofSystem:
@@ -242,8 +231,6 @@ func WriteProvingSystem(system interface{}, path string, pathVkey string) error 
 	if pathVkey != "" {
 		var vk interface{}
 		switch s := system.(type) {
-		case *MerkleProofSystem:
-			vk = s.VerifyingKey
 		case *BatchProofSystem:
 			vk = s.VerifyingKey
 		case *TransferProofSystem:

--- a/prover/server/prover/common/types.go
+++ b/prover/server/prover/common/types.go
@@ -3,11 +3,6 @@ package common
 type CircuitType string
 
 const (
-	CombinedCircuitType           CircuitType = "combined"
-	InclusionCircuitType          CircuitType = "inclusion"
-	NonInclusionCircuitType       CircuitType = "non-inclusion"
-	BatchAppendCircuitType        CircuitType = "append"
-	BatchUpdateCircuitType        CircuitType = "update"
 	BatchAddressAppendCircuitType CircuitType = "address-append"
 
 	TransferP256ConfidentialCircuitType CircuitType = "transfer-p256-confidential"
@@ -32,21 +27,3 @@ const (
 	// to the default merge.
 	MergeZoneCircuitType CircuitType = "merge-zone"
 )
-
-// JSON input structures (these are not in circuit_utils.go)
-type InclusionProofInputsJSON struct {
-	Root         string   `json:"root"`
-	PathIndex    uint32   `json:"pathIndex"`
-	PathElements []string `json:"pathElements"`
-	Leaf         string   `json:"leaf"`
-}
-
-type NonInclusionProofInputsJSON struct {
-	Root                                string   `json:"root"`
-	Value                               string   `json:"value"`
-	LeafLowerRangeValue                 string   `json:"leafLowerRangeValue"`
-	LeafHigherRangeValue                string   `json:"leafHigherRangeValue"`
-	LeafIndex                           uint32   `json:"leafIndex"`
-	MerkleProofHashedIndexedElementLeaf []string `json:"merkleProofHashedIndexedElementLeaf"`
-	IndexHashedIndexedElementLeaf       uint32   `json:"indexHashedIndexedElementLeaf"`
-}

--- a/prover/server/server/queue_routing_test.go
+++ b/prover/server/server/queue_routing_test.go
@@ -20,8 +20,7 @@ func TestGetQueueNameForCircuit(t *testing.T) {
 		{common.TransferZoneAuthorityCircuitType, "zk_transfer_queue"},
 		{common.MergeCircuitType, "zk_transfer_queue"},
 		{common.MergeZoneCircuitType, "zk_transfer_queue"},
-		{common.InclusionCircuitType, ""},
-		{common.NonInclusionCircuitType, ""},
+		{common.CircuitType("unknown"), ""},
 	}
 	for _, c := range cases {
 		if got := GetQueueNameForCircuit(c.circuit); got != c.queue {


### PR DESCRIPTION
Removes the Light zk-compression proving surface Zolana never uses: `MerkleProofSystem` (inclusion / non-inclusion / combined) and the batch `append` / `update` circuits, plus their vestigial CLI flags. Keeps transfer, merge, and the forester's batch `address-append`. Formal verification is untouched (`extract-circuit` / `circuits/formal` never referenced the removed code).
