### PR TITLE
refactor: remove legacy merge ciphertext encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4364,7 +4364,6 @@ dependencies = [
  "tracing-subscriber",
  "utoipa",
  "yellowstone-grpc-proto",
- "zolana-batched-merkle-tree",
  "zolana-event",
  "zolana-indexer-api",
  "zolana-interface",
@@ -5937,7 +5936,6 @@ dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
  "arrayvec",
- "bincode 2.0.1",
  "borsh",
  "bytemuck",
  "groth16-solana",
@@ -5945,8 +5943,6 @@ dependencies = [
  "light-program-profiler",
  "pinocchio 0.11.2",
  "pinocchio-system",
- "serde_json",
- "solana-loader-v3-interface 8.0.1",
  "spl-token-2022-interface",
  "tinyvec",
  "zolana-account-checks",
@@ -5972,7 +5968,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "solana-account 2.2.1",
- "solana-account 3.4.0",
  "solana-address 2.6.1",
  "solana-compute-budget-interface",
  "solana-instruction 2.3.3",
@@ -7220,20 +7215,6 @@ name = "solana-loader-v3-interface"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e0538d4dbc9022e01616f1c58f2db98ece739c5d5ed4a2ef8737a953e76a2d4"
-dependencies = [
- "serde",
- "serde_bytes",
- "serde_derive",
- "solana-instruction 3.4.0",
- "solana-pubkey 4.2.0",
- "solana-sdk-ids 3.1.0",
-]
-
-[[package]]
-name = "solana-loader-v3-interface"
-version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362b468fbde4c20521b9ff5ef743bc0d9b410455a5a92a8b29fd46954e89345f"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -11058,7 +11039,6 @@ dependencies = [
  "solana-hash 4.5.0",
  "solana-instruction 3.4.0",
  "solana-keypair",
- "solana-loader-v3-interface 8.0.1",
  "solana-message 3.1.0",
  "solana-pubkey 4.2.0",
  "solana-signer",
@@ -11067,7 +11047,6 @@ dependencies = [
  "zolana-client",
  "zolana-interface",
  "zolana-program-test",
- "zolana-smart-account-client",
  "zolana-test-utils",
  "zolana-transaction",
  "zolana-user-registry-interface",
@@ -11490,7 +11469,6 @@ name = "zolana-smart-account-client"
 version = "0.1.0"
 dependencies = [
  "borsh",
- "sha2 0.10.9",
  "solana-instruction 3.4.0",
  "solana-pubkey 4.2.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4364,6 +4364,7 @@ dependencies = [
  "tracing-subscriber",
  "utoipa",
  "yellowstone-grpc-proto",
+ "zolana-batched-merkle-tree",
  "zolana-event",
  "zolana-indexer-api",
  "zolana-interface",
@@ -5936,6 +5937,7 @@ dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
  "arrayvec",
+ "bincode 2.0.1",
  "borsh",
  "bytemuck",
  "groth16-solana",
@@ -5943,6 +5945,8 @@ dependencies = [
  "light-program-profiler",
  "pinocchio 0.11.2",
  "pinocchio-system",
+ "serde_json",
+ "solana-loader-v3-interface 8.0.1",
  "spl-token-2022-interface",
  "tinyvec",
  "zolana-account-checks",
@@ -5968,6 +5972,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "solana-account 2.2.1",
+ "solana-account 3.4.0",
  "solana-address 2.6.1",
  "solana-compute-budget-interface",
  "solana-instruction 2.3.3",
@@ -7215,6 +7220,20 @@ name = "solana-loader-v3-interface"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e0538d4dbc9022e01616f1c58f2db98ece739c5d5ed4a2ef8737a953e76a2d4"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-instruction 3.4.0",
+ "solana-pubkey 4.2.0",
+ "solana-sdk-ids 3.1.0",
+]
+
+[[package]]
+name = "solana-loader-v3-interface"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362b468fbde4c20521b9ff5ef743bc0d9b410455a5a92a8b29fd46954e89345f"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -11039,6 +11058,7 @@ dependencies = [
  "solana-hash 4.5.0",
  "solana-instruction 3.4.0",
  "solana-keypair",
+ "solana-loader-v3-interface 8.0.1",
  "solana-message 3.1.0",
  "solana-pubkey 4.2.0",
  "solana-signer",
@@ -11047,6 +11067,7 @@ dependencies = [
  "zolana-client",
  "zolana-interface",
  "zolana-program-test",
+ "zolana-smart-account-client",
  "zolana-test-utils",
  "zolana-transaction",
  "zolana-user-registry-interface",
@@ -11469,6 +11490,7 @@ name = "zolana-smart-account-client"
 version = "0.1.0"
 dependencies = [
  "borsh",
+ "sha2 0.10.9",
  "solana-instruction 3.4.0",
  "solana-pubkey 4.2.0",
 ]

--- a/program-libs/batched-merkle-tree/src/merkle_tree_update.rs
+++ b/program-libs/batched-merkle-tree/src/merkle_tree_update.rs
@@ -157,6 +157,9 @@ impl<'a, const RH: usize, const NUM_ITERS: usize, const BLOOM: usize, const ZKP:
         // applied zkp batch. See `BatchAddressAppendEvent` for how the per-batch
         // values are derived from each root's position.
         let mut event: Option<BatchAddressAppendEvent> = None;
+        // Exit the loop with `break`, not an early `return`: the
+        // `light_program_profiler::profile` end marker runs on the tail path
+        // only, so early returns would hide this function from CU reports.
         loop {
             // 1. Read the pending zkp batch's cached update; stop if missing or
             //    empty.
@@ -175,7 +178,7 @@ impl<'a, const RH: usize, const NUM_ITERS: usize, const BLOOM: usize, const ZKP:
                 .and_then(|updates| updates.get(zkp_batch_index))
             {
                 Some(cached_update) if cached_update.is_occupied() => *cached_update,
-                _ => return Ok(event),
+                _ => break,
             };
 
             // 2. Stop unless the update's old root matches the account tree root.
@@ -199,7 +202,7 @@ impl<'a, const RH: usize, const NUM_ITERS: usize, const BLOOM: usize, const ZKP:
                     pending_batch_index,
                     zkp_batch_index
                 );
-                return Ok(event);
+                break;
             }
 
             // 3. Apply: advance the tree and mark the zkp batch inserted.
@@ -249,6 +252,7 @@ impl<'a, const RH: usize, const NUM_ITERS: usize, const BLOOM: usize, const ZKP:
             event.num_update += 1;
             event.new_root = cached_update.new_root;
         }
+        Ok(event)
     }
 
     /// Reset the cached update at `[pending_batch_index][zkp_batch_index]` to empty (`occupied = 0`),

--- a/program-libs/event/src/lib.rs
+++ b/program-libs/event/src/lib.rs
@@ -8,11 +8,10 @@ pub use output_data::MessageData;
 pub use output_utxo::OutputUtxo;
 pub use proofless::{
     encode_encrypted_zone_deposit_output, encode_encrypted_zone_deposit_output_ref,
-    encode_output_data, encode_output_data_ref, encode_verifiably_encrypted,
-    is_confidential_encrypted_output, EncryptedZoneDepositData, EncryptedZoneDepositDataRef,
-    EncryptedZoneDepositOutput, EncryptedZoneDepositOutputRef, OutputDataEncoding, ProoflessOutput,
-    ProoflessOutputRef, CONFIDENTIAL_ENCRYPTED_SCHEME_TAG, ENCRYPTED_ZONE_DEPOSIT_SCHEME,
-    PLAINTEXT_OUTPUT_FIXED_LEN,
+    encode_output_data, encode_output_data_ref, is_confidential_encrypted_output,
+    EncryptedZoneDepositData, EncryptedZoneDepositDataRef, EncryptedZoneDepositOutput,
+    EncryptedZoneDepositOutputRef, OutputDataEncoding, ProoflessOutput, ProoflessOutputRef,
+    CONFIDENTIAL_ENCRYPTED_SCHEME_TAG, ENCRYPTED_ZONE_DEPOSIT_SCHEME, PLAINTEXT_OUTPUT_FIXED_LEN,
 };
 
 /// `GeneralEvent`, emitted via the `emit_event` self-CPI by state-changing

--- a/program-libs/event/src/proofless.rs
+++ b/program-libs/event/src/proofless.rs
@@ -79,7 +79,6 @@ pub struct EncryptedZoneDepositOutputRef<'a> {
 pub enum OutputDataEncoding {
     Plaintext(Vec<u8>),
     Encrypted(Vec<u8>),
-    VerifiablyEncrypted(Vec<u8>),
 }
 
 /// Scheme byte inside [`OutputDataEncoding::Encrypted`] for owner-hidden
@@ -89,7 +88,6 @@ pub const ENCRYPTED_ZONE_DEPOSIT_SCHEME: u8 = 8;
 impl OutputDataEncoding {
     pub const PLAINTEXT_TAG: u8 = 0;
     pub const ENCRYPTED_TAG: u8 = 1;
-    pub const VERIFIABLY_ENCRYPTED_TAG: u8 = 2;
 }
 
 /// First byte of the encrypted payload for the confidential encryption scheme.
@@ -159,11 +157,6 @@ pub fn encode_output_data_ref(data: ProoflessOutputRef<'_>) -> Vec<u8> {
         .expect("length placeholder written above")
         .copy_from_slice(&body_len.to_le_bytes());
     out
-}
-
-pub fn encode_verifiably_encrypted(blob: Vec<u8>) -> Vec<u8> {
-    borsh::to_vec(&OutputDataEncoding::VerifiablyEncrypted(blob))
-        .expect("shielded-pool output data serialization is infallible")
 }
 
 /// Encodes the mixed public/encrypted payload used by `zone_deposit`.

--- a/program-tests/shielded-pool/tests/localnet_photon_e2e.rs
+++ b/program-tests/shielded-pool/tests/localnet_photon_e2e.rs
@@ -1023,9 +1023,7 @@ fn nullifier_test_forester_batches_queued_nullifiers_with_photon_indexer() -> Te
                 .output_data()
                 .ok_or_else(|| anyhow!("output slot {slot_index} is not decodable output data"))?
             {
-                OutputDataEncoding::Encrypted(blob)
-                | OutputDataEncoding::VerifiablyEncrypted(blob)
-                | OutputDataEncoding::Plaintext(blob) => blob,
+                OutputDataEncoding::Encrypted(blob) | OutputDataEncoding::Plaintext(blob) => blob,
             };
             let (_scheme, body) = blob
                 .split_first()
@@ -1705,9 +1703,7 @@ fn shield_encrypted_transfer_recovered_by_decryption_for(expected_rail: SpendRai
         .output_data()
         .ok_or_else(|| anyhow!("recipient slot is not decodable output data"))?
     {
-        OutputDataEncoding::Encrypted(blob)
-        | OutputDataEncoding::VerifiablyEncrypted(blob)
-        | OutputDataEncoding::Plaintext(blob) => blob,
+        OutputDataEncoding::Encrypted(blob) | OutputDataEncoding::Plaintext(blob) => blob,
     };
     let (_scheme, recipient_ciphertext) = recipient_blob
         .split_first()

--- a/sdk-libs/client/tests/steps/transfer.rs
+++ b/sdk-libs/client/tests/steps/transfer.rs
@@ -245,9 +245,7 @@ fn assert_outputs(
             continue;
         };
         let blob = match output_data {
-            OutputDataEncoding::Encrypted(blob)
-            | OutputDataEncoding::VerifiablyEncrypted(blob)
-            | OutputDataEncoding::Plaintext(blob) => blob,
+            OutputDataEncoding::Encrypted(blob) | OutputDataEncoding::Plaintext(blob) => blob,
         };
         let (_scheme, body) = blob.split_first().expect("scheme byte plus body");
         let Ok(plaintext) =

--- a/sdk-libs/transaction/benches/wallet_ops.rs
+++ b/sdk-libs/transaction/benches/wallet_ops.rs
@@ -185,7 +185,6 @@ fn decrypt(c: &mut Criterion) {
         .expect("recipient slot");
     let recipient_body = match recipient_slot.output_data().expect("recipient output data") {
         zolana_event::OutputDataEncoding::Encrypted(blob)
-        | zolana_event::OutputDataEncoding::VerifiablyEncrypted(blob)
         | zolana_event::OutputDataEncoding::Plaintext(blob) => blob
             .get(1..)
             .map(<[u8]>::to_vec)

--- a/sdk-libs/transaction/src/serialization/mod.rs
+++ b/sdk-libs/transaction/src/serialization/mod.rs
@@ -105,7 +105,6 @@ pub trait UtxoSerialization {
             EncryptedScheme::Proofless | EncryptedScheme::PlaintextTransfer => {
                 OutputDataEncoding::Plaintext(blob)
             }
-            EncryptedScheme::Merge => OutputDataEncoding::VerifiablyEncrypted(blob),
             _ => OutputDataEncoding::Encrypted(blob),
         };
         let data = borsh::to_vec(&output_data)

--- a/sdk-libs/transaction/src/serialization/scheme.rs
+++ b/sdk-libs/transaction/src/serialization/scheme.rs
@@ -8,7 +8,6 @@ pub enum EncryptedScheme {
     AnonymousSender = 2,
     Confidential = 3,
     Split = 5,
-    Merge = 6,
     PlaintextTransfer = 7,
     ZoneDeposit = 8,
 }
@@ -21,7 +20,6 @@ impl EncryptedScheme {
             2 => Ok(Self::AnonymousSender),
             3 => Ok(Self::Confidential),
             5 => Ok(Self::Split),
-            6 => Ok(Self::Merge),
             7 => Ok(Self::PlaintextTransfer),
             8 => Ok(Self::ZoneDeposit),
             other => Err(TransactionError::BadDiscriminator(other)),

--- a/sdk-libs/transaction/src/wallet/sync.rs
+++ b/sdk-libs/transaction/src/wallet/sync.rs
@@ -61,9 +61,7 @@ impl TxIndex {
             for (slot_index, slot) in tx.output_slots.iter().enumerate() {
                 let blob = match slot.output_data() {
                     Some(
-                        OutputDataEncoding::Encrypted(blob)
-                        | OutputDataEncoding::VerifiablyEncrypted(blob)
-                        | OutputDataEncoding::Plaintext(blob),
+                        OutputDataEncoding::Encrypted(blob) | OutputDataEncoding::Plaintext(blob),
                     ) => blob,
                     None => continue,
                 };
@@ -78,7 +76,6 @@ impl TxIndex {
                     | EncryptedScheme::Confidential
                     | EncryptedScheme::Proofless
                     | EncryptedScheme::PlaintextTransfer
-                    | EncryptedScheme::Merge
                     | EncryptedScheme::ZoneDeposit => {
                         recipient_sites
                             .entry(slot.view_tag)
@@ -696,13 +693,6 @@ impl SyncCtx<'_> {
                         self.report.undecryptable_candidates += 1;
                     }
                 }
-            }
-            OutputDataEncoding::VerifiablyEncrypted(blob) => {
-                // Merge outputs no longer carry verifiable encryption; the only
-                // remaining VerifiablyEncrypted payloads are legacy merge
-                // ciphertexts, which are undecodable here.
-                let _ = blob;
-                self.report.undecryptable_candidates += 1;
             }
         }
         Ok(outcome)

--- a/sdk-libs/transaction/tests/steps/split.rs
+++ b/sdk-libs/transaction/tests/steps/split.rs
@@ -83,7 +83,6 @@ fn decode_split(
     let output_data = zolana_event::OutputDataEncoding::try_from_slice(payload).unwrap();
     let blob = match output_data {
         zolana_event::OutputDataEncoding::Encrypted(blob)
-        | zolana_event::OutputDataEncoding::VerifiablyEncrypted(blob)
         | zolana_event::OutputDataEncoding::Plaintext(blob) => blob,
     };
     let body = blob.get(1..).expect("scheme byte");

--- a/sdk-libs/transaction/tests/steps/transfer.rs
+++ b/sdk-libs/transaction/tests/steps/transfer.rs
@@ -305,7 +305,6 @@ fn decode_recipient(
     let output_data = zolana_event::OutputDataEncoding::try_from_slice(payload).unwrap();
     let blob = match output_data {
         zolana_event::OutputDataEncoding::Encrypted(blob)
-        | zolana_event::OutputDataEncoding::VerifiablyEncrypted(blob)
         | zolana_event::OutputDataEncoding::Plaintext(blob) => blob,
     };
     let body = blob.get(1..).expect("scheme byte");
@@ -329,7 +328,6 @@ fn sender_recovers(world: &mut TransactionWorld, sender: String) {
     let output_data = zolana_event::OutputDataEncoding::try_from_slice(payload).unwrap();
     let blob = match output_data {
         zolana_event::OutputDataEncoding::Encrypted(blob)
-        | zolana_event::OutputDataEncoding::VerifiablyEncrypted(blob)
         | zolana_event::OutputDataEncoding::Plaintext(blob) => blob,
     };
     let body = blob.get(1..).expect("scheme byte");
@@ -375,7 +373,6 @@ fn stranger_cannot(world: &mut TransactionWorld, name: String) {
     let output_data = zolana_event::OutputDataEncoding::try_from_slice(payload).unwrap();
     let blob = match output_data {
         zolana_event::OutputDataEncoding::Encrypted(blob)
-        | zolana_event::OutputDataEncoding::VerifiablyEncrypted(blob)
         | zolana_event::OutputDataEncoding::Plaintext(blob) => blob,
     };
     let body = blob.get(1..).expect("scheme byte");

--- a/sdk-libs/transaction/tests/steps/utxo_encryption.rs
+++ b/sdk-libs/transaction/tests/steps/utxo_encryption.rs
@@ -44,7 +44,6 @@ fn body(ciphertext: &MessageData) -> Vec<u8> {
     let output_data = zolana_event::OutputDataEncoding::try_from_slice(&ciphertext.data).unwrap();
     let blob = match output_data {
         zolana_event::OutputDataEncoding::Encrypted(blob)
-        | zolana_event::OutputDataEncoding::VerifiablyEncrypted(blob)
         | zolana_event::OutputDataEncoding::Plaintext(blob) => blob,
     };
     blob.get(1..).expect("scheme byte").to_vec()

--- a/sdk-libs/wallet/tests/transaction.rs
+++ b/sdk-libs/wallet/tests/transaction.rs
@@ -253,9 +253,7 @@ fn decrypt(
             continue;
         };
         let blob = match output_data {
-            OutputDataEncoding::Encrypted(blob)
-            | OutputDataEncoding::VerifiablyEncrypted(blob)
-            | OutputDataEncoding::Plaintext(blob) => blob,
+            OutputDataEncoding::Encrypted(blob) | OutputDataEncoding::Plaintext(blob) => blob,
         };
         let Some((_scheme, body)) = blob.split_first() else {
             continue;
@@ -539,9 +537,7 @@ fn assemble_carries_ciphertext_and_decrypts() {
         let data = ciphertexts.get(slot_index).unwrap();
         let output_data = OutputDataEncoding::try_from_slice(data).unwrap();
         let blob = match output_data {
-            OutputDataEncoding::Encrypted(blob)
-            | OutputDataEncoding::VerifiablyEncrypted(blob)
-            | OutputDataEncoding::Plaintext(blob) => blob,
+            OutputDataEncoding::Encrypted(blob) | OutputDataEncoding::Plaintext(blob) => blob,
         };
         let (_scheme, body) = blob.split_first().expect("scheme byte plus body");
         body.to_vec()

--- a/services/photon/tests/integration_tests/rings_event_parser_tests.rs
+++ b/services/photon/tests/integration_tests/rings_event_parser_tests.rs
@@ -54,8 +54,8 @@ use solana_account::Account;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use zolana_event::{
-    encode_event_instruction, encode_output_data, encode_verifiably_encrypted, EventKind,
-    GeneralEvent, Input, OutputUtxo, ProoflessOutput, SplTransfer,
+    encode_event_instruction, encode_output_data, EventKind, GeneralEvent, Input,
+    OutputDataEncoding, OutputUtxo, ProoflessOutput, SplTransfer,
 };
 use zolana_indexer_api::{
     GetMerkleProofsRequest, GetNonInclusionProofsRequest, GetRingsByTagsRequest,
@@ -161,9 +161,9 @@ fn parses_encrypted_transfer_event_with_photon_parser() {
     assert_eq!(
         rings_tx.outputs,
         vec![
-            expected_output(0, 2, 8, 18, encode_verifiably_encrypted(vec![1, 2, 3]),),
-            expected_output(1, 3, 9, 19, encode_verifiably_encrypted(vec![4, 5, 6]),),
-            expected_output(2, 4, 10, 20, encode_verifiably_encrypted(vec![7, 8, 9]),),
+            expected_output(0, 2, 8, 18, encode_encrypted(vec![1, 2, 3]),),
+            expected_output(1, 3, 9, 19, encode_encrypted(vec![4, 5, 6]),),
+            expected_output(2, 4, 10, 20, encode_encrypted(vec![7, 8, 9]),),
         ]
     );
 }
@@ -1611,9 +1611,9 @@ fn encrypted_transfer_transaction_info() -> TransactionInfo {
         GeneralEvent {
             inputs: vec![test_input(4, 25), test_input(5, 26)],
             outputs: vec![
-                test_output(8, 18, encode_verifiably_encrypted(vec![1, 2, 3])),
-                test_output(9, 19, encode_verifiably_encrypted(vec![4, 5, 6])),
-                test_output(10, 20, encode_verifiably_encrypted(vec![7, 8, 9])),
+                test_output(8, 18, encode_encrypted(vec![1, 2, 3])),
+                test_output(9, 19, encode_encrypted(vec![4, 5, 6])),
+                test_output(10, 20, encode_encrypted(vec![7, 8, 9])),
             ],
             messages: Vec::new(),
             tx_viewing_pk: [5; 33],
@@ -1724,4 +1724,8 @@ fn batch_update_transaction_info(tree: Pubkey) -> TransactionInfo {
         signature: Signature::from([7; 64]),
         error: None,
     }
+}
+
+fn encode_encrypted(blob: Vec<u8>) -> Vec<u8> {
+    borsh::to_vec(&OutputDataEncoding::Encrypted(blob)).unwrap()
 }


### PR DESCRIPTION
## Summary

Removes `OutputDataEncoding::VerifiablyEncrypted` and `EncryptedScheme::Merge` from the event/wallet encoding.

The merge verifiable-encryption gadget was removed in PR171 (merge outputs are now ciphertext-free, derived deterministically), so nothing produces this variant; SPP has not launched, so no legitimate historical consumer exists; and PR172 (P256 restoration) does not use it. It was dead production code kept alive by test fixtures. It is the last variant, so no wire tags are renumbered.

Changes:

- `program-libs/event`: delete the variant, tag constant, encoder, and decode arms.
- `sdk-libs/transaction` wallet sync: delete the legacy decode arm.
- Photon rings fixtures: use a local `encode_encrypted` helper instead of the deleted public encoder.
- `EncryptedScheme::Merge = 6` removed; byte 6 now decodes as `BadDiscriminator`.

**Confirmation requested from reviewers**: no live cluster has ever emitted tag-2 (`VerifiablyEncrypted`) payloads. If any such data existed, wallets would previously soft-skip it and would now hard-error on decode; pre-launch, there is none.

Also included: `apply_cached_tree_updates` exits its loop with `break` + tail `Ok(event)` instead of early `return` — behavior-identical, but the CU profiler's end marker only fires on the tail path, so the function had silently vanished from benchmark reports (its row is back, ~33k CU for the 120-entry cascade).
