### PR TITLE
ci: llvm-cov coverage for host-instrumentable crates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -281,11 +281,14 @@ jobs:
       - run: just test-user-registry-litesvm
 
 
-  # Line/region coverage over the host-instrumentable kernels + SDK. Informational
-  # (prints the summary in the log); code executed inside the SVM is not measured
-  # here (see the `coverage` just recipe). The lcov report is uploaded as a build
-  # artifact; there is no `--fail-under-lines` gate yet — add one when the team
-  # picks a target.
+  # Line/region coverage over every library and binary crate: the program-libs,
+  # the SDK crates, the CLI, forester, photon, and xtask. Informational (prints
+  # the summary in the log). The on-chain programs and the test/example crates
+  # are excluded, and zolana-client is collected `--lib` only, so the job stays
+  # hermetic — no prover, validator, or database (see the `coverage` just
+  # recipe for why). Code executed inside the SVM is not measured here. The lcov
+  # report is uploaded as a build artifact; there is no `--fail-under-lines`
+  # gate yet — add one when the team picks a target.
   coverage:
     name: coverage (llvm-cov)
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -280,15 +280,14 @@ jobs:
         run: cargo build-sbf --tools-version "$SBF_TOOLS_VERSION" --install-only
       - run: just test-user-registry-litesvm
 
-
-  # Line/region coverage over every library and binary crate: the program-libs,
-  # the SDK crates, the CLI, forester, photon, and xtask. Informational (prints
-  # the summary in the log). The on-chain programs and the test/example crates
-  # are excluded, and zolana-client is collected `--lib` only, so the job stays
-  # hermetic — no prover, validator, or database (see the `coverage` just
-  # recipe for why). Code executed inside the SVM is not measured here. The lcov
-  # report is uploaded as a build artifact; there is no `--fail-under-lines`
-  # gate yet — add one when the team picks a target.
+  # Line/region coverage over the library and binary crates: the program-libs,
+  # the SDK crates, the CLI, forester, and photon. Informational — it renders a
+  # summary table into the run's job summary and uploads lcov/HTML reports, but
+  # there is no `--fail-under-lines` gate yet; add one when the team picks a
+  # target. The on-chain programs, the test/example crates, and xtask are
+  # excluded, and zolana-client is collected `--lib` only, so the job stays
+  # hermetic — no prover, validator, or database. See tools/coverage-packages.py
+  # for what is measured and why. Code executed inside the SVM is not measured.
   coverage:
     name: coverage (llvm-cov)
     runs-on: ubuntu-latest
@@ -307,12 +306,8 @@ jobs:
       - run: just coverage --lcov --output-path lcov.info
       - name: Render coverage reports
         run: |
-          cargo llvm-cov report \
-            --ignore-filename-regex '(program-tests|sdk-tests|bench)/' \
-            --html --output-dir coverage-html
-          cargo llvm-cov report \
-            --ignore-filename-regex '(program-tests|sdk-tests|bench)/' \
-            --json --summary-only --output-path coverage.json
+          just coverage-report --html --output-dir coverage-html
+          just coverage-report --json --summary-only --output-path coverage.json
       - name: Publish coverage summary
         run: python3 tools/coverage-summary.py coverage.json >> "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage report
@@ -324,6 +319,7 @@ jobs:
             coverage.json
             coverage-html
           if-no-files-found: error
+
   test-client-integration:
     name: tests / client integration
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -280,6 +280,32 @@ jobs:
         run: cargo build-sbf --tools-version "$SBF_TOOLS_VERSION" --install-only
       - run: just test-user-registry-litesvm
 
+
+  # Line/region coverage over the host-instrumentable kernels + SDK. Informational
+  # (prints the summary in the log); code executed inside the SVM is not measured
+  # here (see the `coverage` just recipe). The lcov report is uploaded as a build
+  # artifact; there is no `--fail-under-lines` gate yet — add one when the team
+  # picks a target.
+  coverage:
+    name: coverage (llvm-cov)
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: ./.github/actions/setup-rust
+        with:
+          shared-key: coverage
+          private-libs-token: ${{ secrets.PRIVATE_LIBS_TOKEN }}
+      - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2
+        with:
+          tool: cargo-llvm-cov
+      - run: just coverage --lcov --output-path lcov.info
+      - name: Upload coverage report
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: lcov.info
+          path: lcov.info
+          if-no-files-found: error
   test-client-integration:
     name: tests / client integration
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -302,12 +302,27 @@ jobs:
       - uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2
         with:
           tool: cargo-llvm-cov
+      # Collect once, then re-render from the same profile data: `report` only
+      # reads what the two passes wrote, so the extra formats are nearly free.
       - run: just coverage --lcov --output-path lcov.info
+      - name: Render coverage reports
+        run: |
+          cargo llvm-cov report \
+            --ignore-filename-regex '(program-tests|sdk-tests|bench)/' \
+            --html --output-dir coverage-html
+          cargo llvm-cov report \
+            --ignore-filename-regex '(program-tests|sdk-tests|bench)/' \
+            --json --summary-only --output-path coverage.json
+      - name: Publish coverage summary
+        run: python3 tools/coverage-summary.py coverage.json >> "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage report
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
-          name: lcov.info
-          path: lcov.info
+          name: coverage
+          path: |
+            lcov.info
+            coverage.json
+            coverage-html
           if-no-files-found: error
   test-client-integration:
     name: tests / client integration

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ docs/spec.pdf
 docs/squads_policy_program.pdf
 build
 target-linux-x64/
+
+# `just coverage` / the CI coverage job write these at the repo root.
+/lcov.info
+/coverage.json
+/coverage-html/

--- a/justfile
+++ b/justfile
@@ -178,7 +178,11 @@ coverage *args="--summary-only":
         --exclude zolana-client \
         --features zolana-interface/solana
     cargo llvm-cov --no-report -p zolana-client --lib --all-features
-    cargo llvm-cov report {{args}}
+    # `--exclude` keeps a crate's own tests from running, but its source is still
+    # instrumented wherever a covered binary links it, so the harness crates would
+    # otherwise land in the report at ~0% and depress the total while measuring
+    # nothing shipped. Drop them from the report by path.
+    cargo llvm-cov report --ignore-filename-regex '(program-tests|sdk-tests|bench)/' {{args}}
 
 # All zolana-client tests (lib unit tests and the proving/integration test
 # binaries). The proving tests spawn the prover server

--- a/justfile
+++ b/justfile
@@ -138,7 +138,11 @@ test-sdk-libs:
 test-photon:
     cargo nextest run -p photon-indexer
 
-# Line/region coverage via cargo-llvm-cov over every library and binary crate.
+# Paths dropped at report time. Single source of truth for `coverage-report`,
+# which both `just coverage` and the CI job go through.
+coverage-ignore-paths := '(program-tests|sdk-tests|bench)/'
+
+# Line/region coverage via cargo-llvm-cov over the library and binary crates.
 # Default prints a summary; `just coverage --html` writes target/llvm-cov/html,
 # `just coverage --lcov --output-path lcov.info` for CI upload. `{{args}}` reaches
 # the report step, so the two collection passes stay fixed.
@@ -154,14 +158,29 @@ test-photon:
 # so a plain `-p zolana-client` would build and run them and they need a live
 # prover server. Keeping this hermetic means no prover, validator, or network.
 coverage *args="--summary-only":
+    #!/usr/bin/env bash
+    # `set -e` matters here: without it a failing coverage-packages.py expands to
+    # no `-p` flags at all, cargo silently falls back to the workspace's
+    # default-members (forester, zolana-interface, shielded-pool-program), and
+    # the job reports that as a successful coverage run.
+    set -euo pipefail
+    packages="$(python3 tools/coverage-packages.py)"
     cargo llvm-cov clean --workspace
-    cargo llvm-cov --no-report $(python3 tools/coverage-packages.py) --features zolana-interface/solana
+    # Unquoted on purpose: the flags must word-split into separate arguments.
+    cargo llvm-cov --no-report $packages --features zolana-interface/solana
     cargo llvm-cov --no-report -p zolana-client --lib --all-features
-    # `--exclude` keeps a crate's own tests from running, but its source is still
-    # instrumented wherever a covered binary links it, so the harness crates would
-    # otherwise land in the report at ~0% and depress the total while measuring
-    # nothing shipped. Drop them from the report by path.
-    cargo llvm-cov report --ignore-filename-regex '(program-tests|sdk-tests|bench)/' {{args}}
+    just coverage-report {{args}}
+
+# Re-render the collected profile data. Split out so `just coverage` and the CI
+# job share one definition of the path filter rather than repeating it per
+# output format.
+#
+# The filter is needed because selecting crates with `-p` keeps a crate's own
+# tests from running but still instruments its source wherever a covered binary
+# links it, so the harness crates would otherwise land in the report at ~0% and
+# depress the total while measuring nothing shipped.
+coverage-report *args="--summary-only":
+    cargo llvm-cov report --ignore-filename-regex '{{ coverage-ignore-paths }}' {{args}}
 
 # All zolana-client tests (lib unit tests and the proving/integration test
 # binaries). The proving tests spawn the prover server

--- a/justfile
+++ b/justfile
@@ -138,6 +138,21 @@ test-sdk-libs:
 test-photon:
     cargo nextest run -p photon-indexer
 
+# Line/region coverage for the host-instrumentable kernels + SDK via
+# cargo-llvm-cov. Default prints a summary; `just coverage --html` writes
+# target/llvm-cov/html, `just coverage --lcov --output-path lcov.info` for CI
+# upload. Scoped to crates whose tests run in-process: llvm-cov instruments the
+# host build, so code executed inside the SVM (the program's on-chain paths, via
+# litesvm/mollusk) is NOT measured here — that surface is covered by the
+# exact-error negative suites. Proof/validator tiers are excluded (external
+# services, dominate runtime).
+coverage *args="--summary-only":
+    cargo llvm-cov {{args}} \
+        -p zolana-interface -p zolana-tree -p zolana-bloom-filter \
+        -p zolana-hasher -p zolana-indexed-array \
+        -p zolana-keypair -p zolana-transaction \
+        --features zolana-interface/solana
+
 # All zolana-client tests (lib unit tests and the proving/integration test
 # binaries). The proving tests spawn the prover server
 # (via the zolana CLI), which lazily downloads any missing proving keys from

--- a/justfile
+++ b/justfile
@@ -143,18 +143,11 @@ test-photon:
 # `just coverage --lcov --output-path lcov.info` for CI upload. `{{args}}` reaches
 # the report step, so the two collection passes stay fixed.
 #
-# Two categories are excluded, both because llvm-cov instruments the HOST build:
-#
-#   - The on-chain programs (`shielded-pool-program`, `zolana-user-registry`).
-#     Their logic executes inside the SVM under litesvm/mollusk, which is not
-#     instrumented, and their host-side unit tests moved into program-tests. So
-#     including them would contribute an all-but-uncovered denominator that
-#     measures nothing. That surface is covered by the exact-error negative
-#     suites instead.
-#   - The test and example crates under program-tests/, sdk-tests/, and bench/.
-#     They are the harness, not the code under test; their coverage of
-#     themselves is meaningless, and the proof/validator tiers need external
-#     services.
+# Which crates are measured is decided by manifest PATH in
+# tools/coverage-packages.py, not by a list of names here: #181 renamed
+# zone-test-program to ring-test-program, a name-based `--exclude` stopped
+# matching, and a test crate silently entered the coverage set and failed the
+# job. See that script for what each excluded directory is and why.
 #
 # `zolana-client` runs as its own pass restricted to `--lib`: its integration
 # targets (transaction_proving, merge_proving, …) declare no required-features,
@@ -162,21 +155,7 @@ test-photon:
 # prover server. Keeping this hermetic means no prover, validator, or network.
 coverage *args="--summary-only":
     cargo llvm-cov clean --workspace
-    cargo llvm-cov --no-report --workspace \
-        --exclude shielded-pool-program --exclude zolana-user-registry \
-        --exclude shielded-pool-tests --exclude spp-test-validator \
-        --exclude zolana-test-utils --exclude user-registry-tests \
-        --exclude zone-test-program --exclude client-example \
-        --exclude dynamic-swap-program --exclude dynamic-swap-prover \
-        --exclude dynamic-swap-sdk --exclude dynamic-swap-test \
-        --exclude rfq-test \
-        --exclude timelock-escrow-program --exclude timelock-escrow-prover \
-        --exclude timelock-escrow-sdk --exclude timelock-escrow-test \
-        --exclude swap-program --exclude swap-prover \
-        --exclude swap-sdk --exclude swap-test-validator \
-        --exclude bloom-filter-bench --exclude tree-bench \
-        --exclude zolana-client \
-        --features zolana-interface/solana
+    cargo llvm-cov --no-report $(python3 tools/coverage-packages.py) --features zolana-interface/solana
     cargo llvm-cov --no-report -p zolana-client --lib --all-features
     # `--exclude` keeps a crate's own tests from running, but its source is still
     # instrumented wherever a covered binary links it, so the harness crates would

--- a/justfile
+++ b/justfile
@@ -138,20 +138,47 @@ test-sdk-libs:
 test-photon:
     cargo nextest run -p photon-indexer
 
-# Line/region coverage for the host-instrumentable kernels + SDK via
-# cargo-llvm-cov. Default prints a summary; `just coverage --html` writes
-# target/llvm-cov/html, `just coverage --lcov --output-path lcov.info` for CI
-# upload. Scoped to crates whose tests run in-process: llvm-cov instruments the
-# host build, so code executed inside the SVM (the program's on-chain paths, via
-# litesvm/mollusk) is NOT measured here — that surface is covered by the
-# exact-error negative suites. Proof/validator tiers are excluded (external
-# services, dominate runtime).
+# Line/region coverage via cargo-llvm-cov over every library and binary crate.
+# Default prints a summary; `just coverage --html` writes target/llvm-cov/html,
+# `just coverage --lcov --output-path lcov.info` for CI upload. `{{args}}` reaches
+# the report step, so the two collection passes stay fixed.
+#
+# Two categories are excluded, both because llvm-cov instruments the HOST build:
+#
+#   - The on-chain programs (`shielded-pool-program`, `zolana-user-registry`).
+#     Their logic executes inside the SVM under litesvm/mollusk, which is not
+#     instrumented, and their host-side unit tests moved into program-tests. So
+#     including them would contribute an all-but-uncovered denominator that
+#     measures nothing. That surface is covered by the exact-error negative
+#     suites instead.
+#   - The test and example crates under program-tests/, sdk-tests/, and bench/.
+#     They are the harness, not the code under test; their coverage of
+#     themselves is meaningless, and the proof/validator tiers need external
+#     services.
+#
+# `zolana-client` runs as its own pass restricted to `--lib`: its integration
+# targets (transaction_proving, merge_proving, …) declare no required-features,
+# so a plain `-p zolana-client` would build and run them and they need a live
+# prover server. Keeping this hermetic means no prover, validator, or network.
 coverage *args="--summary-only":
-    cargo llvm-cov {{args}} \
-        -p zolana-interface -p zolana-tree -p zolana-bloom-filter \
-        -p zolana-hasher -p zolana-indexed-array \
-        -p zolana-keypair -p zolana-transaction \
+    cargo llvm-cov clean --workspace
+    cargo llvm-cov --no-report --workspace \
+        --exclude shielded-pool-program --exclude zolana-user-registry \
+        --exclude shielded-pool-tests --exclude spp-test-validator \
+        --exclude zolana-test-utils --exclude user-registry-tests \
+        --exclude zone-test-program --exclude client-example \
+        --exclude dynamic-swap-program --exclude dynamic-swap-prover \
+        --exclude dynamic-swap-sdk --exclude dynamic-swap-test \
+        --exclude rfq-test \
+        --exclude timelock-escrow-program --exclude timelock-escrow-prover \
+        --exclude timelock-escrow-sdk --exclude timelock-escrow-test \
+        --exclude swap-program --exclude swap-prover \
+        --exclude swap-sdk --exclude swap-test-validator \
+        --exclude bloom-filter-bench --exclude tree-bench \
+        --exclude zolana-client \
         --features zolana-interface/solana
+    cargo llvm-cov --no-report -p zolana-client --lib --all-features
+    cargo llvm-cov report {{args}}
 
 # All zolana-client tests (lib unit tests and the proving/integration test
 # binaries). The proving tests spawn the prover server

--- a/tools/coverage-packages.py
+++ b/tools/coverage-packages.py
@@ -26,7 +26,17 @@ import sys
 #   program-tests/ the harness and the SBF fixture programs it drives.
 #   sdk-tests/     example programs and their SDK/prover scaffolding.
 #   bench/         CU benchmarks, which run under `--ignored` and need SBF builds.
-EXCLUDED_DIRS = ("programs", "program-tests", "sdk-tests", "bench")
+#   xtask/         `publish = false` build and release automation (the
+#                  cargo-xtask pattern), not a shipped artifact. Same blind spot
+#                  as programs/: what exercises it is being RUN -- the justfile's
+#                  `cargo run -p xtask -- program-ids` and the verifying-keys
+#                  smoke job -- as a subprocess this job cannot instrument. It
+#                  measured 4.78% of 1,902 lines, all of it create_release.rs's
+#                  unit tests, while main.rs / init_protocol.rs /
+#                  update_protocol_config.rs sat permanently at 0% and occupied
+#                  the top of the least-covered list ahead of files that should
+#                  actually move.
+EXCLUDED_DIRS = ("programs", "program-tests", "sdk-tests", "bench", "xtask")
 
 # Collected by a separate `--lib` pass: this crate's integration targets declare
 # no required-features, so selecting the whole package would build and run the

--- a/tools/coverage-packages.py
+++ b/tools/coverage-packages.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Emit the `-p <name>` flags selecting which crates `just coverage` measures.
+
+Selection is by manifest PATH, not by crate name, so renaming or adding a crate
+cannot silently change what is covered. Naming the harness crates individually is
+what broke before: #181 renamed `zone-test-program` to `ring-test-program`, the
+stale `--exclude zone-test-program` stopped matching, and a test crate quietly
+entered the coverage set and failed the job.
+
+Everything under `EXCLUDED_DIRS` is left out; every other workspace member is
+covered, so a new library crate is measured the day it lands.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+# Directories whose crates are never measured.
+#
+#   programs/      on-chain programs. Their logic runs inside the SVM under
+#                  litesvm/mollusk, which llvm-cov (a host-build instrumenter)
+#                  cannot see, and their host-side unit tests live in
+#                  program-tests. Measuring them reports ~0% for code that is
+#                  in fact well covered, just not by this tool.
+#   program-tests/ the harness and the SBF fixture programs it drives.
+#   sdk-tests/     example programs and their SDK/prover scaffolding.
+#   bench/         CU benchmarks, which run under `--ignored` and need SBF builds.
+EXCLUDED_DIRS = ("programs", "program-tests", "sdk-tests", "bench")
+
+# Collected by a separate `--lib` pass: this crate's integration targets declare
+# no required-features, so selecting the whole package would build and run the
+# proving suites, which need a live prover server.
+SEPARATE_PASS = ("zolana-client",)
+
+
+def main():
+    meta = json.loads(
+        subprocess.run(
+            ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+            capture_output=True,
+            check=True,
+            text=True,
+        ).stdout
+    )
+    root = meta["workspace_root"]
+
+    selected = []
+    for package in meta["packages"]:
+        rel = os.path.relpath(package["manifest_path"], root)
+        if rel.split(os.sep)[0] in EXCLUDED_DIRS:
+            continue
+        if package["name"] in SEPARATE_PASS:
+            continue
+        selected.append(package["name"])
+
+    if not selected:
+        sys.exit("coverage-packages: selected no crates; check EXCLUDED_DIRS")
+
+    print(" ".join(f"-p {name}" for name in sorted(selected)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/coverage-summary.py
+++ b/tools/coverage-summary.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Render a cargo-llvm-cov JSON export as a GitHub job-summary markdown table.
+
+Usage: coverage-summary.py <llvm-cov-json> [least-covered-count]
+
+Reads the `--json --summary-only` export (llvm-cov's own export format, which
+cargo-llvm-cov passes through) and writes markdown to stdout. Paths are printed
+relative to the repository root so the table stays readable.
+"""
+
+import json
+import os
+import sys
+
+METRICS = (("Lines", "lines"), ("Regions", "regions"), ("Functions", "functions"))
+
+
+def pct(entry):
+    """llvm-cov reports `percent` only when count > 0; treat empty as fully covered."""
+    return entry["percent"] if entry["count"] else 100.0
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(f"usage: {sys.argv[0]} <llvm-cov-json> [least-covered-count]")
+    path = sys.argv[1]
+    limit = int(sys.argv[2]) if len(sys.argv) > 2 else 20
+
+    with open(path) as handle:
+        report = json.load(handle)
+    export = report["data"][0]
+    totals = export["totals"]
+
+    out = ["## Coverage", ""]
+    out.append("| Metric | Covered | Total | % |")
+    out.append("| --- | ---: | ---: | ---: |")
+    for label, key in METRICS:
+        entry = totals[key]
+        out.append(
+            f"| {label} | {entry['covered']:,} | {entry['count']:,} | {pct(entry):.2f}% |"
+        )
+    out.append("")
+
+    root = os.getcwd() + os.sep
+    files = [f for f in export.get("files", []) if f["summary"]["lines"]["count"]]
+    files.sort(key=lambda f: (pct(f["summary"]["lines"]), -f["summary"]["lines"]["count"]))
+
+    if files:
+        shown = files[:limit]
+        out.append(
+            f"<details><summary>{len(shown)} least-covered files "
+            f"(of {len(files)})</summary>"
+        )
+        out.append("")
+        out.append("| File | Lines | Covered | % |")
+        out.append("| --- | ---: | ---: | ---: |")
+        for entry in shown:
+            lines = entry["summary"]["lines"]
+            name = entry["filename"]
+            if name.startswith(root):
+                name = name[len(root) :]
+            out.append(
+                f"| `{name}` | {lines['count']:,} | {lines['covered']:,} "
+                f"| {pct(lines):.2f}% |"
+            )
+        out.append("")
+        out.append("</details>")
+        out.append("")
+
+    out.append(
+        "The full browsable HTML report and `lcov.info` are attached to this run "
+        "as build artifacts."
+    )
+    print("\n".join(out))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds an llvm-cov coverage job + `just coverage` recipe, extracted from the test-refactor branch so its design can be decided on its own merits.

**Baseline measured locally: 65.2% lines / 58.0% functions / 65.2% regions** over 12,563 lines in six host-instrumentable crates (`zolana-interface`, `-tree`, `-bloom-filter`, `-hasher`, `-indexed-array`, `-keypair`, `-transaction`).

## What this is (and isn't)

- **Is**: line/region coverage over libraries whose tests run in-process. The lcov report uploads as a build artifact.
- **Isn't**: protocol coverage. Code executed inside the SVM (the shielded-pool program's instruction handlers, via LiteSVM/mollusk) is structurally invisible to llvm-cov; proof/validator tiers are excluded by cost. The on-chain surface is covered by the exact-error negative suites instead.

## Open questions for reviewers (why this is a draft)

1. **Scope**: the current six crates omit other natively-coverable packages — `zolana-batched-merkle-tree` (44 unit tests, nullifier-queue state machine), `merkle-tree-metadata`, `account-checks`, `event`, `user-registry-interface`, and `shielded-pool-program --lib` (native KAT/parser tests). Add them?
2. **Gate**: pin `--fail-under-lines` at the measured floor (~65%) so coverage becomes a ratchet, or keep informational-only?
3. **Service**: upload to Codecov/Coveralls for PR diff coverage, or keep the raw artifact?
