### PR TITLE
fix(merge): bind merge_transact to the merged owner's own registry record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6210,6 +6210,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "solana-account 2.2.1",
+ "solana-account 3.4.0",
  "solana-address 2.6.1",
  "solana-compute-budget-interface",
  "solana-instruction 2.3.3",
@@ -6233,6 +6234,7 @@ dependencies = [
  "zolana-test-utils",
  "zolana-transaction",
  "zolana-tree",
+ "zolana-user-registry-interface",
  "zolana-wallet",
 ]
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1639,7 +1639,7 @@ struct ZoneDepositIxData {
 | --- | --- | --- | --- | --- |
 | 1 | tree_account | x |   | nullifier queue + nullifier tree + UTXO tree |
 | 2 | payer |   | x | fee payer; any account may run the merge |
-| 3 | user_record |   |   | read-only; the owner's [registry](#registry) record. SPP checks `merging_enabled == true` and binds the proof's signing / viewing `pk_field`s to it |
+| 3 | user_record |   |   | read-only; the owner's [registry](#registry) record, at the canonical record PDA of the `owner` it stores (else `InvalidUserRecord`). SPP checks `merging_enabled == true` and binds the proof's signing / viewing `pk_field`s to it |
 
 **Instruction data**
 
@@ -2055,7 +2055,7 @@ A merge service consolidates a user's fragmented UTXOs into fewer larger ones by
 
 **Identity.** A merge service is a Solana account (Ed25519). It signs its own `merge_transact` transactions as the fee payer, so the Solana runtime verifies the signature; SPP does not check the signer against any registered authority.
 
-**Authorization.** There is no per-user merge authority. The owner enables merging by setting `merging_enabled = true` on their [registry record](#registry). Once enabled, any caller may submit `merge_transact` for that owner; SPP only checks `merging_enabled == true` (else `MergeDisabled`) and binds the merge to the owner's registered `owner_p256` / `viewing_pk` through the proof. In a policy zone, [`merge_zone`](#merge_zone) uses the [`merge_view_tag`](#merge-view-tag) stream instead.
+**Authorization.** There is no per-user merge authority. The owner enables merging by setting `merging_enabled = true` on their [registry record](#registry). Once enabled, any caller may submit `merge_transact` for that owner; SPP only checks `merging_enabled == true` (else `MergeDisabled`) and binds the merge to the owner's registered `owner_p256` / `viewing_pk` through the proof. Nothing signs for the record, so what makes those the owner's keys is the account: SPP requires the canonical record PDA of the `owner` the record stores, and the registry keeps a P-256 owner identity exclusive to one record (see [`register`](#register)). In a policy zone, [`merge_zone`](#merge_zone) uses the [`merge_view_tag`](#merge-view-tag) stream instead.
 
 **Scope.** The merge service consolidates UTXOs in both default and policy zones if the zone program exposes a merge instruction. In policy zones the zone program authorizes the merge (see [`merge_zone`](#merge_zone)); the registry `merging_enabled` flag applies only to default-zone `merge_transact`.
 UTXOs with `utxo_data` set (non-zero `data_hash`) cannot be merged since they are subject to program logic.
@@ -2147,6 +2147,8 @@ struct GetRecordResponse {
 #### `register`
 
 Creates a record with the given owner P-256 pubkey (optional), nullifier pubkey, and viewing pubkey, no delegate, and no entries. Fails if a record for `owner` already exists. Registry rejects non-canonical `nullifier_pk` values (`>= Fr`).
+
+An `owner_p256` is exclusive to the record that claims it, because [`merge_transact`](#merge_transact) reads owner identity out of a record no one signs for. Owner identity drops the SEC1 parity prefix, so `0x02 || x` and `0x03 || x` name the same owner, and `pk_field(0x02 || S)` is the Solana owner identity of the address `S`. `register` therefore claims the identity for the record it creates, and refuses an `owner_p256` whose identity another record already claimed or whose x-coordinate is a registered owner's address. Key rotation applies the same rule and leaves the previously claimed identity reserved for that owner. This is first-claim-wins rather than proof of possession: an identity claimed before its holder registers stays with the first claimant.
 
 Authorized signer: `owner`.
 

--- a/program-libs/user-registry-interface/src/instruction.rs
+++ b/program-libs/user-registry-interface/src/instruction.rs
@@ -56,7 +56,10 @@ mod builders {
         discriminator, RegisterData, RotateSyncDelegateKeyData, SetMergingEnabledData,
         SetSyncDelegateData, UpdateKeysData,
     };
-    use crate::user_registry_program_id;
+    use crate::{
+        owner_p256_identity, p256_owner_claim_pda, state::P256_PUBKEY_LEN, user_record_pda,
+        user_registry_program_id,
+    };
 
     const SYSTEM_PROGRAM_ID: Pubkey = Pubkey::new_from_array([0u8; 32]);
 
@@ -68,15 +71,34 @@ mod builders {
         data
     }
 
-    /// Accounts: `[user_record (writable), owner (writable signer), system_program]`.
+    /// The two accounts that make a P256 owner identity exclusive to one record:
+    /// the claim the registry creates for the key, and the user record of the
+    /// Solana owner whose identity the key would collide with (the key's
+    /// x-coordinate read as an address). Both are derived from the key itself, so
+    /// callers never supply them.
+    fn p256_identity_metas(owner_p256: &[u8; P256_PUBKEY_LEN]) -> Vec<AccountMeta> {
+        let identity = Pubkey::new_from_array(owner_p256_identity(owner_p256));
+        vec![
+            AccountMeta::new(p256_owner_claim_pda(owner_p256).0, false),
+            AccountMeta::new_readonly(user_record_pda(&identity).0, false),
+        ]
+    }
+
+    /// Accounts: `[user_record (writable), owner (writable signer), system_program]`,
+    /// plus `[p256_claim (writable), p256_identity_record]` when the record claims
+    /// an `owner_p256`.
     pub fn register(user_record: Pubkey, owner: Pubkey, data: RegisterData) -> Instruction {
+        let mut accounts = vec![
+            AccountMeta::new(user_record, false),
+            AccountMeta::new(owner, true),
+            AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
+        ];
+        if let Some(owner_p256) = data.owner_p256.as_ref() {
+            accounts.extend(p256_identity_metas(owner_p256));
+        }
         Instruction {
             program_id: user_registry_program_id(),
-            accounts: vec![
-                AccountMeta::new(user_record, false),
-                AccountMeta::new(owner, true),
-                AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false),
-            ],
+            accounts,
             data: encode_instruction(discriminator::REGISTER, &data),
         }
     }
@@ -145,13 +167,22 @@ mod builders {
 
     /// Accounts: `[user_record (writable), owner (signer)]`. The owner may rotate
     /// the shielded keys stored in its existing record without changing the PDA.
+    /// Rotating into an `owner_p256` claims that identity, which needs
+    /// `[system_program, p256_claim (writable), p256_identity_record]` and makes the
+    /// owner writable, since it pays the claim's rent.
     pub fn update_keys(user_record: Pubkey, owner: Pubkey, data: UpdateKeysData) -> Instruction {
+        let mut accounts = vec![AccountMeta::new(user_record, false)];
+        match data.owner_p256.as_ref() {
+            Some(owner_p256) => {
+                accounts.push(AccountMeta::new(owner, true));
+                accounts.push(AccountMeta::new_readonly(SYSTEM_PROGRAM_ID, false));
+                accounts.extend(p256_identity_metas(owner_p256));
+            }
+            None => accounts.push(AccountMeta::new_readonly(owner, true)),
+        }
         Instruction {
             program_id: user_registry_program_id(),
-            accounts: vec![
-                AccountMeta::new(user_record, false),
-                AccountMeta::new_readonly(owner, true),
-            ],
+            accounts,
             data: encode_instruction(discriminator::UPDATE_KEYS, &data),
         }
     }

--- a/program-libs/user-registry-interface/src/lib.rs
+++ b/program-libs/user-registry-interface/src/lib.rs
@@ -1,12 +1,14 @@
 pub mod instruction;
 pub mod state;
 
-pub use state::{SyncDelegateEntry, UserRecord};
+pub use state::{owner_p256_identity, P256OwnerClaim, SyncDelegateEntry, UserRecord};
 
 pub const USER_REGISTRY_PROGRAM_ID: [u8; 32] =
     pubkey_array!("EXM6UUA56UJySzRDCx4dKwN6Xdcrkq3kmizqgZwgwNEc");
 
 pub const USER_RECORD_SEED: &[u8] = b"zolana/registry/v0";
+
+pub const P256_OWNER_CLAIM_SEED: &[u8] = b"zolana/registry/p256-owner/v0";
 
 /// Decode a base58 program id into a `[u8; 32]` const at compile time.
 #[macro_export]
@@ -21,6 +23,18 @@ macro_rules! pubkey_array {
 pub fn user_record_pda(owner: &solana_pubkey::Pubkey) -> (solana_pubkey::Pubkey, u8) {
     solana_pubkey::Pubkey::find_program_address(
         &[USER_RECORD_SEED, owner.as_ref()],
+        &user_registry_program_id(),
+    )
+}
+
+/// The claim account that binds a P256 owner identity to one record. Keyed by the
+/// key's x-coordinate, because owner identity ignores the SEC1 parity prefix.
+#[cfg(feature = "solana")]
+pub fn p256_owner_claim_pda(
+    owner_p256: &[u8; state::P256_PUBKEY_LEN],
+) -> (solana_pubkey::Pubkey, u8) {
+    solana_pubkey::Pubkey::find_program_address(
+        &[P256_OWNER_CLAIM_SEED, &owner_p256_identity(owner_p256)],
         &user_registry_program_id(),
     )
 }

--- a/program-libs/user-registry-interface/src/state.rs
+++ b/program-libs/user-registry-interface/src/state.rs
@@ -32,6 +32,47 @@ pub struct UserRecord {
     pub merging_enabled: bool,
 }
 
+/// Binds one P256 owner identity to the single record allowed to carry it.
+///
+/// Owner identity drops the SEC1 parity prefix (`owner_pk_field_compressed`), so
+/// `0x02 || x` and `0x03 || x` are the same owner and the claim is keyed by `x`
+/// alone. `owner` is the registered Solana owner whose record holds the key; the
+/// registry refuses to hand the same identity to a second record, which is what
+/// lets `merge_transact` treat the `owner_p256` in a canonical record as that
+/// record's own key.
+#[derive(BorshSerialize, BorshDeserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct P256OwnerClaim {
+    pub owner: Address,
+    pub bump: u8,
+}
+
+impl P256OwnerClaim {
+    pub const DISCRIMINATOR: u8 = 2;
+    pub const DISCRIMINATOR_LEN: usize = 1;
+    pub const SPACE: usize = Self::DISCRIMINATOR_LEN + 32 + 1;
+
+    pub fn try_from_account_data(data: &[u8]) -> borsh::io::Result<Self> {
+        match data.split_first() {
+            Some((&Self::DISCRIMINATOR, body)) => Self::deserialize(&mut &*body),
+            _ => Err(invalid_user_record(
+                "missing p256 owner claim discriminator",
+            )),
+        }
+    }
+}
+
+/// The 32-byte x-coordinate of a SEC1-compressed P256 key: the owner identity the
+/// claim and the merge rail both key on.
+pub const fn owner_p256_identity(owner_p256: &[u8; P256_PUBKEY_LEN]) -> [u8; 32] {
+    let mut identity = [0u8; 32];
+    let mut i = 0;
+    while i < 32 {
+        identity[i] = owner_p256[i + 1];
+        i += 1;
+    }
+    identity
+}
+
 impl UserRecord {
     pub const DISCRIMINATOR: u8 = 1;
     pub const DISCRIMINATOR_LEN: usize = 1;

--- a/program-tests/shielded-pool/Cargo.toml
+++ b/program-tests/shielded-pool/Cargo.toml
@@ -32,6 +32,8 @@ zolana-transaction = { workspace = true }
 [dev-dependencies]
 bytemuck = { workspace = true }
 cucumber = { workspace = true }
+solana-account = { workspace = true }
+zolana-user-registry-interface = { workspace = true, features = ["solana"] }
 groth16-solana = { workspace = true }
 zolana-hasher = { workspace = true }
 zolana-merkle-tree = { workspace = true }
@@ -77,6 +79,10 @@ required-features = ["localnet"]
 name = "localnet_wallet_cli_e2e"
 path = "tests/localnet_wallet_cli_e2e.rs"
 required-features = ["localnet"]
+
+[[test]]
+name = "merge_user_record"
+path = "tests/merge_user_record.rs"
 
 [[test]]
 name = "transact"

--- a/program-tests/shielded-pool/tests/merge_user_record.rs
+++ b/program-tests/shielded-pool/tests/merge_user_record.rs
@@ -1,0 +1,368 @@
+//! `merge_transact` reads owner identity, the viewing key, and the `merging_enabled`
+//! opt-in from a `user_record` account. This pins the property those three reads
+//! depend on: the record must be the canonical registry record of the owner whose
+//! UTXOs are merged, not merely some registry-owned account carrying that owner's
+//! signing key.
+//!
+//! Both tests submit a merge with a zeroed proof. That is enough to tell the
+//! account check apart from the proof check: a record SPP accepts runs on to proof
+//! verification (`InvalidTransactProofEncoding` / `TransactProofVerificationFailed`),
+//! a record SPP rejects fails earlier with `InvalidUserRecord`. Skips when the
+//! program `.so` files are missing.
+
+#[path = "common/setup.rs"]
+mod common;
+
+use std::path::PathBuf;
+
+use solana_account::Account;
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_instruction::Instruction;
+use solana_keypair::Keypair;
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+use zolana_interface::instruction::{
+    instruction_data::{
+        merge_transact::{
+            MergeTransactIxData, MERGE_ENCRYPTED_UTXO_LEN, MERGE_ENCRYPTED_UTXO_TYPE_PREFIX,
+            MERGE_INPUT_COUNT,
+        },
+        transact::P256Proof,
+    },
+    MergeTransact,
+};
+use zolana_interface::merge_utils::owner_pk_field_compressed;
+use zolana_keypair::hash::hash_field;
+use zolana_program_test::ZolanaProgramTest;
+use zolana_user_registry_interface::{
+    instruction::{self as registry, set_merging_enabled, RegisterData},
+    user_record_pda, user_registry_program_id,
+};
+
+/// `ShieldedPoolError::InvalidUserRecord`.
+const INVALID_USER_RECORD: u32 = 7018;
+/// `ShieldedPoolError::InvalidTransactProofEncoding`.
+const INVALID_PROOF_ENCODING: u32 = 7007;
+/// `ShieldedPoolError::TransactProofVerificationFailed`.
+const PROOF_VERIFICATION_FAILED: u32 = 7008;
+/// `ShieldedPoolError::MergeDisabled`.
+const MERGE_DISABLED: u32 = 7017;
+
+/// The owner whose UTXOs the merge consolidates. `owner_p256` is public key
+/// material: the compressed prefix is the only thing SPP validates about it.
+const OWNER_P256: [u8; 33] = p256_pubkey(0x11);
+const OWNER_VIEWING: [u8; 33] = p256_pubkey(0x22);
+const IMPOSTOR_VIEWING: [u8; 33] = p256_pubkey(0x33);
+
+const fn p256_pubkey(tag: u8) -> [u8; 33] {
+    let mut pubkey = [0u8; 33];
+    pubkey[0] = 0x02;
+    pubkey[1] = tag;
+    pubkey
+}
+
+fn user_registry_path() -> PathBuf {
+    if let Ok(path) = std::env::var("USER_REGISTRY_PROGRAM_PATH") {
+        return PathBuf::from(path);
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("target")
+        .join("deploy")
+        .join("zolana_user_registry.so")
+}
+
+/// Boot the pool test environment with the user-registry program loaded, or `None`
+/// when either `.so` is missing.
+fn program_test_with_registry() -> Option<ZolanaProgramTest> {
+    let mut rpc = common::program_test()?;
+    let path = user_registry_path();
+    if !path.exists() {
+        eprintln!(
+            "skipping merge user_record test: {} missing - run `just build-programs`",
+            path.display()
+        );
+        return None;
+    }
+    let bytes = std::fs::read(&path).expect("read user-registry program");
+    rpc.svm
+        .add_program(user_registry_program_id(), &bytes)
+        .expect("add user-registry program");
+    Some(rpc)
+}
+
+fn send(
+    rpc: &mut ZolanaProgramTest,
+    ixs: &[Instruction],
+    signers: &[&Keypair],
+) -> Result<(), String> {
+    let payer = rpc.payer.insecure_clone();
+    let mut all_signers: Vec<&Keypair> = vec![&payer];
+    all_signers.extend_from_slice(signers);
+    rpc.svm.expire_blockhash();
+    let blockhash = rpc.svm.latest_blockhash();
+    let message = Message::new(ixs, Some(&payer.pubkey()));
+    let transaction = Transaction::new(&all_signers, message, blockhash);
+    rpc.svm
+        .send_transaction(transaction)
+        .map(|_| ())
+        .map_err(|e| format!("{e:?}"))
+}
+
+/// Register `owner` with the given keys, opting the record into merging when
+/// `enable_merging`. Returns the record address, or the registry's rejection.
+fn register(
+    rpc: &mut ZolanaProgramTest,
+    owner: &Keypair,
+    owner_p256: Option<[u8; 33]>,
+    viewing_pubkey: [u8; 33],
+    enable_merging: bool,
+) -> Result<Pubkey, String> {
+    rpc.airdrop(&owner.pubkey(), 1_000_000_000)
+        .expect("airdrop owner");
+    let record = user_record_pda(&owner.pubkey()).0;
+    let data = RegisterData {
+        owner_p256,
+        nullifier_pubkey: fe(1),
+        viewing_pubkey,
+    };
+    send(
+        rpc,
+        &[registry::register(record, owner.pubkey(), data)],
+        &[&owner.insecure_clone()],
+    )?;
+    if enable_merging {
+        send(
+            rpc,
+            &[set_merging_enabled(record, owner.pubkey(), true)],
+            &[&owner.insecure_clone()],
+        )?;
+    }
+    Ok(record)
+}
+
+/// Register `owner` with the given keys and opt the record into merging.
+fn register_opted_in(
+    rpc: &mut ZolanaProgramTest,
+    owner: &Keypair,
+    owner_p256: [u8; 33],
+    viewing_pubkey: [u8; 33],
+) -> Result<Pubkey, String> {
+    register(rpc, owner, Some(owner_p256), viewing_pubkey, true)
+}
+
+/// A field element holding `value` in its low 8 bytes (big-endian).
+fn fe(value: u64) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    out[24..].copy_from_slice(&value.to_be_bytes());
+    out
+}
+
+/// A well-formed `merge_transact` body with a zeroed proof. `eddsa_owner` picks
+/// the rail SPP derives the owner identity on.
+fn merge_data(eddsa_owner: bool) -> MergeTransactIxData {
+    let mut encrypted_utxo = vec![0u8; MERGE_ENCRYPTED_UTXO_LEN];
+    encrypted_utxo[0] = MERGE_ENCRYPTED_UTXO_TYPE_PREFIX;
+    MergeTransactIxData {
+        expiry_unix_ts: u64::MAX,
+        proof: P256Proof {
+            a: [0u8; 32],
+            b: [0u8; 64],
+            c: [0u8; 32],
+            commitment: [0u8; 32],
+            commitment_pok: [0u8; 32],
+        },
+        output_utxo_hash: fe(900),
+        nullifiers: (0..MERGE_INPUT_COUNT as u64).map(|i| fe(500 + i)).collect(),
+        utxo_tree_root_index: vec![0; MERGE_INPUT_COUNT],
+        nullifier_tree_root_index: vec![0; MERGE_INPUT_COUNT],
+        private_tx_hash: fe(901),
+        encrypted_utxo,
+        eddsa_owner,
+    }
+}
+
+fn send_merge_on_rail(
+    rpc: &mut ZolanaProgramTest,
+    tree: Pubkey,
+    user_record: Pubkey,
+    eddsa_owner: bool,
+) -> Result<(), String> {
+    let payer = rpc.payer.pubkey();
+    let ix = MergeTransact {
+        tree,
+        payer,
+        user_record,
+        data: merge_data(eddsa_owner),
+    }
+    .instruction();
+    // The tree writes and the proof decoding run past the 200k default.
+    let compute_budget = ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
+    send(rpc, &[compute_budget, ix], &[])
+}
+
+fn send_merge(
+    rpc: &mut ZolanaProgramTest,
+    tree: Pubkey,
+    user_record: Pubkey,
+) -> Result<(), String> {
+    send_merge_on_rail(rpc, tree, user_record, false)
+}
+
+#[track_caller]
+fn assert_custom(err: &str, code: u32, context: &str) {
+    let needle = format!("Custom({code})");
+    assert!(
+        err.contains(&needle),
+        "{context}: expected {needle}, got: {err}"
+    );
+}
+
+fn setup() -> Option<(ZolanaProgramTest, Pubkey)> {
+    let mut rpc = program_test_with_registry()?;
+    let authority = Keypair::new();
+    rpc.create_protocol_config(&authority)
+        .expect("create protocol config");
+    let tree = rpc
+        .create_tree(common::tree_account_size(), &authority)
+        .expect("create tree");
+    Some((rpc, tree.pubkey()))
+}
+
+/// The canonical record of the merged owner is accepted, so a rejection of any
+/// other record is attributable to the account check rather than to the proof.
+fn assert_canonical_record_reaches_the_proof(
+    rpc: &mut ZolanaProgramTest,
+    tree: Pubkey,
+    record: Pubkey,
+) {
+    let err = send_merge(rpc, tree, record).expect_err("a zeroed proof must not verify");
+    assert!(
+        err.contains(&format!("Custom({INVALID_PROOF_ENCODING})"))
+            || err.contains(&format!("Custom({PROOF_VERIFICATION_FAILED})")),
+        "the owner's own record must be accepted and the merge reach proof verification, got: {err}"
+    );
+}
+
+/// A second registrant may claim any `owner_p256` it likes, so a record that is
+/// canonical for one Solana owner can carry a different owner's signing key. That
+/// record is not the merged owner's record and must not authorize the merge.
+#[test]
+fn merge_transact_rejects_a_record_registered_under_another_owner() {
+    let Some((mut rpc, tree)) = setup() else {
+        return;
+    };
+
+    let owner = Keypair::new();
+    let owner_record = register_opted_in(&mut rpc, &owner, OWNER_P256, OWNER_VIEWING)
+        .expect("register the merged owner");
+    assert_canonical_record_reaches_the_proof(&mut rpc, tree, owner_record);
+
+    // Claiming another owner's `owner_p256` is the step a registry proof of
+    // possession would refuse; the property holds either way.
+    let impostor = Keypair::new();
+    let Ok(impostor_record) = register_opted_in(&mut rpc, &impostor, OWNER_P256, IMPOSTOR_VIEWING)
+    else {
+        return;
+    };
+
+    let err = send_merge(&mut rpc, tree, impostor_record).expect_err(
+        "merge_transact must reject a record registered under an owner other than the merged owner",
+    );
+    assert_custom(
+        &err,
+        INVALID_USER_RECORD,
+        "a record whose owner_p256 was claimed by a different registrant",
+    );
+}
+
+/// A registry-owned account at an address that is not the record PDA of its stored
+/// `owner`. The registry program only ever creates canonical PDAs, so this state is
+/// planted rather than reachable on-chain; the test pins the derivation check that
+/// would reject it.
+#[test]
+fn merge_transact_rejects_a_non_canonical_record_address() {
+    let Some((mut rpc, tree)) = setup() else {
+        return;
+    };
+
+    let owner = Keypair::new();
+    let owner_record = register_opted_in(&mut rpc, &owner, OWNER_P256, OWNER_VIEWING)
+        .expect("register the merged owner");
+    assert_canonical_record_reaches_the_proof(&mut rpc, tree, owner_record);
+
+    let canonical = rpc.svm.get_account(&owner_record).expect("record account");
+    let copy = Pubkey::new_unique();
+    rpc.svm
+        .set_account(
+            copy,
+            Account {
+                lamports: canonical.lamports,
+                data: canonical.data,
+                owner: user_registry_program_id(),
+                executable: false,
+                rent_epoch: canonical.rent_epoch,
+            },
+        )
+        .expect("plant the record copy");
+
+    let err = send_merge(&mut rpc, tree, copy)
+        .expect_err("merge_transact must reject a record at a non-canonical address");
+    assert_custom(
+        &err,
+        INVALID_USER_RECORD,
+        "a registry-owned record copy at a non-canonical address",
+    );
+}
+
+/// A Solana owner is reachable through the P256 branch, because the owner
+/// encoding drops the parity bit: `owner_pk_field_compressed(0x02 || address)` is
+/// the same field element as the Solana owner's `hash_field(address)`. An
+/// impostor record carrying those 33 bytes therefore speaks for a Solana owner
+/// who never enabled merging.
+#[test]
+fn merge_transact_rejects_an_opt_in_borrowed_from_another_record() {
+    let Some((mut rpc, tree)) = setup() else {
+        return;
+    };
+
+    let owner = Keypair::new();
+    let address = owner.pubkey().to_bytes();
+    let mut claimed_p256 = [0u8; 33];
+    claimed_p256[0] = 0x02;
+    claimed_p256[1..].copy_from_slice(&address);
+    assert_eq!(
+        owner_pk_field_compressed(&claimed_p256).expect("owner pk_field of the claimed key"),
+        hash_field(&address).expect("owner pk_field of the Solana address"),
+        "the two rails must agree for this substitution to be possible"
+    );
+
+    // A Solana owner: no `owner_p256`, and merging left off.
+    let owner_record =
+        register(&mut rpc, &owner, None, OWNER_VIEWING, false).expect("register the merged owner");
+    let err = send_merge_on_rail(&mut rpc, tree, owner_record, true)
+        .expect_err("the owner never enabled merging");
+    assert_custom(
+        &err,
+        MERGE_DISABLED,
+        "the merged owner's own record, merging not enabled",
+    );
+
+    let impostor = Keypair::new();
+    let Ok(impostor_record) =
+        register_opted_in(&mut rpc, &impostor, claimed_p256, IMPOSTOR_VIEWING)
+    else {
+        return;
+    };
+
+    let err = send_merge(&mut rpc, tree, impostor_record)
+        .expect_err("merge_transact must not take the opt-in from someone else's record");
+    assert_custom(
+        &err,
+        INVALID_USER_RECORD,
+        "an impostor record claiming the merged owner's Solana address as a P256 key",
+    );
+}

--- a/program-tests/user-registry/src/lib.rs
+++ b/program-tests/user-registry/src/lib.rs
@@ -9,7 +9,9 @@ use zolana_user_registry_interface::{
     },
     user_record_pda,
 };
-pub use zolana_user_registry_interface::{user_registry_program_id, SyncDelegateEntry, UserRecord};
+pub use zolana_user_registry_interface::{
+    p256_owner_claim_pda, user_registry_program_id, P256OwnerClaim, SyncDelegateEntry, UserRecord,
+};
 
 pub fn build_register_ix(
     owner: &Pubkey,
@@ -96,4 +98,13 @@ pub fn fetch_user_record(svm: &litesvm::LiteSVM, owner: &Pubkey) -> Option<UserR
     let (pda, _bump) = user_record_pda(owner);
     let account = svm.get_account(&pda)?;
     UserRecord::try_from_account_data(&account.data).ok()
+}
+
+pub fn fetch_p256_owner_claim(
+    svm: &litesvm::LiteSVM,
+    owner_p256: &[u8; 33],
+) -> Option<P256OwnerClaim> {
+    let (pda, _bump) = p256_owner_claim_pda(owner_p256);
+    let account = svm.get_account(&pda)?;
+    P256OwnerClaim::try_from_account_data(&account.data).ok()
 }

--- a/program-tests/user-registry/tests/features/user_registry.feature
+++ b/program-tests/user-registry/tests/features/user_registry.feature
@@ -48,6 +48,41 @@ Feature: User registry program
     When "alice" tries to register again
     Then the transaction fails with "AccountAlreadyInitialized"
 
+  # === p256 owner identity exclusivity ===
+
+  Scenario: Registering a p256 owner key claims that owner identity
+    Given owner "alice" with p256 keys
+    When "alice" registers on-chain
+    Then "alice" holds the claim on her owner p256 identity
+
+  Scenario: A second registrant cannot claim another record's owner p256 key
+    Given owner "alice" with p256 keys
+    And "alice" registers on-chain
+    And owner "dave" with p256 keys
+    When "dave" tries to register with the owner p256 key of "alice"
+    Then the transaction fails with "P256IdentityAlreadyClaimed"
+
+  Scenario: An owner p256 key encoding a registered owner's address is refused
+    Given owner "alice" with p256 keys
+    And "alice" registers on-chain without an owner p256 key
+    And owner "dave" with p256 keys
+    When "dave" tries to register with an owner p256 key encoding the address of "alice"
+    Then the transaction fails with "P256IdentityIsRegisteredOwner"
+
+  Scenario: Key rotation cannot take another record's owner p256 key
+    Given owner "alice" with p256 keys
+    And "alice" registers on-chain
+    And owner "dave" with p256 keys
+    And "dave" registers on-chain
+    When "dave" tries to update registry keys to the owner p256 key of "alice"
+    Then the transaction fails with "P256IdentityAlreadyClaimed"
+
+  Scenario: An owner may keep the owner p256 identity it already holds
+    Given owner "alice" with p256 keys
+    And "alice" registers on-chain
+    When "alice" updates registry keys keeping the same owner p256 key
+    Then "alice" holds the claim on her owner p256 identity
+
   # === set_sync_delegate ===
 
   Scenario: Set sync delegate appends an entry

--- a/program-tests/user-registry/tests/steps/user_registry.rs
+++ b/program-tests/user-registry/tests/steps/user_registry.rs
@@ -10,7 +10,7 @@ use solana_transaction::Transaction;
 use user_registry_tests::{
     build_register_ix, build_revoke_sync_delegate_ix, build_rotate_sync_delegate_key_ix,
     build_set_merging_enabled_ix, build_set_sync_delegate_ix, build_update_keys_ix,
-    fetch_user_record, user_registry_program_id,
+    fetch_p256_owner_claim, fetch_user_record, p256_owner_claim_pda, user_registry_program_id,
 };
 use zolana_user_registry_interface::user_record_pda;
 
@@ -184,6 +184,7 @@ fn when_register(world: &mut UserRegistryWorld, name: String) {
     world.send(&[owner_kp], ix);
 }
 
+#[given(regex = r#""(.*)" registers on-chain without an owner p256 key"#)]
 #[when(regex = r#""(.*)" registers on-chain without an owner p256 key"#)]
 fn when_register_no_p256(world: &mut UserRegistryWorld, name: String) {
     let owner = world.owners.get(&name).expect("owner").pubkey();
@@ -237,6 +238,80 @@ fn when_update_keys_no_p256(world: &mut UserRegistryWorld, name: String) {
 #[when(regex = r#""(.*)" tries to register again"#)]
 fn when_register_again(world: &mut UserRegistryWorld, name: String) {
     when_register(world, name);
+}
+
+// === p256 owner identity exclusivity ===
+
+fn register_claiming(world: &mut UserRegistryWorld, name: &str, owner_p256: [u8; 33]) {
+    let owner_kp = world.owners.get(name).expect("owner").insecure_clone();
+    let ix = build_register_ix(
+        &owner_kp.pubkey(),
+        Some(owner_p256),
+        world.nullifier_pubkey[name],
+        world.viewing_pubkey[name],
+    );
+    world.send(&[owner_kp], ix);
+}
+
+/// The owner identity of `0x02 || address` is the Solana owner identity of
+/// `address`, because the encoding drops the SEC1 parity prefix.
+fn p256_key_encoding(address: &Pubkey) -> [u8; 33] {
+    let mut key = [0u8; 33];
+    key[0] = 0x02;
+    key[1..].copy_from_slice(&address.to_bytes());
+    key
+}
+
+#[when(regex = r#"^"(.*)" tries to register with the owner p256 key of "(.*)"$"#)]
+fn when_register_with_claimed_key(
+    world: &mut UserRegistryWorld,
+    name: String,
+    claimed_from: String,
+) {
+    let claimed = world.owner_p256[&claimed_from];
+    register_claiming(world, &name, claimed);
+}
+
+#[when(
+    regex = r#"^"(.*)" tries to register with an owner p256 key encoding the address of "(.*)"$"#
+)]
+fn when_register_with_address_shaped_key(
+    world: &mut UserRegistryWorld,
+    name: String,
+    victim: String,
+) {
+    let address = world.owners.get(&victim).expect("owner").pubkey();
+    register_claiming(world, &name, p256_key_encoding(&address));
+}
+
+#[when(regex = r#"^"(.*)" tries to update registry keys to the owner p256 key of "(.*)"$"#)]
+fn when_update_keys_to_claimed_key(
+    world: &mut UserRegistryWorld,
+    name: String,
+    claimed_from: String,
+) {
+    let owner_kp = world.owners.get(&name).expect("owner").insecure_clone();
+    let ix = build_update_keys_ix(
+        &owner_kp.pubkey(),
+        Some(world.owner_p256[&claimed_from]),
+        world.nullifier_pubkey[&name],
+        world.viewing_pubkey[&name],
+    );
+    world.send(&[owner_kp], ix);
+}
+
+#[when(regex = r#"^"(.*)" updates registry keys keeping the same owner p256 key$"#)]
+fn when_update_keys_same_p256(world: &mut UserRegistryWorld, name: String) {
+    let owner_kp = world.owners.get(&name).expect("owner").insecure_clone();
+    let updated_viewing = test_p256_pubkey(0xF6);
+    world.viewing_pubkey.insert(name.clone(), updated_viewing);
+    let ix = build_update_keys_ix(
+        &owner_kp.pubkey(),
+        Some(world.owner_p256[&name]),
+        world.nullifier_pubkey[&name],
+        updated_viewing,
+    );
+    world.send(&[owner_kp], ix);
 }
 
 // === set_sync_delegate ===
@@ -404,6 +479,24 @@ fn then_no_sync_delegate(world: &mut UserRegistryWorld, name: String) {
     assert_eq!(record.nullifier_pubkey, world.nullifier_pubkey[&name]);
     assert_eq!(record.viewing_pubkey, world.viewing_pubkey[&name]);
     assert_eq!(record.sender_viewing_pubkey(), record.viewing_pubkey);
+}
+
+#[then(regex = r#""(.*)" holds the claim on her owner p256 identity"#)]
+fn then_holds_p256_claim(world: &mut UserRegistryWorld, name: String) {
+    assert_no_error(world);
+    let owner = world.owners.get(&name).expect("owner").pubkey();
+    let owner_p256 = world.owner_p256[&name];
+    let claim = fetch_p256_owner_claim(world.svm.as_ref().expect("rig"), &owner_p256)
+        .expect("claim missing");
+    assert_eq!(claim.owner.to_bytes(), owner.to_bytes());
+    assert_eq!(
+        claim.bump,
+        p256_owner_claim_pda(&owner_p256).1,
+        "stored bump must be canonical"
+    );
+    let record =
+        fetch_user_record(world.svm.as_ref().expect("rig"), &owner).expect("record missing");
+    assert_eq!(record.owner_p256, Some(owner_p256));
 }
 
 #[then(regex = r#""(.*)" has a user record without an owner p256 key"#)]

--- a/programs/shielded-pool/src/instructions/merge/account.rs
+++ b/programs/shielded-pool/src/instructions/merge/account.rs
@@ -1,7 +1,9 @@
 use pinocchio::{address::Address, error::ProgramError, AccountView};
 use zolana_account_checks::AccountIterator;
 use zolana_interface::{error::ShieldedPoolError, merge_utils::owner_pk_field_compressed};
-use zolana_user_registry_interface::{state::UserRecord, USER_REGISTRY_PROGRAM_ID};
+use zolana_user_registry_interface::{
+    state::UserRecord, USER_RECORD_SEED, USER_REGISTRY_PROGRAM_ID,
+};
 
 use crate::instructions::hash::solana_pk_hash;
 
@@ -40,12 +42,21 @@ pub struct UserPkFields {
     pub merging_enabled: bool,
 }
 
-/// Load and validate the `user_record`: owned by the registry program with a
-/// valid `UserRecord` discriminator/body. Returns the per-user `merging_enabled`
-/// opt-in alongside the rail-selected owner identity; the processor rejects the
-/// merge when it is `false`. The owner identity is rail-selected by `eddsa_owner`:
-/// a Solana owner derives `signing_pk_field` from the registry account `owner`
-/// (ed25519), a P256 owner from `owner_p256`.
+/// Load and validate the `user_record`: owned by the registry program, carrying a
+/// valid `UserRecord` discriminator/body, and living at the canonical registry PDA
+/// of the `owner` it stores. Returns the per-user `merging_enabled` opt-in
+/// alongside the rail-selected owner identity; the processor rejects the merge when
+/// it is `false`. The owner identity is rail-selected by `eddsa_owner`: a Solana
+/// owner derives `signing_pk_field` from the registry account `owner` (ed25519), a
+/// P256 owner from `owner_p256`.
+///
+/// The merge is permissionless, so no signature ties the account to the merged
+/// owner; the PDA is what does. On the ed25519 rail that closes the binding: the
+/// address proves the record is `owner`'s, and the proof binds `signing_pk_field`
+/// (derived from that same `owner`) to the input and output UTXO owner hashes. On
+/// the P256 rail it is one half of the binding, because `owner_p256` is a claim the
+/// registry accepts without proof of possession; the registry's exclusive
+/// P256-identity binding is the other half.
 #[inline(never)]
 pub fn load_user_record(
     account: &AccountView,
@@ -60,6 +71,14 @@ pub fn load_user_record(
         .map_err(|_| ShieldedPoolError::InvalidUserRecord)?;
     let record = UserRecord::try_from_account_data(&data)
         .map_err(|_| ShieldedPoolError::InvalidUserRecord)?;
+    let expected = Address::derive_address(
+        &[USER_RECORD_SEED, record.owner.as_array().as_slice()],
+        Some(record.bump),
+        &registry_id,
+    );
+    if account.address() != &expected {
+        return Err(ShieldedPoolError::InvalidUserRecord.into());
+    }
     let merging_enabled = record.merging_enabled;
     let mut signing_view_tag = [0u8; 32];
     let signing_pk_field = if eddsa_owner {

--- a/programs/user-registry/src/error.rs
+++ b/programs/user-registry/src/error.rs
@@ -19,6 +19,14 @@ pub enum UserRegistryError {
     InvalidRecordAccount,
     #[error("system program account mismatch")]
     InvalidSystemProgram,
+    #[error("p256 owner claim account is invalid")]
+    InvalidP256ClaimAccount,
+    #[error("p256 owner identity account does not match the expected PDA")]
+    InvalidP256IdentityAccount,
+    #[error("p256 owner identity is already claimed by another record")]
+    P256IdentityAlreadyClaimed,
+    #[error("p256 owner identity is a registered owner's identity")]
+    P256IdentityIsRegisteredOwner,
 }
 
 impl UserRegistryError {
@@ -32,6 +40,10 @@ impl UserRegistryError {
             Self::OwnerMismatch => "OwnerMismatch",
             Self::InvalidRecordAccount => "InvalidRecordAccount",
             Self::InvalidSystemProgram => "InvalidSystemProgram",
+            Self::InvalidP256ClaimAccount => "InvalidP256ClaimAccount",
+            Self::InvalidP256IdentityAccount => "InvalidP256IdentityAccount",
+            Self::P256IdentityAlreadyClaimed => "P256IdentityAlreadyClaimed",
+            Self::P256IdentityIsRegisteredOwner => "P256IdentityIsRegisteredOwner",
         }
     }
 }

--- a/programs/user-registry/src/instructions/common.rs
+++ b/programs/user-registry/src/instructions/common.rs
@@ -84,41 +84,53 @@ pub fn create_record_account(
     space: usize,
     program_id: &Address,
 ) -> ProgramResult {
-    let required = Rent::get()?.try_minimum_balance(space)?;
     let bump_seed = [bump];
     let seeds = [
         Seed::from(USER_RECORD_SEED),
         Seed::from(owner.as_ref()),
         Seed::from(&bump_seed[..]),
     ];
-    let signer = Signer::from(&seeds[..]);
+    create_pda_account(record, payer, &seeds, space, program_id)
+}
 
-    let top_up = required.saturating_sub(record.lamports());
+/// Fund, allocate and assign `account` at the PDA its `seeds` (bump included)
+/// derive. Handles the cold path where an attacker donated lamports first.
+pub fn create_pda_account(
+    account: &AccountView,
+    payer: &AccountView,
+    seeds: &[Seed],
+    space: usize,
+    program_id: &Address,
+) -> ProgramResult {
+    let required = Rent::get()?.try_minimum_balance(space)?;
+    let signer = Signer::from(seeds);
+
+    let top_up = required.saturating_sub(account.lamports());
     if top_up > 0 {
-        system_transfer(payer, record, top_up)?;
+        system_transfer(payer, account, top_up)?;
     }
 
     let mut allocate_data = [0u8; 12];
     allocate_data[0] = 8;
     allocate_data[4..12].copy_from_slice(&(space as u64).to_le_bytes());
-    let metas = [InstructionAccount::writable_signer(record.address())];
+    let metas = [InstructionAccount::writable_signer(account.address())];
     let instruction = InstructionView {
         program_id: &SYSTEM_PROGRAM_ID,
         accounts: &metas,
         data: &allocate_data,
     };
-    invoke_signed::<1, _>(&instruction, &[record], std::slice::from_ref(&signer))?;
+    invoke_signed::<1, _>(&instruction, &[account], std::slice::from_ref(&signer))?;
 
     let mut assign_data = [0u8; 36];
     assign_data[0] = 1;
     assign_data[4..36].copy_from_slice(program_id.as_ref());
-    let metas = [InstructionAccount::writable_signer(record.address())];
+    let metas = [InstructionAccount::writable_signer(account.address())];
     let instruction = InstructionView {
         program_id: &SYSTEM_PROGRAM_ID,
         accounts: &metas,
         data: &assign_data,
     };
-    invoke_signed::<1, _>(&instruction, &[record], &[signer])
+    invoke_signed::<1, _>(&instruction, &[account], &[signer])
 }
 
 pub fn system_transfer(from: &AccountView, to: &AccountView, lamports: u64) -> ProgramResult {

--- a/programs/user-registry/src/instructions/mod.rs
+++ b/programs/user-registry/src/instructions/mod.rs
@@ -1,4 +1,5 @@
 pub mod common;
+pub mod p256_identity;
 pub mod register;
 pub mod revoke_sync_delegate;
 pub mod rotate_sync_delegate_key;

--- a/programs/user-registry/src/instructions/p256_identity.rs
+++ b/programs/user-registry/src/instructions/p256_identity.rs
@@ -1,0 +1,128 @@
+//! Exclusive binding of a P256 owner identity to the record that carries it.
+//!
+//! `merge_transact` is permissionless and derives the merged owner's identity from
+//! `UserRecord::owner_p256`. The registry writes that key on trust, so without an
+//! exclusivity rule two records can carry the same identity and the pool has no way
+//! to tell which one speaks for the owner. Every record that claims a key therefore
+//! creates a [`P256OwnerClaim`] for it, and a claim is refused when the identity is
+//! already spoken for.
+//!
+//! Two things can already speak for an identity:
+//!
+//! - another record's claim, and
+//! - a registered Solana owner, because owner identity drops the SEC1 parity
+//!   prefix: the identity of `0x02 || x` is the identity of the Solana address `x`.
+//!   The registered owner's own record is that reservation, so the claim checks the
+//!   record PDA of the x-coordinate read as an address.
+//!
+//! This is first-claim-wins, not proof of possession: it binds an identity to the
+//! first record that asks for it. An attacker who claims a key before its holder
+//! registers still holds it. Closing that needs a possession proof at registration.
+
+use pinocchio::{cpi::Seed, error::ProgramError, AccountView, Address, ProgramResult};
+use zolana_user_registry_interface::{
+    owner_p256_identity, state::P256_PUBKEY_LEN, P256OwnerClaim, UserRecord, P256_OWNER_CLAIM_SEED,
+    USER_RECORD_SEED,
+};
+
+use super::common::create_pda_account;
+use crate::error::{fail, UserRegistryError};
+
+/// A record's claim on the owner identity of `owner_p256`. `claim` is the identity's
+/// claim PDA, `identity_record` the user record PDA of the x-coordinate read as a
+/// Solana address, and `payer` funds the claim.
+pub struct P256IdentityClaim<'a> {
+    pub claim: &'a mut AccountView,
+    pub identity_record: &'a AccountView,
+    pub payer: &'a AccountView,
+    pub owner_p256: [u8; P256_PUBKEY_LEN],
+    pub record_owner: Address,
+}
+
+impl P256IdentityClaim<'_> {
+    /// Bind the identity to `record_owner`, creating the claim on first use.
+    /// Re-claiming an identity this owner already holds is a no-op, so rotating
+    /// other keys or re-setting the same `owner_p256` stays possible.
+    pub fn bind(self, program_id: &Address) -> ProgramResult {
+        let identity = owner_p256_identity(&self.owner_p256);
+        self.check_identity_is_not_a_registered_owner(&identity, program_id)?;
+
+        let (expected_claim, bump) =
+            Address::find_program_address(&[P256_OWNER_CLAIM_SEED, &identity], program_id);
+        if self.claim.address() != &expected_claim {
+            return Err(fail(UserRegistryError::InvalidP256ClaimAccount));
+        }
+
+        if self.claim.owned_by(program_id) {
+            let data = self.claim.try_borrow()?;
+            let held = P256OwnerClaim::try_from_account_data(&data)
+                .map_err(|_| fail(UserRegistryError::InvalidP256ClaimAccount))?;
+            if held.owner.as_array() != self.record_owner.as_array() {
+                return Err(fail(UserRegistryError::P256IdentityAlreadyClaimed));
+            }
+            return Ok(());
+        }
+
+        if !self.claim.is_writable() || !self.claim.is_data_empty() {
+            return Err(fail(UserRegistryError::InvalidP256ClaimAccount));
+        }
+
+        let bump_seed = [bump];
+        let seeds = [
+            Seed::from(P256_OWNER_CLAIM_SEED),
+            Seed::from(&identity[..]),
+            Seed::from(&bump_seed[..]),
+        ];
+        create_pda_account(
+            self.claim,
+            self.payer,
+            &seeds,
+            P256OwnerClaim::SPACE,
+            program_id,
+        )?;
+        write_claim(
+            self.claim,
+            &P256OwnerClaim {
+                owner: (*self.record_owner.as_array()).into(),
+                bump,
+            },
+        )
+    }
+
+    /// A key whose x-coordinate is a registered owner's address has that owner's
+    /// identity, so only that owner may claim it.
+    fn check_identity_is_not_a_registered_owner(
+        &self,
+        identity: &[u8; 32],
+        program_id: &Address,
+    ) -> ProgramResult {
+        let (expected, _) =
+            Address::find_program_address(&[USER_RECORD_SEED, identity], program_id);
+        if self.identity_record.address() != &expected {
+            return Err(fail(UserRegistryError::InvalidP256IdentityAccount));
+        }
+        if identity == self.record_owner.as_array() {
+            return Ok(());
+        }
+        if !self.identity_record.owned_by(program_id) {
+            return Ok(());
+        }
+        let data = self.identity_record.try_borrow()?;
+        if data.first() == Some(&UserRecord::DISCRIMINATOR) {
+            return Err(fail(UserRegistryError::P256IdentityIsRegisteredOwner));
+        }
+        Ok(())
+    }
+}
+
+fn write_claim(claim: &mut AccountView, state: &P256OwnerClaim) -> ProgramResult {
+    let body = borsh::to_vec(state).map_err(|_| ProgramError::InvalidAccountData)?;
+    let needed = P256OwnerClaim::DISCRIMINATOR_LEN + body.len();
+    let mut data = claim.try_borrow_mut()?;
+    if data.len() < needed {
+        return Err(ProgramError::AccountDataTooSmall);
+    }
+    data[0] = P256OwnerClaim::DISCRIMINATOR;
+    data[1..needed].copy_from_slice(&body);
+    Ok(())
+}

--- a/programs/user-registry/src/instructions/register.rs
+++ b/programs/user-registry/src/instructions/register.rs
@@ -1,10 +1,18 @@
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 use zolana_user_registry_interface::{instruction::RegisterData, UserRecord};
 
-use super::common::{check_record_pda, check_system_program, create_record_account, write_record};
+use super::{
+    common::{check_record_pda, check_system_program, create_record_account, write_record},
+    p256_identity::P256IdentityClaim,
+};
 use crate::error::{fail, UserRegistryError};
 
 /// Creates a per-owner record with static shielded keys and no sync delegate.
+///
+/// Accounts: `[record (writable), owner (writable signer), system_program]`, plus
+/// `[p256_claim (writable), p256_identity_record]` when `data.owner_p256` is set:
+/// the record's owner identity must be exclusively its own, see
+/// [`P256IdentityClaim`].
 pub fn process_register(
     program_id: &Address,
     accounts: &mut [AccountView],
@@ -15,8 +23,9 @@ pub fn process_register(
     }
     let (head, tail) = accounts.split_at_mut(1);
     let record = &mut head[0];
-    let owner = &tail[0];
-    let system_program = &tail[1];
+    let (fixed, p256_accounts) = tail.split_at_mut(2);
+    let owner = &fixed[0];
+    let system_program = &fixed[1];
 
     if !owner.is_signer() {
         return Err(ProgramError::MissingRequiredSignature);
@@ -31,6 +40,23 @@ pub fn process_register(
 
     if record.owned_by(program_id) || !record.is_data_empty() {
         return Err(ProgramError::AccountAlreadyInitialized);
+    }
+
+    if let Some(owner_p256) = data.owner_p256 {
+        if p256_accounts.len() < 2 {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+        let (claim, identity_record) = p256_accounts.split_at_mut(1);
+        let claim = &mut claim[0];
+        let identity_record = &identity_record[0];
+        P256IdentityClaim {
+            claim,
+            identity_record,
+            payer: owner,
+            owner_p256,
+            record_owner: owner_address,
+        }
+        .bind(program_id)?;
     }
 
     create_record_account(

--- a/programs/user-registry/src/instructions/update_keys.rs
+++ b/programs/user-registry/src/instructions/update_keys.rs
@@ -1,10 +1,19 @@
 use pinocchio::{error::ProgramError, AccountView, Address, ProgramResult};
 use zolana_user_registry_interface::instruction::UpdateKeysData;
 
-use super::common::{check_record_pda_with_bump, read_record, write_record};
+use super::{
+    common::{check_record_pda_with_bump, check_system_program, read_record, write_record},
+    p256_identity::P256IdentityClaim,
+};
 use crate::error::{fail, UserRegistryError};
 
 /// Updates the shielded keys stored in an existing user record.
+///
+/// Accounts: `[record (writable), owner (signer)]`, plus `[system_program,
+/// p256_claim (writable), p256_identity_record]` when `data.owner_p256` is set,
+/// which claims that owner identity for this record exactly as registration does.
+/// The previously claimed identity stays reserved for this owner, so a rotation is
+/// reversible.
 pub fn process_update_keys(
     program_id: &Address,
     accounts: &mut [AccountView],
@@ -15,7 +24,8 @@ pub fn process_update_keys(
     }
     let (head, tail) = accounts.split_at_mut(1);
     let record = &mut head[0];
-    let owner = &tail[0];
+    let (fixed, p256_accounts) = tail.split_at_mut(1);
+    let owner = &fixed[0];
 
     if !owner.is_signer() {
         return Err(ProgramError::MissingRequiredSignature);
@@ -25,6 +35,25 @@ pub fn process_update_keys(
     check_record_pda_with_bump(record, state.owner.as_array(), state.bump, program_id)?;
     if state.owner.as_array() != owner.address().as_array() {
         return Err(fail(UserRegistryError::OwnerMismatch));
+    }
+
+    if let Some(owner_p256) = data.owner_p256 {
+        if p256_accounts.len() < 3 {
+            return Err(ProgramError::NotEnoughAccountKeys);
+        }
+        let (system_program, rest) = p256_accounts.split_at_mut(1);
+        let (claim, identity_record) = rest.split_at_mut(1);
+        let claim = &mut claim[0];
+        let identity_record = &identity_record[0];
+        check_system_program(&system_program[0])?;
+        P256IdentityClaim {
+            claim,
+            identity_record,
+            payer: owner,
+            owner_p256,
+            record_owner: *owner.address(),
+        }
+        .bind(program_id)?;
     }
 
     state.owner_p256 = data.owner_p256;


### PR DESCRIPTION
## Bug

- `merge_transact` takes the merged owner's signing key, viewing key, and `merging_enabled` flag from a `user_record` account, checking only that the account is owned by the registry program and starts with the `UserRecord` discriminator. Any record the registry created passes both checks, so the caller chooses which record the pool reads.
- The proof covers one of those three fields. The circuit checks `signing_pk_field` against the owner hash in each input and output UTXO, so a substituted signing key fails verification. The viewing key is only checked against the ciphertext, and `merging_enabled` is not a circuit input.
- A caller holding the owner's secrets (a current or former sync delegate) can therefore supply another record and have the output encrypted with a key the owner does not hold. The owner cannot decrypt it, so the output's blinding stays unknown to them and they cannot compute its nullifier, while the inputs are nullified either way. The merged balance is unspendable. The same substitution reads `merging_enabled` off the chosen record, so turning the flag off does not stop the merge.

## Fix

- The shielded pool re-derives the record's canonical PDA from the `owner` and `bump` the record stores, and returns `InvalidUserRecord` on a mismatch. The address is then what identifies the owner: on the ed25519 rail the signing key comes from that same `owner`, which the circuit already checks against the UTXOs.
- That is not enough on the P256 rail. The address establishes whose record it is, but `register` writes `owner_p256` without checking that the registrant holds the matching private key, so two records could hold the same key. `register` and `update_keys` now record the identity in a `P256OwnerClaim` PDA and reject a key that another record already holds, or whose x-coordinate is a registered owner's address. The second case is the parity collision: owner identity drops the SEC1 prefix byte, so `0x02 || solana_address` produces the identity of that Solana address.
- Claims are first-come rather than proof of possession, so an identity claimed before its holder registers stays with the first claimant. Closing that needs a secp256r1 signature at registration, which cannot land here because the registry tests register placeholder P256 keys with no known private key.

## Test plan

- [x] `just build-programs`, then `cargo test -p shielded-pool-tests --test merge_user_record`: 3 passed (3 failed before the fix, `Custom(7008)` where `Custom(7018)` is required)
- [x] `just test-shielded-pool`: green, including the prover-backed p256 transact test and 33 BDD scenarios
- [x] `cargo test -p user-registry-tests`: 29 scenarios, 5 of them new
- [x] localnet merge lifecycle, both rails with real proofs and registrations (`merge.feature`, `merge_eddsa.feature`): 18 scenarios passed
- [x] `cargo test -p zolana-wallet`, `cargo fmt --check`, `cargo clippy` on the touched crates
