### PR TITLE
test(circuits): pin the dummy-nullifier queue-poisoning class as unsatisfiable

### DIFF
--- a/prover/server/circuits/spp_merge/dummy_nullifier_attack_test.go
+++ b/prover/server/circuits/spp_merge/dummy_nullifier_attack_test.go
@@ -1,0 +1,98 @@
+package merge_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/test"
+
+	merge "zolana/prover/circuits/spp_merge"
+	mergeshared "zolana/prover/circuits/spp_merge/shared"
+	"zolana/prover/prover-test/poseidon"
+)
+
+// Regression tests for INV-MERGE-16 (pre-PR164): the old spp_merge circuit left
+// a dummy slot's published nullifier a free witness -- the derived-nullifier
+// binding was gated on notDummy and distinctness on both-real -- so a merge
+// delegate could park a victim's real nullifier in a padding slot. The program
+// queues every slot's nullifier: the victim's UTXO is burned without its value
+// entering the merged output, and an unprovable queued value halts the
+// strictly-ordered nullifier queue. Post-PR164 a dummy slot's nullifier is
+// derived deterministically in-circuit via
+// MergeDummyNullifier(nullifierSecret, firstNullifier, slotIndex) and bound
+// to the published signal (shared/inputs.go), and distinctness covers
+// real and dummy slots alike.
+
+// refreshDefaultPublicInputHash recomputes the default-rail public input hash
+// from the fixture's current public columns, so a mutated witness fails only on
+// the constraint under test, not the hash binding.
+func refreshDefaultPublicInputHash(t *testing.T, f *mergeWitnessFixture) {
+	t.Helper()
+	asBigInts := func(vs []frontend.Variable) []*big.Int {
+		out := make([]*big.Int, len(vs))
+		for i, v := range vs {
+			out[i] = v.(*big.Int)
+		}
+		return out
+	}
+	f.publicInputHash = hashChain(t, []*big.Int{
+		hashChain(t, asBigInts(f.public.Nullifiers)),
+		f.public.OutputHash.(*big.Int),
+		hashChain(t, asBigInts(f.public.UtxoTreeRoots)),
+		hashChain(t, asBigInts(f.public.NullifierTreeRoots)),
+		f.public.PrivateTxHash.(*big.Int),
+		f.public.ExternalDataHash.(*big.Int),
+		f.public.AllowDummyInputs.(*big.Int),
+		f.userSigningPkHash,
+	})
+}
+
+// TestMergeRejectsVictimNullifierInDummySlot (INV-MERGE-16): publishing the first real
+// input's genuine nullifier in dummy slot 2 -- the delegate burning that UTXO by
+// queuing its nullifier without merging its value -- must not solve, even with a
+// consistent public input hash. The in-circuit nullifier for a dummy slot is
+// MergeDummyNullifier(nullifierSecret, firstNullifier, 2); the binding to the
+// published signal is the sole rejecting constraint (distinctness runs over the
+// unchanged, still-distinct in-circuit nullifiers). Pre-PR164 this witness
+// solved.
+func TestMergeRejectsVictimNullifierInDummySlot(t *testing.T) {
+	assert := test.NewAssert(t)
+	fixture := buildMergeFixture(t, mergeFixtureOptions{})
+	victimNullifier := fixture.public.Nullifiers[0]
+	fixture.public.Nullifiers[2] = victimNullifier
+	refreshDefaultPublicInputHash(t, fixture)
+
+	assert.SolvingFailed(merge.NewMergeCircuit(), fixture.defaultCircuit(), test.WithCurves(ecc.BN254))
+}
+
+// TestMergeAcceptsDerivedDummyNullifiers is the positive control: the fixture
+// publishes exactly MergeDummyNullifier(nullifierSecret, firstNullifier, slot)
+// in every dummy slot, and that witness solves. It also pins the host-side
+// derivation against the circuit's domain and argument order, so the negative
+// test above cannot pass for a broken-baseline reason.
+func TestMergeAcceptsDerivedDummyNullifiers(t *testing.T) {
+	assert := test.NewAssert(t)
+	fixture := buildMergeFixture(t, mergeFixtureOptions{})
+
+	nullifierSecret := fixture.userNullifierSecret
+	firstNullifier := fixture.public.Nullifiers[0].(*big.Int)
+	for slot := 2; slot < merge.MergeInputs; slot++ {
+		want, err := poseidon.Hash([]*big.Int{
+			big.NewInt(mergeshared.MergeDummyNullifierDomain),
+			nullifierSecret,
+			firstNullifier,
+			big.NewInt(int64(slot)),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := fixture.public.Nullifiers[slot].(*big.Int)
+		if got.Cmp(want) != 0 {
+			t.Fatalf("dummy slot %d nullifier: got %x want derived %x", slot, got, want)
+		}
+	}
+
+	assert.SolvingSucceeded(merge.NewMergeCircuit(), fixture.defaultCircuit(), test.WithCurves(ecc.BN254))
+}

--- a/prover/server/circuits/spp_transaction/shared/nullifier_attack_test.go
+++ b/prover/server/circuits/spp_transaction/shared/nullifier_attack_test.go
@@ -1,0 +1,103 @@
+package shared_test
+
+import (
+	"math/big"
+	"testing"
+
+	. "zolana/prover/circuits/spp_transaction/shared"
+
+	"zolana/prover/prover-test/spp/protocol"
+	"zolana/prover/prover-test/spp/spptest"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/test"
+)
+
+// Regression tests for INV-TRANSACT-31/32 (pre-PR164): the old spp_transaction circuit
+// left a padding/dummy input's public Nullifier a free witness -- the
+// derived-nullifier binding was `assertEqualWhen(api, spendOrAddress, ...)`,
+// vacuous for padding, non-inclusion was gated on notDummy, and the ordering
+// check was remapped to 0 < 1 < 2 for dummies. The on-chain program queues
+// every input slot's nullifier, so an attacker could commit an arbitrary,
+// unprovable value (e.g. one already in the nullifier tree, or 0) into the
+// strictly-ordered nullifier queue: batch append requires low < value < next
+// for every queued value, so one poisoned value halts the queue forever and
+// bricks the pool.
+//
+// Post-PR164 every slot (utxo, address, dummy) goes through checkNonInclusion:
+// the in-circuit derived nullifier must equal the public signal, its low-leaf
+// Merkle proof must verify against the public root, and
+// NullifierLowValue < Nullifier < NullifierNextValue must hold over canonical
+// field values. Distinctness across slots is unconditional.
+
+// TestDummyInputRejectsAttackerChosenNullifier (INV-TRANSACT-31): a dummy slot whose public
+// Nullifier is NOT the circuit-derived value must not solve, even with a
+// consistent public input hash. The constant 0xF01 stands in for a tree-resident
+// poison value; against an empty tree the ordering and Merkle checks would pass
+// for it, so the derived-nullifier binding (inputs.go: checkNonInclusion step 1)
+// is the sole rejecting constraint. Pre-PR164 this witness solved.
+func TestDummyInputRejectsAttackerChosenNullifier(t *testing.T) {
+	assert := test.NewAssert(t)
+	shape := protocol.Shape{NInputs: 1, NOutputs: 2}
+	circuit := MustNewCustomZoneEddsaOnlyCircuit(Shape(shape))
+	assignment := buildDummyInputShield(t, 125)
+	assignment.Inputs[0].Nullifier = spptest.Fe(0xF01)
+	refreshPublicInputHash(t, assignment)
+
+	assert.SolvingFailed(circuit, asCustomZoneEddsaOnly(assignment), test.WithCurves(ecc.BN254))
+}
+
+// TestDummyInputRejectsZeroNullifier (INV-TRANSACT-31): nullifier 0 can never enter the
+// indexed nullifier tree -- strict ordering needs NullifierLowValue < 0, which
+// no canonical field value satisfies -- so queuing it would brick the pool.
+// The derived-nullifier binding also rejects it (a Poseidon-derived nullifier
+// is not 0). Pre-PR164 a padding slot could publish 0 freely.
+func TestDummyInputRejectsZeroNullifier(t *testing.T) {
+	assert := test.NewAssert(t)
+	shape := protocol.Shape{NInputs: 1, NOutputs: 2}
+	circuit := MustNewCustomZoneEddsaOnlyCircuit(Shape(shape))
+	assignment := buildDummyInputShield(t, 125)
+	assignment.Inputs[0].Nullifier = spptest.Fe(0)
+	refreshPublicInputHash(t, assignment)
+
+	assert.SolvingFailed(circuit, asCustomZoneEddsaOnly(assignment), test.WithCurves(ecc.BN254))
+}
+
+// TestCircuitRejectsSharedNullifierAcrossSlots (INV-TRANSACT-31): two input slots carrying
+// the same nullifier must not solve. Slot 1 is an exact copy of slot 0 -- same
+// UTXO, same inclusion and non-inclusion witnesses, same derived nullifier --
+// and the outputs are rebalanced to the duplicated input sum, so every per-slot
+// check passes and the unconditional assertDistinctNullifiers
+// (transaction.go) is the sole rejecting constraint. Without it the same UTXO
+// would be spent twice in one proof.
+func TestCircuitRejectsSharedNullifierAcrossSlots(t *testing.T) {
+	assert := test.NewAssert(t)
+	shape := protocol.Shape{NInputs: 2, NOutputs: 2}
+	circuit := MustNewCustomZoneEddsaOnlyCircuit(Shape(shape))
+	assignment := buildCircuitAssignment(t, shape)
+
+	// Duplicate slot 0 into slot 1: identical private witness and public signals,
+	// so the derived nullifier equals the public one in both slots.
+	assignment.Inputs[1] = assignment.Inputs[0]
+
+	// Rebalance: the inputs now contribute 2 * amount0 (100 + 100), so split the
+	// outputs 100/100 and recompute their hashes.
+	for i := range assignment.Outputs {
+		assignment.Outputs[i].Utxo.Amount = spptest.Fe(100)
+		assignment.Outputs[i].Hash = spptest.MustUtxoHash(t, circuitFieldsToUtxo(assignment.Outputs[i].Utxo))
+	}
+
+	// Recompute the private tx hash with the duplicated input hash, then refresh
+	// the public input hash so distinctness is the only failing constraint.
+	inputHash := spptest.MustUtxoHash(t, circuitFieldsToUtxo(assignment.Inputs[0].Utxo))
+	assignment.PrivateTxHash = spptest.MustPrivateTxHash(
+		t,
+		[]*big.Int{inputHash, inputHash},
+		spptest.ToBigInts(assignment.OutputHashes()),
+		noAddressHashes(2),
+		spptest.AsBigInt(assignment.ExternalDataHash),
+	)
+	refreshPublicInputHash(t, assignment)
+
+	assert.SolvingFailed(circuit, asCustomZoneEddsaOnly(assignment), test.WithCurves(ecc.BN254))
+}


### PR DESCRIPTION
Regression tests for the attack class closed by the circuit hardening in #171. A padding/dummy input slot must not be able to publish an attacker-chosen nullifier.

The old circuits left a dummy slot's public `Nullifier` a free witness: the derived-nullifier binding was gated on `notDummy` and non-inclusion was skipped for padding. The program queues every input slot's nullifier, and batch append requires `low < value < next`, so one arbitrary or tree-resident value halts the nullifier queue permanently.

- `spp_transaction` — an attacker-chosen nullifier, nullifier `0`, and two slots sharing one nullifier each fail to solve.
- `spp_merge` — a victim's real nullifier parked in a dummy slot fails to solve, so a merge delegate cannot burn a UTXO without merging its value.
- Positive control — the derived `MergeDummyNullifier` witness solves, and the host-side derivation is pinned against the circuit's domain and argument order.

Each negative refreshes the public input hash first, so the constraint under test is the sole rejecting one. Test-only; extracted from #165. Independent of the other extracted PRs.
