### PR TITLE
feat(indexer): add shielded transaction signature lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4552,6 +4552,7 @@ dependencies = [
  "cadence",
  "cadence-macros",
  "clap",
+ "criterion",
  "futures",
  "http-body-util",
  "hyper",

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -34,8 +34,9 @@ use crate::{
     retry::{IndexerPollConfig, IndexerRpcConfig},
     rpc::{
         AsyncRpc, GetEncryptedUtxosByTagsResponse, GetMerkleProofsResponse,
-        GetNonInclusionProofsResponse, GetShieldedTransactionsByTagsResponse, ProveResult, Rpc,
-        ShieldedTransactionStream,
+        GetNonInclusionProofsResponse, GetShieldedTransactionsBySignatureResponse,
+        GetShieldedTransactionsByTagsResponse, IndexedShieldedTransaction, ProveResult, Rpc,
+        ShieldedTransaction, ShieldedTransactionStream,
     },
 };
 
@@ -481,6 +482,19 @@ impl<R: AsyncRpc> AsyncRpc for ZolanaClient<R> {
             .await
     }
 
+    async fn get_shielded_transactions_by_signature(
+        &self,
+        signature: Signature,
+        config: Option<IndexerRpcConfig>,
+    ) -> Result<GetShieldedTransactionsBySignatureResponse, ClientError> {
+        self.async_indexer
+            .get_shielded_transactions_by_signature(
+                signature,
+                Some(config.unwrap_or(self.indexer_config)),
+            )
+            .await
+    }
+
     async fn subscribe_to_shielded_transactions_by_tags(
         &self,
         tags: Vec<[u8; 32]>,
@@ -689,6 +703,18 @@ impl<R: Rpc> Rpc for ZolanaClient<R> {
             limit,
             Some(config.unwrap_or(self.indexer_config)),
         )
+    }
+
+    fn get_shielded_transactions_by_signature(
+        &self,
+        signature: Signature,
+        config: Option<IndexerRpcConfig>,
+    ) -> Result<GetShieldedTransactionsBySignatureResponse, ClientError> {
+        self.blocking_indexer()
+            .get_shielded_transactions_by_signature(
+                signature,
+                Some(config.unwrap_or(self.indexer_config)),
+            )
     }
 
     fn subscribe_to_shielded_transactions_by_tags(
@@ -941,10 +967,56 @@ async fn wait_for_rpc_confirmation_async<R: AsyncRpc>(
     )))
 }
 
-/// Poll the indexer until the sent transaction is visible under any output
-/// `view_tag` from the confirmed `TRANSACT` instruction. The indexer lags the
-/// chain, so a plain on-chain confirmation is not enough for a caller that
-/// reads state back immediately.
+fn transaction_matches_tags(transaction: &ShieldedTransaction, tags: &[[u8; 32]]) -> bool {
+    transaction
+        .output_slots
+        .iter()
+        .any(|output| tags.contains(&output.view_tag))
+        || transaction
+            .messages
+            .iter()
+            .any(|message| tags.contains(&message.view_tag))
+}
+
+pub(crate) fn select_indexed_transaction(
+    mut events: Vec<IndexedShieldedTransaction>,
+    signature: Signature,
+    expected_tags: &[[u8; 32]],
+) -> Result<Option<ShieldedTransaction>, ClientError> {
+    if events.len() <= 1 {
+        return Ok(events.pop().map(|event| event.transaction));
+    }
+
+    let event_indices = events
+        .iter()
+        .map(|event| event.event_index)
+        .collect::<Vec<_>>();
+    let mut matching = events
+        .into_iter()
+        .filter(|event| {
+            event.transaction.tx_signature == signature
+                && transaction_matches_tags(&event.transaction, expected_tags)
+        })
+        .collect::<Vec<_>>();
+    if matching.len() == 1 {
+        return Ok(matching.pop().map(|event| event.transaction));
+    }
+
+    let matching_indices = matching
+        .iter()
+        .map(|event| event.event_index)
+        .collect::<Vec<_>>();
+    Err(ClientError::AmbiguousIndexedEvents {
+        signature: signature.to_string(),
+        event_indices: if matching_indices.is_empty() {
+            event_indices
+        } else {
+            matching_indices
+        },
+    })
+}
+
+/// Poll Photon by signature until the confirmed transaction is indexed.
 fn wait_for_indexed_transaction(
     indexer: &ZolanaIndexer,
     tags: &[[u8; 32]],
@@ -960,13 +1032,12 @@ fn wait_for_indexed_transaction(
         if !delay.is_zero() {
             sleep(delay);
         }
-        let response =
-            indexer.get_shielded_transactions_by_tags(tags.to_vec(), None, Some(50), None)?;
-        if response
-            .transactions
-            .iter()
-            .any(|item| item.tx_signature == signature)
-        {
+        let matched = match indexer.get_shielded_transactions_by_signature(signature, None) {
+            Ok(response) => select_indexed_transaction(response.transactions, signature, tags)?,
+            Err(error) if indexer.should_retry(&error) => continue,
+            Err(error) => return Err(error),
+        };
+        if matched.is_some() {
             return Ok(());
         }
     }
@@ -988,15 +1059,19 @@ async fn wait_for_indexed_transaction_async(
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
         }
-        let response = indexer
-            .get_shielded_transactions_by_tags(tags.to_vec(), None, Some(50), None)
-            .await?;
-        if response
-            .transactions
-            .iter()
-            .any(|item| item.tx_signature == signature)
+        match indexer
+            .get_shielded_transactions_by_signature(signature, None)
+            .await
         {
-            return Ok(());
+            Ok(response) => {
+                match select_indexed_transaction(response.transactions, signature, tags) {
+                    Ok(Some(_)) => return Ok(()),
+                    Ok(None) => {}
+                    Err(error) => return Err(error),
+                }
+            }
+            Err(error) if indexer.should_retry(&error) => continue,
+            Err(error) => return Err(error),
         }
     }
     Err(ClientError::IndexerTimeout)
@@ -1083,7 +1158,7 @@ mod tests {
         let server = MockIndexerServer::respond_with(vec![
             merkle_response(tree, commitment.utxo_hash),
             nullifier_response(tree, commitment.nullifier),
-            indexed_transaction_response(signature),
+            indexed_transaction_by_signature_response(signature),
         ]);
         let rpc = MockSubmitRpc::new(signature);
         let sent = rpc.sent.clone();
@@ -1129,7 +1204,7 @@ mod tests {
             [
                 "/get_merkle_proofs",
                 "/get_non_inclusion_proofs",
-                "/get_shielded_transactions_by_tags",
+                "/get_shielded_transactions_by_signature",
             ]
         );
     }
@@ -1228,7 +1303,6 @@ mod tests {
         let server = MockIndexerServer::respond_with(vec![rpc_result(json!({
             "context": { "block_time": 12 },
             "transactions": [],
-            "next_cursor": null,
         }))]);
         let rpc = MockSubmitRpc::new(signature);
         let client = ZolanaClient::new(
@@ -1246,6 +1320,132 @@ mod tests {
         let _ = server.requests();
 
         assert!(matches!(error, ClientError::IndexerTimeout));
+    }
+
+    #[test]
+    fn confirm_private_transaction_async_waits_for_direct_lookup() {
+        let signature = Signature::from([10u8; 64]);
+        let server = MockIndexerServer::respond_with(vec![
+            rpc_result(json!({
+                "context": { "block_time": 12 },
+                "transactions": [],
+            })),
+            indexed_transaction_by_signature_response(signature),
+        ]);
+        let client = ZolanaClient::new(
+            MockSubmitRpc::new(signature),
+            ZolanaIndexer::new(server.url()),
+            ProverClient::new("http://unused.invalid".to_string()),
+            AsyncZolanaIndexer::new(server.url()),
+            AsyncProverClient::new("http://unused.invalid".to_string()),
+            Address::new_from_array([8u8; 32]),
+        )
+        .with_indexer_poll_config(IndexerPollConfig::new(1, 0, 0));
+
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        runtime
+            .block_on(client.confirm_private_transaction(signature))
+            .expect("async direct lookup should retry pending results");
+
+        assert_eq!(
+            server.requests(),
+            [
+                "/get_shielded_transactions_by_signature",
+                "/get_shielded_transactions_by_signature",
+            ]
+        );
+    }
+
+    #[test]
+    fn confirm_private_transaction_sync_retries_direct_provider_error() {
+        let signature = Signature::from([15u8; 64]);
+        let server = MockIndexerServer::respond_with(vec![
+            rpc_error(-32603, "Internal error"),
+            indexed_transaction_by_signature_response(signature),
+        ]);
+        let client = ZolanaClient::new(
+            MockSubmitRpc::new(signature),
+            ZolanaIndexer::new(server.url()),
+            ProverClient::new("http://unused.invalid".to_string()),
+            AsyncZolanaIndexer::new(server.url()),
+            AsyncProverClient::new("http://unused.invalid".to_string()),
+            Address::new_from_array([8u8; 32]),
+        )
+        .with_indexer_poll_config(IndexerPollConfig::new(1, 0, 0));
+
+        client
+            .confirm_private_transaction_sync(signature)
+            .expect("retryable direct provider error should be retried");
+
+        assert_eq!(
+            server.requests(),
+            [
+                "/get_shielded_transactions_by_signature",
+                "/get_shielded_transactions_by_signature",
+            ]
+        );
+    }
+
+    #[test]
+    fn confirm_private_transaction_sync_selects_matching_event() {
+        let signature = Signature::from([16u8; 64]);
+        let mut other = indexed_transaction_json(signature);
+        other["output_slots"][0]["view_tag"] = json!(encode_hash([1u8; 32]));
+        let mut expected = indexed_transaction_json(signature);
+        expected["slot"] = json!(12);
+        let server = MockIndexerServer::respond_with(vec![rpc_result(json!({
+            "context": { "block_time": 12 },
+            "transactions": [
+                { "event_index": 0, "transaction": other },
+                { "event_index": 1, "transaction": expected },
+            ],
+        }))]);
+        let client = ZolanaClient::new(
+            MockSubmitRpc::new(signature),
+            ZolanaIndexer::new(server.url()),
+            ProverClient::new("http://unused.invalid".to_string()),
+            AsyncZolanaIndexer::new(server.url()),
+            AsyncProverClient::new("http://unused.invalid".to_string()),
+            Address::new_from_array([8u8; 32]),
+        )
+        .with_indexer_poll_config(IndexerPollConfig::new(0, 0, 0));
+
+        client
+            .confirm_private_transaction_sync(signature)
+            .expect("the uniquely matching Rings event should be selected");
+    }
+
+    #[test]
+    fn confirm_private_transaction_sync_rejects_ambiguous_events() {
+        let signature = Signature::from([17u8; 64]);
+        let server = MockIndexerServer::respond_with(vec![rpc_result(json!({
+            "context": { "block_time": 12 },
+            "transactions": [
+                { "event_index": 0, "transaction": indexed_transaction_json(signature) },
+                { "event_index": 1, "transaction": indexed_transaction_json(signature) },
+            ],
+        }))]);
+        let client = ZolanaClient::new(
+            MockSubmitRpc::new(signature),
+            ZolanaIndexer::new(server.url()),
+            ProverClient::new("http://unused.invalid".to_string()),
+            AsyncZolanaIndexer::new(server.url()),
+            AsyncProverClient::new("http://unused.invalid".to_string()),
+            Address::new_from_array([8u8; 32]),
+        )
+        .with_indexer_poll_config(IndexerPollConfig::new(0, 0, 0));
+
+        let error = client
+            .confirm_private_transaction_sync(signature)
+            .expect_err("multiple matching Rings events must not select event zero");
+
+        assert!(matches!(
+            error,
+            ClientError::AmbiguousIndexedEvents {
+                event_indices,
+                ..
+            } if event_indices == vec![0, 1]
+        ));
     }
 
     fn state_proof(tree: Address, leaf: [u8; 32]) -> MerkleProof {
@@ -1355,6 +1555,20 @@ mod tests {
         }
     }
 
+    #[async_trait]
+    impl AsyncRpc for MockSubmitRpc {
+        async fn confirm_transaction(&self, _signature: Signature) -> Result<bool, ClientError> {
+            Ok(true)
+        }
+
+        async fn transact_output_view_tags_from_signature(
+            &self,
+            _signature: Signature,
+        ) -> Result<Vec<[u8; 32]>, ClientError> {
+            Ok(self.view_tags.clone())
+        }
+    }
+
     fn merkle_response(tree: Address, leaf: [u8; 32]) -> Value {
         rpc_result(json!({
             "context": { "block_time": 10 },
@@ -1394,19 +1608,33 @@ mod tests {
         }))
     }
 
-    fn indexed_transaction_response(signature: Signature) -> Value {
+    fn indexed_transaction_json(signature: Signature) -> Value {
+        json!({
+            "slot": 11,
+            "tx_signature": signature.to_string(),
+            "tx_viewing_pk": null,
+            "output_slots": [{
+                "view_tag": encode_hash([0u8; 32]),
+                "output_context": {
+                    "hash": encode_hash([1u8; 32]),
+                    "tree": encode_address(Address::new_from_array([8u8; 32])),
+                    "leaf_index": 0,
+                },
+                "payload": "",
+            }],
+            "messages": [],
+            "nullifiers": [],
+            "proofless": false,
+        })
+    }
+
+    fn indexed_transaction_by_signature_response(signature: Signature) -> Value {
         rpc_result(json!({
             "context": { "block_time": 11 },
             "transactions": [{
-                "slot": 11,
-                "tx_signature": signature.to_string(),
-                "tx_viewing_pk": null,
-                "output_slots": [],
-                "messages": [],
-                "nullifiers": [],
-                "proofless": false,
+                "event_index": 0,
+                "transaction": indexed_transaction_json(signature),
             }],
-            "next_cursor": null,
         }))
     }
 
@@ -1415,6 +1643,17 @@ mod tests {
             "id": "test-account",
             "jsonrpc": "2.0",
             "result": result,
+        })
+    }
+
+    fn rpc_error(code: i64, message: &str) -> Value {
+        json!({
+            "id": "test-account",
+            "jsonrpc": "2.0",
+            "error": {
+                "code": code,
+                "message": message,
+            },
         })
     }
 
@@ -1428,8 +1667,12 @@ mod tests {
 
     struct MockIndexerServer {
         url: String,
-        requests: mpsc::Receiver<String>,
+        requests: mpsc::Receiver<MockRequest>,
         handle: thread::JoinHandle<()>,
+    }
+
+    struct MockRequest {
+        path: String,
     }
 
     impl MockIndexerServer {
@@ -1441,7 +1684,7 @@ mod tests {
                 for response in responses {
                     let (mut stream, _) = listener.accept().expect("accept request");
                     request_tx
-                        .send(read_request_path(&mut stream))
+                        .send(read_request(&mut stream))
                         .expect("record request");
                     write_json_response(&mut stream, &response);
                 }
@@ -1459,11 +1702,15 @@ mod tests {
 
         fn requests(self) -> Vec<String> {
             self.handle.join().expect("mock indexer thread");
-            self.requests.try_iter().collect()
+            self.requests
+                .try_iter()
+                .into_iter()
+                .map(|request| request.path)
+                .collect()
         }
     }
 
-    fn read_request_path(stream: &mut TcpStream) -> String {
+    fn read_request(stream: &mut TcpStream) -> MockRequest {
         let mut data = Vec::new();
         let mut buffer = [0u8; 1024];
         let mut body_start = None;
@@ -1492,13 +1739,15 @@ mod tests {
                 }
             }
         }
-        let headers = String::from_utf8_lossy(&data);
-        headers
+        let start = body_start.expect("request body");
+        let headers = String::from_utf8_lossy(&data[..start]);
+        let path = headers
             .lines()
             .next()
             .and_then(|line| line.split_whitespace().nth(1))
             .expect("request path")
-            .to_string()
+            .to_string();
+        MockRequest { path }
     }
 
     fn write_json_response(stream: &mut TcpStream, response: &Value) {

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -1759,7 +1759,6 @@ mod tests {
             self.handle.join().expect("mock indexer thread");
             self.requests
                 .try_iter()
-                .into_iter()
                 .map(|request| request.path)
                 .collect()
         }

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -35,8 +35,7 @@ use crate::{
     rpc::{
         AsyncRpc, GetEncryptedUtxosByTagsResponse, GetMerkleProofsResponse,
         GetNonInclusionProofsResponse, GetShieldedTransactionsBySignatureResponse,
-        GetShieldedTransactionsByTagsResponse, IndexedShieldedTransaction, ProveResult, Rpc,
-        ShieldedTransaction, ShieldedTransactionStream,
+        GetShieldedTransactionsByTagsResponse, ProveResult, Rpc, ShieldedTransactionStream,
     },
 };
 
@@ -256,22 +255,14 @@ impl<R: Rpc> ZolanaClient<R> {
         )
     }
 
-    /// Wait until Solana confirms the transaction and Photon has indexed the
-    /// Rings event that matches its `TRANSACT` output view tags.
+    /// Wait until Solana confirms the transaction and Photon has indexed a
+    /// Rings event for it.
     pub fn confirm_private_transaction_sync(
         &self,
         signature: Signature,
     ) -> Result<(), ClientError> {
         wait_for_rpc_confirmation(self.rpc(), signature, self.indexer_config.poll)?;
-        let tags = self
-            .rpc()
-            .transact_output_view_tags_from_signature(signature)?;
-        wait_for_indexed_transaction(
-            self.blocking_indexer(),
-            &tags,
-            signature,
-            self.indexer_config.poll,
-        )
+        wait_for_indexed_transaction(self.blocking_indexer(), signature, self.indexer_config.poll)
     }
 }
 
@@ -304,24 +295,15 @@ impl<R: AsyncRpc> ZolanaClient<R> {
         )
     }
 
-    /// Wait until Solana confirms the transaction and Photon has indexed the
-    /// Rings event that matches its `TRANSACT` output view tags.
+    /// Wait until Solana confirms the transaction and Photon has indexed a
+    /// Rings event for it.
     pub async fn confirm_private_transaction(
         &self,
         signature: Signature,
     ) -> Result<(), ClientError> {
         wait_for_rpc_confirmation_async(self.rpc(), signature, self.indexer_config.poll).await?;
-        let tags = self
-            .rpc()
-            .transact_output_view_tags_from_signature(signature)
-            .await?;
-        wait_for_indexed_transaction_async(
-            &self.async_indexer,
-            &tags,
-            signature,
-            self.indexer_config.poll,
-        )
-        .await
+        wait_for_indexed_transaction_async(&self.async_indexer, signature, self.indexer_config.poll)
+            .await
     }
 }
 
@@ -969,86 +951,41 @@ async fn wait_for_rpc_confirmation_async<R: AsyncRpc>(
     )))
 }
 
-fn transaction_matches_tags(transaction: &ShieldedTransaction, tags: &[[u8; 32]]) -> bool {
-    transaction
-        .output_slots
-        .iter()
-        .any(|output| tags.contains(&output.view_tag))
-        || transaction
-            .messages
-            .iter()
-            .any(|message| tags.contains(&message.view_tag))
-}
-
-pub(crate) fn select_indexed_transaction(
-    events: Vec<IndexedShieldedTransaction>,
-    signature: Signature,
-    expected_tags: &[[u8; 32]],
-) -> Result<Option<ShieldedTransaction>, ClientError> {
-    let mut matching = events
-        .into_iter()
-        .filter(|event| {
-            event.transaction.tx_signature == signature
-                && transaction_matches_tags(&event.transaction, expected_tags)
-        })
-        .collect::<Vec<_>>();
-    if matching.is_empty() {
-        return Ok(None);
-    }
-    if matching.len() == 1 {
-        return Ok(matching.pop().map(|event| event.transaction));
-    }
-
-    Err(ClientError::AmbiguousIndexedEvents {
-        signature: signature.to_string(),
-        event_indices: matching
-            .into_iter()
-            .map(|event| event.event_index)
-            .collect(),
-    })
-}
-
-/// Poll Photon until the indexed Rings event matches the confirmed `TRANSACT`
-/// output view tags. Photon can lag behind Solana, so confirmation is not
-/// enough for immediate reads.
+/// Poll Photon until it has indexed a Rings event for `signature`. Photon lags
+/// the chain, so an on-chain confirmation alone is not enough for a caller that
+/// reads its own outputs back immediately.
+///
+/// Every Rings event of one Solana transaction is persisted in a single
+/// database transaction, so a single visible event proves the whole transaction
+/// is indexed. Matching the event against the transaction's view tags would add
+/// no guarantee and would reject legitimate transactions whose events share a
+/// tag.
 fn wait_for_indexed_transaction(
     indexer: &ZolanaIndexer,
-    tags: &[[u8; 32]],
     signature: Signature,
     retry: IndexerPollConfig,
 ) -> Result<(), ClientError> {
-    if tags.is_empty() {
-        return Err(ClientError::Rpc(
-            "confirmed TRANSACT instruction has no output view tags".into(),
-        ));
-    }
+    let mut last_error = None;
     for delay in std::iter::once(Duration::ZERO).chain(retry.backoff()) {
         if !delay.is_zero() {
             sleep(delay);
         }
-        let matched = match indexer.get_shielded_transactions_by_signature(signature, None) {
-            Ok(response) => select_indexed_transaction(response.transactions, signature, tags)?,
-            Err(error) if indexer.should_retry(&error) => continue,
+        match indexer.get_shielded_transactions_by_signature(signature, None) {
+            Ok(response) if !response.transactions.is_empty() => return Ok(()),
+            Ok(_) => last_error = None,
+            Err(error) if indexer.should_retry(&error) => last_error = Some(error.to_string()),
             Err(error) => return Err(error),
-        };
-        if matched.is_some() {
-            return Ok(());
         }
     }
-    Err(ClientError::IndexerTimeout)
+    Err(indexer_poll_timeout(retry, last_error))
 }
 
 async fn wait_for_indexed_transaction_async(
     indexer: &AsyncZolanaIndexer,
-    tags: &[[u8; 32]],
     signature: Signature,
     retry: IndexerPollConfig,
 ) -> Result<(), ClientError> {
-    if tags.is_empty() {
-        return Err(ClientError::Rpc(
-            "confirmed TRANSACT instruction has no output view tags".into(),
-        ));
-    }
+    let mut last_error = None;
     for delay in std::iter::once(Duration::ZERO).chain(retry.backoff()) {
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;
@@ -1057,18 +994,29 @@ async fn wait_for_indexed_transaction_async(
             .get_shielded_transactions_by_signature(signature, None)
             .await
         {
-            Ok(response) => {
-                match select_indexed_transaction(response.transactions, signature, tags) {
-                    Ok(Some(_)) => return Ok(()),
-                    Ok(None) => {}
-                    Err(error) => return Err(error),
-                }
-            }
-            Err(error) if indexer.should_retry(&error) => continue,
+            Ok(response) if !response.transactions.is_empty() => return Ok(()),
+            Ok(_) => last_error = None,
+            Err(error) if indexer.should_retry(&error) => last_error = Some(error.to_string()),
             Err(error) => return Err(error),
         }
     }
-    Err(ClientError::IndexerTimeout)
+    Err(indexer_poll_timeout(retry, last_error))
+}
+
+/// Classify an exhausted poll by how the *final* attempt went, since that is
+/// the freshest evidence of what the indexer is doing now: an attempt that
+/// answered without the transaction means the indexer is behind, and one that
+/// failed means it never answered, which is not a lag report the caller should
+/// act on. Earlier failures inside the window are deliberately not reported --
+/// a blip the indexer recovered from should not be blamed for a genuine lag.
+fn indexer_poll_timeout(retry: IndexerPollConfig, last_error: Option<String>) -> ClientError {
+    match last_error {
+        Some(last_error) => ClientError::PollTimedOut {
+            attempts: retry.num_retries.saturating_add(1),
+            last_error: Some(last_error),
+        },
+        None => ClientError::IndexerTimeout,
+    }
 }
 
 #[cfg(test)]
@@ -1089,7 +1037,7 @@ mod tests {
     use super::*;
     use crate::{
         prover::CompressedCommitments,
-        rpc::{MerkleContext, MerkleProof, NonInclusionProof, OutputContext, OutputSlot},
+        rpc::{MerkleContext, MerkleProof, NonInclusionProof},
     };
     use zolana_interface::instruction::{TransactSolWithdrawal, TransactWithdrawal};
     use zolana_transaction::instructions::{
@@ -1317,17 +1265,12 @@ mod tests {
     }
 
     #[test]
-    fn confirm_private_transaction_async_waits_for_direct_lookup() {
+    fn confirm_private_transaction_async_polls_until_the_event_is_indexed() {
         let signature = Signature::from([10u8; 64]);
-        let mut nonmatching = indexed_transaction_json(signature);
-        nonmatching["output_slots"][0]["view_tag"] = json!(encode_hash([1u8; 32]));
         let server = MockIndexerServer::respond_with(vec![
             rpc_result(json!({
                 "context": { "block_time": 12 },
-                "transactions": [{
-                    "event_index": 0,
-                    "transaction": nonmatching,
-                }],
+                "transactions": [],
             })),
             indexed_transaction_by_signature_response(signature),
         ]);
@@ -1344,7 +1287,7 @@ mod tests {
         let runtime = tokio::runtime::Runtime::new().expect("runtime");
         runtime
             .block_on(client.confirm_private_transaction(signature))
-            .expect("async direct lookup should retry pending results");
+            .expect("async lookup should poll past an empty response");
 
         assert_eq!(
             server.requests(),
@@ -1356,7 +1299,7 @@ mod tests {
     }
 
     #[test]
-    fn confirm_private_transaction_sync_retries_direct_provider_error() {
+    fn confirm_private_transaction_sync_retries_transient_indexer_error() {
         let signature = Signature::from([15u8; 64]);
         let server = MockIndexerServer::respond_with(vec![
             rpc_error(-32603, "Internal error"),
@@ -1374,7 +1317,7 @@ mod tests {
 
         client
             .confirm_private_transaction_sync(signature)
-            .expect("retryable direct provider error should be retried");
+            .expect("retryable indexer error should be retried");
 
         assert_eq!(
             server.requests(),
@@ -1385,43 +1328,61 @@ mod tests {
         );
     }
 
+    /// An indexer that fails every attempt has not reported a lag, so reporting
+    /// `IndexerTimeout` would send the caller looking for a transaction that
+    /// was never queried successfully.
     #[test]
-    fn select_indexed_transaction_returns_none_for_one_nonmatching_event() {
-        let signature = Signature::from([16u8; 64]);
-        let events = vec![indexed_event(0, signature, [1u8; 32])];
+    fn confirm_private_transaction_sync_surfaces_the_last_transient_error() {
+        let signature = Signature::from([20u8; 64]);
+        let server = MockIndexerServer::respond_with(vec![
+            rpc_error(-32603, "Internal error"),
+            rpc_error(-32603, "Internal error"),
+        ]);
+        let client = ZolanaClient::new(
+            MockSubmitRpc::new(signature),
+            ZolanaIndexer::new(server.url()),
+            ProverClient::new("http://unused.invalid".to_string()),
+            AsyncZolanaIndexer::new(server.url()),
+            AsyncProverClient::new("http://unused.invalid".to_string()),
+            Address::new_from_array([8u8; 32]),
+        )
+        .with_indexer_poll_config(IndexerPollConfig::new(1, 0, 0));
 
-        let selected =
-            select_indexed_transaction(events, signature, &[[0u8; 32]]).expect("selection");
+        let error = client
+            .confirm_private_transaction_sync(signature)
+            .expect_err("an indexer that never answers must not look like a lag");
 
-        assert!(selected.is_none());
+        assert_eq!(
+            server.requests(),
+            [
+                "/get_shielded_transactions_by_signature",
+                "/get_shielded_transactions_by_signature",
+            ]
+        );
+        let ClientError::PollTimedOut {
+            attempts,
+            last_error,
+        } = error
+        else {
+            panic!("expected PollTimedOut, got {error:?}");
+        };
+        assert_eq!(attempts, 2);
+        assert!(last_error
+            .expect("the last transient error is kept")
+            .contains("Internal error"));
     }
 
+    /// One signature can carry several Rings events, and nothing stops two of
+    /// them from sharing a view tag. Confirmation only proves the transaction
+    /// is indexed, so every event of that signature is an acceptable answer.
     #[test]
-    fn select_indexed_transaction_returns_none_when_no_events_match() {
-        let signature = Signature::from([17u8; 64]);
-        let events = vec![
-            indexed_event(0, signature, [1u8; 32]),
-            indexed_event(1, signature, [2u8; 32]),
-        ];
-
-        let selected =
-            select_indexed_transaction(events, signature, &[[0u8; 32]]).expect("selection");
-
-        assert!(selected.is_none());
-    }
-
-    #[test]
-    fn confirm_private_transaction_sync_selects_matching_event() {
+    fn confirm_private_transaction_sync_accepts_events_sharing_a_view_tag() {
         let signature = Signature::from([18u8; 64]);
-        let mut other = indexed_transaction_json(signature);
-        other["output_slots"][0]["view_tag"] = json!(encode_hash([1u8; 32]));
-        let mut expected = indexed_transaction_json(signature);
-        expected["slot"] = json!(12);
         let server = MockIndexerServer::respond_with(vec![rpc_result(json!({
             "context": { "block_time": 12 },
             "transactions": [
-                { "event_index": 0, "transaction": other },
-                { "event_index": 1, "transaction": expected },
+                { "event_index": 0, "transaction": indexed_transaction_json(signature) },
+                { "event_index": 1, "transaction": indexed_transaction_json(signature) },
             ],
         }))]);
         let client = ZolanaClient::new(
@@ -1436,43 +1397,43 @@ mod tests {
 
         client
             .confirm_private_transaction_sync(signature)
-            .expect("the uniquely matching Rings event should be selected");
+            .expect("events sharing a view tag are not an error");
+
+        assert_eq!(
+            server.requests(),
+            ["/get_shielded_transactions_by_signature"]
+        );
     }
 
+    /// Confirmation no longer reads view tags, so the forwarders are the only
+    /// thing keeping the capability reachable through `ZolanaClient`.
     #[test]
-    fn confirm_private_transaction_sync_rejects_ambiguous_events() {
-        let signature = Signature::from([19u8; 64]);
-        let mut other = indexed_transaction_json(signature);
-        other["output_slots"][0]["view_tag"] = json!(encode_hash([1u8; 32]));
-        let server = MockIndexerServer::respond_with(vec![rpc_result(json!({
-            "context": { "block_time": 12 },
-            "transactions": [
-                { "event_index": 0, "transaction": other },
-                { "event_index": 1, "transaction": indexed_transaction_json(signature) },
-                { "event_index": 2, "transaction": indexed_transaction_json(signature) },
-            ],
-        }))]);
+    fn client_forwards_transact_output_view_tags_to_the_rpc() {
+        let signature = Signature::from([21u8; 64]);
+        let expected = vec![[7u8; 32], [9u8; 32]];
         let client = ZolanaClient::new(
-            MockSubmitRpc::new(signature),
-            ZolanaIndexer::new(server.url()),
+            MockSubmitRpc::new(signature).with_view_tags(expected.clone()),
+            ZolanaIndexer::new("http://unused.invalid"),
             ProverClient::new("http://unused.invalid".to_string()),
-            AsyncZolanaIndexer::new(server.url()),
+            AsyncZolanaIndexer::new("http://unused.invalid"),
             AsyncProverClient::new("http://unused.invalid".to_string()),
             Address::new_from_array([8u8; 32]),
-        )
-        .with_indexer_poll_config(IndexerPollConfig::new(0, 0, 0));
+        );
 
-        let error = client
-            .confirm_private_transaction_sync(signature)
-            .expect_err("multiple matching Rings events must not select event zero");
+        assert_eq!(
+            Rpc::transact_output_view_tags_from_signature(&client, signature).expect("sync tags"),
+            expected
+        );
 
-        assert!(matches!(
-            error,
-            ClientError::AmbiguousIndexedEvents {
-                event_indices,
-                ..
-            } if event_indices == vec![1, 2]
-        ));
+        let runtime = tokio::runtime::Runtime::new().expect("runtime");
+        assert_eq!(
+            runtime
+                .block_on(AsyncRpc::transact_output_view_tags_from_signature(
+                    &client, signature
+                ))
+                .expect("async tags"),
+            expected
+        );
     }
 
     fn state_proof(tree: Address, leaf: [u8; 32]) -> MerkleProof {
@@ -1547,9 +1508,14 @@ mod tests {
         fn new(signature: Signature) -> Self {
             Self {
                 signature,
-                view_tags: vec![[0u8; 32]],
+                view_tags: Vec::new(),
                 sent: Arc::new(Mutex::new(Vec::new())),
             }
+        }
+
+        fn with_view_tags(mut self, view_tags: Vec<[u8; 32]>) -> Self {
+            self.view_tags = view_tags;
+            self
         }
     }
 
@@ -1653,34 +1619,6 @@ mod tests {
             "nullifiers": [],
             "proofless": false,
         })
-    }
-
-    fn indexed_event(
-        event_index: u16,
-        signature: Signature,
-        view_tag: [u8; 32],
-    ) -> IndexedShieldedTransaction {
-        IndexedShieldedTransaction {
-            event_index,
-            transaction: ShieldedTransaction {
-                slot: 11,
-                tx_signature: signature,
-                tx_viewing_pk: None,
-                salt: None,
-                output_slots: vec![OutputSlot {
-                    view_tag,
-                    output_context: OutputContext {
-                        hash: [1u8; 32],
-                        tree: Address::new_from_array([8u8; 32]),
-                        leaf_index: 0,
-                    },
-                    payload: Vec::new(),
-                }],
-                messages: Vec::new(),
-                nullifiers: Vec::new(),
-                proofless: false,
-            },
-        }
     }
 
     fn indexed_transaction_by_signature_response(signature: Signature) -> Value {

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -1189,7 +1189,7 @@ mod tests {
         transaction
             .try_sign(&[&payer], blockhash)
             .expect("sign native transaction");
-        let result = client.rpc().send_transaction(&transaction).expect("send");
+        let result = Rpc::send_transaction(client.rpc(), &transaction).expect("send");
         client
             .confirm_private_transaction_sync(result)
             .expect("indexed");

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -256,7 +256,8 @@ impl<R: Rpc> ZolanaClient<R> {
         )
     }
 
-    /// Wait until the transaction is confirmed on-chain and Photon has indexed it.
+    /// Wait until Solana confirms the transaction and Photon has indexed the
+    /// Rings event that matches its `TRANSACT` output view tags.
     pub fn confirm_private_transaction_sync(
         &self,
         signature: Signature,
@@ -303,7 +304,8 @@ impl<R: AsyncRpc> ZolanaClient<R> {
         )
     }
 
-    /// Wait until the transaction is confirmed on-chain and Photon has indexed it.
+    /// Wait until Solana confirms the transaction and Photon has indexed the
+    /// Rings event that matches its `TRANSACT` output view tags.
     pub async fn confirm_private_transaction(
         &self,
         signature: Signature,
@@ -979,18 +981,10 @@ fn transaction_matches_tags(transaction: &ShieldedTransaction, tags: &[[u8; 32]]
 }
 
 pub(crate) fn select_indexed_transaction(
-    mut events: Vec<IndexedShieldedTransaction>,
+    events: Vec<IndexedShieldedTransaction>,
     signature: Signature,
     expected_tags: &[[u8; 32]],
 ) -> Result<Option<ShieldedTransaction>, ClientError> {
-    if events.len() <= 1 {
-        return Ok(events.pop().map(|event| event.transaction));
-    }
-
-    let event_indices = events
-        .iter()
-        .map(|event| event.event_index)
-        .collect::<Vec<_>>();
     let mut matching = events
         .into_iter()
         .filter(|event| {
@@ -998,25 +992,25 @@ pub(crate) fn select_indexed_transaction(
                 && transaction_matches_tags(&event.transaction, expected_tags)
         })
         .collect::<Vec<_>>();
+    if matching.is_empty() {
+        return Ok(None);
+    }
     if matching.len() == 1 {
         return Ok(matching.pop().map(|event| event.transaction));
     }
 
-    let matching_indices = matching
-        .iter()
-        .map(|event| event.event_index)
-        .collect::<Vec<_>>();
     Err(ClientError::AmbiguousIndexedEvents {
         signature: signature.to_string(),
-        event_indices: if matching_indices.is_empty() {
-            event_indices
-        } else {
-            matching_indices
-        },
+        event_indices: matching
+            .into_iter()
+            .map(|event| event.event_index)
+            .collect(),
     })
 }
 
-/// Poll Photon by signature until the confirmed transaction is indexed.
+/// Poll Photon until the indexed Rings event matches the confirmed `TRANSACT`
+/// output view tags. Photon can lag behind Solana, so confirmation is not
+/// enough for immediate reads.
 fn wait_for_indexed_transaction(
     indexer: &ZolanaIndexer,
     tags: &[[u8; 32]],
@@ -1095,7 +1089,7 @@ mod tests {
     use super::*;
     use crate::{
         prover::CompressedCommitments,
-        rpc::{MerkleContext, MerkleProof, NonInclusionProof},
+        rpc::{MerkleContext, MerkleProof, NonInclusionProof, OutputContext, OutputSlot},
     };
     use zolana_interface::instruction::{TransactSolWithdrawal, TransactWithdrawal};
     use zolana_transaction::instructions::{
@@ -1325,10 +1319,15 @@ mod tests {
     #[test]
     fn confirm_private_transaction_async_waits_for_direct_lookup() {
         let signature = Signature::from([10u8; 64]);
+        let mut nonmatching = indexed_transaction_json(signature);
+        nonmatching["output_slots"][0]["view_tag"] = json!(encode_hash([1u8; 32]));
         let server = MockIndexerServer::respond_with(vec![
             rpc_result(json!({
                 "context": { "block_time": 12 },
-                "transactions": [],
+                "transactions": [{
+                    "event_index": 0,
+                    "transaction": nonmatching,
+                }],
             })),
             indexed_transaction_by_signature_response(signature),
         ]);
@@ -1387,8 +1386,33 @@ mod tests {
     }
 
     #[test]
-    fn confirm_private_transaction_sync_selects_matching_event() {
+    fn select_indexed_transaction_returns_none_for_one_nonmatching_event() {
         let signature = Signature::from([16u8; 64]);
+        let events = vec![indexed_event(0, signature, [1u8; 32])];
+
+        let selected =
+            select_indexed_transaction(events, signature, &[[0u8; 32]]).expect("selection");
+
+        assert!(selected.is_none());
+    }
+
+    #[test]
+    fn select_indexed_transaction_returns_none_when_no_events_match() {
+        let signature = Signature::from([17u8; 64]);
+        let events = vec![
+            indexed_event(0, signature, [1u8; 32]),
+            indexed_event(1, signature, [2u8; 32]),
+        ];
+
+        let selected =
+            select_indexed_transaction(events, signature, &[[0u8; 32]]).expect("selection");
+
+        assert!(selected.is_none());
+    }
+
+    #[test]
+    fn confirm_private_transaction_sync_selects_matching_event() {
+        let signature = Signature::from([18u8; 64]);
         let mut other = indexed_transaction_json(signature);
         other["output_slots"][0]["view_tag"] = json!(encode_hash([1u8; 32]));
         let mut expected = indexed_transaction_json(signature);
@@ -1417,12 +1441,15 @@ mod tests {
 
     #[test]
     fn confirm_private_transaction_sync_rejects_ambiguous_events() {
-        let signature = Signature::from([17u8; 64]);
+        let signature = Signature::from([19u8; 64]);
+        let mut other = indexed_transaction_json(signature);
+        other["output_slots"][0]["view_tag"] = json!(encode_hash([1u8; 32]));
         let server = MockIndexerServer::respond_with(vec![rpc_result(json!({
             "context": { "block_time": 12 },
             "transactions": [
-                { "event_index": 0, "transaction": indexed_transaction_json(signature) },
+                { "event_index": 0, "transaction": other },
                 { "event_index": 1, "transaction": indexed_transaction_json(signature) },
+                { "event_index": 2, "transaction": indexed_transaction_json(signature) },
             ],
         }))]);
         let client = ZolanaClient::new(
@@ -1444,7 +1471,7 @@ mod tests {
             ClientError::AmbiguousIndexedEvents {
                 event_indices,
                 ..
-            } if event_indices == vec![0, 1]
+            } if event_indices == vec![1, 2]
         ));
     }
 
@@ -1626,6 +1653,34 @@ mod tests {
             "nullifiers": [],
             "proofless": false,
         })
+    }
+
+    fn indexed_event(
+        event_index: u16,
+        signature: Signature,
+        view_tag: [u8; 32],
+    ) -> IndexedShieldedTransaction {
+        IndexedShieldedTransaction {
+            event_index,
+            transaction: ShieldedTransaction {
+                slot: 11,
+                tx_signature: signature,
+                tx_viewing_pk: None,
+                salt: None,
+                output_slots: vec![OutputSlot {
+                    view_tag,
+                    output_context: OutputContext {
+                        hash: [1u8; 32],
+                        tree: Address::new_from_array([8u8; 32]),
+                        leaf_index: 0,
+                    },
+                    payload: Vec::new(),
+                }],
+                messages: Vec::new(),
+                nullifiers: Vec::new(),
+                proofless: false,
+            },
+        }
     }
 
     fn indexed_transaction_by_signature_response(signature: Signature) -> Value {

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -181,11 +181,22 @@ pub enum ClientError {
     #[error("indexer error: {0}")]
     Indexer(String),
 
+    #[error("indexer temporarily unavailable: {0}")]
+    IndexerUnavailable(String),
+
     #[error("rpc backend does not implement method `{0}`")]
     UnsupportedRpcMethod(&'static str),
 
     #[error("indexer did not observe the transaction before the poll timeout")]
     IndexerTimeout,
+
+    #[error(
+        "indexed transaction {signature} has ambiguous Rings events at indices {event_indices:?}"
+    )]
+    AmbiguousIndexedEvents {
+        signature: String,
+        event_indices: Vec<u16>,
+    },
 
     #[error("indexer did not reach block_time {target} within {attempts} attempts; latest indexed block_time is {latest}")]
     IndexerNotCaughtUp {

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -181,6 +181,8 @@ pub enum ClientError {
     #[error("indexer error: {0}")]
     Indexer(String),
 
+    /// The indexer answered with a rate-limit or internal JSON-RPC error.
+    /// Acted on by `Rpc::should_retry` during the confirmation poll.
     #[error("indexer temporarily unavailable: {0}")]
     IndexerUnavailable(String),
 
@@ -189,14 +191,6 @@ pub enum ClientError {
 
     #[error("indexer did not observe the transaction before the poll timeout")]
     IndexerTimeout,
-
-    #[error(
-        "indexed transaction {signature} has ambiguous Rings events at indices {event_indices:?}"
-    )]
-    AmbiguousIndexedEvents {
-        signature: String,
-        event_indices: Vec<u16>,
-    },
 
     #[error("indexer did not reach block_time {target} within {attempts} attempts; latest indexed block_time is {latest}")]
     IndexerNotCaughtUp {

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -32,6 +32,9 @@ use crate::{
 const MERKLE_PROOF_POLL_TIMEOUT: Duration = Duration::from_secs(60);
 const MERKLE_PROOF_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
+const JSON_RPC_METHOD_NOT_FOUND: i64 = -32601;
+const JSON_RPC_INTERNAL_ERROR: i64 = -32603;
+
 fn now_unix_seconds() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -505,6 +508,11 @@ impl AsyncRpc for AsyncZolanaIndexer {
     }
 }
 
+/// Split indexer failures into the ones worth polling through and the ones that
+/// will never succeed. Photon reports both a transient database failure and a
+/// permanent internal bug as `-32603` with the body scrubbed, so `-32603` is
+/// retried and the caller is handed the last one it saw rather than a bare
+/// timeout.
 fn indexer_error(error: zolana_api::ApiError) -> ClientError {
     let message = error.to_string();
     match error {
@@ -517,10 +525,13 @@ fn indexer_error(error: zolana_api::ApiError) -> ClientError {
             ClientError::IndexerUnavailable(message)
         }
         zolana_api::ApiError::JsonRpc {
-            code: Some(-32601), ..
-        } => ClientError::UnsupportedRpcMethod("remote indexer method"),
+            method,
+            code: Some(JSON_RPC_METHOD_NOT_FOUND),
+            ..
+        } => ClientError::UnsupportedRpcMethod(method),
         zolana_api::ApiError::JsonRpc {
-            code: Some(-32603), ..
+            code: Some(JSON_RPC_INTERNAL_ERROR),
+            ..
         } => ClientError::IndexerUnavailable(message),
         _ => ClientError::Indexer(message),
     }
@@ -557,7 +568,9 @@ fn convert_shielded_transactions_response(
             .transactions
             .into_iter()
             .enumerate()
-            .map(|(index, item)| convert_shielded_transaction(index, item))
+            .map(|(index, item)| {
+                convert_shielded_transaction(&format!("transactions[{index}]"), item)
+            })
             .collect::<Result<Vec<_>, _>>()?,
         next_cursor: response.next_cursor.map(Into::into),
     })
@@ -575,7 +588,10 @@ fn convert_shielded_transactions_by_signature_response(
             .map(|(index, item)| {
                 Ok(IndexedShieldedTransaction {
                     event_index: item.event_index,
-                    transaction: convert_shielded_transaction(index, item.transaction)?,
+                    transaction: convert_shielded_transaction(
+                        &format!("transactions[{index}].transaction"),
+                        item.transaction,
+                    )?,
                 })
             })
             .collect::<Result<Vec<_>, ClientError>>()?,
@@ -583,17 +599,14 @@ fn convert_shielded_transactions_by_signature_response(
 }
 
 fn convert_shielded_transaction(
-    index: usize,
+    path: &str,
     item: zolana_api::ShieldedTransaction,
 ) -> Result<ShieldedTransaction, ClientError> {
     Ok(ShieldedTransaction {
         slot: item.slot,
         tx_signature: item.tx_signature.0,
-        tx_viewing_pk: decode_optional_p256(
-            item.tx_viewing_pk,
-            &format!("transactions[{index}].tx_viewing_pk"),
-        )?,
-        salt: decode_optional_salt(item.salt, &format!("transactions[{index}].salt"))?,
+        tx_viewing_pk: decode_optional_p256(item.tx_viewing_pk, &format!("{path}.tx_viewing_pk"))?,
+        salt: decode_optional_salt(item.salt, &format!("{path}.salt"))?,
         output_slots: item
             .output_slots
             .into_iter()
@@ -915,9 +928,13 @@ mod tests {
             request.body["params"],
             json!({ "tx_signature": signature.to_string() })
         );
+        let indexed = got
+            .transactions
+            .first()
+            .expect("one indexed Rings event for the signature");
         assert_eq!(got.transactions.len(), 1);
-        assert_eq!(got.transactions[0].event_index, 3);
-        assert_eq!(got.transactions[0].transaction.tx_signature, signature);
+        assert_eq!(indexed.event_index, 3);
+        assert_eq!(indexed.transaction.tx_signature, signature);
     }
 
     #[test]
@@ -1085,7 +1102,7 @@ mod tests {
         });
         assert!(matches!(
             method_not_found,
-            ClientError::UnsupportedRpcMethod("remote indexer method")
+            ClientError::UnsupportedRpcMethod("get_shielded_transactions_by_signature")
         ));
 
         let request_error = reqwest::blocking::Client::new()
@@ -1131,6 +1148,37 @@ mod tests {
         let message = err.to_string();
         assert!(message.contains("wrong size"));
         assert!(message.contains("result.transactions[0].output_slots[0].output_context.hash"));
+    }
+
+    #[test]
+    fn by_signature_error_path_includes_transaction_nesting() {
+        let signature = signature(61);
+        let response = rpc_result(json!({
+            "context": { "block_time": 1 },
+            "transactions": [{
+                "event_index": 0,
+                "transaction": {
+                    "slot": 1,
+                    "tx_signature": signature.to_string(),
+                    "tx_viewing_pk": STANDARD.encode([1u8; 16]),
+                    "output_slots": [],
+                    "messages": [],
+                    "nullifiers": [],
+                    "proofless": false,
+                },
+            }],
+        }));
+        let server = MockServer::respond_once(response);
+        let indexer = ZolanaIndexer::new(server.url());
+
+        let err = indexer
+            .get_shielded_transactions_by_signature(signature, None)
+            .expect_err("short viewing key must fail");
+        let _ = server.request();
+
+        assert!(err
+            .to_string()
+            .contains("transactions[0].transaction.tx_viewing_pk"));
     }
 
     fn assert_json_rpc_request(body: &Value, method: &str) {

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -508,9 +508,7 @@ impl AsyncRpc for AsyncZolanaIndexer {
 fn indexer_error(error: zolana_api::ApiError) -> ClientError {
     let message = error.to_string();
     match error {
-        zolana_api::ApiError::Request(error)
-            if error.is_timeout() || error.is_connect() || error.is_request() =>
-        {
+        zolana_api::ApiError::Request(error) if error.is_timeout() || error.is_connect() => {
             ClientError::IndexerUnavailable(message)
         }
         zolana_api::ApiError::Response { status, .. }
@@ -1060,6 +1058,42 @@ mod tests {
 
         assert!(matches!(&err, ClientError::Indexer(_)));
         assert!(err.to_string().contains("bad tag"));
+    }
+
+    #[test]
+    fn classifies_transient_indexer_errors_for_retry() {
+        let rate_limit = indexer_error(zolana_api::ApiError::Response {
+            status: reqwest::StatusCode::TOO_MANY_REQUESTS,
+            body: "retry later".to_string(),
+        });
+        assert!(matches!(rate_limit, ClientError::IndexerUnavailable(_)));
+
+        let internal_error = indexer_error(zolana_api::ApiError::JsonRpc {
+            method: "get_shielded_transactions_by_signature",
+            code: Some(-32603),
+            message: Some("Internal error".to_string()),
+        });
+        assert!(matches!(internal_error, ClientError::IndexerUnavailable(_)));
+    }
+
+    #[test]
+    fn classifies_non_transient_indexer_errors_without_retry() {
+        let method_not_found = indexer_error(zolana_api::ApiError::JsonRpc {
+            method: "get_shielded_transactions_by_signature",
+            code: Some(-32601),
+            message: Some("Method not found".to_string()),
+        });
+        assert!(matches!(
+            method_not_found,
+            ClientError::UnsupportedRpcMethod("remote indexer method")
+        ));
+
+        let request_error = reqwest::blocking::Client::new()
+            .get("not a url")
+            .send()
+            .expect_err("relative URL should be rejected");
+        let malformed_request = indexer_error(zolana_api::ApiError::Request(request_error));
+        assert!(matches!(malformed_request, ClientError::Indexer(_)));
     }
 
     #[test]

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -7,11 +7,10 @@ use std::{
 
 use async_trait::async_trait;
 use solana_address::Address;
-#[cfg(test)]
 use solana_signature::Signature;
 use zolana_api::{
     Base64String, BlockingZolanaApi, Hash as ApiHash, RingsOutputSlot as ApiOutputSlot,
-    SerializablePubkey, ZolanaApi,
+    SerializablePubkey, SerializableSignature, ZolanaApi,
 };
 use zolana_interface::instruction::instruction_data::transact::TransactIxData;
 use zolana_keypair::{constants::P256_PUBKEY_LEN, P256Pubkey};
@@ -24,8 +23,9 @@ use crate::{
     rpc::{
         AsyncRpc, Context, EncryptedUtxoMatch, GetEncryptedUtxosByTagsResponse,
         GetMerkleProofsResponse, GetNonInclusionProofsResponse,
-        GetShieldedTransactionsByTagsResponse, MerkleContext, MerkleProof, NonInclusionProof,
-        OutputContext, OutputSlot, Rpc, ShieldedTransaction,
+        GetShieldedTransactionsBySignatureResponse, GetShieldedTransactionsByTagsResponse,
+        IndexedShieldedTransaction, MerkleContext, MerkleProof, NonInclusionProof, OutputContext,
+        OutputSlot, Rpc, ShieldedTransaction,
     },
 };
 
@@ -186,6 +186,10 @@ impl AsyncZolanaIndexer {
 }
 
 impl Rpc for ZolanaIndexer {
+    fn should_retry(&self, error: &ClientError) -> bool {
+        matches!(error, ClientError::IndexerUnavailable(_))
+    }
+
     fn get_encrypted_utxos_by_tags(
         &self,
         tags: Vec<[u8; 32]>,
@@ -240,16 +244,26 @@ impl Rpc for ZolanaIndexer {
                     )
                     .map_err(indexer_error)?;
 
-                Ok(GetShieldedTransactionsByTagsResponse {
-                    context: convert_context(response.context),
-                    transactions: response
-                        .transactions
-                        .into_iter()
-                        .enumerate()
-                        .map(|(index, item)| convert_shielded_transaction(index, item))
-                        .collect::<Result<Vec<_>, _>>()?,
-                    next_cursor: response.next_cursor.map(Into::into),
-                })
+                convert_shielded_transactions_response(response)
+            },
+        )
+    }
+
+    fn get_shielded_transactions_by_signature(
+        &self,
+        signature: Signature,
+        config: Option<IndexerRpcConfig>,
+    ) -> Result<GetShieldedTransactionsBySignatureResponse, ClientError> {
+        wait_for_indexer(
+            config,
+            |response: &GetShieldedTransactionsBySignatureResponse| response.context.block_time,
+            || {
+                let response = self
+                    .api
+                    .get_shielded_transactions_by_signature(SerializableSignature(signature))
+                    .map_err(indexer_error)?;
+
+                convert_shielded_transactions_by_signature_response(response)
             },
         )
     }
@@ -338,6 +352,10 @@ impl Rpc for ZolanaIndexer {
 
 #[async_trait]
 impl AsyncRpc for AsyncZolanaIndexer {
+    fn should_retry(&self, error: &ClientError) -> bool {
+        matches!(error, ClientError::IndexerUnavailable(_))
+    }
+
     async fn get_encrypted_utxos_by_tags(
         &self,
         tags: Vec<[u8; 32]>,
@@ -395,16 +413,28 @@ impl AsyncRpc for AsyncZolanaIndexer {
                     .await
                     .map_err(indexer_error)?;
 
-                Ok(GetShieldedTransactionsByTagsResponse {
-                    context: convert_context(response.context),
-                    transactions: response
-                        .transactions
-                        .into_iter()
-                        .enumerate()
-                        .map(|(index, item)| convert_shielded_transaction(index, item))
-                        .collect::<Result<Vec<_>, _>>()?,
-                    next_cursor: response.next_cursor.map(Into::into),
-                })
+                convert_shielded_transactions_response(response)
+            },
+        )
+        .await
+    }
+
+    async fn get_shielded_transactions_by_signature(
+        &self,
+        signature: Signature,
+        config: Option<IndexerRpcConfig>,
+    ) -> Result<GetShieldedTransactionsBySignatureResponse, ClientError> {
+        wait_for_indexer_async(
+            config,
+            |response: &GetShieldedTransactionsBySignatureResponse| response.context.block_time,
+            || async {
+                let response = self
+                    .api
+                    .get_shielded_transactions_by_signature(SerializableSignature(signature))
+                    .await
+                    .map_err(indexer_error)?;
+
+                convert_shielded_transactions_by_signature_response(response)
             },
         )
         .await
@@ -476,7 +506,26 @@ impl AsyncRpc for AsyncZolanaIndexer {
 }
 
 fn indexer_error(error: zolana_api::ApiError) -> ClientError {
-    ClientError::Indexer(error.to_string())
+    let message = error.to_string();
+    match error {
+        zolana_api::ApiError::Request(error)
+            if error.is_timeout() || error.is_connect() || error.is_request() =>
+        {
+            ClientError::IndexerUnavailable(message)
+        }
+        zolana_api::ApiError::Response { status, .. }
+            if status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error() =>
+        {
+            ClientError::IndexerUnavailable(message)
+        }
+        zolana_api::ApiError::JsonRpc {
+            code: Some(-32601), ..
+        } => ClientError::UnsupportedRpcMethod("remote indexer method"),
+        zolana_api::ApiError::JsonRpc {
+            code: Some(-32603), ..
+        } => ClientError::IndexerUnavailable(message),
+        _ => ClientError::Indexer(message),
+    }
 }
 
 fn convert_context(context: zolana_api::Context) -> Context {
@@ -498,6 +547,40 @@ fn convert_encrypted_utxo_match(
             &format!("matches[{index}].tx_viewing_pk"),
         )?,
         salt: decode_optional_salt(item.salt, &format!("matches[{index}].salt"))?,
+    })
+}
+
+fn convert_shielded_transactions_response(
+    response: zolana_api::GetShieldedTransactionsByTagsResponse,
+) -> Result<GetShieldedTransactionsByTagsResponse, ClientError> {
+    Ok(GetShieldedTransactionsByTagsResponse {
+        context: convert_context(response.context),
+        transactions: response
+            .transactions
+            .into_iter()
+            .enumerate()
+            .map(|(index, item)| convert_shielded_transaction(index, item))
+            .collect::<Result<Vec<_>, _>>()?,
+        next_cursor: response.next_cursor.map(Into::into),
+    })
+}
+
+fn convert_shielded_transactions_by_signature_response(
+    response: zolana_api::GetShieldedTransactionsBySignatureResponse,
+) -> Result<GetShieldedTransactionsBySignatureResponse, ClientError> {
+    Ok(GetShieldedTransactionsBySignatureResponse {
+        context: convert_context(response.context),
+        transactions: response
+            .transactions
+            .into_iter()
+            .enumerate()
+            .map(|(index, item)| {
+                Ok(IndexedShieldedTransaction {
+                    event_index: item.event_index,
+                    transaction: convert_shielded_transaction(index, item.transaction)?,
+                })
+            })
+            .collect::<Result<Vec<_>, ClientError>>()?,
     })
 }
 
@@ -800,6 +883,43 @@ mod tests {
                 next_cursor: Some(vec![23]),
             }
         );
+    }
+
+    #[test]
+    fn get_shielded_transactions_by_signature_preserves_event_index() {
+        let signature = signature(24);
+        let response = rpc_result(json!({
+            "context": { "block_time": 52 },
+            "transactions": [{
+                "event_index": 3,
+                "transaction": {
+                    "slot": 50,
+                    "tx_signature": signature.to_string(),
+                    "tx_viewing_pk": null,
+                    "output_slots": [],
+                    "messages": [],
+                    "nullifiers": [],
+                    "proofless": false,
+                },
+            }],
+        }));
+        let server = MockServer::respond_once(response);
+        let indexer = ZolanaIndexer::new(server.url());
+
+        let got = indexer
+            .get_shielded_transactions_by_signature(signature, None)
+            .expect("direct shielded transaction lookup");
+        let request = server.request();
+
+        assert_eq!(request.path, "/get_shielded_transactions_by_signature");
+        assert_json_rpc_request(&request.body, "get_shielded_transactions_by_signature");
+        assert_eq!(
+            request.body["params"],
+            json!({ "tx_signature": signature.to_string() })
+        );
+        assert_eq!(got.transactions.len(), 1);
+        assert_eq!(got.transactions[0].event_index, 3);
+        assert_eq!(got.transactions[0].transaction.tx_signature, signature);
     }
 
     #[test]

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -44,9 +44,11 @@ pub use prover::{
 pub use retry::{IndexerPollConfig, IndexerRpcConfig};
 pub use rpc::{
     AsyncRpc, Context, EncryptedUtxoMatch, GetEncryptedUtxosByTagsResponse,
-    GetMerkleProofsResponse, GetNonInclusionProofsResponse, GetShieldedTransactionsByTagsResponse,
-    MerkleContext, MerkleProof, NonInclusionProof, OutputContext, OutputSlot, ProveResult, Rpc,
-    ShieldedTransaction, ShieldedTransactionStream, NULLIFIER_TREE_HEIGHT, STATE_TREE_HEIGHT,
+    GetMerkleProofsResponse, GetNonInclusionProofsResponse,
+    GetShieldedTransactionsBySignatureResponse, GetShieldedTransactionsByTagsResponse,
+    IndexedShieldedTransaction, MerkleContext, MerkleProof, NonInclusionProof, OutputContext,
+    OutputSlot, ProveResult, Rpc, ShieldedTransaction, ShieldedTransactionStream,
+    NULLIFIER_TREE_HEIGHT, STATE_TREE_HEIGHT,
 };
 #[cfg(feature = "solana-rpc")]
 pub use solana_rpc::{AsyncSolanaRpc, ConfirmedInstructionGroups, SolanaRpc};

--- a/sdk-libs/client/src/rpc.rs
+++ b/sdk-libs/client/src/rpc.rs
@@ -66,6 +66,18 @@ pub struct GetShieldedTransactionsByTagsResponse {
     pub next_cursor: Option<Vec<u8>>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IndexedShieldedTransaction {
+    pub event_index: u16,
+    pub transaction: ShieldedTransaction,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GetShieldedTransactionsBySignatureResponse {
+    pub context: Context,
+    pub transactions: Vec<IndexedShieldedTransaction>,
+}
+
 /// Stream of shielded transactions pushed as they land, one per matching transaction.
 pub type ShieldedTransactionStream =
     Pin<Box<dyn Stream<Item = Result<ShieldedTransaction, ClientError>> + Send>>;
@@ -281,6 +293,14 @@ pub trait Rpc {
         Err(unsupported("get_shielded_transactions_by_tags"))
     }
 
+    fn get_shielded_transactions_by_signature(
+        &self,
+        signature: Signature,
+        config: Option<IndexerRpcConfig>,
+    ) -> Result<GetShieldedTransactionsBySignatureResponse, ClientError> {
+        Err(unsupported("get_shielded_transactions_by_signature"))
+    }
+
     fn subscribe_to_shielded_transactions_by_tags(
         &self,
         tags: Vec<[u8; 32]>,
@@ -464,6 +484,14 @@ pub trait AsyncRpc: Send + Sync {
         config: Option<IndexerRpcConfig>,
     ) -> Result<GetShieldedTransactionsByTagsResponse, ClientError> {
         Err(unsupported("get_shielded_transactions_by_tags"))
+    }
+
+    async fn get_shielded_transactions_by_signature(
+        &self,
+        signature: Signature,
+        config: Option<IndexerRpcConfig>,
+    ) -> Result<GetShieldedTransactionsBySignatureResponse, ClientError> {
+        Err(unsupported("get_shielded_transactions_by_signature"))
     }
 
     async fn subscribe_to_shielded_transactions_by_tags(

--- a/sdk-libs/client/src/rpc.rs
+++ b/sdk-libs/client/src/rpc.rs
@@ -267,6 +267,10 @@ pub trait Rpc {
         Err(unsupported("transact_output_view_tags_from_signature"))
     }
 
+    /// Whether `error` is transient for the post-submission confirmation poll
+    /// (`wait_for_indexed_transaction`). Indexer data-plane polling
+    /// (`IndexerPollConfig::poll_until`, the merkle-proof retry loop) deliberately
+    /// retries every error and does not consult this.
     fn should_retry(&self, error: &ClientError) -> bool {
         false
     }
@@ -462,6 +466,10 @@ pub trait AsyncRpc: Send + Sync {
         Err(unsupported("transact_output_view_tags_from_signature"))
     }
 
+    /// Whether `error` is transient for the post-submission confirmation poll
+    /// (`wait_for_indexed_transaction_async`). Indexer data-plane polling
+    /// (`IndexerPollConfig::poll_until`) deliberately retries every error and does
+    /// not consult this.
     fn should_retry(&self, error: &ClientError) -> bool {
         false
     }

--- a/sdk-libs/indexer-api/src/lib.rs
+++ b/sdk-libs/indexer-api/src/lib.rs
@@ -15,6 +15,7 @@ pub const MIN_PAGE_LIMIT: u64 = 1;
 pub const PAGE_LIMIT: u64 = 1000;
 pub const GET_ENCRYPTED_UTXOS_BY_TAGS: &str = "get_encrypted_utxos_by_tags";
 pub const GET_SHIELDED_TRANSACTIONS_BY_TAGS: &str = "get_shielded_transactions_by_tags";
+pub const GET_SHIELDED_TRANSACTIONS_BY_SIGNATURE: &str = "get_shielded_transactions_by_signature";
 pub const GET_MERKLE_PROOFS: &str = "get_merkle_proofs";
 pub const GET_NON_INCLUSION_PROOFS: &str = "get_non_inclusion_proofs";
 pub const GET_NULLIFIER_QUEUE_ELEMENTS: &str = "get_nullifier_queue_elements";
@@ -35,6 +36,7 @@ pub mod method {
 
     pub struct GetEncryptedUtxosByTags;
     pub struct GetShieldedTransactionsByTags;
+    pub struct GetShieldedTransactionsBySignature;
     pub struct GetMerkleProofs;
     pub struct GetNonInclusionProofs;
     pub struct GetNullifierQueueElements;
@@ -49,6 +51,12 @@ pub mod method {
         const NAME: &'static str = GET_SHIELDED_TRANSACTIONS_BY_TAGS;
         type Request = GetRingsByTagsRequest;
         type Response = GetShieldedTransactionsByTagsResponse;
+    }
+
+    impl RpcMethod for GetShieldedTransactionsBySignature {
+        const NAME: &'static str = GET_SHIELDED_TRANSACTIONS_BY_SIGNATURE;
+        type Request = GetShieldedTransactionsBySignatureRequest;
+        type Response = GetShieldedTransactionsBySignatureResponse;
     }
 
     impl RpcMethod for GetMerkleProofs {
@@ -568,6 +576,29 @@ pub struct GetShieldedTransactionsByTagsResponse {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct GetShieldedTransactionsBySignatureRequest {
+    pub tx_signature: SerializableSignature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct IndexedShieldedTransaction {
+    pub event_index: u16,
+    pub transaction: ShieldedTransaction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct GetShieldedTransactionsBySignatureResponse {
+    pub context: Context,
+    pub transactions: Vec<IndexedShieldedTransaction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetMerkleProofsRequest {
     pub tree_account: SerializablePubkey,
     pub leaves: Vec<Hash>,
@@ -678,6 +709,10 @@ mod tests {
             method::GetNullifierQueueElements::NAME,
             "get_nullifier_queue_elements"
         );
+        assert_eq!(
+            method::GetShieldedTransactionsBySignature::NAME,
+            "get_shielded_transactions_by_signature"
+        );
     }
 
     #[test]
@@ -706,6 +741,21 @@ mod tests {
         .unwrap();
         assert!(value.get("next_cursor").is_some());
         assert!(value.get("nextCursor").is_none());
+    }
+
+    #[test]
+    fn signature_lookup_contract_rejects_malformed_signatures() {
+        let invalid = serde_json::json!({ "tx_signature": "not-a-signature" });
+        assert!(
+            serde_json::from_value::<GetShieldedTransactionsBySignatureRequest>(invalid).is_err()
+        );
+
+        let signature = Signature::from([9u8; 64]);
+        let request = GetShieldedTransactionsBySignatureRequest {
+            tx_signature: SerializableSignature(signature),
+        };
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["tx_signature"], signature.to_string());
     }
 
     #[test]

--- a/sdk-libs/zolana-api/src/lib.rs
+++ b/sdk-libs/zolana-api/src/lib.rs
@@ -6,7 +6,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use zolana_indexer_api::{
     method::{
         GetEncryptedUtxosByTags, GetMerkleProofs, GetNonInclusionProofs, GetNullifierQueueElements,
-        GetShieldedTransactionsByTags,
+        GetShieldedTransactionsBySignature, GetShieldedTransactionsByTags,
     },
     RpcMethod,
 };
@@ -16,8 +16,9 @@ pub use zolana_indexer_api::{
     GetMerkleProofsRequest, GetMerkleProofsResponse, GetNonInclusionProofsRequest,
     GetNonInclusionProofsResponse, GetNullifierQueueElementsRequest,
     GetNullifierQueueElementsResponse, GetRingsByTagsRequest,
-    GetShieldedTransactionsByTagsResponse, Hash, Limit, MerkleContext, MerkleProof,
-    NonInclusionProof, NullifierQueueElement, RingsOutputContext, RingsOutputSlot,
+    GetShieldedTransactionsBySignatureRequest, GetShieldedTransactionsBySignatureResponse,
+    GetShieldedTransactionsByTagsResponse, Hash, IndexedShieldedTransaction, Limit, MerkleContext,
+    MerkleProof, NonInclusionProof, NullifierQueueElement, RingsOutputContext, RingsOutputSlot,
     SerializablePubkey, SerializableSignature, ShieldedTransaction, PAGE_LIMIT,
 };
 
@@ -192,6 +193,16 @@ impl ZolanaApi {
         .await
     }
 
+    pub async fn get_shielded_transactions_by_signature(
+        &self,
+        tx_signature: SerializableSignature,
+    ) -> Result<GetShieldedTransactionsBySignatureResponse, ApiError> {
+        self.call::<GetShieldedTransactionsBySignature>(GetShieldedTransactionsBySignatureRequest {
+            tx_signature,
+        })
+        .await
+    }
+
     pub async fn get_merkle_proofs(
         &self,
         tree_account: SerializablePubkey,
@@ -325,6 +336,15 @@ impl BlockingZolanaApi {
             tags,
             cursor,
             limit: optional_limit(limit)?,
+        })
+    }
+
+    pub fn get_shielded_transactions_by_signature(
+        &self,
+        tx_signature: SerializableSignature,
+    ) -> Result<GetShieldedTransactionsBySignatureResponse, ApiError> {
+        self.call::<GetShieldedTransactionsBySignature>(GetShieldedTransactionsBySignatureRequest {
+            tx_signature,
         })
     }
 

--- a/services/photon/Cargo.toml
+++ b/services/photon/Cargo.toml
@@ -88,5 +88,10 @@ zolana-interface = { path = "../../program-libs/interface", version = "0.1.0", d
 zolana-tree = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 serde_norway = { workspace = true }
 zolana-interface = { path = "../../program-libs/interface", version = "0.1.0", default-features = false, features = ["tree", "borsh"] }
+
+[[bench]]
+name = "rings_signature_lookup"
+harness = false

--- a/services/photon/README.md
+++ b/services/photon/README.md
@@ -3,6 +3,7 @@
 Photon indexes Rings shielded-pool transactions and exposes the Rings JSON-RPC API:
 
 - `get_encrypted_utxos_by_tags`
+- `get_shielded_transactions_by_signature`
 - `get_shielded_transactions_by_tags`
 - `get_merkle_proofs`
 - `get_non_inclusion_proofs`
@@ -92,6 +93,41 @@ non-contiguous nullifier queue or reconstructed-root mismatch makes the indexer 
 block batch until the underlying data or code is fixed. Alert on stale `getIndexerHealth` results,
 `block_batch_index_failures`, and errors containing `Cannot reconstruct nullifier batch` or
 `Reconstructed nullifier root mismatch`.
+
+### Signature lookup rollout
+
+Signature lookup lets a client reconcile a submitted Solana transaction with its exact indexed
+Rings events. Results preserve `event_index` order because one signature can contain multiple
+Rings events. Existing deployments need no migration or reindex: the Rings schema already stores
+these rows under the `(signature, event_index)` index.
+
+Deploy Photon before clients that use the method. Publish the Photon image from the final Zolana
+commit, deploy `public.ecr.aws/f7o9l7p1/photon@sha256:<digest>`, and run both checks below against
+the deployed RPC. `KNOWN_SIGNATURE` must be a signature already indexed by that Photon instance.
+
+```bash
+PHOTON_URL=https://<photon-host>
+KNOWN_SIGNATURE=<indexed-rings-signature>
+UNKNOWN_SIGNATURE=1111111111111111111111111111111111111111111111111111111111111111
+
+lookup() {
+  curl -fsS "$PHOTON_URL" \
+    -H 'content-type: application/json' \
+    --data "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"get_shielded_transactions_by_signature\",\"params\":{\"tx_signature\":\"$1\"}}"
+}
+
+known="$(lookup "$KNOWN_SIGNATURE")"
+jq -e --arg signature "$KNOWN_SIGNATURE" \
+  '.result.transactions | length > 0 and all(.[]; .transaction.tx_signature == $signature)' \
+  <<<"$known"
+
+unknown="$(lookup "$UNKNOWN_SIGNATURE")"
+jq -e '.result.transactions == []' <<<"$unknown"
+```
+
+After the smoke passes, pin the matching full Zolana commit in consumers and deploy each consumer
+as an immutable image or platform revision. No immutable Zolana revision for this change exists
+yet; do not substitute a branch, working tree, or mutable image tag for that release pin.
 
 ### Container releases
 

--- a/services/photon/README.md
+++ b/services/photon/README.md
@@ -94,42 +94,6 @@ block batch until the underlying data or code is fixed. Alert on stale `getIndex
 `block_batch_index_failures`, and errors containing `Cannot reconstruct nullifier batch` or
 `Reconstructed nullifier root mismatch`.
 
-### Signature lookup rollout
-
-`get_shielded_transactions_by_signature` returns the indexed Rings events for one Solana
-transaction signature. Results preserve `event_index` order because one signature can contain
-multiple Rings events. Existing deployments need no migration or reindex: the Rings schema
-already stores these rows under the `(signature, event_index)` index.
-
-Deploy Photon before clients that call `get_shielded_transactions_by_signature`. Publish the
-Photon image from the Zolana commit that contains this method, deploy
-`public.ecr.aws/f7o9l7p1/photon@sha256:<digest>`, and run both checks below against the deployed
-RPC. `KNOWN_SIGNATURE` must be a signature already indexed by that Photon instance.
-
-```bash
-PHOTON_URL=https://<photon-host>
-KNOWN_SIGNATURE=<indexed-rings-signature>
-UNKNOWN_SIGNATURE=1111111111111111111111111111111111111111111111111111111111111111
-
-lookup() {
-  curl -fsS "$PHOTON_URL" \
-    -H 'content-type: application/json' \
-    --data "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"get_shielded_transactions_by_signature\",\"params\":{\"tx_signature\":\"$1\"}}"
-}
-
-known="$(lookup "$KNOWN_SIGNATURE")"
-jq -e --arg signature "$KNOWN_SIGNATURE" \
-  '.result.transactions | length > 0 and all(.[]; .transaction.tx_signature == $signature)' \
-  <<<"$known"
-
-unknown="$(lookup "$UNKNOWN_SIGNATURE")"
-jq -e '.result.transactions == []' <<<"$unknown"
-```
-
-After the smoke passes, pin the matching Zolana commit in consumers and deploy each consumer as
-an immutable image or platform revision. Until that commit is published as an immutable release,
-do not substitute a branch, working tree, or mutable image tag for the pin.
-
 ### Container releases
 
 Production images are published by `.github/workflows/photon-image.yml` through

--- a/services/photon/README.md
+++ b/services/photon/README.md
@@ -96,14 +96,15 @@ block batch until the underlying data or code is fixed. Alert on stale `getIndex
 
 ### Signature lookup rollout
 
-Signature lookup lets a client reconcile a submitted Solana transaction with its exact indexed
-Rings events. Results preserve `event_index` order because one signature can contain multiple
-Rings events. Existing deployments need no migration or reindex: the Rings schema already stores
-these rows under the `(signature, event_index)` index.
+`get_shielded_transactions_by_signature` returns the indexed Rings events for one Solana
+transaction signature. Results preserve `event_index` order because one signature can contain
+multiple Rings events. Existing deployments need no migration or reindex: the Rings schema
+already stores these rows under the `(signature, event_index)` index.
 
-Deploy Photon before clients that use the method. Publish the Photon image from the final Zolana
-commit, deploy `public.ecr.aws/f7o9l7p1/photon@sha256:<digest>`, and run both checks below against
-the deployed RPC. `KNOWN_SIGNATURE` must be a signature already indexed by that Photon instance.
+Deploy Photon before clients that call `get_shielded_transactions_by_signature`. Publish the
+Photon image from the Zolana commit that contains this method, deploy
+`public.ecr.aws/f7o9l7p1/photon@sha256:<digest>`, and run both checks below against the deployed
+RPC. `KNOWN_SIGNATURE` must be a signature already indexed by that Photon instance.
 
 ```bash
 PHOTON_URL=https://<photon-host>
@@ -125,9 +126,9 @@ unknown="$(lookup "$UNKNOWN_SIGNATURE")"
 jq -e '.result.transactions == []' <<<"$unknown"
 ```
 
-After the smoke passes, pin the matching full Zolana commit in consumers and deploy each consumer
-as an immutable image or platform revision. No immutable Zolana revision for this change exists
-yet; do not substitute a branch, working tree, or mutable image tag for that release pin.
+After the smoke passes, pin the matching Zolana commit in consumers and deploy each consumer as
+an immutable image or platform revision. Until that commit is published as an immutable release,
+do not substitute a branch, working tree, or mutable image tag for the pin.
 
 ### Container releases
 

--- a/services/photon/benches/rings_signature_lookup.rs
+++ b/services/photon/benches/rings_signature_lookup.rs
@@ -1,0 +1,92 @@
+//! Latency of resolving one shielded transaction a caller already has the
+//! signature for, against reaching the same transaction through the view tag
+//! index, as the tag's history grows.
+//!
+//! `get_shielded_transactions_by_signature` is one equality on the unique
+//! `(signature, event_index)` index. `get_shielded_transactions_by_tags`
+//! filters with `EXISTS` subqueries over `rings_outputs`, orders by `slot ASC`,
+//! and pages, so a caller looking for the newest transaction walks the whole
+//! tag history and re-runs that filter on every page.
+//!
+//! Read the ratio between the two arms, not the absolute numbers: each sample
+//! includes `block_on`, a fresh `extract_context` query, and a transaction
+//! begin/commit, which put a floor under both arms and understate the gap.
+//!
+//! Run with `cargo bench -p photon-indexer --bench rings_signature_lookup`.
+//! `signature_lookup_cost_is_independent_of_view_tag_history` is what gates the
+//! property in CI; this only measures it, and shares that test's fixture so the
+//! two cannot drift apart.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use tokio::runtime::Runtime;
+
+#[path = "../tests/rings_fixtures/mod.rs"]
+mod rings_fixtures;
+
+use rings_fixtures::{
+    fresh_rings_database, resolve_by_signature, resolve_by_tags, seed_tagged_transaction_history,
+    signature_at, LookupCost, PAGE_LIMIT, VIEW_TAG,
+};
+
+const HISTORY_LENGTHS: [u64; 4] = [50, 200, 800, 3_200];
+
+fn bench_lookups(criterion: &mut Criterion) {
+    let runtime = Runtime::new().expect("tokio runtime");
+    let mut group = criterion.benchmark_group("resolve_newest_tagged_transaction");
+
+    for history in HISTORY_LENGTHS {
+        let db = runtime.block_on(async {
+            let db = fresh_rings_database().await;
+            seed_tagged_transaction_history(&db, VIEW_TAG, 0..history).await;
+            db
+        });
+        // The newest transaction is last under the tag query's `slot ASC`
+        // order, so the tag walk pays for the entire history to reach it.
+        let target = signature_at(history - 1);
+
+        // Confirm outside the timed section that both arms really do the work
+        // the integration test pins, so a fixture change cannot quietly turn
+        // this into a measurement of something else.
+        runtime.block_on(async {
+            assert_eq!(
+                resolve_by_signature(&db, target).await,
+                LookupCost {
+                    requests: 1,
+                    hydrated_transactions: 1,
+                }
+            );
+            assert_eq!(
+                resolve_by_tags(&db, VIEW_TAG, target, PAGE_LIMIT).await,
+                LookupCost {
+                    requests: usize::try_from(history.div_ceil(PAGE_LIMIT))
+                        .expect("page count fits in usize"),
+                    hydrated_transactions: usize::try_from(history).expect("history fits in usize"),
+                }
+            );
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("by_signature", history),
+            &history,
+            |bencher, _| {
+                bencher.iter(|| black_box(runtime.block_on(resolve_by_signature(&db, target))));
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("by_tags", history),
+            &history,
+            |bencher, _| {
+                bencher.iter(|| {
+                    black_box(runtime.block_on(resolve_by_tags(&db, VIEW_TAG, target, PAGE_LIMIT)))
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_lookups);
+criterion_main!(benches);

--- a/services/photon/src/api/method/rings.rs
+++ b/services/photon/src/api/method/rings.rs
@@ -3,12 +3,14 @@ mod get_encrypted_utxos_by_tags;
 mod get_merkle_proofs;
 mod get_non_inclusion_proofs;
 mod get_nullifier_queue_elements;
+mod get_shielded_transactions_by_signature;
 mod get_shielded_transactions_by_tags;
 
 pub use get_encrypted_utxos_by_tags::get_encrypted_utxos_by_tags;
 pub use get_merkle_proofs::get_merkle_proofs;
 pub use get_non_inclusion_proofs::get_non_inclusion_proofs;
 pub use get_nullifier_queue_elements::get_nullifier_queue_elements;
+pub use get_shielded_transactions_by_signature::get_shielded_transactions_by_signature;
 pub use get_shielded_transactions_by_tags::get_shielded_transactions_by_tags;
 
 #[cfg(test)]

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_signature.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_signature.rs
@@ -1,3 +1,4 @@
+use super::common::bind_u64_as_i64;
 use super::get_shielded_transactions_by_tags::{hydrate_shielded_transactions, MatchedRingsTxRow};
 use crate::api::error::PhotonApiError;
 use crate::common::bind_sql_value;
@@ -9,6 +10,7 @@ use sea_orm::{
 use solana_signature::SIGNATURE_BYTES;
 use zolana_indexer_api::{
     GetShieldedTransactionsBySignatureRequest, GetShieldedTransactionsBySignatureResponse,
+    PAGE_LIMIT,
 };
 
 pub async fn get_shielded_transactions_by_signature(
@@ -40,6 +42,7 @@ async fn fetch_rings_transactions_by_signature(
         backend,
         Into::<[u8; SIGNATURE_BYTES]>::into(request.tx_signature.0).to_vec(),
     );
+    let limit = bind_u64_as_i64(&mut params, backend, PAGE_LIMIT)?;
     let sql = format!(
         "SELECT
             pt.rings_tx_id AS rings_tx_id,
@@ -51,7 +54,8 @@ async fn fetch_rings_transactions_by_signature(
             pt.proofless AS proofless
          FROM rings_transactions pt
          WHERE pt.signature = {signature}
-         ORDER BY pt.event_index ASC"
+         ORDER BY pt.event_index ASC
+         LIMIT {limit}"
     );
 
     tx.query_all(Statement::from_sql_and_values(backend, sql, params))

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_signature.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_signature.rs
@@ -1,0 +1,63 @@
+use super::get_shielded_transactions_by_tags::{hydrate_shielded_transactions, MatchedRingsTxRow};
+use crate::api::error::PhotonApiError;
+use crate::common::bind_sql_value;
+use crate::common::indexer_context::extract as extract_context;
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, FromQueryResult, Statement,
+    TransactionTrait,
+};
+use solana_signature::SIGNATURE_BYTES;
+use zolana_indexer_api::{
+    GetShieldedTransactionsBySignatureRequest, GetShieldedTransactionsBySignatureResponse,
+};
+
+pub async fn get_shielded_transactions_by_signature(
+    conn: &DatabaseConnection,
+    request: GetShieldedTransactionsBySignatureRequest,
+) -> Result<GetShieldedTransactionsBySignatureResponse, PhotonApiError> {
+    let context = extract_context(conn).await?;
+    let tx = conn.begin().await?;
+    crate::api::set_transaction_isolation_if_needed(&tx).await?;
+
+    let matched_txs = fetch_rings_transactions_by_signature(&tx, request).await?;
+    let transactions = hydrate_shielded_transactions(&tx, matched_txs).await?;
+    tx.commit().await?;
+
+    Ok(GetShieldedTransactionsBySignatureResponse {
+        context,
+        transactions,
+    })
+}
+
+async fn fetch_rings_transactions_by_signature(
+    tx: &DatabaseTransaction,
+    request: GetShieldedTransactionsBySignatureRequest,
+) -> Result<Vec<MatchedRingsTxRow>, PhotonApiError> {
+    let backend = tx.get_database_backend();
+    let mut params = Vec::new();
+    let signature = bind_sql_value(
+        &mut params,
+        backend,
+        Into::<[u8; SIGNATURE_BYTES]>::into(request.tx_signature.0).to_vec(),
+    );
+    let sql = format!(
+        "SELECT
+            pt.rings_tx_id AS rings_tx_id,
+            pt.slot AS slot,
+            pt.signature AS signature,
+            pt.event_index AS event_index,
+            pt.tx_viewing_pk AS tx_viewing_pk,
+            pt.salt AS salt,
+            pt.proofless AS proofless
+         FROM rings_transactions pt
+         WHERE pt.signature = {signature}
+         ORDER BY pt.event_index ASC"
+    );
+
+    tx.query_all(Statement::from_sql_and_values(backend, sql, params))
+        .await?
+        .into_iter()
+        .map(|row| MatchedRingsTxRow::from_query_result(&row, ""))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use super::common::{
     bind_u64_as_i64, cursor_sort_key, decode_cursor, encode_cursor, hash_from_vec, int_list_sql,
     next_cursor_from_rows, rings_output_slot_from_parts, signature_from_bytes, tags_sql,
-    tx_cursor_sql_condition, u64_from_i64, validate_tags,
+    tx_cursor_sql_condition, u16_from_i16, u64_from_i64, validate_tags,
 };
 use crate::api::error::PhotonApiError;
 use crate::common::indexer_context::extract as extract_context;
@@ -14,12 +14,12 @@ use sea_orm::{
 };
 use solana_signature::SIGNATURE_BYTES;
 use zolana_indexer_api::{
-    Base64String, GetRingsByTagsRequest, GetShieldedTransactionsByTagsResponse, Hash, RingsMessage,
-    RingsOutputSlot, ShieldedTransaction,
+    Base64String, GetRingsByTagsRequest, GetShieldedTransactionsByTagsResponse, Hash,
+    IndexedShieldedTransaction, RingsMessage, RingsOutputSlot, ShieldedTransaction,
 };
 
 #[derive(FromQueryResult, Debug)]
-struct MatchedRingsTxRow {
+pub(super) struct MatchedRingsTxRow {
     rings_tx_id: i64,
     slot: i64,
     signature: Vec<u8>,
@@ -82,14 +82,33 @@ pub async fn get_shielded_transactions_by_tags(
         fetch_matching_rings_transactions(&tx, &request.tags, cursor.as_ref(), limit).await?;
     let next_cursor = next_cursor_from_rows(&matched_txs, limit, shielded_tx_cursor_from_row)?;
 
+    let transactions = hydrate_shielded_transactions(&tx, matched_txs)
+        .await?
+        .into_iter()
+        .map(|item| item.transaction)
+        .collect();
+
+    tx.commit().await?;
+
+    Ok(GetShieldedTransactionsByTagsResponse {
+        context,
+        transactions,
+        next_cursor,
+    })
+}
+
+pub(super) async fn hydrate_shielded_transactions(
+    tx: &DatabaseTransaction,
+    matched_txs: Vec<MatchedRingsTxRow>,
+) -> Result<Vec<IndexedShieldedTransaction>, PhotonApiError> {
     let rings_tx_ids = matched_txs
         .iter()
         .map(|row| row.rings_tx_id)
         .collect::<Vec<_>>();
 
-    let output_rows = fetch_rings_outputs(&tx, &rings_tx_ids).await?;
-    let message_rows = fetch_rings_messages(&tx, &rings_tx_ids).await?;
-    let nullifier_rows = fetch_rings_nullifiers(&tx, &rings_tx_ids).await?;
+    let output_rows = fetch_rings_outputs(tx, &rings_tx_ids).await?;
+    let message_rows = fetch_rings_messages(tx, &rings_tx_ids).await?;
+    let nullifier_rows = fetch_rings_nullifiers(tx, &rings_tx_ids).await?;
 
     let mut outputs_by_tx: BTreeMap<i64, Vec<RingsOutputSlot>> = BTreeMap::new();
     for row in output_rows {
@@ -124,31 +143,26 @@ pub async fn get_shielded_transactions_by_tags(
             .push(hash_from_vec(row.nullifier)?);
     }
 
-    let transactions = matched_txs
+    matched_txs
         .into_iter()
         .map(|row| {
-            Ok(ShieldedTransaction {
-                slot: u64_from_i64(row.slot, "slot")?,
-                tx_signature: signature_from_bytes(&row.signature)?,
-                tx_viewing_pk: row.tx_viewing_pk.map(Base64String),
-                salt: row.salt.map(Base64String),
-                output_slots: outputs_by_tx.remove(&row.rings_tx_id).unwrap_or_default(),
-                messages: messages_by_tx.remove(&row.rings_tx_id).unwrap_or_default(),
-                nullifiers: nullifiers_by_tx
-                    .remove(&row.rings_tx_id)
-                    .unwrap_or_default(),
-                proofless: row.proofless,
+            Ok(IndexedShieldedTransaction {
+                event_index: u16_from_i16(row.event_index, "event index")?,
+                transaction: ShieldedTransaction {
+                    slot: u64_from_i64(row.slot, "slot")?,
+                    tx_signature: signature_from_bytes(&row.signature)?,
+                    tx_viewing_pk: row.tx_viewing_pk.map(Base64String),
+                    salt: row.salt.map(Base64String),
+                    output_slots: outputs_by_tx.remove(&row.rings_tx_id).unwrap_or_default(),
+                    messages: messages_by_tx.remove(&row.rings_tx_id).unwrap_or_default(),
+                    nullifiers: nullifiers_by_tx
+                        .remove(&row.rings_tx_id)
+                        .unwrap_or_default(),
+                    proofless: row.proofless,
+                },
             })
         })
-        .collect::<Result<Vec<_>, PhotonApiError>>()?;
-
-    tx.commit().await?;
-
-    Ok(GetShieldedTransactionsByTagsResponse {
-        context,
-        transactions,
-        next_cursor,
-    })
+        .collect()
 }
 
 async fn fetch_matching_rings_transactions(

--- a/services/photon/src/api/rpc_server.rs
+++ b/services/photon/src/api/rpc_server.rs
@@ -11,7 +11,7 @@ use tower_http::cors::{Any, CorsLayer};
 use zolana_indexer_api::{
     method::{
         GetEncryptedUtxosByTags, GetMerkleProofs, GetNonInclusionProofs, GetNullifierQueueElements,
-        GetShieldedTransactionsByTags,
+        GetShieldedTransactionsBySignature, GetShieldedTransactionsByTags,
     },
     RpcMethod,
 };
@@ -99,6 +99,17 @@ fn build_rpc_module(api_and_indexer: PhotonApi) -> Result<RpcModule<PhotonApi>, 
     )?;
 
     module.register_async_method(
+        GetShieldedTransactionsBySignature::NAME,
+        |rpc_params, rpc_context, _extensions| async move {
+            let api = rpc_context.as_ref();
+            let payload = rpc_params.parse()?;
+            api.get_shielded_transactions_by_signature(payload)
+                .await
+                .map_err(ErrorObjectOwned::from)
+        },
+    )?;
+
+    module.register_async_method(
         GetShieldedTransactionsByTags::NAME,
         |rpc_params, rpc_context, _extensions| async move {
             let api = rpc_context.as_ref();
@@ -162,6 +173,7 @@ mod tests {
         assert!(methods.contains(&"getIndexerHealth"));
         assert!(methods.contains(&"getIndexerSlot"));
         assert!(methods.contains(&"get_encrypted_utxos_by_tags"));
+        assert!(methods.contains(&"get_shielded_transactions_by_signature"));
         assert!(methods.contains(&"get_shielded_transactions_by_tags"));
         assert!(methods.contains(&"get_merkle_proofs"));
         assert!(methods.contains(&"get_non_inclusion_proofs"));

--- a/services/photon/src/api/service.rs
+++ b/services/photon/src/api/service.rs
@@ -7,11 +7,12 @@ use utoipa::PartialSchema;
 use zolana_indexer_api::{
     method::{
         GetEncryptedUtxosByTags, GetMerkleProofs, GetNonInclusionProofs, GetNullifierQueueElements,
-        GetShieldedTransactionsByTags,
+        GetShieldedTransactionsBySignature, GetShieldedTransactionsByTags,
     },
     GetEncryptedUtxosByTagsResponse, GetMerkleProofsRequest, GetMerkleProofsResponse,
     GetNonInclusionProofsRequest, GetNonInclusionProofsResponse, GetNullifierQueueElementsRequest,
     GetNullifierQueueElementsResponse, GetRingsByTagsRequest,
+    GetShieldedTransactionsBySignatureRequest, GetShieldedTransactionsBySignatureResponse,
     GetShieldedTransactionsByTagsResponse, RpcMethod,
 };
 
@@ -22,7 +23,8 @@ use super::{
         get_indexer_slot::get_indexer_slot,
         rings::{
             get_encrypted_utxos_by_tags, get_merkle_proofs, get_non_inclusion_proofs,
-            get_nullifier_queue_elements, get_shielded_transactions_by_tags,
+            get_nullifier_queue_elements, get_shielded_transactions_by_signature,
+            get_shielded_transactions_by_tags,
         },
     },
 };
@@ -95,6 +97,13 @@ impl PhotonApi {
         get_shielded_transactions_by_tags(self.db_conn.as_ref(), request).await
     }
 
+    pub async fn get_shielded_transactions_by_signature(
+        &self,
+        request: GetShieldedTransactionsBySignatureRequest,
+    ) -> Result<GetShieldedTransactionsBySignatureResponse, PhotonApiError> {
+        get_shielded_transactions_by_signature(self.db_conn.as_ref(), request).await
+    }
+
     pub async fn get_merkle_proofs(
         &self,
         request: GetMerkleProofsRequest,
@@ -119,6 +128,7 @@ impl PhotonApi {
     pub fn rings_method_api_specs() -> Vec<OpenApiSpec> {
         vec![
             method_api_spec::<GetEncryptedUtxosByTags>(),
+            method_api_spec::<GetShieldedTransactionsBySignature>(),
             method_api_spec::<GetShieldedTransactionsByTags>(),
             method_api_spec::<GetMerkleProofs>(),
             method_api_spec::<GetNonInclusionProofs>(),

--- a/services/photon/src/openapi/mod.rs
+++ b/services/photon/src/openapi/mod.rs
@@ -10,9 +10,10 @@ use zolana_indexer_api::{
     GetMerkleProofsRequest, GetMerkleProofsResponse, GetNonInclusionProofsRequest,
     GetNonInclusionProofsResponse, GetNullifierQueueElementsRequest,
     GetNullifierQueueElementsResponse, GetRingsByTagsRequest,
-    GetShieldedTransactionsByTagsResponse, Hash, Limit, MerkleContext, MerkleProof,
-    NonInclusionProof, NullifierQueueElement, RingsMessage, RingsOutputContext, RingsOutputSlot,
-    SerializablePubkey, SerializableSignature, ShieldedTransaction,
+    GetShieldedTransactionsBySignatureRequest, GetShieldedTransactionsBySignatureResponse,
+    GetShieldedTransactionsByTagsResponse, Hash, IndexedShieldedTransaction, Limit, MerkleContext,
+    MerkleProof, NonInclusionProof, NullifierQueueElement, RingsMessage, RingsOutputContext,
+    RingsOutputSlot, SerializablePubkey, SerializableSignature, ShieldedTransaction,
 };
 
 use crate::common::relative_project_path;
@@ -54,6 +55,9 @@ const RINGS_API_TEST_SPEC_FILE: &str = "rings.test.yaml";
     RingsOutputContext,
     RingsOutputSlot,
     ShieldedTransaction,
+    IndexedShieldedTransaction,
+    GetShieldedTransactionsBySignatureRequest,
+    GetShieldedTransactionsBySignatureResponse,
     GetShieldedTransactionsByTagsResponse,
     GetMerkleProofsRequest,
     GetMerkleProofsResponse,

--- a/services/photon/src/openapi/specs/rings.yaml
+++ b/services/photon/src/openapi/specs/rings.yaml
@@ -503,6 +503,121 @@ paths:
                     type: string
                   jsonrpc:
                     type: string
+  /get_shielded_transactions_by_signature:
+    summary: get_shielded_transactions_by_signature
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - jsonrpc
+              - id
+              - method
+              - params
+              properties:
+                id:
+                  type: string
+                  description: An ID to identify the request.
+                  enum:
+                  - test-account
+                jsonrpc:
+                  type: string
+                  description: The version of the JSON-RPC protocol.
+                  enum:
+                  - '2.0'
+                method:
+                  type: string
+                  description: The name of the method to invoke.
+                  enum:
+                  - get_shielded_transactions_by_signature
+                params:
+                  type: object
+                  required:
+                  - tx_signature
+                  properties:
+                    tx_signature:
+                      $ref: '#/components/schemas/SerializableSignature'
+                  additionalProperties: false
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - jsonrpc
+                - id
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: integer
+                      message:
+                        type: string
+                  id:
+                    type: string
+                    description: An ID to identify the response.
+                    enum:
+                    - test-account
+                  jsonrpc:
+                    type: string
+                    description: The version of the JSON-RPC protocol.
+                    enum:
+                    - '2.0'
+                  result:
+                    type: object
+                    required:
+                    - context
+                    - transactions
+                    properties:
+                      context:
+                        $ref: '#/components/schemas/Context'
+                      transactions:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/IndexedShieldedTransaction'
+                    additionalProperties: false
+        '429':
+          description: Exceeded rate limit.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: integer
+                      message:
+                        type: string
+                  id:
+                    type: string
+                  jsonrpc:
+                    type: string
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: integer
+                      message:
+                        type: string
+                  id:
+                    type: string
+                  jsonrpc:
+                    type: string
   /get_shielded_transactions_by_tags:
     summary: get_shielded_transactions_by_tags
     post:
@@ -677,6 +792,19 @@ components:
     Hash:
       type: string
       description: A 32-byte hash represented as a base58 string.
+    IndexedShieldedTransaction:
+      type: object
+      required:
+      - event_index
+      - transaction
+      properties:
+        event_index:
+          type: integer
+          format: u-int16
+          minimum: 0
+        transaction:
+          $ref: '#/components/schemas/ShieldedTransaction'
+      additionalProperties: false
     Limit:
       type: integer
       format: u-int64

--- a/services/photon/tests/integration_tests/open_api_tests.rs
+++ b/services/photon/tests/integration_tests/open_api_tests.rs
@@ -1,11 +1,12 @@
 use photon_indexer::openapi::update_docs;
 use utoipa::openapi::{OpenApi, RefOr, Required};
 
-const METHODS: [&str; 5] = [
+const METHODS: [&str; 6] = [
     "get_encrypted_utxos_by_tags",
     "get_merkle_proofs",
     "get_non_inclusion_proofs",
     "get_nullifier_queue_elements",
+    "get_shielded_transactions_by_signature",
     "get_shielded_transactions_by_tags",
 ];
 

--- a/services/photon/tests/integration_tests/rings_event_parser_tests.rs
+++ b/services/photon/tests/integration_tests/rings_event_parser_tests.rs
@@ -1,5 +1,13 @@
 use std::collections::HashMap;
 
+#[path = "../rings_fixtures/mod.rs"]
+mod rings_fixtures;
+
+use rings_fixtures::{
+    fresh_rings_database, resolve_by_signature, resolve_by_tags, seed_tagged_transaction_history,
+    signature_at, tag_page, LookupCost, PAGE_LIMIT, VIEW_TAG,
+};
+
 use photon_indexer::{
     api::{
         error::PhotonApiError,
@@ -377,6 +385,72 @@ async fn signature_lookup_returns_multiple_events_in_event_order() {
     .await
     .unwrap();
     assert!(missing.transactions.is_empty());
+}
+
+/// A caller that already knows its signature -- the confirmation path, or
+/// anyone resolving a signature seen elsewhere -- can ask for that one
+/// transaction instead of walking the view tag index.
+///
+/// The signature lookup is one equality on the unique `(signature,
+/// event_index)` index, so it costs the same on a tag with 40 or 400
+/// transactions. Reaching the same transaction through the tag index costs one
+/// request per page and hydrates every older transaction it walks past, because
+/// that query filters with `EXISTS` subqueries over `rings_outputs` and orders
+/// by `slot ASC`. This test pins that difference so it cannot regress back into
+/// a tag scan.
+#[tokio::test]
+async fn signature_lookup_cost_is_independent_of_view_tag_history() {
+    const SHORT_HISTORY: u64 = 40;
+    const LONG_HISTORY: u64 = 400;
+
+    let db = fresh_rings_database().await;
+
+    seed_tagged_transaction_history(&db, VIEW_TAG, 0..SHORT_HISTORY).await;
+    let short_signature = signature_at(SHORT_HISTORY - 1);
+    let short_by_signature = resolve_by_signature(&db, short_signature).await;
+    let short_by_tags = resolve_by_tags(&db, VIEW_TAG, short_signature, PAGE_LIMIT).await;
+
+    seed_tagged_transaction_history(&db, VIEW_TAG, SHORT_HISTORY..LONG_HISTORY).await;
+    let long_signature = signature_at(LONG_HISTORY - 1);
+    let long_by_signature = resolve_by_signature(&db, long_signature).await;
+    let long_by_tags = resolve_by_tags(&db, VIEW_TAG, long_signature, PAGE_LIMIT).await;
+
+    // The signature lookup does not notice that the tag grew tenfold.
+    let flat = LookupCost {
+        requests: 1,
+        hydrated_transactions: 1,
+    };
+    assert_eq!(short_by_signature, flat);
+    assert_eq!(long_by_signature, flat);
+
+    // The tag walk pays for the whole history every time.
+    assert_eq!(
+        short_by_tags,
+        LookupCost {
+            requests: 1,
+            hydrated_transactions: usize::try_from(SHORT_HISTORY).unwrap(),
+        }
+    );
+    assert_eq!(
+        long_by_tags,
+        LookupCost {
+            requests: usize::try_from(LONG_HISTORY.div_ceil(PAGE_LIMIT)).unwrap(),
+            hydrated_transactions: usize::try_from(LONG_HISTORY).unwrap(),
+        }
+    );
+
+    // The confirmation path on a single unpaginated page is not just slower on
+    // a long tag, it never sees the transaction at all: the tag query orders by
+    // `slot ASC`, so the newest transaction sits on the last page.
+    let first_page = tag_page(&db, VIEW_TAG, None, PAGE_LIMIT).await;
+    assert_eq!(
+        usize::try_from(PAGE_LIMIT).unwrap(),
+        first_page.transactions.len()
+    );
+    assert!(!first_page
+        .transactions
+        .iter()
+        .any(|item| item.tx_signature.0 == long_signature));
 }
 
 #[tokio::test]
@@ -1278,12 +1352,16 @@ async fn assert_rings_api_exposes_output_hashes(
     )
     .await
     .unwrap();
+    let indexed = direct
+        .transactions
+        .first()
+        .expect("one indexed Rings event for the signature");
     assert_eq!(direct.transactions.len(), 1);
     assert_eq!(
-        direct.transactions[0].event_index,
-        rings_tx.event_index as u16
+        indexed.event_index,
+        u16::try_from(rings_tx.event_index).expect("event index is non-negative")
     );
-    assert_eq!(direct.transactions[0].transaction.tx_signature.0, signature);
+    assert_eq!(indexed.transaction.tx_signature.0, signature);
 
     let encrypted = get_encrypted_utxos_by_tags(db, request).await.unwrap();
     assert_eq!(encrypted.context.block_time, UNSHIELD_SLOT as i64);

--- a/services/photon/tests/integration_tests/rings_event_parser_tests.rs
+++ b/services/photon/tests/integration_tests/rings_event_parser_tests.rs
@@ -5,7 +5,7 @@ use photon_indexer::{
         error::PhotonApiError,
         method::rings::{
             get_encrypted_utxos_by_tags, get_merkle_proofs, get_non_inclusion_proofs,
-            get_shielded_transactions_by_tags,
+            get_shielded_transactions_by_signature, get_shielded_transactions_by_tags,
         },
     },
     common::rings_tree::RingsTreeKind,
@@ -50,8 +50,8 @@ use zolana_event::{
     EventKind, GeneralEvent, Input, OutputUtxo, ProoflessOutput,
 };
 use zolana_indexer_api::{
-    GetMerkleProofsRequest, GetNonInclusionProofsRequest, GetRingsByTagsRequest, Hash,
-    SerializablePubkey,
+    GetMerkleProofsRequest, GetNonInclusionProofsRequest, GetRingsByTagsRequest,
+    GetShieldedTransactionsBySignatureRequest, Hash, SerializablePubkey, SerializableSignature,
 };
 use zolana_interface::{
     instruction::{encode_instruction, tag, BatchUpdateNullifierTreeData, CompressedProof},
@@ -326,6 +326,57 @@ async fn persists_rings_events() {
         .first()
         .expect("persisted Rings outputs should not be empty");
     assert_rings_api_exposes_output_hashes(&db, output).await;
+}
+
+#[tokio::test]
+async fn signature_lookup_returns_multiple_events_in_event_order() {
+    let db = Database::connect("sqlite::memory:").await.unwrap();
+    RingsMigrator::up(&db, None).await.unwrap();
+    let slot = SHIELDED_TRANSFER_SLOT;
+    insert_test_blocks(&db, &[slot]).await;
+
+    let mut transaction = shielded_transfer_transaction_info();
+    transaction
+        .instruction_groups
+        .extend(proofless_shield_transaction_info().instruction_groups);
+    let state_update = parse_ingestion_update(transaction.clone(), slot);
+    insert_known_rings_tree_accounts_from_outputs(&db, &state_update).await;
+    let txn = db.begin().await.unwrap();
+    persist_state_update(&txn, state_update).await.unwrap();
+    txn.commit().await.unwrap();
+
+    let response = get_shielded_transactions_by_signature(
+        &db,
+        GetShieldedTransactionsBySignatureRequest {
+            tx_signature: SerializableSignature(transaction.signature),
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(response.transactions.len(), 2);
+    assert_eq!(
+        response
+            .transactions
+            .iter()
+            .map(|item| item.event_index)
+            .collect::<Vec<_>>(),
+        vec![0, 1]
+    );
+    assert!(response
+        .transactions
+        .iter()
+        .all(|item| item.transaction.tx_signature.0 == transaction.signature));
+
+    let missing = get_shielded_transactions_by_signature(
+        &db,
+        GetShieldedTransactionsBySignatureRequest {
+            tx_signature: SerializableSignature(Signature::from([99u8; 64])),
+        },
+    )
+    .await
+    .unwrap();
+    assert!(missing.transactions.is_empty());
 }
 
 #[tokio::test]
@@ -1210,6 +1261,29 @@ async fn assert_rings_api_exposes_output_hashes(
         output.leaf_index as u64
     );
     assert_eq!(output_slot.payload.0, payload.payload);
+
+    let rings_tx = rings_transactions::Entity::find_by_id(output.rings_tx_id)
+        .one(db)
+        .await
+        .unwrap()
+        .expect("rings transaction should exist");
+    let signature = Signature::from(
+        <[u8; 64]>::try_from(rings_tx.signature.as_slice()).expect("stored signature length"),
+    );
+    let direct = get_shielded_transactions_by_signature(
+        db,
+        GetShieldedTransactionsBySignatureRequest {
+            tx_signature: SerializableSignature(signature),
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(direct.transactions.len(), 1);
+    assert_eq!(
+        direct.transactions[0].event_index,
+        rings_tx.event_index as u16
+    );
+    assert_eq!(direct.transactions[0].transaction.tx_signature.0, signature);
 
     let encrypted = get_encrypted_utxos_by_tags(db, request).await.unwrap();
     assert_eq!(encrypted.context.block_time, UNSHIELD_SLOT as i64);

--- a/services/photon/tests/rings_fixtures/mod.rs
+++ b/services/photon/tests/rings_fixtures/mod.rs
@@ -1,0 +1,253 @@
+//! Shared fixture for the two places that compare resolving a shielded
+//! transaction by signature against reaching it through the view tag index:
+//! the `signature_lookup_cost_is_independent_of_view_tag_history` integration
+//! test, which pins the cost in requests and hydrated rows, and
+//! `benches/rings_signature_lookup.rs`, which measures what that costs in
+//! wall-clock time.
+//!
+//! Both go through the same seeding and the same `resolve` pager so the bench
+//! cannot drift into measuring something the test does not pin.
+
+use std::future::Future;
+
+use photon_indexer::{
+    api::method::rings::{
+        get_shielded_transactions_by_signature, get_shielded_transactions_by_tags,
+    },
+    dao::generated::{
+        blocks, rings_output_payloads, rings_outputs, rings_transactions, transactions,
+    },
+    migration::RingsMigrator,
+};
+use sea_orm::{Database, DatabaseConnection, EntityTrait, Set};
+use sea_orm_migration::MigratorTrait;
+use solana_signature::Signature;
+use zolana_indexer_api::{
+    Base64String, GetRingsByTagsRequest, GetShieldedTransactionsBySignatureRequest,
+    GetShieldedTransactionsByTagsResponse, Hash, Limit, SerializableSignature,
+};
+
+pub const VIEW_TAG: [u8; 32] = [77u8; 32];
+/// The page size the confirmation path used before the signature lookup.
+pub const PAGE_LIMIT: u64 = 50;
+
+const BASE_SLOT: u64 = 100_000;
+/// Keep each insert under the SQLite bound on statement parameters.
+const SEED_INSERT_CHUNK: usize = 50;
+
+/// Requests issued and transaction rows hydrated to reach one transaction.
+/// These are the terms the database cost actually grows in, so they stay stable
+/// under a loaded machine in a way wall-clock timings would not.
+#[derive(Debug, PartialEq, Eq)]
+pub struct LookupCost {
+    pub requests: usize,
+    pub hydrated_transactions: usize,
+}
+
+/// One page of a lookup: the signatures it surfaced, how many transactions the
+/// server hydrated to produce it, and where the next page would start.
+pub struct Page {
+    pub signatures: Vec<Signature>,
+    pub hydrated: usize,
+    pub next_cursor: Option<Base64String>,
+}
+
+pub fn signature_at(index: u64) -> Signature {
+    let mut bytes = [0u8; 64];
+    bytes
+        .get_mut(..8)
+        .expect("signature is longer than the index prefix")
+        .copy_from_slice(&index.to_be_bytes());
+    Signature::from(bytes)
+}
+
+pub async fn fresh_rings_database() -> DatabaseConnection {
+    let db = Database::connect("sqlite::memory:")
+        .await
+        .expect("in-memory database");
+    RingsMigrator::up(&db, None)
+        .await
+        .expect("rings migrations");
+    db
+}
+
+/// Drive `fetch` until `target` shows up, counting what it took to get there.
+/// Both lookups run through this, so the signature lookup's request count is
+/// derived from that endpoint reporting no next cursor rather than assumed.
+pub async fn resolve<F, Fut>(target: Signature, mut fetch: F) -> LookupCost
+where
+    F: FnMut(Option<Base64String>) -> Fut,
+    Fut: Future<Output = Page>,
+{
+    let mut cost = LookupCost {
+        requests: 0,
+        hydrated_transactions: 0,
+    };
+    let mut cursor = None;
+    loop {
+        let page = fetch(cursor).await;
+        cost.requests += 1;
+        cost.hydrated_transactions += page.hydrated;
+        if page.signatures.contains(&target) {
+            return cost;
+        }
+        cursor = page.next_cursor;
+        assert!(cursor.is_some(), "lookup ran out of pages before {target}");
+    }
+}
+
+pub async fn resolve_by_signature(db: &DatabaseConnection, target: Signature) -> LookupCost {
+    resolve(target, move |_cursor| async move {
+        let response = get_shielded_transactions_by_signature(
+            db,
+            GetShieldedTransactionsBySignatureRequest {
+                tx_signature: SerializableSignature(target),
+            },
+        )
+        .await
+        .expect("signature lookup");
+
+        Page {
+            signatures: response
+                .transactions
+                .iter()
+                .map(|item| item.transaction.tx_signature.0)
+                .collect(),
+            hydrated: response.transactions.len(),
+            next_cursor: None,
+        }
+    })
+    .await
+}
+
+pub async fn resolve_by_tags(
+    db: &DatabaseConnection,
+    view_tag: [u8; 32],
+    target: Signature,
+    page_limit: u64,
+) -> LookupCost {
+    resolve(target, move |cursor| async move {
+        let page = tag_page(db, view_tag, cursor, page_limit).await;
+        Page {
+            signatures: page
+                .transactions
+                .iter()
+                .map(|item| item.tx_signature.0)
+                .collect(),
+            hydrated: page.transactions.len(),
+            next_cursor: page.next_cursor,
+        }
+    })
+    .await
+}
+
+pub async fn tag_page(
+    db: &DatabaseConnection,
+    view_tag: [u8; 32],
+    cursor: Option<Base64String>,
+    page_limit: u64,
+) -> GetShieldedTransactionsByTagsResponse {
+    get_shielded_transactions_by_tags(
+        db,
+        GetRingsByTagsRequest {
+            tags: vec![Hash::from(view_tag)],
+            cursor,
+            limit: Some(Limit::new(page_limit).expect("page limit is within the shared bounds")),
+        },
+    )
+    .await
+    .expect("tag lookup")
+}
+
+/// Insert one transaction per index, each carrying `view_tag` on its single
+/// output and sitting in its own slot so the tag query's `slot ASC` order is
+/// deterministic and the highest index is always the newest.
+pub async fn seed_tagged_transaction_history(
+    db: &DatabaseConnection,
+    view_tag: [u8; 32],
+    indexes: std::ops::Range<u64>,
+) {
+    let mut block_rows = Vec::new();
+    let mut transaction_rows = Vec::new();
+    let mut rings_rows = Vec::new();
+    let mut output_rows = Vec::new();
+    let mut payload_rows = Vec::new();
+
+    for index in indexes {
+        let slot = i64::try_from(BASE_SLOT + index).expect("slot fits in i64");
+        let signature = signature_at(index).as_ref().to_vec();
+        let rings_tx_id = i64::try_from(index).expect("index fits in i64") + 1;
+
+        block_rows.push(blocks::ActiveModel {
+            slot: Set(slot),
+            parent_slot: Set(slot - 1),
+            parent_blockhash: Set(vec![0; 32]),
+            blockhash: Set(rings_tx_id.to_be_bytes().repeat(4)),
+            block_height: Set(slot),
+            block_time: Set(slot),
+        });
+        transaction_rows.push(transactions::ActiveModel {
+            signature: Set(signature.clone()),
+            slot: Set(slot),
+            error: Set(None),
+        });
+        rings_rows.push(rings_transactions::ActiveModel {
+            rings_tx_id: Set(rings_tx_id),
+            signature: Set(signature),
+            event_index: Set(0),
+            slot: Set(slot),
+            rings_program_id: Set(vec![1u8; 32]),
+            source_instruction_tag: Set(0),
+            output_tree: Set(vec![8u8; 32]),
+            first_output_leaf_index: Set(rings_tx_id),
+            tx_viewing_pk: Set(Some(vec![2u8; 33])),
+            salt: Set(Some(vec![3u8; 16])),
+            proofless: Set(false),
+        });
+        output_rows.push(rings_outputs::ActiveModel {
+            output_id: Set(rings_tx_id),
+            rings_tx_id: Set(rings_tx_id),
+            slot: Set(slot),
+            output_index: Set(0),
+            output_tree: Set(vec![8u8; 32]),
+            leaf_index: Set(rings_tx_id),
+            view_tag: Set(view_tag.to_vec()),
+            utxo_hash: Set(rings_tx_id.to_be_bytes().repeat(4)),
+        });
+        payload_rows.push(rings_output_payloads::ActiveModel {
+            output_id: Set(rings_tx_id),
+            payload: Set(vec![9u8; 32]),
+        });
+    }
+
+    for chunk in block_rows.chunks(SEED_INSERT_CHUNK) {
+        blocks::Entity::insert_many(chunk.to_vec())
+            .exec(db)
+            .await
+            .expect("seed blocks");
+    }
+    for chunk in transaction_rows.chunks(SEED_INSERT_CHUNK) {
+        transactions::Entity::insert_many(chunk.to_vec())
+            .exec(db)
+            .await
+            .expect("seed transactions");
+    }
+    for chunk in rings_rows.chunks(SEED_INSERT_CHUNK) {
+        rings_transactions::Entity::insert_many(chunk.to_vec())
+            .exec(db)
+            .await
+            .expect("seed rings transactions");
+    }
+    for chunk in output_rows.chunks(SEED_INSERT_CHUNK) {
+        rings_outputs::Entity::insert_many(chunk.to_vec())
+            .exec(db)
+            .await
+            .expect("seed rings outputs");
+    }
+    for chunk in payload_rows.chunks(SEED_INSERT_CHUNK) {
+        rings_output_payloads::Entity::insert_many(chunk.to_vec())
+            .exec(db)
+            .await
+            .expect("seed output payloads");
+    }
+}


### PR DESCRIPTION
- add `get_shielded_transactions_by_signature` across the indexer api and Zolana clients
- implement to Photon
- respects existence of distinct Rings events by `(signature, event_index)`
- make private transaction confirmation use the direct signature lookup without a tag-pagination fallback

The flow is:

1. Submit and confirm the Solana transaction.
2. Read the output view tags from its first shielded-pool TRANSACT instruction.
3. Poll Photon using get_shielded_transactions_by_signature.
4. Photon returns every Rings event associated with that Solana signature.
5. The client identifies the intended event using view tags.

one signature can have multiple ring events, when multiple rings are invoked . 
selecting the event allows us to confirm the right event

## Test plan
- [x] `cargo test -p zolana-client --lib --features indexer-api`
- [x] `cargo test -p zolana-indexer-api`
- [x] `cargo test -p photon-indexer registers_only_rings_product_methods`
- [x] `cargo test -p photon-indexer signature_lookup`
- [x] `cargo fmt --all --check`
- [x] `git diff --check`