### PR TITLE
feat: reimburse foresters for nullifier batches

### DIFF
--- a/forester/src/forest.rs
+++ b/forester/src/forest.rs
@@ -54,6 +54,7 @@ pub fn build_forester_execute_ix(
     let inner = BatchUpdateNullifierTree {
         authority: vault,
         tree: pool_tree,
+        reimbursement_recipient: *member,
         new_root: batch_update.new_root,
         old_root: batch_update.old_root,
         zkp_batch_index: batch_update.zkp_batch_index,
@@ -116,11 +117,13 @@ mod tests {
     fn inner_instruction_targets_spp_with_vault_authority() {
         let settings = Pubkey::new_unique();
         let tree = Pubkey::new_unique();
+        let member = Pubkey::new_unique();
         let (vault, _) = smart_account_pda(&settings, 0);
 
         let ix = BatchUpdateNullifierTree {
             authority: vault,
             tree,
+            reimbursement_recipient: member,
             new_root: [1u8; 32],
             old_root: [5u8; 32],
             zkp_batch_index: 0,
@@ -147,6 +150,7 @@ mod tests {
                 AccountMeta::new_readonly(vault, true),
                 AccountMeta::new_readonly(pda::protocol_config(), false),
                 AccountMeta::new(tree, false),
+                AccountMeta::new(member, false),
                 AccountMeta::new_readonly(program_id, false),
             ],
             data: encode_instruction(tag::BATCH_UPDATE_NULLIFIER_TREE, &data),

--- a/program-libs/interface/src/error.rs
+++ b/program-libs/interface/src/error.rs
@@ -78,6 +78,12 @@ pub enum ShieldedPoolError {
     MissingP256SigningKey = 7024,
     #[error("output owner tag account index is out of range")]
     OwnerTagAccountMissing = 7025,
+    #[error("forester fee calculation overflowed or used an invalid tree configuration")]
+    InvalidForesterFee = 7026,
+    #[error("tree does not contain enough fee funds to reimburse the forester")]
+    InsufficientForesterFeeBalance = 7027,
+    #[error("system program account is invalid")]
+    InvalidSystemProgram = 7028,
 }
 
 impl From<ShieldedPoolError> for ProgramError {
@@ -141,6 +147,9 @@ mod tests {
             (BothPublicAmountsSet as u32, 7023),
             (MissingP256SigningKey as u32, 7024),
             (OwnerTagAccountMissing as u32, 7025),
+            (InvalidForesterFee as u32, 7026),
+            (InsufficientForesterFeeBalance as u32, 7027),
+            (InvalidSystemProgram as u32, 7028),
         ];
         for (got, want) in table {
             assert_eq!(got, want, "error code drifted");

--- a/program-libs/interface/src/instruction/builders/batch_update_nullifier_tree.rs
+++ b/program-libs/interface/src/instruction/builders/batch_update_nullifier_tree.rs
@@ -9,6 +9,7 @@ use crate::{
 pub struct BatchUpdateNullifierTree {
     pub authority: Pubkey,
     pub tree: Pubkey,
+    pub reimbursement_recipient: Pubkey,
     pub new_root: [u8; 32],
     pub old_root: [u8; 32],
     pub zkp_batch_index: u16,
@@ -36,6 +37,7 @@ impl BatchUpdateNullifierTree {
                 AccountMeta::new_readonly(self.authority, true),
                 AccountMeta::new_readonly(pda::protocol_config(), false),
                 AccountMeta::new(self.tree, false),
+                AccountMeta::new(self.reimbursement_recipient, false),
                 AccountMeta::new_readonly(PROGRAM_ID_PUBKEY, false),
             ],
             data: encode_instruction(tag::BATCH_UPDATE_NULLIFIER_TREE, &data),

--- a/program-libs/interface/src/instruction/builders/merge_transact.rs
+++ b/program-libs/interface/src/instruction/builders/merge_transact.rs
@@ -31,6 +31,7 @@ impl MergeTransact {
             AccountMeta::new(self.tree, false),
             AccountMeta::new(self.payer, true),
             AccountMeta::new_readonly(self.user_record, false),
+            AccountMeta::new_readonly(Pubkey::default(), false),
             AccountMeta::new_readonly(PROGRAM_ID_PUBKEY, false),
         ];
 

--- a/program-libs/interface/src/instruction/builders/merge_zone.rs
+++ b/program-libs/interface/src/instruction/builders/merge_zone.rs
@@ -54,6 +54,7 @@ impl MergeZone {
             AccountMeta::new(self.tree, false),
             AccountMeta::new_readonly(zone_config, auth_signer),
             AccountMeta::new(self.payer, true),
+            AccountMeta::new_readonly(Pubkey::default(), false),
             AccountMeta::new_readonly(PROGRAM_ID_PUBKEY, false),
         ];
 
@@ -107,7 +108,13 @@ mod tests {
         let keys: Vec<_> = ix.accounts.iter().map(|m| m.pubkey).collect();
         assert_eq!(
             keys,
-            vec![builder.tree, zone_config, builder.payer, PROGRAM_ID_PUBKEY]
+            vec![
+                builder.tree,
+                zone_config,
+                builder.payer,
+                Pubkey::default(),
+                PROGRAM_ID_PUBKEY
+            ]
         );
         // `.instruction()` targets the zone program, so the `zone_auth` PDA is not
         // a transaction-level signer.

--- a/program-libs/interface/src/instruction/builders/transact.rs
+++ b/program-libs/interface/src/instruction/builders/transact.rs
@@ -62,8 +62,6 @@ impl Transact {
             Some(TransactWithdrawal::Sol(sol)) => {
                 accounts.push(AccountMeta::new(SOL_INTERFACE_PUBKEY, false));
                 accounts.push(AccountMeta::new(sol.recipient, false));
-                // System program for the `settle_sol` Transfer CPI.
-                accounts.push(AccountMeta::new_readonly(Pubkey::default(), false));
             }
             Some(TransactWithdrawal::Spl(spl)) => {
                 if let Some(cpi_authority) = spl.cpi_authority {
@@ -76,6 +74,9 @@ impl Transact {
             }
             None => {}
         }
+        // System program for the forester-fee collection CPI and, on the native
+        // SOL rail, public settlement.
+        accounts.push(AccountMeta::new_readonly(Pubkey::default(), false));
         // Program account, loadable for the `emit_event` self-CPI.
         accounts.push(AccountMeta::new_readonly(PROGRAM_ID_PUBKEY, false));
 

--- a/program-libs/interface/src/instruction/builders/zone_authority_transact.rs
+++ b/program-libs/interface/src/instruction/builders/zone_authority_transact.rs
@@ -55,7 +55,6 @@ impl ZoneAuthorityTransact {
             Some(TransactWithdrawal::Sol(sol)) => {
                 accounts.push(AccountMeta::new(SOL_INTERFACE_PUBKEY, false));
                 accounts.push(AccountMeta::new(sol.recipient, false));
-                accounts.push(AccountMeta::new_readonly(Pubkey::default(), false));
             }
             Some(TransactWithdrawal::Spl(spl)) => {
                 if let Some(cpi_authority) = spl.cpi_authority {
@@ -68,6 +67,7 @@ impl ZoneAuthorityTransact {
             }
             None => {}
         }
+        accounts.push(AccountMeta::new_readonly(Pubkey::default(), false));
         accounts.push(AccountMeta::new_readonly(PROGRAM_ID_PUBKEY, false));
 
         Instruction {
@@ -121,7 +121,13 @@ mod tests {
         let keys: Vec<_> = ix.accounts.iter().map(|m| m.pubkey).collect();
         assert_eq!(
             keys,
-            vec![builder.payer, builder.tree, zone_config, PROGRAM_ID_PUBKEY]
+            vec![
+                builder.payer,
+                builder.tree,
+                zone_config,
+                Pubkey::default(),
+                PROGRAM_ID_PUBKEY
+            ]
         );
         assert!(!ix.accounts[2].is_signer);
     }

--- a/program-libs/interface/src/instruction/builders/zone_transact.rs
+++ b/program-libs/interface/src/instruction/builders/zone_transact.rs
@@ -56,8 +56,6 @@ impl ZoneTransact {
             Some(TransactWithdrawal::Sol(sol)) => {
                 accounts.push(AccountMeta::new(SOL_INTERFACE_PUBKEY, false));
                 accounts.push(AccountMeta::new(sol.recipient, false));
-                // System program for the `settle_sol` Transfer CPI.
-                accounts.push(AccountMeta::new_readonly(Pubkey::default(), false));
             }
             Some(TransactWithdrawal::Spl(spl)) => {
                 if let Some(cpi_authority) = spl.cpi_authority {
@@ -70,6 +68,7 @@ impl ZoneTransact {
             }
             None => {}
         }
+        accounts.push(AccountMeta::new_readonly(Pubkey::default(), false));
         // Program account, loadable for the `emit_event` self-CPI.
         accounts.push(AccountMeta::new_readonly(PROGRAM_ID_PUBKEY, false));
 
@@ -105,9 +104,9 @@ mod tests {
         }
     }
 
-    /// A pure shielded `zone_transact` lays out exactly `payer`, `tree`, the
-    /// `ZoneConfig` (canonical `zone_auth` PDA), and the program account, and tags
-    /// the instruction data with `ZONE_TRANSACT`.
+    /// A pure shielded `zone_transact` lays out `payer`, `tree`, the
+    /// `ZoneConfig` (canonical `zone_auth` PDA), the System Program, and the
+    /// program account, and tags the instruction data with `ZONE_TRANSACT`.
     #[test]
     fn instruction_account_order_and_zone_config() {
         let zone_program_id = Pubkey::new_unique();
@@ -127,7 +126,13 @@ mod tests {
         let keys: Vec<_> = ix.accounts.iter().map(|m| m.pubkey).collect();
         assert_eq!(
             keys,
-            vec![builder.payer, builder.tree, zone_config, PROGRAM_ID_PUBKEY]
+            vec![
+                builder.payer,
+                builder.tree,
+                zone_config,
+                Pubkey::default(),
+                PROGRAM_ID_PUBKEY
+            ]
         );
         // `.instruction()` targets the zone program, so the `zone_auth` PDA is not
         // a transaction-level signer.

--- a/program-libs/interface/src/state/mod.rs
+++ b/program-libs/interface/src/state/mod.rs
@@ -11,8 +11,9 @@ pub use spl_asset_counter::SplAssetCounter;
 pub use spl_asset_registry::SplAssetRegistry;
 #[cfg(feature = "tree")]
 pub use tree::{
-    address_tree_params, state_root_offset, tree_account_size, ADDRESS_TREE_HEIGHT,
-    ADDRESS_TREE_INPUT_QUEUE_BATCH_SIZE, ADDRESS_TREE_INPUT_QUEUE_ZKP_BATCH_SIZE,
-    ADDRESS_TREE_ROOT_HISTORY_CAPACITY, STATE_HEIGHT,
+    address_tree_params, forester_fee_per_queue_element, state_root_offset, tree_account_size,
+    ADDRESS_TREE_HEIGHT, ADDRESS_TREE_INPUT_QUEUE_BATCH_SIZE,
+    ADDRESS_TREE_INPUT_QUEUE_ZKP_BATCH_SIZE, ADDRESS_TREE_ROOT_HISTORY_CAPACITY,
+    FORESTER_REIMBURSEMENT_LAMPORTS, STATE_HEIGHT,
 };
 pub use zone_config::ZoneConfig;

--- a/program-libs/interface/src/state/tree.rs
+++ b/program-libs/interface/src/state/tree.rs
@@ -8,6 +8,15 @@ pub const ADDRESS_TREE_INPUT_QUEUE_BATCH_SIZE: u64 = 30_000;
 pub const ADDRESS_TREE_INPUT_QUEUE_ZKP_BATCH_SIZE: u64 = 250;
 pub const ADDRESS_TREE_HEIGHT: u32 = 40;
 pub const ADDRESS_TREE_ROOT_HISTORY_CAPACITY: u32 = 120;
+/// Lamports reimbursed for each applied nullifier-tree ZKP batch.
+pub const FORESTER_REIMBURSEMENT_LAMPORTS: u64 = 5_000;
+
+/// Derive the fee charged for each element inserted into a tree's nullifier
+/// queue. The standard tree configuration is pinned by the test below so the
+/// division is exact.
+pub fn forester_fee_per_queue_element(zkp_batch_size: u64) -> Option<u64> {
+    FORESTER_REIMBURSEMENT_LAMPORTS.checked_div(zkp_batch_size)
+}
 
 /// Canonical nullifier (batched address) tree parameters for the shielded pool.
 pub fn address_tree_params() -> InitAddressTreeAccountsInstructionData {
@@ -28,4 +37,23 @@ pub fn tree_account_size() -> usize {
 /// Byte offset of the state (utxo) tree's current root within the account.
 pub fn state_root_offset() -> usize {
     TreeAccount::state_root_offset()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_tree_forester_fee_exactly_funds_reimbursement() {
+        let zkp_batch_size = address_tree_params().input_queue_zkp_batch_size;
+
+        assert_eq!(FORESTER_REIMBURSEMENT_LAMPORTS % zkp_batch_size, 0);
+        let fee_per_element =
+            forester_fee_per_queue_element(zkp_batch_size).expect("non-zero ZKP batch size");
+        assert_eq!(fee_per_element, 20);
+        assert_eq!(
+            fee_per_element * zkp_batch_size,
+            FORESTER_REIMBURSEMENT_LAMPORTS
+        );
+    }
 }

--- a/program-tests/shielded-pool/tests/common/nullifier_test_forester.rs
+++ b/program-tests/shielded-pool/tests/common/nullifier_test_forester.rs
@@ -40,8 +40,13 @@ impl NullifierTestForester {
         pool_tree: Pubkey,
         queued_nullifiers: &[[u8; 32]],
     ) -> Result<Signature> {
-        let (batch_update, batch_len) =
-            self.build_instruction(rpc, authority.vault, pool_tree, queued_nullifiers)?;
+        let (batch_update, batch_len) = self.build_instruction(
+            rpc,
+            authority.vault,
+            authority.signer.pubkey(),
+            pool_tree,
+            queued_nullifiers,
+        )?;
         let execute = execute_sync_ix(
             &authority.settings,
             authority.account_index,
@@ -61,6 +66,7 @@ impl NullifierTestForester {
         &self,
         rpc: &SolanaRpc,
         authority: Pubkey,
+        reimbursement_recipient: Pubkey,
         pool_tree: Pubkey,
         queued_nullifiers: &[[u8; 32]],
     ) -> Result<(solana_instruction::Instruction, usize)> {
@@ -96,6 +102,7 @@ impl NullifierTestForester {
             BatchUpdateNullifierTree {
                 authority,
                 tree: pool_tree,
+                reimbursement_recipient,
                 new_root: batch_update.new_root,
                 old_root: batch_update.old_root,
                 zkp_batch_index: batch_update.zkp_batch_index,

--- a/program-tests/shielded-pool/tests/transact/transact.rs
+++ b/program-tests/shielded-pool/tests/transact/transact.rs
@@ -50,6 +50,10 @@ fn tree_roots(rpc: &ZolanaProgramTest, tree: &Pubkey) -> ([u8; 32], [u8; 32]) {
     )
 }
 
+fn tree_lamports(rpc: &ZolanaProgramTest, tree: &Pubkey) -> u64 {
+    rpc.svm.get_account(tree).expect("tree account").lamports
+}
+
 /// Boot a program-test environment with a protocol config and one pool tree,
 /// the shared precondition for every `transact` scenario.
 struct TransactEnv {
@@ -173,9 +177,11 @@ fn transact_sends_valid_proof() {
 
     let payer = env.rpc.payer.pubkey();
     let transact_ix_data = build_valid_transact_ix(&env);
+    let tree_balance_before = tree_lamports(&env.rpc, &env.tree.pubkey());
 
-    // Accounts: `[payer (signer), tree (writable)]`. Index 0 is the fee payer
-    // and the eddsa signer the inputs reference (`eddsa_signer_index = 0`).
+    // Index 0 is the fee payer and the eddsa signer the inputs reference
+    // (`eddsa_signer_index = 0`); the builder also supplies the System Program
+    // for the single forester-fee CPI.
     let ix = Transact {
         payer,
         tree: env.tree.pubkey(),
@@ -188,6 +194,12 @@ fn transact_sends_valid_proof() {
         .rpc
         .create_and_send_default_payer_transaction(&[ix], &[]);
     assert!(result.is_ok(), "transact failed: {result:?}");
+    let tree_balance_after = tree_lamports(&env.rpc, &env.tree.pubkey());
+    assert_eq!(
+        tree_balance_after - tree_balance_before,
+        40,
+        "two inserted nullifiers must fund two 20-lamport forester shares"
+    );
 }
 
 /// A tampered output owner tag (changed after proving, so
@@ -203,6 +215,7 @@ fn transact_rejects_tampered_output_view_tag() {
 
     let payer = env.rpc.payer.pubkey();
     let mut transact_ix_data = build_valid_transact_ix(&env);
+    let tree_balance_before = tree_lamports(&env.rpc, &env.tree.pubkey());
 
     // Flip a recipient output's owner tag. The proof committed to the original
     // `hash_field(resolved_owner_tag)`, so the program's reconstruction now
@@ -224,5 +237,10 @@ fn transact_rejects_tampered_output_view_tag() {
     assert!(
         result.is_err(),
         "tampered output view_tag must be rejected, got: {result:?}"
+    );
+    let tree_balance_after = tree_lamports(&env.rpc, &env.tree.pubkey());
+    assert_eq!(
+        tree_balance_after, tree_balance_before,
+        "a rejected transact must not collect a forester fee"
     );
 }

--- a/program-tests/spp-test-validator/tests/world.rs
+++ b/program-tests/spp-test-validator/tests/world.rs
@@ -129,6 +129,9 @@ impl LifecycleWorld {
         // The shielded pool program requires the fee payer == protocol_authority,
         // so we CPI via execute_sync_ix with the protocol vault as the inner fee payer.
         rpc.airdrop(&accounts.protocol_vault, 5_000_000_000)?;
+        // Merge instructions likewise use the merge vault as their inner payer.
+        // Fund it so it can collect the per-nullifier forester fee.
+        rpc.airdrop(&accounts.merge_vault, 5_000_000_000)?;
 
         let create_config_ix = CreateProtocolConfig {
             authority: accounts.protocol_vault,

--- a/programs/shielded-pool/Cargo.toml
+++ b/programs/shielded-pool/Cargo.toml
@@ -34,6 +34,9 @@ zolana-interface = { workspace = true, features = ["borsh"] }
 zolana-tree = { workspace = true }
 zolana-user-registry-interface = { workspace = true }
 
+[dev-dependencies]
+zolana-account-checks = { workspace = true, features = ["test-only"] }
+
 [lints.rust.unexpected_cfgs]
 level = "allow"
 check-cfg = [

--- a/programs/shielded-pool/src/instructions/batch_update_nullifier_tree.rs
+++ b/programs/shielded-pool/src/instructions/batch_update_nullifier_tree.rs
@@ -9,6 +9,7 @@ use zolana_tree::TreeAccount;
 
 use crate::instructions::{
     event::emit_batch_address_append_event, protocol_config::loader::load_protocol_config,
+    shared::reimburse_forester,
 };
 
 pub fn process_batch_update_nullifier_tree(
@@ -21,6 +22,7 @@ pub fn process_batch_update_nullifier_tree(
     let authority = iter.next_signer("authority")?;
     let protocol_config = iter.next_account("protocol_config")?;
     let tree = iter.next_mut("tree")?;
+    let reimbursement_recipient = iter.next_mut("reimbursement_recipient")?;
 
     let config = load_protocol_config(protocol_config)?;
     config
@@ -28,16 +30,19 @@ pub fn process_batch_update_nullifier_tree(
         .map_err(ShieldedPoolError::from)?;
     drop(config);
 
-    let mut tree = TreeAccount::from_account_view_mut(tree, &crate::ID, TREE_ACCOUNT_DISCRIMINATOR)
-        .map_err(ShieldedPoolError::from)?;
-
-    let event = tree
-        .nullifer_tree()
-        .update_tree_from_address_queue(instruction)
-        .map_err(|_| ShieldedPoolError::NullifierTreeUpdateFailed)?;
+    let event = {
+        let mut tree_account =
+            TreeAccount::from_account_view_mut(&mut *tree, &crate::ID, TREE_ACCOUNT_DISCRIMINATOR)
+                .map_err(ShieldedPoolError::from)?;
+        tree_account
+            .nullifer_tree()
+            .update_tree_from_address_queue(instruction)
+            .map_err(|_| ShieldedPoolError::NullifierTreeUpdateFailed)?
+    };
 
     // The emit self-CPI passes no accounts, so the tree borrow does not conflict.
     if let Some(event) = event {
+        reimburse_forester(tree, reimbursement_recipient, event.num_update)?;
         emit_batch_address_append_event(&event)?;
     }
     Ok(())

--- a/programs/shielded-pool/src/instructions/merge/account.rs
+++ b/programs/shielded-pool/src/instructions/merge/account.rs
@@ -9,6 +9,7 @@ use crate::instructions::hash::solana_pk_hash;
 /// `payer` (signer, pays fees), `user_record` (read-only).
 pub struct MergeTransactAccounts<'a> {
     pub tree: &'a mut AccountView,
+    pub payer: &'a AccountView,
     pub user_record: &'a AccountView,
 }
 
@@ -19,9 +20,17 @@ impl<'a> MergeTransactAccounts<'a> {
     ) -> Result<Self, ProgramError> {
         let mut iter = AccountIterator::new(accounts);
         let tree = iter.next_mut("tree")?;
-        let _payer = iter.next_signer("payer")?;
+        let payer = iter.next_signer("payer")?;
         let user_record = iter.next_account("user_record")?;
-        Ok(Self { tree, user_record })
+        let system_program = iter.next_account("system_program")?;
+        if !pinocchio_system::check_id(system_program.address()) {
+            return Err(ShieldedPoolError::InvalidSystemProgram.into());
+        }
+        Ok(Self {
+            tree,
+            payer,
+            user_record,
+        })
     }
 }
 
@@ -78,4 +87,31 @@ pub fn load_user_record(
         viewing: record.viewing_pubkey,
         merging_enabled,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use pinocchio::error::ProgramError;
+    use zolana_account_checks::account_info::test_account_info::get_account_view;
+
+    use super::*;
+
+    #[test]
+    fn rejects_invalid_system_program_with_specific_error() {
+        let mut accounts = [
+            get_account_view([1; 32], crate::ID.to_bytes(), false, true, false, vec![]),
+            get_account_view([2; 32], [0; 32], true, true, false, vec![]),
+            get_account_view([3; 32], [0; 32], false, false, false, vec![]),
+            get_account_view([4; 32], [0; 32], false, false, true, vec![]),
+        ];
+
+        let error = match MergeTransactAccounts::validate_and_parse(&crate::ID, &mut accounts) {
+            Ok(_) => panic!("invalid System Program must fail"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            error,
+            ProgramError::Custom(ShieldedPoolError::InvalidSystemProgram as u32)
+        );
+    }
 }

--- a/programs/shielded-pool/src/instructions/merge/processor.rs
+++ b/programs/shielded-pool/src/instructions/merge/processor.rs
@@ -22,7 +22,10 @@ use super::{
     event::{build_merge_event, MergeTreeWrite},
     verify::{pk_field, MergeOwnerBinding, MergeProof, MergeProofInputs},
 };
-use crate::instructions::{event::emit_general_event, shared::check_not_expired};
+use crate::instructions::{
+    event::emit_general_event,
+    shared::{check_not_expired, collect_forester_fee},
+};
 
 #[inline(never)]
 pub fn process_merge_transact_ix(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
@@ -73,7 +76,14 @@ pub fn process_merge_transact_ix(accounts: &mut [AccountView], data: &[u8]) -> P
         },
     };
 
-    process_merge_core(merge_accounts.tree, &ix, derived, output_view_tag, None)
+    process_merge_core(
+        merge_accounts.tree,
+        merge_accounts.payer,
+        &ix,
+        derived,
+        output_view_tag,
+        None,
+    )
 }
 
 /// Shared tail for `merge_transact` and `merge_zone`: read roots, nullify the
@@ -84,24 +94,33 @@ pub fn process_merge_transact_ix(accounts: &mut [AccountView], data: &[u8]) -> P
 #[inline(never)]
 pub(crate) fn process_merge_core(
     tree_account: &mut AccountView,
+    payer: &AccountView,
     ix: &MergeTransactIxDataRef<'_>,
     mut derived: MergeProofInputs,
     output_view_tag: [u8; 32],
     single_use_tag: Option<[u8; 32]>,
 ) -> ProgramResult {
-    let tree_write = {
+    let (tree_write, zkp_batch_size) = {
         let output_tree = tree_account.address().to_bytes();
         let mut tree = TreeAccount::from_account_view_mut(
-            tree_account,
+            &mut *tree_account,
             &crate::ID,
             TREE_ACCOUNT_DISCRIMINATOR,
         )
         .map_err(tree_error)?;
-        apply_tree(&mut tree, ix, output_tree, &mut derived, single_use_tag)?
+        let tree_write = apply_tree(&mut tree, ix, output_tree, &mut derived, single_use_tag)?;
+        let zkp_batch_size = tree.nullifer_tree().queue_batches.zkp_batch_size;
+        (tree_write, zkp_batch_size)
     };
 
     let event = build_merge_event(ix, tree_write, output_view_tag);
     MergeProof::new(ix, derived).verify()?;
+    collect_forester_fee(
+        payer,
+        tree_account,
+        MERGE_INPUT_COUNT as u64 + u64::from(single_use_tag.is_some()),
+        zkp_batch_size,
+    )?;
     emit_general_event(EventKind::Merge, event)
 }
 

--- a/programs/shielded-pool/src/instructions/merge_zone/account.rs
+++ b/programs/shielded-pool/src/instructions/merge_zone/account.rs
@@ -1,5 +1,6 @@
 use pinocchio::{error::ProgramError, AccountView, Address};
 use zolana_account_checks::AccountIterator;
+use zolana_interface::error::ShieldedPoolError;
 
 use crate::instructions::zone_config::loader::load_zone_config;
 
@@ -10,6 +11,7 @@ use crate::instructions::zone_config::loader::load_zone_config;
 /// check is the zone's authorization.
 pub struct MergeZoneAccounts<'a> {
     pub tree: &'a mut AccountView,
+    pub payer: &'a AccountView,
     /// The calling zone's `program_id`, read from the signed `zone_config`. Bound
     /// into the proof as the UTXO `zone_program_id`.
     pub zone_program_id: Address,
@@ -21,9 +23,14 @@ impl<'a> MergeZoneAccounts<'a> {
         let tree = iter.next_mut("tree")?;
         let zone_config = iter.next_signer("zone_config")?;
         let zone_program_id = load_zone_config(zone_config)?.program_id;
-        iter.next_signer("payer")?;
+        let payer = iter.next_signer("payer")?;
+        let system_program = iter.next_account("system_program")?;
+        if !pinocchio_system::check_id(system_program.address()) {
+            return Err(ShieldedPoolError::InvalidSystemProgram.into());
+        }
         Ok(Self {
             tree,
+            payer,
             zone_program_id,
         })
     }

--- a/programs/shielded-pool/src/instructions/merge_zone/processor.rs
+++ b/programs/shielded-pool/src/instructions/merge_zone/processor.rs
@@ -71,6 +71,7 @@ pub fn process_merge_zone_ix(accounts: &mut [AccountView], data: &[u8]) -> Progr
     // also inserted into the nullifier queue for replay protection.
     process_merge_core(
         merge_accounts.tree,
+        merge_accounts.payer,
         merge,
         derived,
         merge_view_tag,

--- a/programs/shielded-pool/src/instructions/shared.rs
+++ b/programs/shielded-pool/src/instructions/shared.rs
@@ -1,10 +1,88 @@
 use pinocchio::{
     cpi::{Seed, Signer},
     error::ProgramError,
-    sysvars::clock::Clock,
+    sysvars::{clock::Clock, rent::Rent, Sysvar},
     AccountView, Address, ProgramResult,
 };
-use zolana_interface::error::ShieldedPoolError;
+use pinocchio_system::instructions::Transfer;
+use zolana_interface::{
+    error::ShieldedPoolError,
+    state::{forester_fee_per_queue_element, FORESTER_REIMBURSEMENT_LAMPORTS},
+};
+
+/// Collect one tree's per-element forester fee with one System Program CPI.
+///
+/// Every current insertion instruction has one tree. If an instruction gains
+/// multiple trees, aggregate their amounts into the first tree and redistribute
+/// from that program-owned tree, following Light's multi-transfer pattern.
+#[inline(never)]
+pub fn collect_forester_fee(
+    payer: &AccountView,
+    tree: &AccountView,
+    inserted_elements: u64,
+    zkp_batch_size: u64,
+) -> ProgramResult {
+    if !tree.is_writable() || !tree.owned_by(&crate::ID) {
+        return Err(ShieldedPoolError::InvalidTreeAccounts.into());
+    }
+    let amount = forester_fee_amount(inserted_elements, zkp_batch_size)?;
+    if amount == 0 {
+        return Ok(());
+    }
+
+    Transfer {
+        from: payer,
+        to: tree,
+        lamports: amount,
+    }
+    .invoke()
+}
+
+fn forester_fee_amount(inserted_elements: u64, zkp_batch_size: u64) -> Result<u64, ProgramError> {
+    forester_fee_per_queue_element(zkp_batch_size)
+        .and_then(|fee| fee.checked_mul(inserted_elements))
+        .ok_or_else(|| ShieldedPoolError::InvalidForesterFee.into())
+}
+
+/// Reimburse the caller that paid for successfully applied forester batches.
+/// The tree is program-owned, so this transfer requires no CPI.
+pub fn reimburse_forester(
+    tree: &mut AccountView,
+    recipient: &mut AccountView,
+    applied_batches: u32,
+) -> ProgramResult {
+    if applied_batches == 0 {
+        return Ok(());
+    }
+    if tree.address() == recipient.address() {
+        return Err(ShieldedPoolError::InvalidTreeAccounts.into());
+    }
+    let amount = u64::from(applied_batches)
+        .checked_mul(FORESTER_REIMBURSEMENT_LAMPORTS)
+        .ok_or(ShieldedPoolError::InvalidForesterFee)?;
+    let rent_minimum = Rent::get()?.try_minimum_balance(tree.data_len())?;
+    reimburse_forester_with_rent_minimum(tree, recipient, amount, rent_minimum)
+}
+
+fn reimburse_forester_with_rent_minimum(
+    tree: &mut AccountView,
+    recipient: &mut AccountView,
+    amount: u64,
+    rent_minimum: u64,
+) -> ProgramResult {
+    let remaining = tree
+        .lamports()
+        .checked_sub(amount)
+        .filter(|remaining| *remaining >= rent_minimum)
+        .ok_or(ShieldedPoolError::InsufficientForesterFeeBalance)?;
+    let recipient_balance = recipient
+        .lamports()
+        .checked_add(amount)
+        .ok_or(ShieldedPoolError::InvalidForesterFee)?;
+    tree.set_lamports(remaining);
+    recipient.set_lamports(recipient_balance);
+    Ok(())
+}
 
 /// Reject a transaction whose `expiry_unix_ts` has passed (or a negative clock).
 /// Shared by every instruction that carries an `expiry_unix_ts`.
@@ -96,4 +174,60 @@ pub fn verify_pda(
     _program_id: &Address,
 ) -> Result<u8, ProgramError> {
     unimplemented!("verify_pda requires Solana runtime syscalls")
+}
+
+#[cfg(test)]
+mod tests {
+    use zolana_account_checks::account_info::test_account_info::get_account_view;
+
+    use super::*;
+
+    #[test]
+    fn per_tree_fee_scales_with_inserted_elements() {
+        assert_eq!(forester_fee_amount(3, 250).unwrap(), 60);
+    }
+
+    #[test]
+    fn reimbursement_moves_funded_lamports_and_preserves_rent() {
+        let mut tree = get_account_view(
+            [1; 32],
+            crate::ID.to_bytes(),
+            false,
+            true,
+            false,
+            vec![0; 10],
+        );
+        let mut recipient = get_account_view([2; 32], [0; 32], false, true, false, vec![]);
+        tree.set_lamports(6_500);
+        recipient.set_lamports(1_000);
+
+        reimburse_forester_with_rent_minimum(&mut tree, &mut recipient, 5_000, 1_500).unwrap();
+
+        assert_eq!(tree.lamports(), 1_500);
+        assert_eq!(recipient.lamports(), 6_000);
+    }
+
+    #[test]
+    fn reimbursement_cannot_spend_tree_rent() {
+        let mut tree = get_account_view(
+            [1; 32],
+            crate::ID.to_bytes(),
+            false,
+            true,
+            false,
+            vec![0; 10],
+        );
+        let mut recipient = get_account_view([2; 32], [0; 32], false, true, false, vec![]);
+        tree.set_lamports(6_499);
+
+        let error = reimburse_forester_with_rent_minimum(&mut tree, &mut recipient, 5_000, 1_500)
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            ProgramError::Custom(ShieldedPoolError::InsufficientForesterFeeBalance as u32)
+        );
+        assert_eq!(tree.lamports(), 6_499);
+        assert_eq!(recipient.lamports(), 1_000);
+    }
 }

--- a/programs/shielded-pool/src/instructions/transact/account.rs
+++ b/programs/shielded-pool/src/instructions/transact/account.rs
@@ -1,6 +1,8 @@
 use pinocchio::{error::ProgramError, AccountView};
 use zolana_account_checks::AccountIterator;
-use zolana_interface::instruction::instruction_data::transact::TransactIxDataRef;
+use zolana_interface::{
+    error::ShieldedPoolError, instruction::instruction_data::transact::TransactIxDataRef,
+};
 
 use crate::instructions::settlement::{
     validate_cpi_authority, validate_sol_interface, validate_spl_settlement, Settlement,
@@ -75,6 +77,10 @@ impl<'a> TransactAccounts<'a> {
         } else {
             None
         };
+        let system_program = iter.next_account("system_program")?;
+        if !pinocchio_system::check_id(system_program.address()) {
+            return Err(ShieldedPoolError::InvalidSystemProgram.into());
+        }
 
         Ok(Self {
             payer,

--- a/programs/shielded-pool/src/instructions/transact/processor.rs
+++ b/programs/shielded-pool/src/instructions/transact/processor.rs
@@ -27,7 +27,7 @@ use crate::instructions::{
     event::emit_general_event,
     hash::solana_pk_hash,
     settlement::{settle_sol, settle_spl, Settlement},
-    shared::check_not_expired,
+    shared::{check_not_expired, collect_forester_fee},
     transact::verify::{TransactProof, TransactProofInputs},
     verifier,
 };
@@ -125,17 +125,18 @@ pub(crate) fn process_transact_core<const IS_ZONE: bool, const IS_AUTHORITY: boo
         return Err(ShieldedPoolError::BothPublicAmountsSet.into());
     }
 
-    let tree_write = {
+    let (tree_write, zkp_batch_size) = {
         let output_tree = transact_accounts.tree.address().to_bytes();
         // Note currently only one tree is supported for the entire protocol
         let mut tree = TreeAccount::from_account_view_mut(
-            transact_accounts.tree,
+            &mut *transact_accounts.tree,
             &crate::ID,
             TREE_ACCOUNT_DISCRIMINATOR,
         )
         .map_err(tree_error)?;
-
-        apply_tree(&mut tree, ix, output_tree, proof_inputs)?
+        let tree_write = apply_tree(&mut tree, ix, output_tree, proof_inputs)?;
+        let zkp_batch_size = tree.nullifer_tree().queue_batches.zkp_batch_size;
+        (tree_write, zkp_batch_size)
     };
 
     let (user_sol_account, user_spl_token_account, spl_token_interface) =
@@ -172,6 +173,12 @@ pub(crate) fn process_transact_core<const IS_ZONE: bool, const IS_AUTHORITY: boo
         Some(Settlement::Spl(spl)) => settle_spl(spl, public_amount(ix.public_spl_amount)?)?,
         None => {}
     }
+    collect_forester_fee(
+        transact_accounts.payer,
+        transact_accounts.tree,
+        ix.inputs.len() as u64,
+        zkp_batch_size,
+    )?;
     emit_general_event(EventKind::Transact, event)
 }
 

--- a/sdk-tests/dynamic-swap/sdk/src/instructions/create_escrow/instruction.rs
+++ b/sdk-tests/dynamic-swap/sdk/src/instructions/create_escrow/instruction.rs
@@ -39,7 +39,8 @@ impl CreateEscrow {
         } = self;
 
         // SPP resolves each spent input's owner by position within the forwarded
-        // transact account tail: [authority(payer)=0, tree=1, owner=2, program=3].
+        // transact account tail: [authority(payer)=0, tree=1, owner=2,
+        // system_program=3, program=4].
         // create_escrow's two inputs are the source UTXO (owned by `owner`) and
         // maker_funding (owned by `authority`), so route each to its owner's slot.
         const PAYER_POSITION: u8 = 0;
@@ -64,10 +65,11 @@ impl CreateEscrow {
             AccountMeta::new(escrow, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
             // Forwarded SPP `transact` CPI tail: payer, tree, the owner signer,
-            // then the shielded-pool program id last.
+            // System Program for fee collection, then the shielded-pool program.
             AccountMeta::new(authority, true),
             AccountMeta::new(tree, false),
             AccountMeta::new_readonly(owner, true),
+            AccountMeta::new_readonly(Pubkey::default(), false),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];
 

--- a/sdk-tests/dynamic-swap/sdk/src/instructions/create_escrow/instruction.rs
+++ b/sdk-tests/dynamic-swap/sdk/src/instructions/create_escrow/instruction.rs
@@ -39,12 +39,12 @@ impl CreateEscrow {
         } = self;
 
         // SPP resolves each spent input's owner by position within the forwarded
-        // transact account tail: [authority(payer)=0, tree=1, owner=2,
-        // system_program=3, program=4].
+        // transact account tail: [authority(payer)=0, tree=1, system_program=2,
+        // owner=3, program=4].
         // create_escrow's two inputs are the source UTXO (owned by `owner`) and
         // maker_funding (owned by `authority`), so route each to its owner's slot.
         const PAYER_POSITION: u8 = 0;
-        const OWNER_POSITION: u8 = 2;
+        const OWNER_POSITION: u8 = 3;
         route_input(&mut transact, 0, OWNER_POSITION)?;
         route_input(&mut transact, 1, PAYER_POSITION)?;
 
@@ -64,12 +64,12 @@ impl CreateEscrow {
             AccountMeta::new_readonly(pair, false),
             AccountMeta::new(escrow, false),
             AccountMeta::new_readonly(solana_system_interface::program::ID, false),
-            // Forwarded SPP `transact` CPI tail: payer, tree, the owner signer,
-            // System Program for fee collection, then the shielded-pool program.
+            // Forwarded SPP `transact` CPI tail: payer, tree, System Program for
+            // fee collection, the owner signer, then the shielded-pool program.
             AccountMeta::new(authority, true),
             AccountMeta::new(tree, false),
-            AccountMeta::new_readonly(owner, true),
             AccountMeta::new_readonly(Pubkey::default(), false),
+            AccountMeta::new_readonly(owner, true),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];
 

--- a/sdk-tests/dynamic-swap/sdk/src/instructions/settle/instruction.rs
+++ b/sdk-tests/dynamic-swap/sdk/src/instructions/settle/instruction.rs
@@ -35,7 +35,8 @@ impl Settle {
 
         // Both inputs (order, reservation) are owned by the escrow_authority PDA,
         // forwarded at tail slot 2: [caller(payer)=0, tree=1, escrow_authority=2,
-        // program=3]. The program flips the PDA to a signer via invoke_signed.
+        // system_program=3, program=4]. The program flips the PDA to a signer via
+        // invoke_signed.
         const ESCROW_AUTHORITY_POSITION: u8 = 2;
         route_input(&mut transact, 0, ESCROW_AUTHORITY_POSITION)?;
         route_input(&mut transact, 1, ESCROW_AUTHORITY_POSITION)?;
@@ -52,10 +53,12 @@ impl Settle {
             AccountMeta::new(escrow, false),
             AccountMeta::new(rent_recipient, false),
             // Forwarded SPP `transact` CPI tail: payer, tree, the escrow_authority
-            // account (flipped to a signer in-program), then the program id last.
+            // account (flipped to a signer in-program), System Program for fee
+            // collection, then the shielded-pool program.
             AccountMeta::new_readonly(caller, true),
             AccountMeta::new(tree, false),
             AccountMeta::new_readonly(escrow_authority_pda(&pair), false),
+            AccountMeta::new_readonly(Pubkey::default(), false),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];
 

--- a/sdk-tests/dynamic-swap/sdk/src/instructions/settle/instruction.rs
+++ b/sdk-tests/dynamic-swap/sdk/src/instructions/settle/instruction.rs
@@ -34,10 +34,10 @@ impl Settle {
         } = self;
 
         // Both inputs (order, reservation) are owned by the escrow_authority PDA,
-        // forwarded at tail slot 2: [caller(payer)=0, tree=1, escrow_authority=2,
-        // system_program=3, program=4]. The program flips the PDA to a signer via
+        // forwarded at tail slot 3: [caller(payer)=0, tree=1, system_program=2,
+        // escrow_authority=3, program=4]. The program flips the PDA to a signer via
         // invoke_signed.
-        const ESCROW_AUTHORITY_POSITION: u8 = 2;
+        const ESCROW_AUTHORITY_POSITION: u8 = 3;
         route_input(&mut transact, 0, ESCROW_AUTHORITY_POSITION)?;
         route_input(&mut transact, 1, ESCROW_AUTHORITY_POSITION)?;
 
@@ -52,13 +52,13 @@ impl Settle {
             AccountMeta::new_readonly(pair, false),
             AccountMeta::new(escrow, false),
             AccountMeta::new(rent_recipient, false),
-            // Forwarded SPP `transact` CPI tail: payer, tree, the escrow_authority
-            // account (flipped to a signer in-program), System Program for fee
-            // collection, then the shielded-pool program.
+            // Forwarded SPP `transact` CPI tail: payer, tree, System Program for
+            // fee collection, the escrow_authority account (flipped to a signer
+            // in-program), then the shielded-pool program.
             AccountMeta::new_readonly(caller, true),
             AccountMeta::new(tree, false),
-            AccountMeta::new_readonly(escrow_authority_pda(&pair), false),
             AccountMeta::new_readonly(Pubkey::default(), false),
+            AccountMeta::new_readonly(escrow_authority_pda(&pair), false),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];
 

--- a/sdk-tests/rfq/tests/rfq.rs
+++ b/sdk-tests/rfq/tests/rfq.rs
@@ -18,7 +18,9 @@ use zolana_transaction::{
 };
 use zolana_wallet::sync_wallet;
 
-const TAKER_SIGNER_INDEX: u8 = 3;
+// `Transact` appends the System Program and shielded-pool program after the
+// payer/tree pair, so the additional taker signer lands at account index 4.
+const TAKER_SIGNER_INDEX: u8 = 4;
 
 #[test]
 fn cosigned_rfq_settlement() -> Result<()> {

--- a/sdk-tests/timelock-escrow/sdk/src/instructions/escrow/instruction.rs
+++ b/sdk-tests/timelock-escrow/sdk/src/instructions/escrow/instruction.rs
@@ -33,6 +33,7 @@ impl Escrow {
             AccountMeta::new(payer, true),
             AccountMeta::new(payer, true),
             AccountMeta::new(tree, false),
+            AccountMeta::new_readonly(Pubkey::default(), false),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];
         let mut instruction_data = vec![tag::ESCROW];

--- a/sdk-tests/timelock-escrow/sdk/src/instructions/withdraw/instruction.rs
+++ b/sdk-tests/timelock-escrow/sdk/src/instructions/withdraw/instruction.rs
@@ -19,11 +19,11 @@ pub struct Withdraw {
 }
 
 /// The escrow utxo (input 0) is owned by the escrow-authority PDA appended
-/// readonly after `tree`; the timelock escrow program signs for it via
+/// readonly after the System Program; the timelock escrow program signs for it via
 /// `invoke_signed`. The signer index selects the account whose pubkey the SPP
 /// proof's input_owner_pk_hash must match; it is not itself a proof public
 /// input, so overriding it post-proof is safe.
-const ESCROW_AUTHORITY_SIGNER_INDEX: u8 = 2;
+const ESCROW_AUTHORITY_SIGNER_INDEX: u8 = 3;
 
 impl Withdraw {
     pub fn instruction(self) -> Result<Instruction> {
@@ -54,6 +54,7 @@ impl Withdraw {
             AccountMeta::new_readonly(creator, true),
             AccountMeta::new(payer, true),
             AccountMeta::new(tree, false),
+            AccountMeta::new_readonly(Pubkey::default(), false),
             AccountMeta::new_readonly(escrow_authority_pda(), false),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];

--- a/sdk-tests/zk-program-swap/sdk/src/instructions/cancel/instruction.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/instructions/cancel/instruction.rs
@@ -55,6 +55,7 @@ impl Cancel {
             AccountMeta::new(payer, true),
             AccountMeta::new(tree, false),
             AccountMeta::new_readonly(order_authority_pda(), false),
+            AccountMeta::new_readonly(Pubkey::default(), false),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];
         let mut instruction_data = vec![tag::CANCEL];

--- a/sdk-tests/zk-program-swap/sdk/src/instructions/cancel/instruction.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/instructions/cancel/instruction.rs
@@ -24,7 +24,7 @@ pub struct Cancel {
 /// index selects the account whose pubkey the SPP proof's input_owner_pk_hash
 /// must match; it is not itself a proof public input, so overriding it post-proof
 /// is safe.
-const ORDER_AUTHORITY_SIGNER_INDEX: u8 = 2;
+const ORDER_AUTHORITY_SIGNER_INDEX: u8 = 3;
 
 impl Cancel {
     pub fn instruction(self) -> Result<Instruction> {
@@ -54,8 +54,8 @@ impl Cancel {
             AccountMeta::new_readonly(maker, true),
             AccountMeta::new(payer, true),
             AccountMeta::new(tree, false),
-            AccountMeta::new_readonly(order_authority_pda(), false),
             AccountMeta::new_readonly(Pubkey::default(), false),
+            AccountMeta::new_readonly(order_authority_pda(), false),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];
         let mut instruction_data = vec![tag::CANCEL];

--- a/sdk-tests/zk-program-swap/sdk/src/instructions/make/instruction.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/instructions/make/instruction.rs
@@ -59,6 +59,7 @@ impl Make {
             AccountMeta::new(payer, true),
             AccountMeta::new(payer, true),
             AccountMeta::new(tree, false),
+            AccountMeta::new_readonly(Pubkey::default(), false),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];
         let mut instruction_data = vec![tag::MAKE];

--- a/sdk-tests/zk-program-swap/sdk/src/instructions/take/instruction.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/instructions/take/instruction.rs
@@ -40,6 +40,7 @@ impl Take {
             AccountMeta::new(payer, true),
             AccountMeta::new(tree, false),
             AccountMeta::new_readonly(order_authority_pda(), false),
+            AccountMeta::new_readonly(Pubkey::default(), false),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];
         let mut instruction_data = vec![tag::TAKE];

--- a/sdk-tests/zk-program-swap/sdk/src/instructions/take/instruction.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/instructions/take/instruction.rs
@@ -15,7 +15,7 @@ pub struct Take {
     pub spp_proof: TransactIxData,
 }
 
-const ORDER_AUTHORITY_SIGNER_INDEX: u8 = 2;
+const ORDER_AUTHORITY_SIGNER_INDEX: u8 = 3;
 
 impl Take {
     pub fn instruction(self) -> Result<Instruction> {
@@ -39,8 +39,8 @@ impl Take {
             AccountMeta::new(payer, true),
             AccountMeta::new(payer, true),
             AccountMeta::new(tree, false),
-            AccountMeta::new_readonly(order_authority_pda(), false),
             AccountMeta::new_readonly(Pubkey::default(), false),
+            AccountMeta::new_readonly(order_authority_pda(), false),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];
         let mut instruction_data = vec![tag::TAKE];

--- a/sdk-tests/zk-program-swap/sdk/src/instructions/take_verifiable_encryption/instruction.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/instructions/take_verifiable_encryption/instruction.rs
@@ -46,6 +46,7 @@ impl TakeVerifiableEncryption {
             AccountMeta::new(payer, true),
             AccountMeta::new(tree, false),
             AccountMeta::new_readonly(order_authority_pda(), false),
+            AccountMeta::new_readonly(Pubkey::default(), false),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];
         let mut instruction_data = vec![tag::TAKE_VERIFIABLE_ENCRYPTION];

--- a/sdk-tests/zk-program-swap/sdk/src/instructions/take_verifiable_encryption/instruction.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/instructions/take_verifiable_encryption/instruction.rs
@@ -21,7 +21,7 @@ pub struct TakeVerifiableEncryption {
 /// selects the account whose pubkey the SPP proof's input_owner_pk_hash must
 /// match; it is not itself a proof public input, so overriding it post-proof is
 /// safe.
-const ORDER_AUTHORITY_SIGNER_INDEX: u8 = 2;
+const ORDER_AUTHORITY_SIGNER_INDEX: u8 = 3;
 
 impl TakeVerifiableEncryption {
     pub fn instruction(self) -> Result<Instruction> {
@@ -45,8 +45,8 @@ impl TakeVerifiableEncryption {
             AccountMeta::new(payer, true),
             AccountMeta::new(payer, true),
             AccountMeta::new(tree, false),
-            AccountMeta::new_readonly(order_authority_pda(), false),
             AccountMeta::new_readonly(Pubkey::default(), false),
+            AccountMeta::new_readonly(order_authority_pda(), false),
             AccountMeta::new_readonly(Pubkey::new_from_array(SHIELDED_POOL_PROGRAM_ID), false),
         ];
         let mut instruction_data = vec![tag::TAKE_VERIFIABLE_ENCRYPTION];


### PR DESCRIPTION
**Changes:**
1. add reimbursement for forester batch Merkle tree update
2. add collection of lamports to fund forester reimbursement at nullifier queue insertion. Lamports must scale dynamically based on the number of nullifiers and be paid to the tree account the nullifiers are inserted into.
3. use 1 sol transfer via cpi and distribute other lamports by manipulating lamports balances of tree accounts directly without cpi.