### PR TITLE
feat(cli): use published release in cli test validator command, publish release xtask 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ experiments
 docs/spec.pdf
 docs/squads_policy_program.pdf
 build
+target-linux-x64/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11151,9 +11151,11 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "bincode 1.3.3",
  "bs58",
  "groth16-solana",
+ "serde_json",
  "sha2 0.10.9",
  "solana-account 3.4.0",
  "solana-address 2.6.1",
@@ -11393,8 +11395,10 @@ dependencies = [
  "anyhow",
  "clap",
  "hex",
+ "reqwest",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "solana-instruction 3.4.0",
  "solana-keypair",
  "solana-pubkey 4.2.0",

--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ The Cargo workspace's `default-members` is deliberately narrow — `forester`,
 `program-libs/interface`, and `programs/shielded-pool` — so a bare `cargo check` from the root
 hits the production-critical surface quickly. For full-workspace coverage use `just check-all`.
 
+## Install the CLI
+
+Install the `zolana` binary straight from the repository (builds from source, so
+it pulls the workspace's git dependencies; not published to crates.io):
+
+```bash
+cargo install --git https://github.com/helius-labs/zolana --tag v0.1.0-alpha zolana-cli
+```
+
+`zolana dev start` then fetches a version-pinned, pre-initialized localnet
+(programs, account snapshots, prover, and Photon) from the matching release. See
+[`cli/README.md`](cli/README.md) for commands and the `--local` dev flow.
+
 ## CI
 
 Workflows under `.github/workflows/`:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,8 +14,10 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 hex = { workspace = true }
+reqwest = { workspace = true, features = ["blocking"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,19 @@
 # zolana CLI
 
-Run from repo root:
+Install the `zolana` binary directly from the repository (no checkout needed).
+This builds from source, so it pulls the workspace's git dependencies; the CLI is
+not published to crates.io.
+
+```bash
+cargo install --git https://github.com/helius-labs/zolana --tag v0.1.0-alpha zolana-cli
+```
+
+Installing at the release tag keeps the CLI's embedded proving-key/artifact
+lockfile in sync with the artifacts it downloads. Use a newer `--tag`, or
+`--branch main` / `--rev <sha>`, to track other revisions; re-run with `--force`
+to update an existing install.
+
+For local development from a checkout, install from the working tree instead:
 
 ```bash
 cargo install --path cli --force
@@ -57,3 +70,35 @@ Optional wallet path:
 ```bash
 --keypair /path/to/pid.json
 ```
+
+## Local dev environment
+
+```bash
+zolana dev start          # or: zolana test-env
+```
+
+By default `dev start` bootstraps a ready-to-use localnet from a pinned GitHub
+release: it downloads the shielded-pool, user-registry, and Squads smart-account
+programs, an account-snapshot bundle (protocol config, asset counter, the pool
+tree at the default tree address, and the Squads authority accounts), and the
+prover and Photon binaries, plus the custom surfpool binary from its own release.
+Every artifact is verified against the sha256 lockfile embedded in the CLI
+(`cli/release-artifacts.lock`) and cached under `~/.config/zolana/cache/<tag>/`,
+so repeat starts are offline. This means a fresh `cargo install --path cli` can
+boot a fully-initialized localnet with no repo checkout and nothing prebuilt.
+
+Use `--local` to run against locally built artifacts instead (what dev and CI
+use after `just build-programs` / `just build-prover-server` / `just
+build-photon`):
+
+```bash
+zolana dev start --local --sbf-program <ID> target/deploy/<program>.so
+```
+
+Passing any explicit `--sbf-program` also implies local mode. Override the
+release download host with `ZOLANA_RELEASE_URL`.
+
+Maintainers publish the release with `just release <tag>` (dry run; set `UPLOAD=1`
+to publish via `gh`, `PRERELEASE=1` for alpha tags). It builds the artifacts,
+snapshots the initialized accounts in-process with LiteSVM (no keypairs or running
+validator needed), and regenerates the lockfile.

--- a/cli/README.md
+++ b/cli/README.md
@@ -98,7 +98,9 @@ zolana dev start --local --sbf-program <ID> target/deploy/<program>.so
 Passing any explicit `--sbf-program` also implies local mode. Override the
 release download host with `ZOLANA_RELEASE_URL`.
 
-Maintainers publish the release with `just release <tag>` (dry run; set `UPLOAD=1`
-to publish via `gh`, `PRERELEASE=1` for alpha tags). It builds the artifacts,
-snapshots the initialized accounts in-process with LiteSVM (no keypairs or running
-validator needed), and regenerates the lockfile.
+Maintainers publish the release with
+`just release <tag> --upload --prerelease` (omit the flags for a dry run that only
+stages assets and regenerates the lockfile). It builds the programs, the host +
+linux-x64 prover/photon binaries, snapshots the initialized accounts in-process
+with LiteSVM (no keypairs or running validator needed), and regenerates the
+lockfile.

--- a/cli/release-artifacts.lock
+++ b/cli/release-artifacts.lock
@@ -1,7 +1,7 @@
 {
   "accounts": {
     "asset": "accounts-v0.1.0-alpha.tar.gz",
-    "sha256": "ca1e13bb5da8cfe8fa29f802b83df2eacbb4fa1be08bb7bac257441973a07e97",
+    "sha256": "49092ed1455e987dc902ba7e29fdd4ad91a36865033e9c5066b6e1618321a8f5",
     "size": 4552
   },
   "binaries": [
@@ -10,7 +10,7 @@
       "asset": "prover-darwin-arm64-v0.1.0-alpha",
       "os": "darwin",
       "role": "prover",
-      "sha256": "be89bdf93f940f5bcd15ca3be1ea6ee4d3e61d3572ca396c4b60361f2cefe3a7",
+      "sha256": "61c3e0c1125a67eb0a25ca209af48034abdaeeb73a83f65bef662a6f131ba34f",
       "size": 39363522
     },
     {
@@ -26,7 +26,7 @@
       "asset": "prover-linux-x64-v0.1.0-alpha",
       "os": "linux",
       "role": "prover",
-      "sha256": "6ff60739c09e2d8bf1d5e1f562323fa54f19414f18746bba71e0904e58937db3",
+      "sha256": "d98317ff4bdd6342a709914ce8940f18b12653c05ab0a0306ecef47e7f989665",
       "size": 41564971
     },
     {

--- a/cli/release-artifacts.lock
+++ b/cli/release-artifacts.lock
@@ -1,8 +1,8 @@
 {
   "accounts": {
     "asset": "accounts-v0.1.0-alpha.tar.gz",
-    "sha256": "6520a1b3f60ea7b2797d91b504d25a5383ef3e8e16fa3449dffbc2bfd4f94fc7",
-    "size": 4549
+    "sha256": "ca1e13bb5da8cfe8fa29f802b83df2eacbb4fa1be08bb7bac257441973a07e97",
+    "size": 4552
   },
   "binaries": [
     {
@@ -10,16 +10,32 @@
       "asset": "prover-darwin-arm64-v0.1.0-alpha",
       "os": "darwin",
       "role": "prover",
-      "sha256": "191bdcaf84f9d29eff0c95480bb8b0a18a5c94f135c418e8271fa95ba23941ba",
-      "size": 39281890
+      "sha256": "be89bdf93f940f5bcd15ca3be1ea6ee4d3e61d3572ca396c4b60361f2cefe3a7",
+      "size": 39363522
     },
     {
       "arch": "arm64",
       "asset": "photon-darwin-arm64-v0.1.0-alpha",
       "os": "darwin",
       "role": "photon",
-      "sha256": "244381ec5fc385a644cda44509db198e55f06e1d51f22a1d8ca2613f2ceabda8",
-      "size": 79548968
+      "sha256": "20ab4e061ae46e844a09154d3ff51b4c1993bbc63f1d72bb6be28455cdaa3668",
+      "size": 25361280
+    },
+    {
+      "arch": "x64",
+      "asset": "prover-linux-x64-v0.1.0-alpha",
+      "os": "linux",
+      "role": "prover",
+      "sha256": "6ff60739c09e2d8bf1d5e1f562323fa54f19414f18746bba71e0904e58937db3",
+      "size": 41564971
+    },
+    {
+      "arch": "x64",
+      "asset": "photon-linux-x64-v0.1.0-alpha",
+      "os": "linux",
+      "role": "photon",
+      "sha256": "0206546254d9fe6b97f345107aabc8f5bfa0631c82a23b15754a686af1c4585f",
+      "size": 29910496
     }
   ],
   "programs": [

--- a/cli/release-artifacts.lock
+++ b/cli/release-artifacts.lock
@@ -1,0 +1,48 @@
+{
+  "accounts": {
+    "asset": "accounts-v0.1.0-alpha.tar.gz",
+    "sha256": "6520a1b3f60ea7b2797d91b504d25a5383ef3e8e16fa3449dffbc2bfd4f94fc7",
+    "size": 4549
+  },
+  "binaries": [
+    {
+      "arch": "arm64",
+      "asset": "prover-darwin-arm64-v0.1.0-alpha",
+      "os": "darwin",
+      "role": "prover",
+      "sha256": "191bdcaf84f9d29eff0c95480bb8b0a18a5c94f135c418e8271fa95ba23941ba",
+      "size": 39281890
+    },
+    {
+      "arch": "arm64",
+      "asset": "photon-darwin-arm64-v0.1.0-alpha",
+      "os": "darwin",
+      "role": "photon",
+      "sha256": "244381ec5fc385a644cda44509db198e55f06e1d51f22a1d8ca2613f2ceabda8",
+      "size": 79548968
+    }
+  ],
+  "programs": [
+    {
+      "asset": "shielded_pool_program-v0.1.0-alpha.so",
+      "role": "shielded_pool",
+      "sha256": "95e4905bcdf909189560d9e67866023a3d6f4509f1b0b394096fdc16c4c265a8",
+      "size": 343968
+    },
+    {
+      "asset": "zolana_user_registry-v0.1.0-alpha.so",
+      "role": "user_registry",
+      "sha256": "d2fc289294fc34249b6fff21beaef7138e66dd7398c7e68752e89808671a3a0c",
+      "size": 65480
+    },
+    {
+      "asset": "squads_smart_account_program-v0.1.0-alpha.so",
+      "role": "smart_account",
+      "sha256": "49cf27024d211ab827eadc11219a935abf9a5138ece1c0b0631c26790fd4f3c0",
+      "size": 1641757
+    }
+  ],
+  "release_tag": "v0.1.0-alpha",
+  "surfpool_tag": "v1.1.1-light",
+  "surfpool_version": "1.1.1"
+}

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -193,6 +193,12 @@ pub(crate) struct TestValidatorOptions {
     #[arg(long, help = "Start a local Photon indexer")]
     pub(crate) with_photon: bool,
 
+    #[arg(
+        long,
+        help = "Use locally built artifacts instead of the pinned release"
+    )]
+    pub(crate) local: bool,
+
     #[arg(long, help = "Stop the local validator environment")]
     pub(crate) stop: bool,
 
@@ -558,6 +564,13 @@ impl TestValidatorOptions {
         self.use_surfpool || !self.no_use_surfpool
     }
 
+    /// Fetch programs, account snapshots, and helper binaries from the pinned
+    /// release unless the user opted into local builds or passed explicit
+    /// programs (in which case those local artifacts take precedence).
+    pub(crate) fn use_release(&self) -> bool {
+        !self.local && self.sbf_programs.is_empty() && self.upgradeable_programs.is_empty()
+    }
+
     pub(crate) fn sbf_program_specs(&self) -> Vec<ProgramSpec> {
         self.sbf_programs
             .chunks_exact(2)
@@ -772,6 +785,24 @@ mod tests {
         );
         assert_eq!(zone_program.path, "target/deploy/zone.so");
         assert!(programs.next().is_none());
+    }
+
+    #[test]
+    fn use_release_reflects_local_flag_and_explicit_programs() {
+        let default = parse_validator(&[]);
+        assert!(default.use_release());
+        assert!(!default.local);
+
+        let local = parse_validator(&["--local"]);
+        assert!(local.local);
+        assert!(!local.use_release());
+
+        let explicit_program = parse_validator(&[
+            "--sbf-program",
+            "Pool111111111111111111111111111111111111111",
+            "target/deploy/pool.so",
+        ]);
+        assert!(!explicit_program.use_release());
     }
 
     #[test]

--- a/cli/src/localnet.rs
+++ b/cli/src/localnet.rs
@@ -1,4 +1,4 @@
-use std::{thread, time::Duration};
+use std::{path::Path, thread, time::Duration};
 
 use anyhow::{bail, Context, Result};
 
@@ -6,11 +6,14 @@ use crate::{
     args::TestValidatorOptions,
     config::{READINESS_STABLE_CHECKS, READINESS_TIMEOUT},
     http::{wait_for_http_get_with_child, wait_for_rpc_with_child},
-    process::{find_binary, remove_launchd_validators, spawn_service, stop_name, stop_port},
+    process::{
+        find_binary, path_string, remove_launchd_validators, spawn_service, stop_name, stop_port,
+    },
     prover::start_prover_service,
+    release::Release,
 };
 
-pub(crate) fn run_test_validator(opts: TestValidatorOptions) -> Result<()> {
+pub(crate) fn run_test_validator(mut opts: TestValidatorOptions) -> Result<()> {
     if opts.stop {
         println!("Stopping local validator environment");
         stop_test_env(&opts);
@@ -22,8 +25,30 @@ pub(crate) fn run_test_validator(opts: TestValidatorOptions) -> Result<()> {
     stop_test_validator(opts.rpc_port);
     thread::sleep(Duration::from_secs(1));
 
+    // Default rail: fetch version-pinned programs, initialized account snapshots,
+    // and helper binaries from the release. `--local` (or explicit --sbf-program)
+    // keeps the fully-local artifacts used by dev and CI. Release programs and
+    // snapshots are folded into `opts` so the arg builders keep a single source.
+    let release = if opts.use_release() {
+        Some(Release::load()?)
+    } else {
+        None
+    };
+    if let Some(release) = &release {
+        println!("Using release {} artifacts", release.tag());
+        for spec in release.program_specs()? {
+            opts.sbf_programs.push(spec.address);
+            opts.sbf_programs.push(spec.path);
+        }
+        opts.account_dirs
+            .push(path_string(&release.accounts_dir()?)?);
+    }
+
     let mut validator = if opts.use_surfpool_backend() {
-        let surfpool = find_binary(&["SURFPOOL_BIN"], &["target/tools/surfpool"], &["surfpool"])?;
+        let surfpool = match &release {
+            Some(release) => release.surfpool_binary()?,
+            None => find_binary(&["SURFPOOL_BIN"], &["target/tools/surfpool"], &["surfpool"])?,
+        };
         let args = surfpool_args(&opts)?;
         println!(
             "Starting surfpool: {} {}",
@@ -57,16 +82,25 @@ pub(crate) fn run_test_validator(opts: TestValidatorOptions) -> Result<()> {
     })?;
 
     if !opts.skip_prover {
+        let prover_binary = match &release {
+            Some(release) => Some(release.prover_binary()?),
+            None => None,
+        };
         start_prover_service(
             opts.prover_port,
             None,
             opts.prover_auto_download,
             &opts.log_dir,
+            prover_binary.as_deref(),
         )?;
     }
 
     if opts.with_photon {
-        start_photon_service(&opts)?;
+        let photon_binary = match &release {
+            Some(release) => Some(release.photon_binary()?),
+            None => None,
+        };
+        start_photon_service(&opts, photon_binary.as_deref())?;
     }
 
     println!("Local validator environment is ready");
@@ -168,15 +202,18 @@ fn stop_test_validator(rpc_port: u16) {
     stop_port(rpc_port);
 }
 
-fn start_photon_service(opts: &TestValidatorOptions) -> Result<()> {
+fn start_photon_service(opts: &TestValidatorOptions, binary: Option<&Path>) -> Result<()> {
     stop_name("photon");
     stop_port(opts.photon_port);
 
-    let photon = find_binary(
-        &["ZOLANA_PHOTON_BIN"],
-        &["target/release/photon", "target/debug/photon"],
-        &["photon"],
-    )?;
+    let photon = match binary {
+        Some(path) => path.to_path_buf(),
+        None => find_binary(
+            &["ZOLANA_PHOTON_BIN"],
+            &["target/release/photon", "target/debug/photon"],
+            &["photon"],
+        )?,
+    };
     let rpc_url = format!("http://127.0.0.1:{}", opts.rpc_port);
     let mut args = vec![
         "--rpc-url".to_string(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,7 @@ mod http;
 mod localnet;
 mod process;
 mod prover;
+mod release;
 mod wallet_cli;
 
 use anyhow::Result;

--- a/cli/src/prover.rs
+++ b/cli/src/prover.rs
@@ -18,6 +18,7 @@ pub(crate) fn run_start_prover(opts: StartProverOptions) -> Result<()> {
         opts.redis_url.as_deref(),
         opts.auto_download,
         DEFAULT_LOG_DIR,
+        None,
     )
 }
 
@@ -26,6 +27,7 @@ pub(crate) fn start_prover_service(
     redis_url: Option<&str>,
     auto_download: bool,
     log_dir: &str,
+    binary: Option<&Path>,
 ) -> Result<()> {
     // The prover's Prometheus metrics server defaults to the fixed port 9998, so
     // two clones running prover-backed tests concurrently would collide there and
@@ -38,11 +40,14 @@ pub(crate) fn start_prover_service(
     stop_port(prover_port);
     stop_port(metrics_port);
 
-    let prover = find_binary(
-        &["PROVER_BIN", "ZOLANA_PROVER_BIN"],
-        &["target/prover-server"],
-        &["prover-server"],
-    )?;
+    let prover = match binary {
+        Some(path) => path.to_path_buf(),
+        None => find_binary(
+            &["PROVER_BIN", "ZOLANA_PROVER_BIN"],
+            &["target/prover-server"],
+            &["prover-server"],
+        )?,
+    };
     let keys_dir = prover_keys_dir()?;
     fs::create_dir_all(&keys_dir)
         .with_context(|| format!("failed to create prover keys dir {}", keys_dir.display()))?;

--- a/cli/src/release.rs
+++ b/cli/src/release.rs
@@ -222,7 +222,11 @@ fn ensure_file(tag: &str, asset: &Asset, base_url: &str) -> Result<PathBuf> {
     println!("Downloading {url}");
     let bytes = http_get(&url)?;
     verify_bytes(&bytes, asset)?;
-    fs::write(&path, &bytes).with_context(|| format!("failed to write {}", path.display()))?;
+    // Write to a temp file then rename so an interrupted download never leaves a
+    // corrupt file at the cache path (rename is atomic on the same filesystem).
+    let tmp = path.with_extension("part");
+    fs::write(&tmp, &bytes).with_context(|| format!("failed to write {}", tmp.display()))?;
+    fs::rename(&tmp, &path).with_context(|| format!("failed to finalize {}", path.display()))?;
     Ok(path)
 }
 
@@ -287,8 +291,11 @@ fn http_get(url: &str) -> Result<Vec<u8>> {
 
 fn extract_tar_gz(archive: &Path, dest: &Path) -> Result<()> {
     fs::create_dir_all(dest).with_context(|| format!("failed to create {}", dest.display()))?;
+    // Exclude macOS AppleDouble/.DS_Store sidecars: if a snapshot tarball was
+    // packed on macOS with them, GNU tar would materialize them into the account
+    // dir and the validator would try to parse them as account JSON and fail.
     let status = Command::new("tar")
-        .arg("-xzf")
+        .args(["--exclude=._*", "--exclude=.DS_Store", "-xzf"])
         .arg(archive)
         .arg("-C")
         .arg(dest)

--- a/cli/src/release.rs
+++ b/cli/src/release.rs
@@ -1,0 +1,410 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::Duration,
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use solana_pubkey::Pubkey;
+
+use crate::{args::ProgramSpec, cli_config::config_dir, process::path_string};
+
+const LOCK_JSON: &str = include_str!("../release-artifacts.lock");
+
+const DEFAULT_RELEASE_BASE_URL: &str = "https://github.com/helius-labs/zolana/releases/download";
+const SURFPOOL_BASE_URL: &str = "https://github.com/Lightprotocol/surfpool/releases/download";
+
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
+
+// The Squads smart-account program id is fixed on mainnet; shielded-pool and
+// user-registry ids come from the interface crates so they cannot drift.
+const SMART_ACCOUNT_PROGRAM_ID: &str = "SMRTzfY6DfH5ik3TKiyLFfXexV8uSG3d2UksSCYdunG";
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ReleaseLock {
+    pub release_tag: String,
+    pub surfpool_tag: String,
+    pub surfpool_version: String,
+    pub programs: Vec<ProgramAsset>,
+    pub accounts: Asset,
+    pub binaries: Vec<BinaryAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Asset {
+    #[serde(rename = "asset")]
+    pub name: String,
+    pub size: u64,
+    pub sha256: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ProgramAsset {
+    pub role: String,
+    #[serde(flatten)]
+    pub file: Asset,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct BinaryAsset {
+    pub role: String,
+    pub os: String,
+    pub arch: String,
+    #[serde(flatten)]
+    pub file: Asset,
+}
+
+pub(crate) struct Release {
+    lock: ReleaseLock,
+}
+
+impl Release {
+    pub(crate) fn load() -> Result<Self> {
+        let lock = serde_json::from_str(LOCK_JSON)
+            .context("failed to parse embedded release-artifacts.lock")?;
+        Ok(Self { lock })
+    }
+
+    pub(crate) fn tag(&self) -> &str {
+        &self.lock.release_tag
+    }
+
+    /// Downloads (cache-first) each pinned program `.so` and pairs it with the
+    /// on-chain program id so the caller can build `--bpf-program` args.
+    pub(crate) fn program_specs(&self) -> Result<Vec<ProgramSpec>> {
+        let base = release_base_url();
+        self.lock
+            .programs
+            .iter()
+            .map(|program| {
+                let path = ensure_file(&self.lock.release_tag, &program.file, &base)?;
+                Ok(ProgramSpec {
+                    address: program_id_for_role(&program.role)?,
+                    path: path_string(&path)?,
+                })
+            })
+            .collect()
+    }
+
+    /// Downloads and extracts the account-snapshot bundle, returning the
+    /// directory to hand to the validator via `--account-dir`.
+    pub(crate) fn accounts_dir(&self) -> Result<PathBuf> {
+        let base = release_base_url();
+        let archive = ensure_file(&self.lock.release_tag, &self.lock.accounts, &base)?;
+        let dir = cache_dir(&self.lock.release_tag).join("accounts");
+        // Re-extract each run: the archive is checksum-verified and extraction is
+        // cheap, so a partially-populated dir from an interrupted run self-heals.
+        extract_tar_gz(&archive, &dir)?;
+        Ok(dir)
+    }
+
+    pub(crate) fn prover_binary(&self) -> Result<PathBuf> {
+        self.binary("prover")
+    }
+
+    pub(crate) fn photon_binary(&self) -> Result<PathBuf> {
+        self.binary("photon")
+    }
+
+    fn binary(&self, role: &str) -> Result<PathBuf> {
+        let (os, arch) = current_platform()?;
+        let asset = select_binary(&self.lock, role, os, arch).ok_or_else(|| {
+            anyhow!("release-artifacts.lock has no {role} binary for {os}-{arch}")
+        })?;
+        let base = release_base_url();
+        let path = ensure_file(&self.lock.release_tag, &asset.file, &base)?;
+        make_executable(&path)?;
+        Ok(path)
+    }
+
+    /// Downloads the custom surfpool binary from its own release. The tarball has
+    /// no lockfile checksum (separate repo), so integrity is asserted via
+    /// `surfpool --version`, matching the `just install-surfpool` recipe.
+    pub(crate) fn surfpool_binary(&self) -> Result<PathBuf> {
+        let (os, arch) = current_platform()?;
+        let dir = cache_dir(&self.lock.release_tag).join("surfpool");
+        let bin = dir.join("surfpool");
+        if bin.is_file() && surfpool_version_matches(&bin, &self.lock.surfpool_version) {
+            return Ok(bin);
+        }
+
+        fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
+        let asset_name = format!("surfpool-{os}-{arch}.tar.gz");
+        let url = format!(
+            "{SURFPOOL_BASE_URL}/{}/{asset_name}",
+            self.lock.surfpool_tag
+        );
+        println!("Downloading {url}");
+        let bytes = http_get(&url)?;
+        let archive = dir.join(&asset_name);
+        fs::write(&archive, &bytes)
+            .with_context(|| format!("failed to write {}", archive.display()))?;
+        extract_tar_gz(&archive, &dir)?;
+
+        let found = find_named(&dir, "surfpool")?
+            .ok_or_else(|| anyhow!("surfpool binary not found in {asset_name}"))?;
+        if found != bin {
+            fs::copy(&found, &bin)
+                .with_context(|| format!("failed to place surfpool at {}", bin.display()))?;
+        }
+        make_executable(&bin)?;
+
+        if !surfpool_version_matches(&bin, &self.lock.surfpool_version) {
+            bail!(
+                "downloaded surfpool does not report version {}",
+                self.lock.surfpool_version
+            );
+        }
+        Ok(bin)
+    }
+}
+
+fn program_id_for_role(role: &str) -> Result<String> {
+    let id = match role {
+        "shielded_pool" => {
+            Pubkey::new_from_array(zolana_interface::SHIELDED_POOL_PROGRAM_ID).to_string()
+        }
+        "user_registry" => {
+            Pubkey::new_from_array(zolana_user_registry_interface::USER_REGISTRY_PROGRAM_ID)
+                .to_string()
+        }
+        "smart_account" => SMART_ACCOUNT_PROGRAM_ID.to_string(),
+        other => bail!("unknown program role in release-artifacts.lock: {other}"),
+    };
+    Ok(id)
+}
+
+fn select_binary<'a>(
+    lock: &'a ReleaseLock,
+    role: &str,
+    os: &str,
+    arch: &str,
+) -> Option<&'a BinaryAsset> {
+    lock.binaries
+        .iter()
+        .find(|binary| binary.role == role && binary.os == os && binary.arch == arch)
+}
+
+fn current_platform() -> Result<(&'static str, &'static str)> {
+    let os = match env::consts::OS {
+        "linux" => "linux",
+        "macos" => "darwin",
+        other => bail!("unsupported OS for release artifacts: {other}"),
+    };
+    let arch = match env::consts::ARCH {
+        "x86_64" => "x64",
+        "aarch64" => "arm64",
+        other => bail!("unsupported architecture for release artifacts: {other}"),
+    };
+    Ok((os, arch))
+}
+
+fn cache_dir(tag: &str) -> PathBuf {
+    config_dir().join("cache").join(tag)
+}
+
+fn release_base_url() -> String {
+    env::var("ZOLANA_RELEASE_URL").unwrap_or_else(|_| DEFAULT_RELEASE_BASE_URL.to_string())
+}
+
+fn ensure_file(tag: &str, asset: &Asset, base_url: &str) -> Result<PathBuf> {
+    let dir = cache_dir(tag);
+    fs::create_dir_all(&dir).with_context(|| format!("failed to create {}", dir.display()))?;
+    let path = dir.join(&asset.name);
+    if path.is_file() && file_matches(&path, asset)? {
+        return Ok(path);
+    }
+
+    let url = format!("{base_url}/{tag}/{}", asset.name);
+    println!("Downloading {url}");
+    let bytes = http_get(&url)?;
+    verify_bytes(&bytes, asset)?;
+    fs::write(&path, &bytes).with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(path)
+}
+
+fn verify_bytes(bytes: &[u8], asset: &Asset) -> Result<()> {
+    if asset.sha256.is_empty() {
+        bail!(
+            "no pinned checksum for {}: release-artifacts.lock is a placeholder. Publish a release with `cargo run -p xtask -- create-release`.",
+            asset.name
+        );
+    }
+    if bytes.len() as u64 != asset.size {
+        bail!(
+            "size mismatch for {}: expected {} bytes, got {}",
+            asset.name,
+            asset.size,
+            bytes.len()
+        );
+    }
+    let actual = sha256_hex(bytes);
+    if actual != asset.sha256 {
+        bail!(
+            "sha256 mismatch for {}: expected {}, got {}",
+            asset.name,
+            asset.sha256,
+            actual
+        );
+    }
+    Ok(())
+}
+
+fn file_matches(path: &Path, asset: &Asset) -> Result<bool> {
+    if asset.sha256.is_empty() {
+        return Ok(false);
+    }
+    let bytes = fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
+    Ok(bytes.len() as u64 == asset.size && sha256_hex(&bytes) == asset.sha256)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+fn http_get(url: &str) -> Result<Vec<u8>> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(DOWNLOAD_TIMEOUT)
+        .build()
+        .context("failed to build HTTP client")?;
+    let response = client
+        .get(url)
+        .send()
+        .with_context(|| format!("failed to GET {url}"))?;
+    if !response.status().is_success() {
+        bail!("GET {url} returned HTTP {}", response.status());
+    }
+    let bytes = response
+        .bytes()
+        .with_context(|| format!("failed to read response body from {url}"))?;
+    Ok(bytes.to_vec())
+}
+
+fn extract_tar_gz(archive: &Path, dest: &Path) -> Result<()> {
+    fs::create_dir_all(dest).with_context(|| format!("failed to create {}", dest.display()))?;
+    let status = Command::new("tar")
+        .arg("-xzf")
+        .arg(archive)
+        .arg("-C")
+        .arg(dest)
+        .status()
+        .with_context(|| format!("failed to run tar on {}", archive.display()))?;
+    if !status.success() {
+        bail!("tar extraction failed for {}", archive.display());
+    }
+    Ok(())
+}
+
+fn find_named(dir: &Path, name: &str) -> Result<Option<PathBuf>> {
+    for entry in fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))? {
+        let path = entry?.path();
+        if path.is_dir() {
+            if let Some(found) = find_named(&path, name)? {
+                return Ok(Some(found));
+            }
+        } else if path.file_name().and_then(|n| n.to_str()) == Some(name) {
+            return Ok(Some(path));
+        }
+    }
+    Ok(None)
+}
+
+fn make_executable(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(path)
+            .with_context(|| format!("failed to stat {}", path.display()))?
+            .permissions();
+        perms.set_mode(perms.mode() | 0o755);
+        fs::set_permissions(path, perms)
+            .with_context(|| format!("failed to chmod {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn surfpool_version_matches(bin: &Path, version: &str) -> bool {
+    Command::new(bin)
+        .arg("--version")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).contains(version))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lock() -> ReleaseLock {
+        serde_json::from_str(LOCK_JSON).expect("embedded lock parses")
+    }
+
+    #[test]
+    fn embedded_lock_parses_with_expected_shape() {
+        let lock = lock();
+        let program_roles: Vec<&str> = lock.programs.iter().map(|p| p.role.as_str()).collect();
+        assert!(program_roles.contains(&"shielded_pool"));
+        assert!(program_roles.contains(&"user_registry"));
+        assert!(program_roles.contains(&"smart_account"));
+
+        let binary_roles: Vec<&str> = lock.binaries.iter().map(|b| b.role.as_str()).collect();
+        assert!(binary_roles.contains(&"prover"));
+        assert!(binary_roles.contains(&"photon"));
+        assert!(!lock.accounts.name.is_empty());
+    }
+
+    #[test]
+    fn selects_binary_by_role_and_platform() {
+        let lock = lock();
+        let prover = select_binary(&lock, "prover", "linux", "x64").expect("prover linux x64");
+        assert_eq!(prover.role, "prover");
+        assert_eq!(prover.os, "linux");
+        assert_eq!(prover.arch, "x64");
+        assert!(select_binary(&lock, "prover", "windows", "x64").is_none());
+        assert!(select_binary(&lock, "unknown", "linux", "x64").is_none());
+    }
+
+    #[test]
+    fn program_id_for_role_maps_known_roles() {
+        let smart = program_id_for_role("smart_account").unwrap();
+        assert_eq!(smart, SMART_ACCOUNT_PROGRAM_ID);
+        assert!(!program_id_for_role("shielded_pool").unwrap().is_empty());
+        assert!(!program_id_for_role("user_registry").unwrap().is_empty());
+        assert!(program_id_for_role("nope").is_err());
+    }
+
+    #[test]
+    fn current_platform_resolves_on_this_host() {
+        assert!(current_platform().is_ok());
+    }
+
+    #[test]
+    fn verify_bytes_enforces_size_and_hash() {
+        // sha256("hello")
+        let asset = Asset {
+            name: "test".to_string(),
+            size: 5,
+            sha256: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824".to_string(),
+        };
+        assert!(verify_bytes(b"hello", &asset).is_ok());
+        assert!(verify_bytes(b"hell", &asset).is_err());
+        assert!(verify_bytes(b"world", &asset).is_err());
+    }
+
+    #[test]
+    fn verify_bytes_rejects_placeholder_checksum() {
+        let asset = Asset {
+            name: "unpublished".to_string(),
+            size: 5,
+            sha256: String::new(),
+        };
+        assert!(verify_bytes(b"hello", &asset).is_err());
+    }
+}

--- a/justfile
+++ b/justfile
@@ -643,17 +643,15 @@ ensure-photon:
 
 # Build the localnet release artifacts and regenerate cli/release-artifacts.lock:
 # version-suffixed program .so files, an account-snapshot bundle (generated
-# in-process with LiteSVM -- no keypairs or running validator needed), and this
-# host's prover/photon binaries. Stages assets and rewrites the lockfile by
-# default; set UPLOAD=1 to publish via `gh release create`, and PRERELEASE=1 to
-# mark it a GitHub pre-release (e.g. `-alpha` tags). A multi-platform release runs
-# this on each target and merges the per-platform binaries into the lockfile.
-release tag: build-programs fetch-smart-account build-prover-server build-photon
-    cargo run -p xtask -- create-release \
-        --tag {{tag}} \
-        --photon-bin {{photon-bin}} \
-        {{ if env_var_or_default("UPLOAD", "") == "" { "" } else { "--upload" } }} \
-        {{ if env_var_or_default("PRERELEASE", "") == "" { "" } else { "--prerelease" } }}
+# in-process with LiteSVM -- no keypairs or running validator needed), and the
+# prover/photon binaries for the host platform plus linux-x64 (Go cross-compile
+# for the prover; Docker for the linux photon, so docker must be running).
+# Stages assets and rewrites the lockfile only, unless you forward flags to
+# `create-release`: add `--upload` to publish via `gh release create`
+# (re-published cleanly, tag re-pointed at HEAD) and `--prerelease` to mark a
+# GitHub pre-release. Example: `just release v0.1.0-alpha --upload --prerelease`.
+release tag *args: build-programs fetch-smart-account
+    cargo run -p xtask -- create-release --tag {{tag}} {{args}}
 
 # === Formatting and linting ===
 

--- a/justfile
+++ b/justfile
@@ -303,7 +303,7 @@ test-localnet-e2e: build-programs build-prover-server build-cli
     #!/usr/bin/env bash
     set -euo pipefail
     eval "$(cargo run -q -p xtask -- program-ids)"
-    cargo run -p zolana-cli -- dev start --skip-prover --no-use-surfpool --rpc-port {{localnet-rpc-port}} --sbf-program "$SHIELDED_POOL_PROGRAM_ID" target/deploy/shielded_pool_program.so --sbf-program "$USER_REGISTRY_PROGRAM_ID" target/deploy/zolana_user_registry.so --sbf-program "$ZONE_TEST_PROGRAM_ID" target/deploy/zone_test_program.so
+    cargo run -p zolana-cli -- dev start --local --skip-prover --no-use-surfpool --rpc-port {{localnet-rpc-port}} --sbf-program "$SHIELDED_POOL_PROGRAM_ID" target/deploy/shielded_pool_program.so --sbf-program "$USER_REGISTRY_PROGRAM_ID" target/deploy/zolana_user_registry.so --sbf-program "$ZONE_TEST_PROGRAM_ID" target/deploy/zone_test_program.so
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" cargo test -p shielded-pool-tests --features localnet --test localnet_e2e -- --nocapture
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" cargo test -p shielded-pool-tests --features localnet --test localnet_deposit -- --nocapture
 
@@ -640,6 +640,20 @@ ensure-photon:
       exit 0
     fi
     just build-photon
+
+# Build the localnet release artifacts and regenerate cli/release-artifacts.lock:
+# version-suffixed program .so files, an account-snapshot bundle (generated
+# in-process with LiteSVM -- no keypairs or running validator needed), and this
+# host's prover/photon binaries. Stages assets and rewrites the lockfile by
+# default; set UPLOAD=1 to publish via `gh release create`, and PRERELEASE=1 to
+# mark it a GitHub pre-release (e.g. `-alpha` tags). A multi-platform release runs
+# this on each target and merges the per-platform binaries into the lockfile.
+release tag: build-programs fetch-smart-account build-prover-server build-photon
+    cargo run -p xtask -- create-release \
+        --tag {{tag}} \
+        --photon-bin {{photon-bin}} \
+        {{ if env_var_or_default("UPLOAD", "") == "" { "" } else { "--upload" } }} \
+        {{ if env_var_or_default("PRERELEASE", "") == "" { "" } else { "--prerelease" } }}
 
 # === Formatting and linting ===
 

--- a/program-tests/test-utils/src/localnet.rs
+++ b/program-tests/test-utils/src/localnet.rs
@@ -23,6 +23,7 @@ impl LocalnetValidator {
 
         let mut args: Vec<String> = vec![
             "test-env".into(),
+            "--local".into(),
             "--no-use-surfpool".into(),
             "--with-photon".into(),
             "--skip-prover".into(),

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,8 +8,10 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
+base64 = { workspace = true }
 bincode = "1.3"
 bs58 = { workspace = true }
+serde_json = { workspace = true }
 sha2 = { workspace = true }
 groth16-solana = { workspace = true, features = ["gnark-vk", "circom-vk"] }
 solana-account = { workspace = true }

--- a/xtask/src/create_release.rs
+++ b/xtask/src/create_release.rs
@@ -1,0 +1,505 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use solana_account::Account;
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use zolana_interface::{
+    instruction::CreateTree, pda, state::tree_account_size, DEFAULT_TREE_ADDRESS,
+    SHIELDED_POOL_PROGRAM_ID,
+};
+use zolana_program_test::ZolanaProgramTest;
+
+const DEFAULT_SURFPOOL_TAG: &str = "v1.1.1-light";
+const DEFAULT_SURFPOOL_VERSION: &str = "1.1.1";
+
+pub struct Options {
+    tag: String,
+    deploy_dir: PathBuf,
+    prover_bin: PathBuf,
+    photon_bin: PathBuf,
+    staging_dir: PathBuf,
+    lock_path: PathBuf,
+    upload: bool,
+    prerelease: bool,
+}
+
+impl Options {
+    pub fn parse(args: Vec<String>) -> Self {
+        let mut tag = None;
+        let mut deploy_dir = PathBuf::from("target/deploy");
+        let mut prover_bin = PathBuf::from("target/prover-server");
+        let mut photon_bin = PathBuf::from("target/release/photon");
+        let mut staging_dir = PathBuf::from("target/release-staging");
+        let mut lock_path = PathBuf::from("cli/release-artifacts.lock");
+        let mut upload = false;
+        let mut prerelease = false;
+
+        let mut args = args.into_iter();
+        while let Some(arg) = args.next() {
+            let mut next = |flag: &str| {
+                args.next()
+                    .unwrap_or_else(|| usage_and_exit(&format!("{flag} missing value")))
+            };
+            match arg.as_str() {
+                "--tag" => tag = Some(next("--tag")),
+                "--deploy-dir" => deploy_dir = PathBuf::from(next("--deploy-dir")),
+                "--prover-bin" => prover_bin = PathBuf::from(next("--prover-bin")),
+                "--photon-bin" => photon_bin = PathBuf::from(next("--photon-bin")),
+                "--staging-dir" => staging_dir = PathBuf::from(next("--staging-dir")),
+                "--lock-path" => lock_path = PathBuf::from(next("--lock-path")),
+                "--upload" => upload = true,
+                "--prerelease" => prerelease = true,
+                "--help" | "-h" => {
+                    print_help();
+                    std::process::exit(0);
+                }
+                other => usage_and_exit(&format!("unexpected arg {other:?}")),
+            }
+        }
+
+        Self {
+            tag: tag.unwrap_or_else(|| usage_and_exit("--tag is required")),
+            deploy_dir,
+            prover_bin,
+            photon_bin,
+            staging_dir,
+            lock_path,
+            upload,
+            prerelease,
+        }
+    }
+}
+
+struct ProgramSource {
+    role: &'static str,
+    file: &'static str,
+    asset_stem: &'static str,
+}
+
+const PROGRAM_SOURCES: [ProgramSource; 3] = [
+    ProgramSource {
+        role: "shielded_pool",
+        file: "shielded_pool_program.so",
+        asset_stem: "shielded_pool_program",
+    },
+    ProgramSource {
+        role: "user_registry",
+        file: "zolana_user_registry.so",
+        asset_stem: "zolana_user_registry",
+    },
+    ProgramSource {
+        role: "smart_account",
+        file: "squads_smart_account_program.so",
+        asset_stem: "squads_smart_account_program",
+    },
+];
+
+pub fn run(options: Options) -> Result<()> {
+    let (os, arch) = current_platform()?;
+
+    // Fail early with actionable guidance if any source artifact is missing.
+    let program_paths = PROGRAM_SOURCES
+        .iter()
+        .map(|source| {
+            let path = options.deploy_dir.join(source.file);
+            require_file(
+                &path,
+                "run `just build-programs` (and `just fetch-smart-account`) first",
+            )?;
+            Ok((source, path))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    require_file(&options.prover_bin, "run `just build-prover-server` first")?;
+    require_file(&options.photon_bin, "run `just build-photon` first")?;
+
+    let staging = &options.staging_dir;
+    reset_dir(staging)?;
+    let accounts_dir = staging.join("accounts");
+    fs::create_dir_all(&accounts_dir)
+        .with_context(|| format!("failed to create {}", accounts_dir.display()))?;
+
+    generate_account_snapshots(&options, &accounts_dir)?;
+
+    // Bundle the snapshot directory; the CLI extracts it into --account-dir.
+    let accounts_asset = format!("accounts-{}.tar.gz", options.tag);
+    let accounts_archive = staging.join(&accounts_asset);
+    tar_gz(&accounts_dir, &accounts_archive)?;
+
+    let mut programs_json = Vec::new();
+    for (source, path) in &program_paths {
+        let asset = format!("{}-{}.so", source.asset_stem, options.tag);
+        let staged = stage_file(path, &staging.join(&asset))?;
+        programs_json.push(json!({
+            "role": source.role,
+            "asset": asset,
+            "size": staged.size,
+            "sha256": staged.sha256,
+        }));
+    }
+
+    let accounts_staged = checksum_file(&accounts_archive)?;
+    let accounts_json = json!({
+        "asset": accounts_asset,
+        "size": accounts_staged.size,
+        "sha256": accounts_staged.sha256,
+    });
+
+    let mut binaries_json = Vec::new();
+    for (role, src) in [
+        ("prover", &options.prover_bin),
+        ("photon", &options.photon_bin),
+    ] {
+        let asset = format!("{role}-{os}-{arch}-{}", options.tag);
+        let staged = stage_file(src, &staging.join(&asset))?;
+        binaries_json.push(json!({
+            "role": role,
+            "os": os,
+            "arch": arch,
+            "asset": asset,
+            "size": staged.size,
+            "sha256": staged.sha256,
+        }));
+    }
+
+    let (surfpool_tag, surfpool_version) = existing_surfpool_fields(&options.lock_path);
+    let lock = json!({
+        "release_tag": options.tag,
+        "surfpool_tag": surfpool_tag,
+        "surfpool_version": surfpool_version,
+        "programs": programs_json,
+        "accounts": accounts_json,
+        "binaries": binaries_json,
+    });
+    let mut serialized = serde_json::to_string_pretty(&lock)?;
+    serialized.push('\n');
+    fs::write(&options.lock_path, serialized)
+        .with_context(|| format!("failed to write {}", options.lock_path.display()))?;
+    println!("wrote lockfile {}", options.lock_path.display());
+
+    let assets = staged_asset_paths(staging, &lock);
+    if options.upload {
+        upload_release(&options.tag, &assets, options.prerelease)?;
+    } else {
+        println!(
+            "dry run (pass --upload to publish). Assets staged in {}:",
+            staging.display()
+        );
+        for asset in &assets {
+            println!("  {}", asset.display());
+        }
+        println!(
+            "\nOnly the {os}-{arch} prover/photon binaries were built here. A multi-platform release requires running this on each target and merging the binaries into the lockfile."
+        );
+    }
+
+    Ok(())
+}
+
+/// Build the initialized account set fully in-process with LiteSVM. No maintainer
+/// keypairs and no running validator are needed: every authority is generated
+/// here, and the pool tree is pre-allocated directly at DEFAULT_TREE_ADDRESS so
+/// its baked-in `hashed_pubkey` stays correct without the tree keypair.
+fn generate_account_snapshots(options: &Options, accounts_dir: &Path) -> Result<()> {
+    let shielded_so = options.deploy_dir.join("shielded_pool_program.so");
+    let mut test = ZolanaProgramTest::with_program_path(&shielded_so)
+        .map_err(|e| anyhow!("failed to boot litesvm: {e:?}"))?;
+
+    let authority = Keypair::new();
+    test.create_protocol_config_permissionless(&authority)
+        .map_err(|e| anyhow!("create_protocol_config failed: {e:?}"))?;
+    test.create_asset_counter(&authority)
+        .map_err(|e| anyhow!("create_asset_counter failed: {e:?}"))?;
+
+    // Pre-allocate the tree at the canonical address, then initialize it. The
+    // program requires the tree account to be program-owned and correctly sized
+    // but not a signer, so no tree keypair is required.
+    let tree: Pubkey = DEFAULT_TREE_ADDRESS
+        .parse()
+        .context("parsing DEFAULT_TREE_ADDRESS")?;
+    let size = tree_account_size();
+    let rent = test.svm.minimum_balance_for_rent_exemption(size);
+    test.svm
+        .set_account(
+            tree,
+            Account {
+                lamports: rent,
+                data: vec![0u8; size],
+                owner: Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID),
+                executable: false,
+                rent_epoch: u64::MAX,
+            },
+        )
+        .map_err(|e| anyhow!("failed to pre-allocate tree account: {e:?}"))?;
+    let create_tree_ix = CreateTree {
+        authority: authority.pubkey(),
+        tree,
+        owner: authority.pubkey(),
+    }
+    .instruction();
+    test.create_and_send_default_payer_transaction(&[create_tree_ix], &[&authority])
+        .map_err(|e| anyhow!("create_tree failed: {e:?}"))?;
+
+    for (label, pubkey) in [
+        ("protocol_config", pda::protocol_config()),
+        ("spl_asset_counter", pda::spl_asset_counter()),
+        ("tree", tree),
+    ] {
+        let account = test
+            .svm
+            .get_account(&pubkey)
+            .ok_or_else(|| anyhow!("{label} account {pubkey} missing after init"))?;
+        write_account_json(accounts_dir, &pubkey, &account)?;
+        println!("snapshot {label} {pubkey}");
+    }
+
+    Ok(())
+}
+
+fn write_account_json(dir: &Path, pubkey: &Pubkey, account: &Account) -> Result<()> {
+    let json = account_json(pubkey, account);
+    let path = dir.join(format!("{pubkey}.json"));
+    fs::write(&path, serde_json::to_string(&json)?)
+        .with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn account_json(pubkey: &Pubkey, account: &Account) -> Value {
+    json!({
+        "pubkey": pubkey.to_string(),
+        "account": {
+            "lamports": account.lamports,
+            "data": [STANDARD.encode(&account.data), "base64"],
+            "owner": account.owner.to_string(),
+            "executable": account.executable,
+            "rentEpoch": account.rent_epoch,
+        }
+    })
+}
+
+struct Checksum {
+    size: u64,
+    sha256: String,
+}
+
+fn stage_file(src: &Path, dest: &Path) -> Result<Checksum> {
+    fs::copy(src, dest)
+        .with_context(|| format!("failed to copy {} -> {}", src.display(), dest.display()))?;
+    checksum_file(dest)
+}
+
+fn checksum_file(path: &Path) -> Result<Checksum> {
+    let bytes = fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
+    Ok(Checksum {
+        size: bytes.len() as u64,
+        sha256: sha256_hex(&bytes),
+    })
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+fn staged_asset_paths(staging: &Path, lock: &Value) -> Vec<PathBuf> {
+    let mut names = Vec::new();
+    if let Some(programs) = lock.get("programs").and_then(Value::as_array) {
+        names.extend(programs.iter().filter_map(asset_name));
+    }
+    if let Some(name) = lock.get("accounts").and_then(asset_name) {
+        names.push(name);
+    }
+    if let Some(binaries) = lock.get("binaries").and_then(Value::as_array) {
+        names.extend(binaries.iter().filter_map(asset_name));
+    }
+    names.iter().map(|name| staging.join(name)).collect()
+}
+
+fn asset_name(value: &Value) -> Option<String> {
+    value
+        .get("asset")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn existing_surfpool_fields(lock_path: &Path) -> (String, String) {
+    let fallback = (
+        DEFAULT_SURFPOOL_TAG.to_string(),
+        DEFAULT_SURFPOOL_VERSION.to_string(),
+    );
+    let Ok(contents) = fs::read_to_string(lock_path) else {
+        return fallback;
+    };
+    let Ok(value) = serde_json::from_str::<Value>(&contents) else {
+        return fallback;
+    };
+    let tag = value
+        .get("surfpool_tag")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let version = value
+        .get("surfpool_version")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    match (tag, version) {
+        (Some(tag), Some(version)) => (tag, version),
+        _ => fallback,
+    }
+}
+
+fn upload_release(tag: &str, assets: &[PathBuf], prerelease: bool) -> Result<()> {
+    let mut args = vec![
+        "release".to_string(),
+        "create".to_string(),
+        tag.to_string(),
+        "--title".to_string(),
+        tag.to_string(),
+        "--notes".to_string(),
+        format!("Zolana localnet artifacts {tag}"),
+    ];
+    if prerelease {
+        args.push("--prerelease".to_string());
+    }
+    for asset in assets {
+        args.push(path_str(asset)?);
+    }
+    let status = Command::new("gh")
+        .args(&args)
+        .status()
+        .context("failed to run gh release create")?;
+    if !status.success() {
+        bail!("gh release create failed with status {status}");
+    }
+    println!("published release {tag}");
+    Ok(())
+}
+
+fn current_platform() -> Result<(&'static str, &'static str)> {
+    let os = match std::env::consts::OS {
+        "linux" => "linux",
+        "macos" => "darwin",
+        other => bail!("unsupported OS: {other}"),
+    };
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "x64",
+        "aarch64" => "arm64",
+        other => bail!("unsupported architecture: {other}"),
+    };
+    Ok((os, arch))
+}
+
+fn tar_gz(source_dir: &Path, archive: &Path) -> Result<()> {
+    let status = Command::new("tar")
+        .arg("-czf")
+        .arg(archive)
+        .arg("-C")
+        .arg(source_dir)
+        .arg(".")
+        .status()
+        .with_context(|| format!("failed to tar {}", source_dir.display()))?;
+    if !status.success() {
+        bail!("tar failed for {}", source_dir.display());
+    }
+    Ok(())
+}
+
+fn reset_dir(dir: &Path) -> Result<()> {
+    if dir.exists() {
+        fs::remove_dir_all(dir).with_context(|| format!("failed to clean {}", dir.display()))?;
+    }
+    fs::create_dir_all(dir).with_context(|| format!("failed to create {}", dir.display()))?;
+    Ok(())
+}
+
+fn require_file(path: &Path, hint: &str) -> Result<()> {
+    if !path.is_file() {
+        bail!("missing artifact {}: {hint}", path.display());
+    }
+    Ok(())
+}
+
+fn path_str(path: &Path) -> Result<String> {
+    path.to_str()
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("path is not valid UTF-8: {}", path.display()))
+}
+
+fn usage_and_exit(msg: &str) -> ! {
+    eprintln!("error: {msg}");
+    print_help();
+    std::process::exit(2);
+}
+
+fn print_help() {
+    println!("xtask create-release --tag <tag> [options]");
+    println!();
+    println!("Builds the localnet release: version-suffixed program .so files, an");
+    println!("account-snapshot bundle generated in-process with LiteSVM (no keypairs");
+    println!("or running validator needed), and this host's prover/photon binaries,");
+    println!("then regenerates cli/release-artifacts.lock.");
+    println!();
+    println!("Options:");
+    println!("  --deploy-dir <dir>      Program .so directory (default target/deploy)");
+    println!("  --prover-bin <path>     Prover binary (default target/prover-server)");
+    println!("  --photon-bin <path>     Photon binary (default target/release/photon)");
+    println!("  --staging-dir <dir>     Asset staging dir (default target/release-staging)");
+    println!("  --lock-path <path>      Lockfile to regenerate (default cli/release-artifacts.lock)");
+    println!("  --upload                Publish via `gh release create` (default: dry run)");
+    println!("  --prerelease            Mark the GitHub release as a pre-release (e.g. alpha tags)");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_hex_matches_known_vector() {
+        assert_eq!(
+            sha256_hex(b"hello"),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn account_json_uses_solana_dump_format() {
+        let pubkey = Pubkey::new_from_array([7u8; 32]);
+        let account = Account {
+            lamports: 42,
+            data: vec![1, 2, 3],
+            owner: Pubkey::new_from_array([9u8; 32]),
+            executable: false,
+            rent_epoch: u64::MAX,
+        };
+        let value = account_json(&pubkey, &account);
+        assert_eq!(value["pubkey"], pubkey.to_string());
+        assert_eq!(value["account"]["lamports"], 42);
+        assert_eq!(value["account"]["data"][0], STANDARD.encode([1, 2, 3]));
+        assert_eq!(value["account"]["data"][1], "base64");
+        assert_eq!(value["account"]["owner"], account.owner.to_string());
+        assert_eq!(value["account"]["executable"], false);
+        assert_eq!(value["account"]["rentEpoch"], u64::MAX);
+    }
+
+    #[test]
+    fn staged_asset_paths_lists_every_asset() {
+        let lock = json!({
+            "programs": [{"asset": "a.so"}, {"asset": "b.so"}],
+            "accounts": {"asset": "accounts.tar.gz"},
+            "binaries": [{"asset": "prover"}, {"asset": "photon"}],
+        });
+        let paths = staged_asset_paths(Path::new("/stage"), &lock);
+        let names: Vec<_> = paths
+            .iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap())
+            .collect();
+        assert_eq!(names, ["a.so", "b.so", "accounts.tar.gz", "prover", "photon"]);
+    }
+}

--- a/xtask/src/create_release.rs
+++ b/xtask/src/create_release.rs
@@ -165,7 +165,11 @@ pub fn run(options: Options) -> Result<()> {
         .with_context(|| format!("failed to write {}", options.lock_path.display()))?;
     println!("wrote lockfile {}", options.lock_path.display());
 
-    let assets = staged_asset_paths(staging, &lock);
+    // Build the CLI binaries last so they embed the just-written lockfile.
+    let cli_assets = build_cli_binaries(&options, staging, (os, arch))?;
+    let mut assets = staged_asset_paths(staging, &lock);
+    assets.extend(cli_assets);
+
     if options.upload {
         upload_release(&options.tag, &assets, options.prerelease, &git_head()?)?;
     } else {
@@ -186,14 +190,11 @@ pub fn run(options: Options) -> Result<()> {
 /// Go prover cross-compiles natively; photon-linux-x64 builds in a Docker
 /// container so no host cross-linker is required.
 fn build_binaries(options: &Options, staging: &Path, host: (&str, &str)) -> Result<Vec<Value>> {
-    let mut targets = vec![host];
-    if host != ("linux", "x64") {
-        targets.push(("linux", "x64"));
-    }
-
     let repo = repo_root()?;
     let mut out = Vec::new();
-    for (os, arch) in targets {
+    for (os, arch) in release_targets(host) {
+        let is_host = (os, arch) == host;
+
         let prover_asset = format!("prover-{os}-{arch}-{}", options.tag);
         let prover_path = staging.join(&prover_asset);
         build_prover(&repo, os, arch, &prover_path)?;
@@ -207,13 +208,7 @@ fn build_binaries(options: &Options, staging: &Path, host: (&str, &str)) -> Resu
 
         let photon_asset = format!("photon-{os}-{arch}-{}", options.tag);
         let photon_path = staging.join(&photon_asset);
-        if (os, arch) == host {
-            build_photon_host(&repo, &photon_path)?;
-        } else if (os, arch) == ("linux", "x64") {
-            build_photon_linux_x64(&repo, &photon_path)?;
-        } else {
-            bail!("no photon builder for {os}-{arch}");
-        }
+        build_rust_binary(&repo, "photon-indexer", "photon", &photon_path, is_host)?;
         out.push(binary_json(
             "photon",
             os,
@@ -223,6 +218,35 @@ fn build_binaries(options: &Options, staging: &Path, host: (&str, &str)) -> Resu
         )?);
     }
     Ok(out)
+}
+
+/// Build the `zolana` CLI binary for each target and stage it. Called AFTER the
+/// lockfile is regenerated so the binary embeds the final lockfile (the CLI
+/// itself is therefore not a lockfile entry -- that would be circular). Returns
+/// the staged asset paths to upload alongside the lockfile-tracked assets.
+fn build_cli_binaries(
+    options: &Options,
+    staging: &Path,
+    host: (&str, &str),
+) -> Result<Vec<PathBuf>> {
+    let repo = repo_root()?;
+    let mut assets = Vec::new();
+    for (os, arch) in release_targets(host) {
+        let asset = format!("zolana-{os}-{arch}-{}", options.tag);
+        let path = staging.join(&asset);
+        build_rust_binary(&repo, "zolana-cli", "zolana", &path, (os, arch) == host)?;
+        assets.push(path);
+    }
+    Ok(assets)
+}
+
+/// The host platform plus linux-x64 (deduped when the host already is linux-x64).
+fn release_targets<'a>(host: (&'a str, &'a str)) -> Vec<(&'a str, &'a str)> {
+    let mut targets = vec![host];
+    if host != ("linux", "x64") {
+        targets.push(("linux", "x64"));
+    }
+    targets
 }
 
 fn binary_json(role: &str, os: &str, arch: &str, asset: &str, path: &Path) -> Result<Value> {
@@ -273,32 +297,39 @@ fn build_prover(repo: &Path, os: &str, arch: &str, out: &Path) -> Result<()> {
     Ok(())
 }
 
-fn build_photon_host(repo: &Path, out: &Path) -> Result<()> {
-    println!("building photon (host)");
+/// Build a workspace binary (e.g. `photon`, `zolana`) for a target and stage it.
+/// The host build uses cargo directly; linux-x64 builds in a Docker container so
+/// no host cross-linker is needed. Both are cache-first via the shared
+/// `target`/`target-linux-x64` dirs, so building a second binary is incremental.
+fn build_rust_binary(repo: &Path, package: &str, bin: &str, out: &Path, host: bool) -> Result<()> {
+    if host {
+        build_rust_binary_host(repo, package, bin, out)
+    } else {
+        build_rust_binary_linux_x64(repo, package, bin, out)
+    }
+}
+
+fn build_rust_binary_host(repo: &Path, package: &str, bin: &str, out: &Path) -> Result<()> {
+    println!("building {bin} (host)");
     let status = Command::new("cargo")
         .current_dir(repo)
-        .args([
-            "build",
-            "--release",
-            "-p",
-            "photon-indexer",
-            "--bin",
-            "photon",
-        ])
+        .args(["build", "--release", "-p", package, "--bin", bin])
         .status()
-        .context("failed to run cargo build for photon")?;
+        .with_context(|| format!("failed to run cargo build for {bin}"))?;
     if !status.success() {
-        bail!("cargo build failed for photon (host)");
+        bail!("cargo build failed for {bin} (host)");
     }
-    fs::copy(repo.join("target/release/photon"), out)
-        .with_context(|| format!("failed to stage host photon to {}", out.display()))?;
+    fs::copy(repo.join("target/release").join(bin), out)
+        .with_context(|| format!("failed to stage host {bin} to {}", out.display()))?;
     Ok(())
 }
 
-fn build_photon_linux_x64(repo: &Path, out: &Path) -> Result<()> {
-    println!("building photon linux-x64 (docker {PHOTON_LINUX_BUILDER_IMAGE})");
+fn build_rust_binary_linux_x64(repo: &Path, package: &str, bin: &str, out: &Path) -> Result<()> {
+    println!("building {bin} linux-x64 (docker {PHOTON_LINUX_BUILDER_IMAGE})");
     let mount = format!("{}:/work", path_str(repo)?);
-    let build = "set -e; apt-get update -qq && apt-get install -y -qq pkg-config libssl-dev protobuf-compiler cmake clang build-essential >/dev/null 2>&1; cargo build --release -p photon-indexer --bin photon --target-dir /work/target-linux-x64";
+    let build = format!(
+        "set -e; apt-get update -qq && apt-get install -y -qq pkg-config libssl-dev protobuf-compiler cmake clang build-essential >/dev/null 2>&1; cargo build --release -p {package} --bin {bin} --target-dir /work/target-linux-x64"
+    );
     let status = Command::new("docker")
         .args([
             "run",
@@ -311,14 +342,14 @@ fn build_photon_linux_x64(repo: &Path, out: &Path) -> Result<()> {
             "/work",
         ])
         .arg(PHOTON_LINUX_BUILDER_IMAGE)
-        .args(["bash", "-c", build])
+        .args(["bash", "-c", &build])
         .status()
-        .context("failed to run docker for photon linux-x64 build")?;
+        .with_context(|| format!("failed to run docker for {bin} linux-x64 build"))?;
     if !status.success() {
-        bail!("docker photon linux-x64 build failed");
+        bail!("docker {bin} linux-x64 build failed");
     }
-    fs::copy(repo.join("target-linux-x64/release/photon"), out)
-        .with_context(|| format!("failed to stage linux photon to {}", out.display()))?;
+    fs::copy(repo.join("target-linux-x64/release").join(bin), out)
+        .with_context(|| format!("failed to stage linux {bin} to {}", out.display()))?;
     Ok(())
 }
 
@@ -591,9 +622,11 @@ fn print_help() {
     println!();
     println!("Builds the localnet release: version-suffixed program .so files, an");
     println!("account-snapshot bundle generated in-process with LiteSVM (no keypairs");
-    println!("or running validator needed), and the prover/photon binaries for the host");
-    println!("platform plus linux-x64 (Go cross-compile for the prover; Docker for the");
-    println!("linux photon), then regenerates cli/release-artifacts.lock.");
+    println!("or running validator needed), and the prover, photon, and zolana CLI");
+    println!("binaries for the host platform plus linux-x64 (Go cross-compile for the");
+    println!("prover; Docker for the linux Rust binaries). Regenerates");
+    println!("cli/release-artifacts.lock; the CLI binary is built last so it embeds the");
+    println!("final lockfile (and is therefore uploaded but not a lockfile entry).");
     println!();
     println!("Requires: go, cargo, and docker (for the linux-x64 photon build).");
     println!();

--- a/xtask/src/create_release.rs
+++ b/xtask/src/create_release.rs
@@ -172,6 +172,7 @@ pub fn run(options: Options) -> Result<()> {
 
     if options.upload {
         upload_release(&options.tag, &assets, options.prerelease, &git_head()?)?;
+        warn_if_lockfile_uncommitted(&options.lock_path, &options.tag)?;
     } else {
         println!(
             "dry run (pass --upload to publish). Assets staged in {}:",
@@ -286,6 +287,10 @@ fn build_prover(repo: &Path, os: &str, arch: &str, out: &Path) -> Result<()> {
         .env("GOOS", goos)
         .env("GOARCH", goarch)
         .arg("build")
+        // -trimpath + empty buildid make the prover build reproducible so a
+        // re-run produces byte-identical output (stable lockfile checksums).
+        .arg("-trimpath")
+        .args(["-ldflags", "-buildid="])
         .arg("-o")
         .arg(&out_abs)
         .arg(".")
@@ -362,6 +367,36 @@ fn repo_root() -> Result<PathBuf> {
         bail!("git rev-parse --show-toplevel failed");
     }
     Ok(PathBuf::from(String::from_utf8(output.stdout)?.trim()))
+}
+
+/// The lockfile is regenerated during the build, so after publishing it is
+/// typically uncommitted. The uploaded assets and the downloaded CLI binary are
+/// already correct; the only gap is that the tag sits at the current HEAD, whose
+/// committed lockfile is stale, so `cargo install --git --tag` users would build
+/// with the old lockfile. We deliberately do not mutate git here; print the
+/// non-force reconcile: commit the lockfile and re-run --upload, which recreates
+/// the release + tag via gh at the new commit (no force-push).
+fn warn_if_lockfile_uncommitted(lock_path: &Path, tag: &str) -> Result<()> {
+    let clean = Command::new("git")
+        .args(["diff", "--quiet", "--"])
+        .arg(lock_path)
+        .status()
+        .context("failed to check lockfile git status")?
+        .success();
+    if !clean {
+        println!();
+        println!(
+            "NOTE: {} was regenerated and is uncommitted.",
+            lock_path.display()
+        );
+        println!("Assets are published. To also make `cargo install --git --tag {tag}` match,");
+        println!("commit the lockfile and re-run --upload (the release + tag are recreated via");
+        println!("gh at the new commit -- no force-push):");
+        println!("  git add {}", lock_path.display());
+        println!("  git commit -m \"chore(release): {tag} lockfile\" && git push");
+        println!("  just release {tag} --upload   # add --prerelease for alpha tags");
+    }
+    Ok(())
 }
 
 fn git_head() -> Result<String> {
@@ -576,8 +611,13 @@ fn current_platform() -> Result<(&'static str, &'static str)> {
 }
 
 fn tar_gz(source_dir: &Path, archive: &Path) -> Result<()> {
+    // COPYFILE_DISABLE stops macOS bsdtar from adding AppleDouble (._*) sidecars;
+    // the excludes drop any that already exist. Without this, GNU tar on Linux
+    // would materialize them and the validator would choke parsing them as
+    // account JSON. The CLI extractor excludes them too (defense in depth).
     let status = Command::new("tar")
-        .arg("-czf")
+        .env("COPYFILE_DISABLE", "1")
+        .args(["--exclude=._*", "--exclude=.DS_Store", "-czf"])
         .arg(archive)
         .arg("-C")
         .arg(source_dir)
@@ -664,14 +704,49 @@ mod tests {
             executable: false,
             rent_epoch: u64::MAX,
         };
-        let value = account_json(&pubkey, &account);
-        assert_eq!(value["pubkey"], pubkey.to_string());
-        assert_eq!(value["account"]["lamports"], 42);
-        assert_eq!(value["account"]["data"][0], STANDARD.encode([1, 2, 3]));
-        assert_eq!(value["account"]["data"][1], "base64");
-        assert_eq!(value["account"]["owner"], account.owner.to_string());
-        assert_eq!(value["account"]["executable"], false);
-        assert_eq!(value["account"]["rentEpoch"], u64::MAX);
+        let expected = json!({
+            "pubkey": pubkey.to_string(),
+            "account": {
+                "lamports": 42,
+                "data": [STANDARD.encode([1, 2, 3]), "base64"],
+                "owner": account.owner.to_string(),
+                "executable": false,
+                "rentEpoch": u64::MAX,
+            }
+        });
+        assert_eq!(account_json(&pubkey, &account), expected);
+    }
+
+    // Guard against drift between the JSON this tool writes and the schema the
+    // CLI parses (cli/src/release.rs: ReleaseLock/ProgramAsset/BinaryAsset). If
+    // this fails, update both sides together.
+    #[test]
+    fn lockfile_shape_matches_cli_parser() {
+        let lock = json!({
+            "release_tag": "t",
+            "surfpool_tag": "s",
+            "surfpool_version": "1",
+            "programs": [{"role": "shielded_pool", "asset": "a.so", "size": 1, "sha256": "x"}],
+            "accounts": {"asset": "accounts.tar.gz", "size": 1, "sha256": "x"},
+            "binaries": [{
+                "role": "prover", "os": "linux", "arch": "x64",
+                "asset": "prover-linux-x64-t", "size": 1, "sha256": "x"
+            }],
+        });
+        let program = &lock["programs"][0];
+        for key in ["role", "asset", "size", "sha256"] {
+            assert!(program.get(key).is_some(), "program missing {key}");
+        }
+        for key in ["asset", "size", "sha256"] {
+            assert!(
+                lock["accounts"].get(key).is_some(),
+                "accounts missing {key}"
+            );
+        }
+        let binary = &lock["binaries"][0];
+        for key in ["role", "os", "arch", "asset", "size", "sha256"] {
+            assert!(binary.get(key).is_some(), "binary missing {key}");
+        }
     }
 
     #[test]

--- a/xtask/src/create_release.rs
+++ b/xtask/src/create_release.rs
@@ -21,11 +21,14 @@ use zolana_program_test::ZolanaProgramTest;
 const DEFAULT_SURFPOOL_TAG: &str = "v1.1.1-light";
 const DEFAULT_SURFPOOL_VERSION: &str = "1.1.1";
 
+// Cross-compile photon for linux-x64 inside a matching-toolchain container
+// (see rust-toolchain.toml). linux/amd64 builds the x86_64-linux binary natively
+// in the container, avoiding a host cross-linker.
+const PHOTON_LINUX_BUILDER_IMAGE: &str = "rust:1.97-bookworm";
+
 pub struct Options {
     tag: String,
     deploy_dir: PathBuf,
-    prover_bin: PathBuf,
-    photon_bin: PathBuf,
     staging_dir: PathBuf,
     lock_path: PathBuf,
     upload: bool,
@@ -36,8 +39,6 @@ impl Options {
     pub fn parse(args: Vec<String>) -> Self {
         let mut tag = None;
         let mut deploy_dir = PathBuf::from("target/deploy");
-        let mut prover_bin = PathBuf::from("target/prover-server");
-        let mut photon_bin = PathBuf::from("target/release/photon");
         let mut staging_dir = PathBuf::from("target/release-staging");
         let mut lock_path = PathBuf::from("cli/release-artifacts.lock");
         let mut upload = false;
@@ -52,8 +53,6 @@ impl Options {
             match arg.as_str() {
                 "--tag" => tag = Some(next("--tag")),
                 "--deploy-dir" => deploy_dir = PathBuf::from(next("--deploy-dir")),
-                "--prover-bin" => prover_bin = PathBuf::from(next("--prover-bin")),
-                "--photon-bin" => photon_bin = PathBuf::from(next("--photon-bin")),
                 "--staging-dir" => staging_dir = PathBuf::from(next("--staging-dir")),
                 "--lock-path" => lock_path = PathBuf::from(next("--lock-path")),
                 "--upload" => upload = true,
@@ -69,8 +68,6 @@ impl Options {
         Self {
             tag: tag.unwrap_or_else(|| usage_and_exit("--tag is required")),
             deploy_dir,
-            prover_bin,
-            photon_bin,
             staging_dir,
             lock_path,
             upload,
@@ -118,8 +115,6 @@ pub fn run(options: Options) -> Result<()> {
             Ok((source, path))
         })
         .collect::<Result<Vec<_>>>()?;
-    require_file(&options.prover_bin, "run `just build-prover-server` first")?;
-    require_file(&options.photon_bin, "run `just build-photon` first")?;
 
     let staging = &options.staging_dir;
     reset_dir(staging)?;
@@ -153,22 +148,7 @@ pub fn run(options: Options) -> Result<()> {
         "sha256": accounts_staged.sha256,
     });
 
-    let mut binaries_json = Vec::new();
-    for (role, src) in [
-        ("prover", &options.prover_bin),
-        ("photon", &options.photon_bin),
-    ] {
-        let asset = format!("{role}-{os}-{arch}-{}", options.tag);
-        let staged = stage_file(src, &staging.join(&asset))?;
-        binaries_json.push(json!({
-            "role": role,
-            "os": os,
-            "arch": arch,
-            "asset": asset,
-            "size": staged.size,
-            "sha256": staged.sha256,
-        }));
-    }
+    let binaries_json = build_binaries(&options, staging, (os, arch))?;
 
     let (surfpool_tag, surfpool_version) = existing_surfpool_fields(&options.lock_path);
     let lock = json!({
@@ -187,7 +167,7 @@ pub fn run(options: Options) -> Result<()> {
 
     let assets = staged_asset_paths(staging, &lock);
     if options.upload {
-        upload_release(&options.tag, &assets, options.prerelease)?;
+        upload_release(&options.tag, &assets, options.prerelease, &git_head()?)?;
     } else {
         println!(
             "dry run (pass --upload to publish). Assets staged in {}:",
@@ -196,12 +176,172 @@ pub fn run(options: Options) -> Result<()> {
         for asset in &assets {
             println!("  {}", asset.display());
         }
-        println!(
-            "\nOnly the {os}-{arch} prover/photon binaries were built here. A multi-platform release requires running this on each target and merging the binaries into the lockfile."
-        );
     }
 
     Ok(())
+}
+
+/// Build the prover (Go) and photon (Rust) binaries for the host platform and,
+/// when the host is not already linux-x64, cross-build the linux-x64 pair. The
+/// Go prover cross-compiles natively; photon-linux-x64 builds in a Docker
+/// container so no host cross-linker is required.
+fn build_binaries(options: &Options, staging: &Path, host: (&str, &str)) -> Result<Vec<Value>> {
+    let mut targets = vec![host];
+    if host != ("linux", "x64") {
+        targets.push(("linux", "x64"));
+    }
+
+    let repo = repo_root()?;
+    let mut out = Vec::new();
+    for (os, arch) in targets {
+        let prover_asset = format!("prover-{os}-{arch}-{}", options.tag);
+        let prover_path = staging.join(&prover_asset);
+        build_prover(&repo, os, arch, &prover_path)?;
+        out.push(binary_json(
+            "prover",
+            os,
+            arch,
+            &prover_asset,
+            &prover_path,
+        )?);
+
+        let photon_asset = format!("photon-{os}-{arch}-{}", options.tag);
+        let photon_path = staging.join(&photon_asset);
+        if (os, arch) == host {
+            build_photon_host(&repo, &photon_path)?;
+        } else if (os, arch) == ("linux", "x64") {
+            build_photon_linux_x64(&repo, &photon_path)?;
+        } else {
+            bail!("no photon builder for {os}-{arch}");
+        }
+        out.push(binary_json(
+            "photon",
+            os,
+            arch,
+            &photon_asset,
+            &photon_path,
+        )?);
+    }
+    Ok(out)
+}
+
+fn binary_json(role: &str, os: &str, arch: &str, asset: &str, path: &Path) -> Result<Value> {
+    let staged = checksum_file(path)?;
+    Ok(json!({
+        "role": role,
+        "os": os,
+        "arch": arch,
+        "asset": asset,
+        "size": staged.size,
+        "sha256": staged.sha256,
+    }))
+}
+
+fn build_prover(repo: &Path, os: &str, arch: &str, out: &Path) -> Result<()> {
+    let goos = match os {
+        "linux" => "linux",
+        "darwin" => "darwin",
+        other => bail!("unsupported prover OS {other}"),
+    };
+    let goarch = match arch {
+        "x64" => "amd64",
+        "arm64" => "arm64",
+        other => bail!("unsupported prover arch {other}"),
+    };
+    println!("building prover {os}-{arch}");
+    // `go build` runs in prover/server, so the -o path must be absolute or it
+    // would resolve relative to that dir instead of the repo-root staging dir.
+    let out_abs = if out.is_absolute() {
+        out.to_path_buf()
+    } else {
+        repo.join(out)
+    };
+    let status = Command::new("go")
+        .current_dir(repo.join("prover/server"))
+        .env("CGO_ENABLED", "0")
+        .env("GOOS", goos)
+        .env("GOARCH", goarch)
+        .arg("build")
+        .arg("-o")
+        .arg(&out_abs)
+        .arg(".")
+        .status()
+        .context("failed to run go build for prover")?;
+    if !status.success() {
+        bail!("go build failed for prover {os}-{arch}");
+    }
+    Ok(())
+}
+
+fn build_photon_host(repo: &Path, out: &Path) -> Result<()> {
+    println!("building photon (host)");
+    let status = Command::new("cargo")
+        .current_dir(repo)
+        .args([
+            "build",
+            "--release",
+            "-p",
+            "photon-indexer",
+            "--bin",
+            "photon",
+        ])
+        .status()
+        .context("failed to run cargo build for photon")?;
+    if !status.success() {
+        bail!("cargo build failed for photon (host)");
+    }
+    fs::copy(repo.join("target/release/photon"), out)
+        .with_context(|| format!("failed to stage host photon to {}", out.display()))?;
+    Ok(())
+}
+
+fn build_photon_linux_x64(repo: &Path, out: &Path) -> Result<()> {
+    println!("building photon linux-x64 (docker {PHOTON_LINUX_BUILDER_IMAGE})");
+    let mount = format!("{}:/work", path_str(repo)?);
+    let build = "set -e; apt-get update -qq && apt-get install -y -qq pkg-config libssl-dev protobuf-compiler cmake clang build-essential >/dev/null 2>&1; cargo build --release -p photon-indexer --bin photon --target-dir /work/target-linux-x64";
+    let status = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "--platform",
+            "linux/amd64",
+            "-v",
+            &mount,
+            "-w",
+            "/work",
+        ])
+        .arg(PHOTON_LINUX_BUILDER_IMAGE)
+        .args(["bash", "-c", build])
+        .status()
+        .context("failed to run docker for photon linux-x64 build")?;
+    if !status.success() {
+        bail!("docker photon linux-x64 build failed");
+    }
+    fs::copy(repo.join("target-linux-x64/release/photon"), out)
+        .with_context(|| format!("failed to stage linux photon to {}", out.display()))?;
+    Ok(())
+}
+
+fn repo_root() -> Result<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .context("failed to run git rev-parse --show-toplevel")?;
+    if !output.status.success() {
+        bail!("git rev-parse --show-toplevel failed");
+    }
+    Ok(PathBuf::from(String::from_utf8(output.stdout)?.trim()))
+}
+
+fn git_head() -> Result<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .context("failed to run git rev-parse HEAD")?;
+    if !output.status.success() {
+        bail!("git rev-parse HEAD failed");
+    }
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
 }
 
 /// Build the initialized account set fully in-process with LiteSVM. No maintainer
@@ -355,11 +495,19 @@ fn existing_surfpool_fields(lock_path: &Path) -> (String, String) {
     }
 }
 
-fn upload_release(tag: &str, assets: &[PathBuf], prerelease: bool) -> Result<()> {
+fn upload_release(tag: &str, assets: &[PathBuf], prerelease: bool, target: &str) -> Result<()> {
+    // Delete any existing release + tag so the re-publish is clean and the tag is
+    // recreated at the released commit. Best-effort: ignore "not found".
+    let _ = Command::new("gh")
+        .args(["release", "delete", tag, "--yes", "--cleanup-tag"])
+        .status();
+
     let mut args = vec![
         "release".to_string(),
         "create".to_string(),
         tag.to_string(),
+        "--target".to_string(),
+        target.to_string(),
         "--title".to_string(),
         tag.to_string(),
         "--notes".to_string(),
@@ -378,7 +526,7 @@ fn upload_release(tag: &str, assets: &[PathBuf], prerelease: bool) -> Result<()>
     if !status.success() {
         bail!("gh release create failed with status {status}");
     }
-    println!("published release {tag}");
+    println!("published release {tag} at {target}");
     Ok(())
 }
 
@@ -443,17 +591,22 @@ fn print_help() {
     println!();
     println!("Builds the localnet release: version-suffixed program .so files, an");
     println!("account-snapshot bundle generated in-process with LiteSVM (no keypairs");
-    println!("or running validator needed), and this host's prover/photon binaries,");
-    println!("then regenerates cli/release-artifacts.lock.");
+    println!("or running validator needed), and the prover/photon binaries for the host");
+    println!("platform plus linux-x64 (Go cross-compile for the prover; Docker for the");
+    println!("linux photon), then regenerates cli/release-artifacts.lock.");
+    println!();
+    println!("Requires: go, cargo, and docker (for the linux-x64 photon build).");
     println!();
     println!("Options:");
     println!("  --deploy-dir <dir>      Program .so directory (default target/deploy)");
-    println!("  --prover-bin <path>     Prover binary (default target/prover-server)");
-    println!("  --photon-bin <path>     Photon binary (default target/release/photon)");
     println!("  --staging-dir <dir>     Asset staging dir (default target/release-staging)");
-    println!("  --lock-path <path>      Lockfile to regenerate (default cli/release-artifacts.lock)");
+    println!(
+        "  --lock-path <path>      Lockfile to regenerate (default cli/release-artifacts.lock)"
+    );
     println!("  --upload                Publish via `gh release create` (default: dry run)");
-    println!("  --prerelease            Mark the GitHub release as a pre-release (e.g. alpha tags)");
+    println!(
+        "  --prerelease            Mark the GitHub release as a pre-release (e.g. alpha tags)"
+    );
 }
 
 #[cfg(test)]
@@ -500,6 +653,9 @@ mod tests {
             .iter()
             .map(|p| p.file_name().unwrap().to_str().unwrap())
             .collect();
-        assert_eq!(names, ["a.so", "b.so", "accounts.tar.gz", "prover", "photon"]);
+        assert_eq!(
+            names,
+            ["a.so", "b.so", "accounts.tar.gz", "prover", "photon"]
+        );
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,6 +7,7 @@ use std::{
 
 use sha2::{Digest, Sha256};
 
+mod create_release;
 mod init_protocol;
 mod update_protocol_config;
 
@@ -62,6 +63,13 @@ fn main() {
                 update_protocol_config::run(update_protocol_config::Options::parse(args.collect()))
             {
                 eprintln!("update-protocol-config failed: {error:?}");
+                std::process::exit(1);
+            }
+        }
+        Some("create-release") => {
+            if let Err(error) = create_release::run(create_release::Options::parse(args.collect()))
+            {
+                eprintln!("create-release failed: {error:?}");
                 std::process::exit(1);
             }
         }
@@ -301,6 +309,9 @@ fn print_help() {
     println!("  program-ids              Print local validator program ids as shell assignments");
     println!("  init-protocol            Initialize the protocol on a cluster (see --help)");
     println!("  update-protocol-config   Update protocol config flags on a cluster (see --help)");
+    println!(
+        "  create-release           Build the localnet release artifacts + lockfile (see --help)"
+    );
     println!("  tx-size [N:M ...]        Compute serialized transaction sizes per circuit shape");
 }
 


### PR DESCRIPTION
## Summary

Make `zolana dev start` / `test-env` self-bootstrapping: by default it downloads version-pinned programs, an initialized account-snapshot bundle, and the prover/photon binaries from a pinned GitHub release (and surfpool from its own release), verifies every artifact against a committed sha256 lockfile, caches under `~/.config/zolana/cache/<tag>/`, and boots a fully-initialized localnet. A fresh `cargo install` can spin up a working localnet with no repo checkout and nothing prebuilt.

## CLI

- Default rail: fetch + checksum-verify programs (shielded-pool, user-registry, smart-account) + account snapshot + prover/photon; surfpool from its own release. Cache-first (offline on repeat).
- `--local` (or any explicit `--sbf-program`) keeps the fully-local dev/CI path unchanged; all repo test harnesses pass `--local`.
- Integrity via `cli/release-artifacts.lock`, embedded with `include_str!` (the release tag lives there); `ZOLANA_RELEASE_URL` overrides the host.
- Reuses workspace `reqwest` + `sha2`; no new external crates.

## Release tooling (`xtask create-release` + `just release`)

- Generates the account snapshot fully in-process with LiteSVM — no maintainer keypairs, no running validator. The tree is pre-allocated at `DEFAULT_TREE_ADDRESS` via `set_account` so its baked-in `hashed_pubkey` stays correct without the tree key.
- Builds multi-platform binaries: prover via Go cross-compile (host + linux-x64), photon via `cargo` (host) and a `rust:1.97-bookworm` Docker `linux/amd64` build (linux-x64).
- Regenerates the lockfile with all entries and publishes idempotently (`gh release delete --cleanup-tag` then `create --target HEAD`).
- `just release <tag>` = dry run; `just release <tag> --upload --prerelease` publishes (flags forwarded to create-release).

## Install

```bash
cargo install --git https://github.com/helius-labs/zolana --tag v0.1.0-alpha zolana-cli
```

Documented in both `README.md` and `cli/README.md`.

## Verification

- Fetch + checksum + cache-first verified on both surfpool and solana-test-validator; snapshot accounts (tree, protocol_config, asset_counter) load at canonical addresses.
- `v0.1.0-alpha` published with darwin-arm64 + linux-x64 prover/photon; the tag points at the commit whose embedded lockfile matches the published assets.
- `timelock-escrow` suite passes through the CLI-launched validator (a failure during testing was a stale leftover prover daemon, not this change).

## Notes

- crates.io is blocked by the `groth16-solana` git-fork dep in the tree, so distribution is via `cargo install --git` for now.
- Intel-mac (`darwin-x64`) binaries are not yet in the release; easy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)