### PR TITLE
feat(sdk-tests): confidential RFQ settlement example, no escrow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -206,6 +206,8 @@ jobs:
             recipe: test-swap-and-escrow-validator
           - name: dynamic-swap lifecycle
             recipe: test-dynamic-swap
+          - name: rfq settlement
+            recipe: test-rfq-validator
     env:
       AGAVE_VERSION: v4.0.2
       # GH_TOKEN is for the gh-release swap/escrow key downloads (ensure-swap-keys /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5425,6 +5425,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfq-test"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bincode 1.3.3",
+ "light-program-profiler",
+ "mollusk-svm",
+ "num-bigint 0.4.8",
+ "solana-account 2.2.1",
+ "solana-address 2.6.1",
+ "solana-address-lookup-table-interface",
+ "solana-compute-budget-interface",
+ "solana-instruction 2.3.3",
+ "solana-instruction 3.4.0",
+ "solana-keypair",
+ "solana-message 3.1.0",
+ "solana-pubkey 2.4.0",
+ "solana-pubkey 4.2.0",
+ "solana-signature 3.4.1",
+ "solana-signer",
+ "solana-transaction",
+ "zolana-client",
+ "zolana-hasher",
+ "zolana-interface",
+ "zolana-keypair",
+ "zolana-merkle-tree",
+ "zolana-program-test",
+ "zolana-test-utils",
+ "zolana-transaction",
+ "zolana-tree",
+ "zolana-user-registry-interface",
+ "zolana-wallet",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "sdk-tests/dynamic-swap/prover",
     "sdk-tests/dynamic-swap/sdk",
     "sdk-tests/dynamic-swap/test",
+    "sdk-tests/rfq",
     "sdk-tests/zk-program-swap/program",
     "sdk-tests/zk-program-swap/prover",
     "sdk-tests/zk-program-swap/sdk",

--- a/justfile
+++ b/justfile
@@ -279,6 +279,19 @@ bench-swap: ensure-swap-keys
         -- --features bpf-entrypoint,profile-program
     cargo test -p swap-test-validator --test bench_cu -- --ignored --nocapture
 
+# Confidential RFQ settlement CU benchmark: profiles a single co-signed
+# shielded-pool `transact` (SOL for USDC, no escrow, no custom program) under
+# mollusk. The shielded-pool program is built with profile-program so its
+# `#[profile]` functions appear in the CU table; it must never land in
+# target/deploy, so build into a dedicated dir matching PROFILING_SBF_DIR in
+# bench_cu.rs.
+bench-rfq:
+    cargo build-sbf --tools-version {{sbf-tools-version}} \
+        --sbf-out-dir target/rfq-bench \
+        --manifest-path programs/shielded-pool/Cargo.toml \
+        -- --features bpf-entrypoint,profile-program
+    cargo test -p rfq-test --test bench_cu -- --ignored --nocapture
+
 # Fetch the pinned escrow/withdraw proving keys from the escrow-keys release
 # and verify them against the committed manifest. groth16.Setup is
 # non-deterministic, so the published keys are the only set matching the
@@ -635,6 +648,28 @@ test-dynamic-swap *args: ensure-dynamic-swap-keys build-programs build-prover-se
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
       cargo test -p dynamic-swap-test {{args}} -- --nocapture
+
+# Confidential RFQ settlement on a local validator: the maker and taker co-sign
+# one shielded-pool transact that swaps SOL for USDC with no escrow and no custom
+# program (sdk-tests/rfq/tests/rfq.rs). Boots solana-test-validator via the
+# `zolana` CLI with the shielded pool, the user registry, and the Squads smart
+# account, plus Photon and the SPP prover -- mirroring test-client-example.
+test-rfq-validator: build-programs build-prover-server build-cli ensure-photon ensure-smart-account
+    #!/usr/bin/env bash
+    set -euo pipefail
+    eval "$(cargo run -q -p xtask -- program-ids)"
+    cleanup() {
+      lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
+      lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
+      pkill -f solana-test-validator 2>/dev/null || true
+    }
+    trap cleanup EXIT
+    export SHIELDED_POOL_PROGRAM_ID
+    export ZOLANA_PHOTON_BIN="{{photon-bin}}"
+    export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
+    export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
+    env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
+      cargo test -p rfq-test --test rfq -- --nocapture
 
 install-surfpool:
     #!/usr/bin/env bash

--- a/sdk-tests/rfq/BENCHMARK.md
+++ b/sdk-tests/rfq/BENCHMARK.md
@@ -1,0 +1,37 @@
+# RFQ Settlement -- CU Benchmark
+
+Compute unit profiling for a confidential RFQ settlement, replayed under mollusk. The settlement is a single shielded-pool `transact` co-signed by a maker and a taker that swaps SOL for USDC with no escrow and no custom program: the maker spends one SOL UTXO and receives USDC, the taker spends one USDC UTXO and receives SOL (shape IN2_OUT2, eddsa rail). The shielded-pool program is built with `profile-program`, so its `#[profile]` functions appear in the CU table; the tree account is built directly (the program's `create_tree` init plus the input utxo hashes appended). The section also records the SPP transfer proving time (warm, key already loaded) and the serialized transaction size: the instruction prefixed with a compute-budget limit ix, as a legacy transaction and as a v0 transaction with every non-signer account and the program id in one address lookup table (Solana's packet limit is 1232 bytes).
+
+Regenerate with `just bench-rfq`.
+
+## Definitions
+
+- **Total CU**: Compute units consumed by the function including all children
+- **Net CU**: Compute units consumed by the function itself (excluding children)
+
+## Table of Contents
+
+1. [Settlement](#settlement)
+
+## 1. Settlement
+
+| Function                      |   Total CU |     Net CU |
+| ----------------------------- | ---------- | ---------- |
+| `check_input_signers`         |      1,875 |      1,875 |
+| `fill_output_owner_pk_hashes` |      1,828 |      1,828 |
+| `apply_tree`                  |     30,667 |     30,667 |
+| `verify_groth16`              |     93,350 |     93,350 |
+| `process_instruction`         |         31 |         31 |
+| `process_transact_ix`         |    155,148 |     27,397 |
+| `process_instruction`         |    155,198 |         50 |
+
+**Proving Time**
+| SPP transfer proof |
+| ------------------ |
+|             116 ms |
+
+**Transaction Size**
+| Instruction Data | Accounts | Legacy Tx | v0 + ALT Tx |
+| ---------------- | -------- | --------- | ----------- |
+|        617 bytes |        4 | 959 bytes |   964 bytes |
+

--- a/sdk-tests/rfq/Cargo.toml
+++ b/sdk-tests/rfq/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "rfq-test"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+autotests = false
+
+[dependencies]
+anyhow = { workspace = true }
+solana-address = { workspace = true }
+solana-address-lookup-table-interface = { workspace = true }
+solana-compute-budget-interface = { workspace = true }
+solana-instruction = { workspace = true }
+solana-keypair = { workspace = true }
+solana-message = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-signature = { workspace = true }
+solana-signer = { workspace = true }
+solana-transaction = { workspace = true, features = ["bincode"] }
+zolana-client = { workspace = true, features = ["indexer-api", "solana-rpc"] }
+zolana-interface = { workspace = true }
+zolana-keypair = { workspace = true }
+zolana-program-test = { workspace = true }
+zolana-test-utils = { workspace = true }
+zolana-transaction = { workspace = true }
+zolana-user-registry-interface = { workspace = true, features = ["solana"] }
+zolana-wallet = { workspace = true }
+
+[dev-dependencies]
+bincode = "1.3"
+num-bigint = { workspace = true }
+zolana-hasher = { workspace = true, features = ["poseidon"] }
+zolana-merkle-tree = { workspace = true }
+zolana-tree = { workspace = true }
+mollusk-svm = "0.3.0"
+light-program-profiler = { workspace = true, features = ["mollusk"] }
+mollusk-solana-account = { package = "solana-account", version = "2.2" }
+mollusk-solana-instruction = { package = "solana-instruction", version = "2.2" }
+mollusk-solana-pubkey = { package = "solana-pubkey", version = "2.2" }
+
+[[test]]
+name = "rfq"
+path = "tests/rfq.rs"
+
+[[test]]
+name = "bench_cu"
+path = "tests/bench_cu.rs"

--- a/sdk-tests/rfq/tests/bench_cu.rs
+++ b/sdk-tests/rfq/tests/bench_cu.rs
@@ -1,0 +1,469 @@
+use std::time::{Duration, Instant};
+
+use light_program_profiler::{
+    mollusk::{register_profiling_syscalls, take_profiling_entries},
+    report::{CuBenchmark, ReadmeConfig, SectionTable},
+};
+use mollusk_solana_account::Account as MolluskAccount;
+use mollusk_solana_instruction::{
+    AccountMeta as MolluskAccountMeta, Instruction as MolluskInstruction,
+};
+use mollusk_solana_pubkey::Pubkey as MolluskPubkey;
+use mollusk_svm::{program::loader_keys::LOADER_V3, result::Check, Mollusk};
+use num_bigint::BigUint;
+use solana_address::Address;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_instruction::{AccountMeta, Instruction};
+use solana_keypair::Keypair;
+use solana_message::{v0, AddressLookupTableAccount, Message, VersionedMessage};
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use solana_transaction::{versioned::VersionedTransaction, Transaction};
+use zolana_client::{
+    MerkleContext, MerkleProof, NonInclusionProof, ProverClient, SpendProof, NULLIFIER_TREE_HEIGHT,
+    STATE_TREE_HEIGHT,
+};
+use zolana_hasher::Poseidon;
+use zolana_interface::{
+    instruction::{instruction_data::transact::TransactIxData, Transact},
+    state::{
+        address_tree_params, discriminator::TREE_ACCOUNT_DISCRIMINATOR, tree_account_size,
+        STATE_HEIGHT,
+    },
+    SHIELDED_POOL_PROGRAM_ID,
+};
+use zolana_keypair::{random_blinding, ShieldedKeypair, ViewingKey};
+use zolana_merkle_tree::{indexed::IndexedMerkleTree, MerkleTree};
+use zolana_transaction::{
+    instructions::{
+        transact::{
+            encrypt_transaction_data, get_transaction_viewing_key,
+            spp_proof_inputs::BN254_MODULUS_DEC, ExternalData, SppProofInputs, SppProofOutputUtxo,
+        },
+        types::{InputUtxoContext, SppProofInputUtxo},
+    },
+    AssetRegistry, Data, Utxo, SOL_MINT,
+};
+use zolana_tree::TreeAccount;
+
+const SELL_SOL: u64 = 250_000_000;
+const BUY_USDC: u64 = 100_000_000;
+const USDC_ASSET_ID: u64 = 2;
+const TAKER_SIGNER_INDEX: u8 = 3;
+
+const PROFILING_SBF_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/rfq-bench");
+const OUTPUT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/BENCHMARK.md");
+const PROVER_KEYS_DIR: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../prover/server/proving-keys"
+);
+
+fn to_mollusk_pubkey(key: &Pubkey) -> MolluskPubkey {
+    MolluskPubkey::new_from_array(key.to_bytes())
+}
+
+fn to_mollusk_instruction(ix: &Instruction) -> MolluskInstruction {
+    MolluskInstruction {
+        program_id: to_mollusk_pubkey(&ix.program_id),
+        accounts: ix
+            .accounts
+            .iter()
+            .map(|meta| MolluskAccountMeta {
+                pubkey: to_mollusk_pubkey(&meta.pubkey),
+                is_signer: meta.is_signer,
+                is_writable: meta.is_writable,
+            })
+            .collect(),
+        data: ix.data.clone(),
+    }
+}
+
+fn mollusk_program_account(program_id: &MolluskPubkey) -> (MolluskPubkey, MolluskAccount) {
+    let account = mollusk_svm::program::create_program_account_loader_v3(program_id);
+    (*program_id, account)
+}
+
+fn system_owned_account(lamports: u64) -> MolluskAccount {
+    MolluskAccount {
+        lamports,
+        data: Vec::new(),
+        owner: MolluskPubkey::new_from_array([0u8; 32]),
+        executable: false,
+        rent_epoch: 0,
+    }
+}
+
+fn build_tree_fixture(
+    tree: &Pubkey,
+    leaves: &[[u8; 32]],
+) -> (MolluskAccount, [u8; 32], [u8; 32], u16) {
+    let mut tree_account_bytes = vec![0u8; tree_account_size()];
+    let root_index = leaves.len() as u16;
+    let (utxo_root, nullifier_root) = {
+        let mut account = TreeAccount::init(
+            &mut tree_account_bytes,
+            TREE_ACCOUNT_DISCRIMINATOR,
+            STATE_HEIGHT as u8,
+            [1u8; 32],
+            tree.to_bytes(),
+            address_tree_params(),
+        )
+        .expect("init tree account");
+        for leaf in leaves {
+            account.utxo_tree().append(*leaf);
+        }
+        (
+            account.get_utxo_tree_root(root_index).expect("utxo root"),
+            account.get_nullifier_tree_root(0).expect("nullifier root"),
+        )
+    };
+    let fixture = MolluskAccount {
+        lamports: 1_000_000_000_000,
+        data: tree_account_bytes,
+        owner: MolluskPubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID),
+        executable: false,
+        rent_epoch: 0,
+    };
+    (fixture, utxo_root, nullifier_root, root_index)
+}
+
+fn local_state_tree(leaves: &[[u8; 32]]) -> MerkleTree<Poseidon> {
+    let mut tree = MerkleTree::<Poseidon>::new(STATE_TREE_HEIGHT, 0);
+    for leaf in leaves {
+        tree.append(leaf).expect("append state leaf");
+    }
+    tree
+}
+
+fn nullifier_tree() -> IndexedMerkleTree<Poseidon, usize> {
+    let modulus_minus_one =
+        BigUint::parse_bytes(BN254_MODULUS_DEC.as_bytes(), 10).expect("parse bn254 modulus") - 1u32;
+    IndexedMerkleTree::<Poseidon, usize>::new_with_next_value(
+        NULLIFIER_TREE_HEIGHT,
+        0,
+        modulus_minus_one,
+    )
+    .expect("nullifier tree")
+}
+
+fn build_spend_proofs(
+    tree: &Pubkey,
+    state_tree: &MerkleTree<Poseidon>,
+    nf_tree: &IndexedMerkleTree<Poseidon, usize>,
+    commitments: &[InputUtxoContext],
+    utxo_root: [u8; 32],
+    nullifier_root: [u8; 32],
+    root_index: u16,
+) -> Vec<SpendProof> {
+    let merkle_context = MerkleContext {
+        tree_type: 0,
+        tree: Address::new_from_array(tree.to_bytes()),
+    };
+    commitments
+        .iter()
+        .enumerate()
+        .map(|(leaf_index, commitment)| {
+            let state_path = state_tree
+                .get_proof_of_leaf(leaf_index, true)
+                .expect("state proof")
+                .to_vec();
+            let nf = nf_tree
+                .get_non_inclusion_proof(&BigUint::from_bytes_be(&commitment.nullifier))
+                .expect("non inclusion proof");
+            SpendProof {
+                state: MerkleProof {
+                    leaf: commitment.utxo_hash,
+                    merkle_context: merkle_context.clone(),
+                    path: state_path,
+                    leaf_index: leaf_index as u64,
+                    root: utxo_root,
+                    root_seq: 0,
+                    root_index,
+                },
+                nullifier: NonInclusionProof {
+                    leaf: commitment.nullifier,
+                    merkle_context: merkle_context.clone(),
+                    path: nf.merkle_proof.to_vec(),
+                    low_element: nf.leaf_lower_range_value,
+                    low_element_index: nf.leaf_index as u64,
+                    high_element: nf.leaf_higher_range_value,
+                    high_element_index: 0,
+                    root: nullifier_root,
+                    root_seq: 0,
+                    root_index: 0,
+                },
+            }
+        })
+        .collect()
+}
+
+fn assemble_accounts(
+    ix: &Instruction,
+    spp_id: &MolluskPubkey,
+    fixtures: &[(Pubkey, MolluskAccount)],
+) -> Vec<(MolluskPubkey, MolluskAccount)> {
+    let spp = Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID);
+    ix.accounts
+        .iter()
+        .map(|meta| {
+            if meta.pubkey == spp {
+                mollusk_program_account(spp_id)
+            } else if meta.pubkey == Pubkey::default() {
+                mollusk_svm::program::keyed_account_for_system_program()
+            } else if let Some((_, account)) = fixtures.iter().find(|(key, _)| *key == meta.pubkey)
+            {
+                (to_mollusk_pubkey(&meta.pubkey), account.clone())
+            } else {
+                (
+                    to_mollusk_pubkey(&meta.pubkey),
+                    system_owned_account(1_000_000_000),
+                )
+            }
+        })
+        .collect()
+}
+
+fn keypair_from_payer(payer: &Keypair) -> ShieldedKeypair {
+    let seed: [u8; 32] = payer.to_bytes()[..32]
+        .try_into()
+        .expect("ed25519 seed is the first 32 bytes");
+    ShieldedKeypair::from_ed25519(&seed, ViewingKey::new()).expect("keypair from payer")
+}
+
+fn prove_transact_timed(
+    proof_inputs: SppProofInputs,
+    spend_proofs: &[SpendProof],
+    prover: &ProverClient,
+) -> (TransactIxData, Duration) {
+    prover
+        .prove_transact(proof_inputs.clone(), spend_proofs)
+        .expect("warm prove transact");
+    let start = Instant::now();
+    let transact = prover
+        .prove_transact(proof_inputs, spend_proofs)
+        .expect("prove transact");
+    (transact, start.elapsed())
+}
+
+fn start_prover() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        std::env::set_var("ZOLANA_PROVER_KEYS_DIR", PROVER_KEYS_DIR);
+    });
+    zolana_client::spawn_prover().expect("spawn prover");
+}
+
+fn proving_time_table(spp: Duration) -> SectionTable {
+    SectionTable {
+        title: "Proving Time".into(),
+        headers: vec!["SPP transfer proof".into()],
+        rows: vec![vec![format!("{} ms", spp.as_millis())]],
+    }
+}
+
+fn tx_size_table(ix: &Instruction, payer: &Pubkey) -> SectionTable {
+    let compute = ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
+
+    let message = Message::new(&[compute.clone(), ix.clone()], Some(payer));
+    let legacy = bincode::serialize(&Transaction::new_unsigned(message))
+        .expect("serialize legacy")
+        .len();
+
+    let alt = AddressLookupTableAccount {
+        key: Address::new_from_array([250u8; 32]),
+        addresses: ix
+            .accounts
+            .iter()
+            .filter(|meta| !meta.is_signer)
+            .map(|meta| Address::new_from_array(meta.pubkey.to_bytes()))
+            .chain(std::iter::once(Address::new_from_array(
+                ix.program_id.to_bytes(),
+            )))
+            .collect(),
+    };
+    let v0_message = v0::Message::try_compile(
+        payer,
+        &[compute, ix.clone()],
+        std::slice::from_ref(&alt),
+        Default::default(),
+    )
+    .expect("compile v0 message");
+    let versioned = VersionedMessage::V0(v0_message);
+    let signature_count = versioned.header().num_required_signatures as usize;
+    let tx = VersionedTransaction {
+        signatures: vec![Default::default(); signature_count],
+        message: versioned,
+    };
+    let v0_alt = bincode::serialize(&tx).expect("serialize v0").len();
+
+    SectionTable {
+        title: "Transaction Size".into(),
+        headers: vec![
+            "Instruction Data".into(),
+            "Accounts".into(),
+            "Legacy Tx".into(),
+            "v0 + ALT Tx".into(),
+        ],
+        rows: vec![vec![
+            format!("{} bytes", ix.data.len()),
+            ix.accounts.len().to_string(),
+            format!("{} bytes", legacy),
+            format!("{} bytes", v0_alt),
+        ]],
+    }
+}
+
+#[test]
+#[ignore = "CU benchmark; slow, needs SBF binaries + prover. Run via just bench-rfq"]
+fn bench_cu_rfq() {
+    std::env::set_var("SBF_OUT_DIR", PROFILING_SBF_DIR);
+
+    let spp_id = MolluskPubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID);
+
+    let mut mollusk = Mollusk::default();
+    register_profiling_syscalls(&mut mollusk);
+    mollusk.add_program(&spp_id, "shielded_pool_program", &LOADER_V3);
+
+    let mut bench = CuBenchmark::new(ReadmeConfig {
+        title: "RFQ Settlement -- CU Benchmark".into(),
+        description:
+            "Compute unit profiling for a confidential RFQ settlement, replayed under mollusk. The \
+             settlement is a single shielded-pool `transact` co-signed by a maker and a taker that \
+             swaps SOL for USDC with no escrow and no custom program: the maker spends one SOL UTXO \
+             and receives USDC, the taker spends one USDC UTXO and receives SOL (shape IN2_OUT2, \
+             eddsa rail). The shielded-pool program is built with `profile-program`, so its \
+             `#[profile]` functions appear in the CU table; the tree account is built directly (the \
+             program's `create_tree` init plus the input utxo hashes appended). The section also \
+             records the SPP transfer proving time (warm, key already loaded) and the serialized \
+             transaction size: the instruction prefixed with a compute-budget limit ix, as a legacy \
+             transaction and as a v0 transaction with every non-signer account and the program id in \
+             one address lookup table (Solana's packet limit is 1232 bytes)."
+                .into(),
+        output_path: OUTPUT_PATH.into(),
+        regenerate_command: Some("just bench-rfq".into()),
+        ..Default::default()
+    });
+
+    start_prover();
+    bench_settlement(&mut mollusk, &spp_id, &mut bench);
+
+    bench.generate().expect("write BENCHMARK.md");
+}
+
+fn bench_settlement(mollusk: &mut Mollusk, spp_id: &MolluskPubkey, bench: &mut CuBenchmark) {
+    let tree = Keypair::new().pubkey();
+    let maker_payer = Keypair::new();
+    let taker_payer = Keypair::new();
+    let maker = keypair_from_payer(&maker_payer);
+    let taker = keypair_from_payer(&taker_payer);
+    let maker_address = maker.shielded_address().expect("maker address");
+    let taker_address = taker.shielded_address().expect("taker address");
+
+    let usdc_mint = Address::new_from_array([7u8; 32]);
+
+    let maker_sol_utxo = Utxo {
+        owner: maker.signing_pubkey(),
+        asset: SOL_MINT,
+        amount: SELL_SOL,
+        blinding: random_blinding(),
+        zone_program_id: None,
+        data: Data::default(),
+    };
+    let taker_usdc_utxo = Utxo {
+        owner: taker.signing_pubkey(),
+        asset: usdc_mint,
+        amount: BUY_USDC,
+        blinding: random_blinding(),
+        zone_program_id: None,
+        data: Data::default(),
+    };
+
+    let maker_spend = SppProofInputUtxo::new(maker_sol_utxo, &maker);
+    let taker_spend = SppProofInputUtxo::new(taker_usdc_utxo, &taker);
+    let input_utxos = vec![maker_spend, taker_spend];
+
+    let sol_to_taker =
+        SppProofOutputUtxo::new(SOL_MINT, SELL_SOL, taker_address).expect("sol output");
+    let usdc_to_maker =
+        SppProofOutputUtxo::new(usdc_mint, BUY_USDC, maker_address).expect("usdc output");
+
+    let mut assets = AssetRegistry::default();
+    assets
+        .insert(USDC_ASSET_ID, usdc_mint)
+        .expect("register usdc");
+
+    let transaction_viewing_key =
+        get_transaction_viewing_key(&maker, &input_utxos).expect("transaction viewing key");
+    let encoded = encrypt_transaction_data(
+        &[sol_to_taker, usdc_to_maker],
+        &assets,
+        &transaction_viewing_key,
+    )
+    .expect("encode settlement slots");
+
+    let external_data = ExternalData::new(
+        *transaction_viewing_key.pubkey().as_bytes(),
+        encoded.salt,
+        encoded.outputs,
+        encoded.resolved_owner_tags,
+        vec![],
+    );
+    let payer_address = Address::new_from_array(maker_payer.pubkey().to_bytes());
+    let spp_proof_inputs = SppProofInputs::new(
+        input_utxos,
+        encoded.output_utxos,
+        external_data,
+        payer_address,
+    );
+
+    let commitments = spp_proof_inputs
+        .input_utxo_hashes()
+        .expect("input commitments");
+    let leaves: Vec<[u8; 32]> = commitments.iter().map(|input| input.utxo_hash).collect();
+    let (tree_account, utxo_root, nullifier_root, root_index) = build_tree_fixture(&tree, &leaves);
+    let state_tree = local_state_tree(&leaves);
+    assert_eq!(state_tree.root(), utxo_root, "state root gate");
+    let nf_tree = nullifier_tree();
+    assert_eq!(nf_tree.root(), nullifier_root, "nullifier root gate");
+    let spend_proofs = build_spend_proofs(
+        &tree,
+        &state_tree,
+        &nf_tree,
+        &commitments,
+        utxo_root,
+        nullifier_root,
+        root_index,
+    );
+
+    let prover = ProverClient::local();
+    let (mut transact, spp_dur) = prove_transact_timed(spp_proof_inputs, &spend_proofs, &prover);
+    transact
+        .inputs
+        .get_mut(1)
+        .expect("taker input")
+        .eddsa_signer_index = TAKER_SIGNER_INDEX;
+
+    let mut ix = Transact {
+        payer: maker_payer.pubkey(),
+        tree,
+        withdrawal: None,
+        data: transact,
+    }
+    .instruction();
+    ix.accounts
+        .push(AccountMeta::new_readonly(taker_payer.pubkey(), true));
+
+    let fixtures = vec![
+        (tree, tree_account),
+        (maker_payer.pubkey(), system_owned_account(100_000_000_000)),
+    ];
+    let accounts = assemble_accounts(&ix, spp_id, &fixtures);
+    let mollusk_ix = to_mollusk_instruction(&ix);
+    mollusk.process_and_validate_instruction(&mollusk_ix, &accounts, &[Check::success()]);
+
+    let entries = take_profiling_entries();
+    assert!(!entries.is_empty(), "no profiling entries for 'settlement'");
+    bench.add_from_entries("settlement", entries);
+    bench.add_table("settlement", proving_time_table(spp_dur));
+    bench.add_table("settlement", tx_size_table(&ix, &maker_payer.pubkey()));
+}

--- a/sdk-tests/rfq/tests/rfq.rs
+++ b/sdk-tests/rfq/tests/rfq.rs
@@ -1,0 +1,170 @@
+mod shared;
+
+use anyhow::{anyhow, Result};
+use shared::{send_cosigned_v0_with_lookup_table, setup, TestEnv, BUY_USDC, SELL_SOL};
+use solana_instruction::AccountMeta;
+use solana_signer::Signer;
+use zolana_client::{IndexerRpcConfig, Rpc};
+use zolana_interface::instruction::Transact;
+use zolana_transaction::{
+    instructions::{
+        transact::{
+            encrypt_transaction_data, get_transaction_viewing_key, ExternalData, SppProofInputs,
+            SppProofOutputUtxo,
+        },
+        types::SppProofInputUtxo,
+    },
+    AssetBalance, Data, Filter, Utxo, SOL_ASSET_ID, SOL_MINT,
+};
+use zolana_wallet::sync_wallet;
+
+const TAKER_SIGNER_INDEX: u8 = 3;
+
+#[test]
+fn cosigned_rfq_settlement() -> Result<()> {
+    let TestEnv {
+        client,
+        tree,
+        mut maker,
+        mut taker,
+        usdc_mint,
+    } = setup()?;
+
+    let maker_address = maker.keypair.shielded_address()?;
+    let taker_address = taker.keypair.shielded_address()?;
+    let maker_solana = maker.keypair.to_solana_keypair()?;
+    let taker_solana = taker.keypair.to_solana_keypair()?;
+
+    let maker_sol_utxo = maker
+        .balance(SOL_MINT, Some(Filter::MinAmount(SELL_SOL)))?
+        .utxos
+        .first()
+        .cloned()
+        .ok_or_else(|| anyhow!("no maker sol utxo >= {SELL_SOL}"))?;
+    let taker_usdc_utxo = taker
+        .balance(usdc_mint, Some(Filter::MinAmount(BUY_USDC)))?
+        .utxos
+        .first()
+        .cloned()
+        .ok_or_else(|| anyhow!("no taker usdc utxo >= {BUY_USDC}"))?;
+
+    let maker_spend = SppProofInputUtxo::new(maker_sol_utxo, &maker.keypair);
+    let taker_spend = SppProofInputUtxo::new(taker_usdc_utxo, &taker.keypair);
+    let inputs = vec![maker_spend, taker_spend];
+
+    let sol_to_taker = SppProofOutputUtxo::new(SOL_MINT, SELL_SOL, taker_address)?;
+    let usdc_to_maker = SppProofOutputUtxo::new(usdc_mint, BUY_USDC, maker_address)?;
+    let outputs = vec![sol_to_taker, usdc_to_maker];
+
+    let transaction_viewing_key = get_transaction_viewing_key(&maker.keypair, &inputs)
+        .map_err(|e| anyhow!("transaction viewing key: {e:?}"))?;
+    let encoded = encrypt_transaction_data(&outputs, &maker.registry, &transaction_viewing_key)?;
+
+    let external_data = ExternalData::new(
+        *transaction_viewing_key.pubkey().as_bytes(),
+        encoded.salt,
+        encoded.outputs,
+        encoded.resolved_owner_tags,
+        vec![],
+    );
+    let proof_inputs = SppProofInputs::new(
+        inputs,
+        encoded.output_utxos,
+        external_data,
+        maker_address.solana_address()?,
+    );
+
+    let mut data = client
+        .prove_transact(proof_inputs, Some(IndexerRpcConfig::wait()))
+        .map_err(|e| anyhow!("prove transact: {e:?}"))?;
+    data.inputs
+        .get_mut(1)
+        .ok_or_else(|| anyhow!("missing taker input"))?
+        .eddsa_signer_index = TAKER_SIGNER_INDEX;
+
+    let mut ix = Transact {
+        payer: maker_solana.pubkey(),
+        tree,
+        withdrawal: None,
+        data,
+    }
+    .instruction();
+    ix.accounts
+        .push(AccountMeta::new_readonly(taker_solana.pubkey(), true));
+
+    let signature =
+        send_cosigned_v0_with_lookup_table(client.rpc(), &maker_solana, &taker_solana, ix)?;
+    client
+        .confirm_private_transaction_sync(signature)
+        .map_err(|e| anyhow!("confirm settlement indexed: {e:?}"))?;
+
+    let sol_output = outputs
+        .first()
+        .ok_or_else(|| anyhow!("missing sol output"))?;
+    let usdc_output = outputs
+        .get(1)
+        .ok_or_else(|| anyhow!("missing usdc output"))?;
+    let sol_to_taker_hash = sol_output
+        .hash()
+        .map_err(|e| anyhow!("sol output hash: {e:?}"))?;
+    let usdc_to_maker_hash = usdc_output
+        .hash()
+        .map_err(|e| anyhow!("usdc output hash: {e:?}"))?;
+    client
+        .indexer()
+        .get_merkle_proofs(tree, vec![sol_to_taker_hash, usdc_to_maker_hash], None)
+        .map_err(|e| anyhow!("settlement outputs index: {e}"))?;
+
+    sync_wallet(&mut maker.wallet, &maker.keypair, client.indexer())
+        .map_err(|e| anyhow!("resync maker: {e:?}"))?;
+    sync_wallet(&mut taker.wallet, &taker.keypair, client.indexer())
+        .map_err(|e| anyhow!("resync taker: {e:?}"))?;
+
+    let usdc_asset_id = maker.registry.asset_id(&usdc_mint)?;
+    assert_eq!(
+        taker.balance(SOL_MINT, None)?,
+        AssetBalance {
+            asset_id: SOL_ASSET_ID,
+            mint: SOL_MINT,
+            amount: SELL_SOL,
+            utxos: vec![Utxo {
+                owner: taker_address.signing_pubkey,
+                asset: SOL_MINT,
+                amount: SELL_SOL,
+                blinding: sol_output.blinding,
+                zone_program_id: None,
+                data: Data::default(),
+            }],
+        },
+        "taker received the settled SOL utxo"
+    );
+    assert_eq!(
+        maker.balance(usdc_mint, None)?,
+        AssetBalance {
+            asset_id: usdc_asset_id,
+            mint: usdc_mint,
+            amount: BUY_USDC,
+            utxos: vec![Utxo {
+                owner: maker_address.signing_pubkey,
+                asset: usdc_mint,
+                amount: BUY_USDC,
+                blinding: usdc_output.blinding,
+                zone_program_id: None,
+                data: Data::default(),
+            }],
+        },
+        "maker received the settled USDC utxo"
+    );
+    assert_eq!(
+        maker.balance(SOL_MINT, None)?.amount,
+        0,
+        "maker spent its entire SOL position"
+    );
+    assert_eq!(
+        taker.balance(usdc_mint, None)?.amount,
+        0,
+        "taker spent its entire USDC position"
+    );
+
+    Ok(())
+}

--- a/sdk-tests/rfq/tests/shared.rs
+++ b/sdk-tests/rfq/tests/shared.rs
@@ -1,0 +1,374 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use solana_address::Address;
+use solana_address_lookup_table_interface::instruction::{
+    create_lookup_table, extend_lookup_table,
+};
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_instruction::Instruction;
+use solana_keypair::Keypair;
+use solana_message::{v0, AddressLookupTableAccount, Message, VersionedMessage};
+use solana_pubkey::Pubkey;
+use solana_signature::Signature;
+use solana_signer::Signer;
+use solana_transaction::{versioned::VersionedTransaction, Transaction};
+use zolana_client::{
+    spawn_prover, AsyncProverClient, AsyncZolanaIndexer, ProverClient, Rpc, SolanaRpc,
+    ZolanaClient, ZolanaIndexer,
+};
+use zolana_interface::{
+    instruction::{CreateAssetCounter, CreateProtocolConfig, CreateSplInterface, CreateTree},
+    pda,
+    state::tree_account_size,
+    SHIELDED_POOL_PROGRAM_ID,
+};
+use zolana_keypair::{ShieldedKeypair, ViewingKey};
+use zolana_program_test::system_create_account_ix;
+use zolana_test_utils::{
+    localnet::LocalnetValidator,
+    smart_account::{self, StandardSigners},
+    spl::{create_mint, create_token_account, mint_to},
+};
+use zolana_transaction::{AssetRegistry, Wallet, SOL_MINT};
+use zolana_user_registry_interface::user_registry_program_id;
+use zolana_wallet::{sync_wallet, Deposit, DepositParams};
+
+pub const SELL_SOL: u64 = 250_000_000;
+pub const BUY_USDC: u64 = 100_000_000;
+pub const MAKER_SHIELD_SOL: u64 = SELL_SOL;
+pub const TAKER_SHIELD_USDC: u64 = BUY_USDC;
+
+pub struct TestEnv {
+    pub client: ZolanaClient<SolanaRpc>,
+    pub tree: Pubkey,
+    pub maker: TestWallet,
+    pub taker: TestWallet,
+    pub usdc_mint: Address,
+}
+
+pub struct TestWallet {
+    pub wallet: Wallet,
+    pub keypair: ShieldedKeypair,
+}
+
+impl std::ops::Deref for TestWallet {
+    type Target = Wallet;
+    fn deref(&self) -> &Self::Target {
+        &self.wallet
+    }
+}
+
+impl std::ops::DerefMut for TestWallet {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.wallet
+    }
+}
+
+pub fn setup() -> Result<TestEnv> {
+    let root = concat!(env!("CARGO_MANIFEST_DIR"), "/../..");
+    let cli =
+        std::env::var("ZOLANA_CLI_BIN").unwrap_or_else(|_| format!("{root}/target/debug/zolana"));
+    let rpc_port = std::env::var("ZOLANA_LOCALNET_RPC_PORT").unwrap_or_else(|_| "8899".to_string());
+    let photon_port =
+        std::env::var("ZOLANA_LOCALNET_PHOTON_PORT").unwrap_or_else(|_| "8784".to_string());
+
+    let spp_program_id = Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID).to_string();
+    let spp_program_so = format!("{root}/target/deploy/shielded_pool_program.so");
+    let user_registry_id = user_registry_program_id().to_string();
+    let user_registry_so = format!("{root}/target/deploy/zolana_user_registry.so");
+    let smart_account_id = smart_account::SMART_ACCOUNT_PROGRAM_ID.to_string();
+    let smart_account_so = format!("{root}/target/deploy/squads_smart_account_program.so");
+
+    LocalnetValidator {
+        cli_bin: cli,
+        working_dir: root.to_string(),
+        rpc_port,
+        photon_port,
+        ledger: "/tmp/zolana-rfq-inline-test-ledger".to_string(),
+        account_dir: "/tmp/zolana-rfq-inline-smart-account-accounts".to_string(),
+        programs: vec![
+            (spp_program_id, spp_program_so),
+            (user_registry_id, user_registry_so),
+            (smart_account_id, smart_account_so),
+        ],
+    }
+    .start();
+
+    std::env::set_var(
+        "ZOLANA_PROVER_KEYS_DIR",
+        concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../prover/server/proving-keys"
+        ),
+    );
+    spawn_prover()?;
+
+    let rpc_url = std::env::var("ZOLANA_LOCALNET_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:8899".to_string());
+    let indexer_url =
+        std::env::var("ZOLANA_INDEXER_URL").unwrap_or_else(|_| "http://127.0.0.1:8784".to_string());
+    let mut rpc = SolanaRpc::new(rpc_url);
+    let indexer = ZolanaIndexer::new(indexer_url.clone());
+
+    rpc.assert_executable(&Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID))?;
+
+    let payer = Keypair::new();
+    let authority = Keypair::new();
+    let forester_authority = Keypair::new();
+    let merge_authority = Keypair::new();
+    let tree_creation_authority = Keypair::new();
+    let zone_creation_authority = Keypair::new();
+    rpc.airdrop(&payer.pubkey(), 100_000_000_000)?;
+    rpc.airdrop(&authority.pubkey(), 1_000_000_000)?;
+    rpc.airdrop(&forester_authority.pubkey(), 1_000_000_000)?;
+    rpc.airdrop(&merge_authority.pubkey(), 1_000_000_000)?;
+    rpc.airdrop(&tree_creation_authority.pubkey(), 1_000_000_000)?;
+    rpc.airdrop(&zone_creation_authority.pubkey(), 1_000_000_000)?;
+
+    let payer_address = payer.pubkey();
+
+    let accounts = smart_account::standard_accounts();
+    for ix in accounts.create_ixs(
+        &payer.pubkey(),
+        StandardSigners {
+            protocol: authority.pubkey(),
+            forester: forester_authority.pubkey(),
+            merge: merge_authority.pubkey(),
+            tree: tree_creation_authority.pubkey(),
+            zone: zone_creation_authority.pubkey(),
+        },
+    ) {
+        rpc.create_and_send_transaction(&[ix], payer_address, &[&payer])?;
+    }
+
+    rpc.airdrop(&accounts.protocol_vault, 5_000_000_000)?;
+
+    let create_config_ix = CreateProtocolConfig {
+        authority: accounts.protocol_vault,
+        protocol_authority: accounts.protocol_vault,
+        tree_creation_authority: accounts.tree_vault,
+        tree_creation_is_permissionless: false,
+        forester_authority: accounts.forester_vault,
+        zone_creation_authority: accounts.zone_vault,
+        zone_creation_is_permissionless: false,
+        spl_interface_creation_is_permissionless: false,
+    }
+    .instruction();
+    let create_config_sync = smart_account::execute_sync_ix(
+        &accounts.protocol_settings,
+        0,
+        &[authority.pubkey()],
+        &[create_config_ix],
+    );
+    rpc.create_and_send_transaction(&[create_config_sync], payer_address, &[&payer, &authority])?;
+
+    let tree = Keypair::new();
+    let rent = rpc
+        .get_minimum_balance_for_rent_exemption(tree_account_size())
+        .map_err(|e| anyhow!("{e}"))?;
+    let alloc_ix = system_create_account_ix(
+        &payer.pubkey(),
+        &tree.pubkey(),
+        rent,
+        tree_account_size() as u64,
+        &pda::shielded_pool_program_id(),
+    );
+    let create_tree_ix = CreateTree {
+        authority: accounts.tree_vault,
+        tree: tree.pubkey(),
+        owner: accounts.tree_vault,
+    }
+    .instruction();
+    let create_tree_sync = smart_account::execute_sync_ix(
+        &accounts.tree_settings,
+        0,
+        &[tree_creation_authority.pubkey()],
+        &[create_tree_ix],
+    );
+    rpc.create_and_send_transaction(
+        &[alloc_ix, create_tree_sync],
+        payer_address,
+        &[&payer, &tree, &tree_creation_authority],
+    )?;
+
+    let tree = tree.pubkey();
+
+    let usdc_mint = create_mint(&rpc, &payer)?;
+    if rpc.get_account(pda::spl_asset_counter())?.is_none() {
+        let counter_ix = CreateAssetCounter {
+            authority: accounts.protocol_vault,
+        }
+        .instruction();
+        let counter_sync = smart_account::execute_sync_ix(
+            &accounts.protocol_settings,
+            0,
+            &[authority.pubkey()],
+            &[counter_ix],
+        );
+        rpc.create_and_send_transaction(&[counter_sync], payer_address, &[&payer, &authority])?;
+    }
+    let interface_ix = CreateSplInterface {
+        authority: accounts.protocol_vault,
+        mint: usdc_mint,
+    }
+    .instruction();
+    let interface_sync = smart_account::execute_sync_ix(
+        &accounts.protocol_settings,
+        0,
+        &[authority.pubkey()],
+        &[interface_ix],
+    );
+    rpc.create_and_send_transaction(&[interface_sync], payer_address, &[&payer, &authority])?;
+
+    let usdc_asset_id = 2u64;
+    let mut assets = AssetRegistry::default();
+    assets.insert(usdc_asset_id, usdc_mint)?;
+
+    let usdc_funding = create_token_account(&rpc, &payer, &usdc_mint, &payer.pubkey())?;
+    mint_to(&rpc, &payer, &usdc_mint, &usdc_funding, 1_000_000_000)?;
+
+    let maker_solana_keypair = Keypair::new();
+    let maker_seed: [u8; 32] = maker_solana_keypair.to_bytes()[..32]
+        .try_into()
+        .expect("ed25519 seed is the first 32 bytes");
+    let maker_shielded_keypair = ShieldedKeypair::from_ed25519(&maker_seed, ViewingKey::new())?;
+    rpc.airdrop(&maker_solana_keypair.pubkey(), 10_000_000_000)?;
+
+    let taker_solana_keypair = Keypair::new();
+    rpc.airdrop(&taker_solana_keypair.pubkey(), 10_000_000_000)?;
+    let taker_seed: [u8; 32] = taker_solana_keypair.to_bytes()[..32]
+        .try_into()
+        .expect("ed25519 seed is the first 32 bytes");
+    let taker_shielded_keypair = ShieldedKeypair::from_ed25519(&taker_seed, ViewingKey::new())?;
+
+    Deposit::new(DepositParams {
+        recipient: &maker_shielded_keypair.shielded_address()?,
+        asset: SOL_MINT,
+        amount: MAKER_SHIELD_SOL,
+        spl_token_account: None,
+        memo: None,
+    })?
+    .send(&rpc, &payer, tree, &payer)?;
+    Deposit::new(DepositParams {
+        recipient: &taker_shielded_keypair.shielded_address()?,
+        asset: usdc_mint,
+        amount: TAKER_SHIELD_USDC,
+        spl_token_account: Some(usdc_funding),
+        memo: None,
+    })?
+    .send(&rpc, &payer, tree, &payer)?;
+
+    let maker_address = maker_shielded_keypair
+        .shielded_address()
+        .map_err(|e| anyhow!("maker address: {e:?}"))?;
+    let taker_address = taker_shielded_keypair
+        .shielded_address()
+        .map_err(|e| anyhow!("taker address: {e:?}"))?;
+
+    let mut maker_wallet =
+        Wallet::new(maker_address, assets.clone()).map_err(|e| anyhow!("maker wallet: {e:?}"))?;
+    sync_wallet(&mut maker_wallet, &maker_shielded_keypair, &indexer)
+        .map_err(|e| anyhow!("sync maker deposit: {e:?}"))?;
+
+    let mut taker_wallet =
+        Wallet::new(taker_address, assets.clone()).map_err(|e| anyhow!("taker wallet: {e:?}"))?;
+    sync_wallet(&mut taker_wallet, &taker_shielded_keypair, &indexer)
+        .map_err(|e| anyhow!("sync taker deposit: {e:?}"))?;
+
+    let client = ZolanaClient::new(
+        rpc,
+        indexer,
+        ProverClient::default(),
+        AsyncZolanaIndexer::new(indexer_url),
+        AsyncProverClient::default(),
+        tree,
+    );
+
+    Ok(TestEnv {
+        client,
+        tree,
+        maker: TestWallet {
+            wallet: maker_wallet,
+            keypair: maker_shielded_keypair,
+        },
+        taker: TestWallet {
+            wallet: taker_wallet,
+            keypair: taker_shielded_keypair,
+        },
+        usdc_mint,
+    })
+}
+
+pub fn send_cosigned_v0_with_lookup_table(
+    rpc: &SolanaRpc,
+    payer: &Keypair,
+    cosigner: &Keypair,
+    ix: Instruction,
+) -> Result<Signature> {
+    let alt_addresses: Vec<Pubkey> = ix
+        .accounts
+        .iter()
+        .filter(|meta| !meta.is_signer)
+        .map(|meta| meta.pubkey)
+        .chain(std::iter::once(ix.program_id))
+        .collect();
+    let compute = ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
+
+    let client = rpc.client();
+    let recent_slot = client.get_slot().map_err(|e| anyhow!("get_slot: {e}"))?;
+    loop {
+        let tip = client.get_slot().map_err(|e| anyhow!("get_slot: {e}"))?;
+        if tip > recent_slot {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let (lut_create_ix, table_address) =
+        create_lookup_table(payer.pubkey(), payer.pubkey(), recent_slot);
+    let lut_extend_ix = extend_lookup_table(
+        table_address,
+        payer.pubkey(),
+        Some(payer.pubkey()),
+        alt_addresses.clone(),
+    );
+    let blockhash = client
+        .get_latest_blockhash()
+        .map_err(|e| anyhow!("blockhash: {e}"))?;
+    let setup = Transaction::new(
+        &[payer],
+        Message::new(&[lut_create_ix, lut_extend_ix], Some(&payer.pubkey())),
+        blockhash,
+    );
+    client
+        .send_and_confirm_transaction(&setup)
+        .map_err(|e| anyhow!("create+extend ALT: {e}"))?;
+    let extended_slot = client.get_slot().map_err(|e| anyhow!("get_slot: {e}"))?;
+    loop {
+        let tip = client.get_slot().map_err(|e| anyhow!("get_slot: {e}"))?;
+        if tip > extended_slot {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let alt = AddressLookupTableAccount {
+        key: table_address,
+        addresses: alt_addresses.clone(),
+    };
+    let blockhash = client
+        .get_latest_blockhash()
+        .map_err(|e| anyhow!("blockhash: {e}"))?;
+    let message = v0::Message::try_compile(
+        &payer.pubkey(),
+        &[compute, ix],
+        std::slice::from_ref(&alt),
+        blockhash,
+    )
+    .map_err(|e| anyhow!("compile v0: {e}"))?;
+    let tx = VersionedTransaction::try_new(VersionedMessage::V0(message), &[payer, cosigner])
+        .map_err(|e| anyhow!("sign v0: {e}"))?;
+    let signature = client
+        .send_and_confirm_transaction(&tx)
+        .map_err(|e| anyhow!("send v0: {e}"))?;
+    Ok(signature)
+}


### PR DESCRIPTION
## What

Adds `sdk-tests/rfq`: a confidential RFQ settlement where a maker and taker co-sign a single shielded-pool `transact` that swaps SOL for USDC with **no escrow and no custom program**.

The mechanism is one raw `transact` with two ed25519 co-signers: the taker input's `eddsa_signer_index` is overridden to point at the taker signer account appended to the instruction, and the whole thing is sent as a v0 transaction with an address lookup table (IN2_OUT2 fits under the 1232-byte packet limit).

## Contents

- `tests/rfq.rs` + `tests/shared.rs` — localnet end-to-end settlement against a validator + Photon + prover + Squads smart account. Asserts both recipients' indexed UTXOs against fully-reconstructed expected values (owner, amount, blinding, empty data) and that the spent sides are zero.
- `tests/bench_cu.rs` — mollusk CU benchmark mirroring the swap tooling (`light-program-profiler`), regenerating `BENCHMARK.md` via `just bench-rfq`. The shielded-pool program is built with `profile-program` so its `#[profile]` functions appear in the per-function CU table; proving time is the warm (key-loaded) SPP transfer proof.
- `justfile` — `test-rfq-validator` and `bench-rfq` recipes.
- CI — `test-rfq-validator` added to the `test-localnet-photon` matrix (the benchmark is not run in CI, matching `bench-swap`).

## Benchmark snapshot

~155k CU total (`verify_groth16` dominating at ~93k), 116 ms warm proving, 617 B instruction data, 964 B v0+ALT transaction.