### PR TITLE
forester: expose Prometheus metrics and resolve config at the boundary

### DIFF
--- a/.github/workflows/forester.yml
+++ b/.github/workflows/forester.yml
@@ -34,7 +34,7 @@ env:
 # integration tests will be reintroduced against the new combined tree type.
 jobs:
   unit:
-    name: forester / compile
+    name: forester / compile + test
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
@@ -43,3 +43,7 @@ jobs:
         with:
           private-libs-token: ${{ secrets.PRIVATE_LIBS_TOKEN }}
       - run: cargo check -p forester --all-targets
+        # The crate had no unit tests when this job was written, so it only
+        # compiled them. It now has coverage for config resolution and the
+        # metrics exposition format, which is worth nothing unless CI runs it.
+      - run: cargo test -p forester

--- a/forester/Dockerfile
+++ b/forester/Dockerfile
@@ -9,12 +9,23 @@
 # A bare `docker build forester/` will NOT work; the root .dockerignore keeps the
 # context small.
 #
-# rust:1.95: the workspace pulls solana crates that need a recent toolchain.
+# No build secret is needed. The workspace's three git dependencies
+# (Lightprotocol/groth16-solana, light-program-profiler, token) are all public,
+# so the PRIVATE_LIBS_TOKEN that CI's setup-rust action configures is not
+# required here. Verify with `git ls-remote` before adding secret plumbing.
 #
-# Pinned by digest, and to the same digests services/photon/Dockerfile uses: this
-# image is attested now, and a mutable tag lets one commit produce different
-# bytes depending on when it was built, which is exactly what the attestation is
-# supposed to rule out. Sharing photon's pins also shares the base layers.
+# Ships NO keys. The forester's signing keypair arrives at runtime as PAYER,
+# injected from Secrets Manager by the ECS task definition.
+
+# Pinned by digest, to the same digests services/photon/Dockerfile uses: a
+# mutable tag lets one commit produce different bytes depending on when it was
+# built, which is what the build attestation exists to rule out. Sharing photon's
+# pins also shares the base layers.
+#
+# rust-toolchain.toml pins 1.97.0, so rustup downloads it over this base on every
+# build. That costs ~30s and is harmless: the pinned toolchain is the one that
+# compiles. Moving this FROM to a 1.97 digest would remove the download and
+# unshare photon's layers.
 FROM rust:1.95-slim-bookworm@sha256:d7482085ff5b415f84dba5647ae71606650bdef00db7aeb69f4b3d170c3e4082 AS builder
 WORKDIR /app
 
@@ -31,6 +42,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Repository root as context (kept small by the root .dockerignore, which
 # excludes target/, .git/, proving-keys/, ...).
+#
+# Deliberately not split into a deps-then-source build: pre-building
+# dependencies needs every workspace member's Cargo.toml staged first, and this
+# workspace has enough members that the manifest list silently goes stale. A
+# slower cold build beats a cache that skips a changed crate.
 COPY . .
 RUN cargo build --release --package forester
 
@@ -38,8 +54,23 @@ FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates libssl3 \
     && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/target/release/forester /usr/local/bin/forester
+
+# Runs unprivileged: the forester opens one listening socket and signs with a
+# key from the environment. It never writes to disk. 65532 matches the
+# distroless `nonroot` uid the prover image uses, so both services present the
+# same identity to the platform.
+RUN groupadd --gid 65532 nonroot \
+    && useradd --uid 65532 --gid 65532 --no-create-home --shell /usr/sbin/nologin nonroot
+USER 65532:65532
+
 WORKDIR /app
+
+# Prometheus metrics, served when --metrics-address is passed. Same port the
+# prover uses; the two run as separate ECS services with separate awsvpc ENIs,
+# so there is no collision and one scrape config shape works for both.
+EXPOSE 9998
 
 ENTRYPOINT ["/usr/local/bin/forester"]
 CMD []

--- a/forester/metrics-contract.json
+++ b/forester/metrics-contract.json
@@ -1,23 +1,115 @@
 {
-  "description": "Forester metrics contract — single source of truth for metric names. Both the Rust forester crate and the k8s monitoring repo validate against this file.",
+  "description": "Forester metrics contract \u2014 single source of truth for metric names. Both the Rust forester crate and the k8s monitoring repo validate against this file.",
   "notes": [
     "The `epoch`-labelled entries and the two epoch gauges describe the upstream Light Protocol epoch/registry design. This fork's forester submits through a smart-account vault and has no epoch concept, so it does not serve them; see forester/src/metrics.rs.",
     "forester_batches_submitted_total is this fork's replacement for forester_transactions_processed_total: the same 'work completed' counter, keyed by tree rather than by epoch. It is additive, so consumers validating served-names-are-listed are unaffected."
   ],
   "metrics": [
-    { "name": "queue_length", "labels": ["tree_type", "tree_pubkey"] },
-    { "name": "queue_capacity", "labels": ["tree_type", "tree_pubkey"] },
-    { "name": "forester_last_run_timestamp", "labels": [] },
-    { "name": "forester_transactions_processed_total", "labels": ["epoch"] },
-    { "name": "forester_transaction_timestamp", "labels": ["epoch"] },
-    { "name": "forester_transaction_rate", "labels": ["epoch"] },
-    { "name": "forester_sol_balance", "labels": ["pubkey"] },
-    { "name": "registered_foresters", "labels": ["epoch", "authority"] },
-    { "name": "forester_transactions_failed_total", "labels": ["reason"] },
-    { "name": "forester_batches_submitted_total", "labels": ["tree_type", "tree_pubkey"] },
-    { "name": "forester_epoch_detected", "labels": [] },
-    { "name": "forester_epoch_registered", "labels": [] },
-    { "name": "forester_indexer_response_time_seconds", "labels": ["operation", "tree_type"] },
-    { "name": "forester_indexer_proof_count", "labels": ["tree_type", "tree_pubkey", "metric"] }
+    {
+      "name": "queue_length",
+      "labels": [
+        "tree_type",
+        "tree_pubkey"
+      ]
+    },
+    {
+      "name": "queue_capacity",
+      "labels": [
+        "tree_type",
+        "tree_pubkey"
+      ]
+    },
+    {
+      "name": "queue_zkp_batch_size",
+      "labels": [
+        "tree_type",
+        "tree_pubkey"
+      ]
+    },
+    {
+      "name": "queue_zkp_batches_ready",
+      "labels": [
+        "tree_type",
+        "tree_pubkey"
+      ]
+    },
+    {
+      "name": "queue_zkp_batches_applied",
+      "labels": [
+        "tree_type",
+        "tree_pubkey"
+      ]
+    },
+    {
+      "name": "forester_last_run_timestamp",
+      "labels": []
+    },
+    {
+      "name": "forester_transactions_processed_total",
+      "labels": [
+        "epoch"
+      ]
+    },
+    {
+      "name": "forester_transaction_timestamp",
+      "labels": [
+        "epoch"
+      ]
+    },
+    {
+      "name": "forester_transaction_rate",
+      "labels": [
+        "epoch"
+      ]
+    },
+    {
+      "name": "forester_sol_balance",
+      "labels": [
+        "pubkey"
+      ]
+    },
+    {
+      "name": "registered_foresters",
+      "labels": [
+        "epoch",
+        "authority"
+      ]
+    },
+    {
+      "name": "forester_transactions_failed_total",
+      "labels": [
+        "reason"
+      ]
+    },
+    {
+      "name": "forester_batches_submitted_total",
+      "labels": [
+        "tree_type",
+        "tree_pubkey"
+      ]
+    },
+    {
+      "name": "forester_epoch_detected",
+      "labels": []
+    },
+    {
+      "name": "forester_epoch_registered",
+      "labels": []
+    },
+    {
+      "name": "forester_indexer_response_time_seconds",
+      "labels": [
+        "operation",
+        "tree_type"
+      ]
+    },
+    {
+      "name": "forester_indexer_proof_count",
+      "labels": [
+        "tree_type",
+        "tree_pubkey",
+        "metric"
+      ]
+    }
   ]
 }

--- a/forester/metrics-contract.json
+++ b/forester/metrics-contract.json
@@ -1,5 +1,9 @@
 {
   "description": "Forester metrics contract — single source of truth for metric names. Both the Rust forester crate and the k8s monitoring repo validate against this file.",
+  "notes": [
+    "The `epoch`-labelled entries and the two epoch gauges describe the upstream Light Protocol epoch/registry design. This fork's forester submits through a smart-account vault and has no epoch concept, so it does not serve them; see forester/src/metrics.rs.",
+    "forester_batches_submitted_total is this fork's replacement for forester_transactions_processed_total: the same 'work completed' counter, keyed by tree rather than by epoch. It is additive, so consumers validating served-names-are-listed are unaffected."
+  ],
   "metrics": [
     { "name": "queue_length", "labels": ["tree_type", "tree_pubkey"] },
     { "name": "queue_capacity", "labels": ["tree_type", "tree_pubkey"] },
@@ -10,6 +14,7 @@
     { "name": "forester_sol_balance", "labels": ["pubkey"] },
     { "name": "registered_foresters", "labels": ["epoch", "authority"] },
     { "name": "forester_transactions_failed_total", "labels": ["reason"] },
+    { "name": "forester_batches_submitted_total", "labels": ["tree_type", "tree_pubkey"] },
     { "name": "forester_epoch_detected", "labels": [] },
     { "name": "forester_epoch_registered", "labels": [] },
     { "name": "forester_indexer_response_time_seconds", "labels": ["operation", "tree_type"] },

--- a/forester/src/cli.rs
+++ b/forester/src/cli.rs
@@ -55,5 +55,9 @@ pub enum Commands {
         /// — without proving or submitting.
         #[arg(long)]
         dry_run: bool,
+        /// Serve Prometheus metrics on `host:port`, e.g. 0.0.0.0:9999. Omitted
+        /// serves nothing. Names come from forester/metrics-contract.json.
+        #[arg(long)]
+        metrics_address: Option<String>,
     },
 }

--- a/forester/src/config.rs
+++ b/forester/src/config.rs
@@ -1,0 +1,126 @@
+//! Environment configuration, resolved once at the process boundary.
+//!
+//! Every value the forester needs from the environment is read here, in `main`,
+//! before any work starts. Previously each of `RPC_URL`, `PHOTON_URL`,
+//! `PROVER_URL`, and `PAYER` was read with `env::var` from inside `run` and
+//! `info`, which had three costs:
+//!
+//! - a missing variable surfaced partway through an operation instead of at
+//!   startup, sometimes after network calls had already been made;
+//! - the same variable was read with different strictness in different places
+//!   (`PROVER_URL` was required by `run` and optional in `info`);
+//! - neither entry point could be exercised without mutating process
+//!   environment, so they had no unit tests.
+//!
+//! Resolving into a struct fixes all three and leaves the environment as an
+//! implementation detail of `main`.
+
+use std::env;
+
+use anyhow::{Context, Result};
+use solana_keypair::Keypair;
+
+/// Endpoints and credentials resolved from the environment.
+#[derive(Debug)]
+pub struct ForesterConfig {
+    pub rpc_url: String,
+    pub photon_url: String,
+    /// `None` when `PROVER_URL` is unset. Required to submit, optional for
+    /// read-only commands, so the requirement is enforced where it applies
+    /// rather than at load time.
+    pub prover_url: Option<String>,
+    /// Raw `PAYER` value, not yet parsed into a keypair.
+    ///
+    /// Held as the unparsed string so a caller that does not sign never
+    /// materialises key bytes. `info` reports the forester pubkey when it is
+    /// present and degrades gracefully when it is not.
+    payer: Option<String>,
+}
+
+impl ForesterConfig {
+    /// Read every supported variable. Fails only on the two that no command can
+    /// work without.
+    pub fn from_env() -> Result<Self> {
+        Ok(Self {
+            rpc_url: env::var("RPC_URL").context("RPC_URL is not set")?,
+            photon_url: env::var("PHOTON_URL").context("PHOTON_URL is not set")?,
+            prover_url: env::var("PROVER_URL").ok().filter(|url| !url.is_empty()),
+            payer: env::var("PAYER").ok().filter(|payer| !payer.is_empty()),
+        })
+    }
+
+    /// The prover endpoint, for operations that must submit.
+    pub fn require_prover_url(&self) -> Result<&str> {
+        self.prover_url
+            .as_deref()
+            .context("PROVER_URL is not set (required to prove and submit)")
+    }
+
+    /// Whether a signing key is configured, without parsing it.
+    pub fn has_payer(&self) -> bool {
+        self.payer.is_some()
+    }
+
+    /// Parse `PAYER` into the forester's signing keypair.
+    ///
+    /// A JSON byte array, as `solana-keygen` writes. This is the one place key
+    /// bytes are materialised; see the mainnet gap list for why a remote signer
+    /// should replace it.
+    pub fn signer(&self) -> Result<Keypair> {
+        let payer = self
+            .payer
+            .as_deref()
+            .context("PAYER is not set (forester signing keypair)")?;
+        crate::parse_payer_keypair(payer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The point of the refactor: a config can be built without touching process
+    /// environment, so callers become testable.
+    fn config(prover: Option<&str>, payer: Option<&str>) -> ForesterConfig {
+        ForesterConfig {
+            rpc_url: "http://rpc".into(),
+            photon_url: "http://photon".into(),
+            prover_url: prover.map(str::to_string),
+            payer: payer.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn require_prover_url_reports_the_missing_variable_by_name() {
+        let err = config(None, None).require_prover_url().unwrap_err();
+        assert!(err.to_string().contains("PROVER_URL"));
+    }
+
+    #[test]
+    fn require_prover_url_returns_the_configured_endpoint() {
+        assert_eq!(
+            config(Some("http://prover"), None)
+                .require_prover_url()
+                .unwrap(),
+            "http://prover"
+        );
+    }
+
+    #[test]
+    fn has_payer_does_not_require_a_parseable_key() {
+        assert!(config(None, Some("not-a-keypair")).has_payer());
+        assert!(!config(None, None).has_payer());
+    }
+
+    #[test]
+    fn signer_rejects_a_non_json_payer() {
+        let err = config(None, Some("not-json")).signer().unwrap_err();
+        assert!(err.to_string().contains("JSON byte array"));
+    }
+
+    #[test]
+    fn signer_reports_a_missing_payer_by_name() {
+        let err = config(None, None).signer().unwrap_err();
+        assert!(err.to_string().contains("PAYER"));
+    }
+}

--- a/forester/src/info.rs
+++ b/forester/src/info.rs
@@ -7,14 +7,14 @@
 //! monitoring / gating a run (e.g.
 //! `forester info --json | jq '.nullifier_queue.ready_to_forest_zkp_batches'`).
 
-use std::env;
-
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use serde_json::json;
 use solana_commitment_config::CommitmentConfig;
 use solana_pubkey::Pubkey;
 use solana_rpc_client::rpc_client::RpcClient;
 use solana_signer::Signer;
+
+use crate::config::ForesterConfig;
 use zolana_batched_merkle_tree::batch::BatchState;
 use zolana_tree::TreeAccount;
 
@@ -33,10 +33,9 @@ struct BatchInfo {
 }
 
 /// Print the current state of `tree`, its nullifier queue, and the forester
-/// balance. Reads `RPC_URL`, `PAYER`, and `PROVER_URL` from the environment.
-pub fn run(tree: Pubkey, json_output: bool) -> Result<()> {
-    let rpc_url = env::var("RPC_URL").context("RPC_URL is not set")?;
-    let rpc = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+/// balance. Endpoints and credentials come from `config`.
+pub fn run(config: &ForesterConfig, tree: Pubkey, json_output: bool) -> Result<()> {
+    let rpc = RpcClient::new_with_commitment(config.rpc_url.clone(), CommitmentConfig::confirmed());
 
     let mut data = rpc
         .get_account_with_commitment(&tree, CommitmentConfig::confirmed())
@@ -101,8 +100,8 @@ pub fn run(tree: Pubkey, json_output: bool) -> Result<()> {
     let ready_nullifiers = ready_total.saturating_mul(zkp_batch_size);
 
     // --- forester balance (fee capacity); None when PAYER is unset ---
-    let forester = read_forester(&rpc)?;
-    let prover_url = env::var("PROVER_URL").ok();
+    let forester = read_forester(config, &rpc)?;
+    let prover_url = config.prover_url.clone();
 
     if json_output {
         let value = json!({
@@ -185,12 +184,11 @@ pub fn run(tree: Pubkey, json_output: bool) -> Result<()> {
 /// Resolve the forester keypair from `PAYER` and fetch its balance. `Ok(None)`
 /// when `PAYER` is unset (info still succeeds); errors only when `PAYER` is set
 /// but malformed or the balance RPC fails.
-fn read_forester(rpc: &RpcClient) -> Result<Option<(Pubkey, u64)>> {
-    let payer = match env::var("PAYER") {
-        Ok(payer) => payer,
-        Err(_) => return Ok(None),
-    };
-    let keypair = crate::parse_payer_keypair(&payer)?;
+fn read_forester(config: &ForesterConfig, rpc: &RpcClient) -> Result<Option<(Pubkey, u64)>> {
+    if !config.has_payer() {
+        return Ok(None);
+    }
+    let keypair = config.signer()?;
     let pubkey = keypair.pubkey();
     let lamports = rpc
         .get_balance(&pubkey)

--- a/forester/src/lib.rs
+++ b/forester/src/lib.rs
@@ -4,9 +4,11 @@
 //! submission path only.
 
 pub mod cli;
+pub mod config;
 pub mod forest;
 pub mod info;
 pub mod logging;
+pub mod metrics;
 pub mod run;
 
 pub use forest::{batch_update_nullifier_tree_once, ForestError, ForestParams};

--- a/forester/src/main.rs
+++ b/forester/src/main.rs
@@ -1,8 +1,12 @@
 use std::process::ExitCode;
 
+use anyhow::Result;
 use clap::Parser;
-use forester::cli::{Cli, Commands};
-use forester::run::RunOptions;
+use forester::{
+    cli::{Cli, Commands},
+    config::ForesterConfig,
+    run::RunOptions,
+};
 
 // Plain `fn main` (no Tokio runtime): the prover and photon clients use
 // `reqwest::blocking`, which panics inside an async runtime.
@@ -10,22 +14,29 @@ fn main() -> ExitCode {
     dotenvy::dotenv().ok();
     forester::logging::setup();
 
-    let cli = Cli::parse();
+    match dispatch(Cli::parse()) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("error: {err:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// Run one command. Each arm resolves the environment it needs and no more, so
+/// `start` does not demand endpoints it never uses.
+fn dispatch(cli: Cli) -> Result<()> {
     match cli.command {
         Commands::Start => {
             // Placeholder for the always-on worker (future work): a daemon that
             // watches every configured tree and drains queues continuously.
             // Today, `run --watch` is the drain loop; use it instead.
             tracing::info!("forester: no worker configured");
-            ExitCode::SUCCESS
+            Ok(())
         }
-        Commands::Info { tree, json } => match forester::info::run(tree, json) {
-            Ok(()) => ExitCode::SUCCESS,
-            Err(err) => {
-                eprintln!("error: {err:#}");
-                ExitCode::FAILURE
-            }
-        },
+        Commands::Info { tree, json } => {
+            forester::info::run(&ForesterConfig::from_env()?, tree, json)
+        }
         Commands::Run {
             tree,
             settings,
@@ -34,23 +45,30 @@ fn main() -> ExitCode {
             watch,
             poll_secs,
             dry_run,
+            metrics_address,
         } => {
-            let options = RunOptions {
-                tree,
-                settings,
-                account_index,
-                max_batches,
-                watch,
-                poll_secs,
-                dry_run,
-            };
-            match forester::run::run(options) {
-                Ok(()) => ExitCode::SUCCESS,
-                Err(err) => {
-                    eprintln!("error: {err:#}");
-                    ExitCode::FAILURE
-                }
+            // Resolved before the drain loop so a missing endpoint fails at
+            // startup rather than partway through an iteration.
+            let config = ForesterConfig::from_env()?;
+
+            // Served before the loop too, so a scrape during the first iteration
+            // succeeds rather than connection-refusing.
+            if let Some(address) = metrics_address.as_deref() {
+                forester::metrics::serve(address);
             }
+
+            forester::run::run(
+                &config,
+                RunOptions {
+                    tree,
+                    settings,
+                    account_index,
+                    max_batches,
+                    watch,
+                    poll_secs,
+                    dry_run,
+                },
+            )
         }
     }
 }

--- a/forester/src/metrics.rs
+++ b/forester/src/metrics.rs
@@ -48,6 +48,7 @@ pub mod names {
     pub const LAST_RUN_TIMESTAMP: &str = "forester_last_run_timestamp";
     pub const SOL_BALANCE: &str = "forester_sol_balance";
     pub const TRANSACTIONS_FAILED: &str = "forester_transactions_failed_total";
+    pub const BATCHES_SUBMITTED: &str = "forester_batches_submitted_total";
     pub const INDEXER_RESPONSE_SECONDS: &str = "forester_indexer_response_time_seconds";
     pub const INDEXER_PROOF_COUNT: &str = "forester_indexer_proof_count";
 
@@ -57,6 +58,7 @@ pub mod names {
         LAST_RUN_TIMESTAMP,
         SOL_BALANCE,
         TRANSACTIONS_FAILED,
+        BATCHES_SUBMITTED,
         INDEXER_RESPONSE_SECONDS,
         INDEXER_PROOF_COUNT,
     ];
@@ -129,18 +131,40 @@ pub fn set_sol_balance(pubkey: &str, lamports: u64) {
     );
 }
 
+/// Add to a counter series, creating it on first use.
+fn add(name: &'static str, tags: BTreeMap<&'static str, String>, delta: f64) {
+    let mut registry = registry().lock().expect("metrics registry poisoned");
+    let series = registry.counters.entry(name).or_default();
+    match series.iter_mut().find(|(existing, _)| *existing == tags) {
+        Some(slot) => slot.1 += delta,
+        None => series.push((tags, delta)),
+    }
+}
+
 /// Count a failed submission, bucketed by a short stable reason.
 pub fn count_failure(reason: &str) {
-    let tags = labels(&[("reason", reason)]);
-    let mut registry = registry().lock().expect("metrics registry poisoned");
-    let series = registry
-        .counters
-        .entry(names::TRANSACTIONS_FAILED)
-        .or_default();
-    match series.iter_mut().find(|(existing, _)| *existing == tags) {
-        Some(slot) => slot.1 += 1.0,
-        None => series.push((tags, 1.0)),
+    add(
+        names::TRANSACTIONS_FAILED,
+        labels(&[("reason", reason)]),
+        1.0,
+    );
+}
+
+/// Count zkp-batches successfully submitted on-chain for one tree.
+///
+/// This fork's stand-in for the contract's `forester_transactions_processed_total`,
+/// which is keyed by an epoch this forester does not have. Together with
+/// `forester_last_run_timestamp` it separates "alive" from "making progress": a
+/// forester that loops without submitting is live and useless.
+pub fn count_batches_submitted(tree_pubkey: &str, batches: u64) {
+    if batches == 0 {
+        return;
     }
+    add(
+        names::BATCHES_SUBMITTED,
+        labels(&[("tree_type", "nullifier"), ("tree_pubkey", tree_pubkey)]),
+        batches as f64,
+    );
 }
 
 /// Record how long an indexer call took.
@@ -310,6 +334,26 @@ mod tests {
         assert!(
             out.contains(r#"forester_transactions_failed_total{reason="metrics-test-reason"} 2"#),
             "counter did not accumulate:\n{out}"
+        );
+    }
+
+    /// A counter that only ever increments by one cannot express batch work, and
+    /// a zero submission must not create a series that reads as "submitted here".
+    #[test]
+    fn submitted_batches_accumulate_by_amount_and_ignore_zero() {
+        count_batches_submitted("treeSubmit", 3);
+        count_batches_submitted("treeSubmit", 4);
+        count_batches_submitted("treeZero", 0);
+        let out = render();
+        assert!(
+            out.contains(
+                r#"forester_batches_submitted_total{tree_pubkey="treeSubmit",tree_type="nullifier"} 7"#
+            ),
+            "counter did not add by amount:\n{out}"
+        );
+        assert!(
+            !out.contains("treeZero"),
+            "zero submission created a series:\n{out}"
         );
     }
 

--- a/forester/src/metrics.rs
+++ b/forester/src/metrics.rs
@@ -1,0 +1,320 @@
+//! Prometheus metrics for the forester, served over plain HTTP.
+//!
+//! Only the metrics this forester can actually populate are served. The names
+//! come from `forester/metrics-contract.json`, and `contract_covers_served_names`
+//! below asserts that every served name appears there.
+//!
+//! Six contract entries are deliberately NOT served: `forester_epoch_detected`,
+//! `forester_epoch_registered`, `registered_foresters`, and the three
+//! `epoch`-labelled transaction metrics. They describe the upstream Light
+//! Protocol epoch/registry design; this forester submits through a smart-account
+//! vault and has no epoch concept, so there is nothing to report. A gauge that is
+//! permanently zero reads as healthy data, which is worse than an absent one.
+//!
+//! No HTTP or metrics dependency: the forester is a small synchronous binary that
+//! pulls neither tokio nor hyper, and the Prometheus text format is a few lines.
+//! Adding an async runtime to expose seven gauges would change the binary's
+//! runtime model for no benefit.
+
+use std::{
+    collections::BTreeMap,
+    io::{BufRead, BufReader, Write},
+    net::{TcpListener, TcpStream},
+    sync::{Mutex, OnceLock},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+/// A metric sample: label pairs (sorted, so output is deterministic) and a value.
+type Sample = (BTreeMap<&'static str, String>, f64);
+
+#[derive(Default)]
+struct Registry {
+    /// Gauges keyed by metric name, each holding its label sets.
+    gauges: BTreeMap<&'static str, Vec<Sample>>,
+    /// Counters keyed by metric name. Monotonic; only ever incremented.
+    counters: BTreeMap<&'static str, Vec<Sample>>,
+}
+
+fn registry() -> &'static Mutex<Registry> {
+    static REGISTRY: OnceLock<Mutex<Registry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(Registry::default()))
+}
+
+/// Metric names served by this forester. Every one must appear in the contract
+/// file; see `contract_covers_served_names`.
+pub mod names {
+    pub const QUEUE_LENGTH: &str = "queue_length";
+    pub const QUEUE_CAPACITY: &str = "queue_capacity";
+    pub const LAST_RUN_TIMESTAMP: &str = "forester_last_run_timestamp";
+    pub const SOL_BALANCE: &str = "forester_sol_balance";
+    pub const TRANSACTIONS_FAILED: &str = "forester_transactions_failed_total";
+    pub const INDEXER_RESPONSE_SECONDS: &str = "forester_indexer_response_time_seconds";
+    pub const INDEXER_PROOF_COUNT: &str = "forester_indexer_proof_count";
+
+    pub const ALL: &[&str] = &[
+        QUEUE_LENGTH,
+        QUEUE_CAPACITY,
+        LAST_RUN_TIMESTAMP,
+        SOL_BALANCE,
+        TRANSACTIONS_FAILED,
+        INDEXER_RESPONSE_SECONDS,
+        INDEXER_PROOF_COUNT,
+    ];
+}
+
+fn set(kind: &mut BTreeMap<&'static str, Vec<Sample>>, name: &'static str, labels: Sample) {
+    let series = kind.entry(name).or_default();
+    match series
+        .iter_mut()
+        .find(|(existing, _)| *existing == labels.0)
+    {
+        Some(slot) => slot.1 = labels.1,
+        None => series.push(labels),
+    }
+}
+
+fn labels(pairs: &[(&'static str, &str)]) -> BTreeMap<&'static str, String> {
+    pairs
+        .iter()
+        .map(|(key, value)| (*key, (*value).to_string()))
+        .collect()
+}
+
+/// Record the nullifier queue's depth and capacity for one tree.
+pub fn set_queue(tree_pubkey: &str, length: u64, capacity: u64) {
+    let tags = labels(&[("tree_type", "nullifier"), ("tree_pubkey", tree_pubkey)]);
+    let mut registry = registry().lock().expect("metrics registry poisoned");
+    set(
+        &mut registry.gauges,
+        names::QUEUE_LENGTH,
+        (tags.clone(), length as f64),
+    );
+    set(
+        &mut registry.gauges,
+        names::QUEUE_CAPACITY,
+        (tags, capacity as f64),
+    );
+}
+
+/// Stamp the current time as the last completed run iteration.
+///
+/// This is the metric that answers "is the forester alive?", which is currently
+/// unanswerable without reading logs.
+pub fn mark_run() {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_secs() as f64)
+        .unwrap_or(0.0);
+    let mut registry = registry().lock().expect("metrics registry poisoned");
+    set(
+        &mut registry.gauges,
+        names::LAST_RUN_TIMESTAMP,
+        (BTreeMap::new(), now),
+    );
+}
+
+/// Record the fee payer's balance in SOL.
+///
+/// The forester silently stops being able to submit when this reaches zero, so it
+/// is the metric worth alerting on.
+pub fn set_sol_balance(pubkey: &str, lamports: u64) {
+    let mut registry = registry().lock().expect("metrics registry poisoned");
+    set(
+        &mut registry.gauges,
+        names::SOL_BALANCE,
+        (
+            labels(&[("pubkey", pubkey)]),
+            lamports as f64 / 1_000_000_000.0,
+        ),
+    );
+}
+
+/// Count a failed submission, bucketed by a short stable reason.
+pub fn count_failure(reason: &str) {
+    let tags = labels(&[("reason", reason)]);
+    let mut registry = registry().lock().expect("metrics registry poisoned");
+    let series = registry
+        .counters
+        .entry(names::TRANSACTIONS_FAILED)
+        .or_default();
+    match series.iter_mut().find(|(existing, _)| *existing == tags) {
+        Some(slot) => slot.1 += 1.0,
+        None => series.push((tags, 1.0)),
+    }
+}
+
+/// Record how long an indexer call took.
+pub fn observe_indexer(operation: &str, seconds: f64) {
+    let mut registry = registry().lock().expect("metrics registry poisoned");
+    set(
+        &mut registry.gauges,
+        names::INDEXER_RESPONSE_SECONDS,
+        (
+            labels(&[("operation", operation), ("tree_type", "nullifier")]),
+            seconds,
+        ),
+    );
+}
+
+/// Record a count the indexer reported for a tree, e.g. queued values fetched.
+pub fn set_indexer_proof_count(tree_pubkey: &str, metric: &str, count: u64) {
+    let mut registry = registry().lock().expect("metrics registry poisoned");
+    set(
+        &mut registry.gauges,
+        names::INDEXER_PROOF_COUNT,
+        (
+            labels(&[
+                ("tree_type", "nullifier"),
+                ("tree_pubkey", tree_pubkey),
+                ("metric", metric),
+            ]),
+            count as f64,
+        ),
+    );
+}
+
+fn render_series(out: &mut String, kind: &str, series: &BTreeMap<&'static str, Vec<Sample>>) {
+    for (name, samples) in series {
+        if samples.is_empty() {
+            continue;
+        }
+        out.push_str(&format!("# TYPE {name} {kind}\n"));
+        for (tags, value) in samples {
+            if tags.is_empty() {
+                out.push_str(&format!("{name} {value}\n"));
+                continue;
+            }
+            let rendered = tags
+                .iter()
+                .map(|(key, value)| format!("{key}=\"{}\"", escape(value)))
+                .collect::<Vec<_>>()
+                .join(",");
+            out.push_str(&format!("{name}{{{rendered}}} {value}\n"));
+        }
+    }
+}
+
+/// Escape a label value per the Prometheus exposition format.
+fn escape(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}
+
+/// Render the registry in Prometheus text exposition format.
+pub fn render() -> String {
+    let registry = registry().lock().expect("metrics registry poisoned");
+    let mut out = String::new();
+    render_series(&mut out, "gauge", &registry.gauges);
+    render_series(&mut out, "counter", &registry.counters);
+    out
+}
+
+/// Serve `GET /metrics` on `address` from a background thread.
+///
+/// Failure to bind is logged and ignored: metrics are observability, and the
+/// forester must keep draining the queue without them.
+pub fn serve(address: &str) {
+    let listener = match TcpListener::bind(address) {
+        Ok(listener) => listener,
+        Err(err) => {
+            tracing::warn!(%address, %err, "metrics server failed to bind; continuing without it");
+            return;
+        }
+    };
+    tracing::info!(%address, "metrics server listening on /metrics");
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            match stream {
+                Ok(stream) => {
+                    if let Err(err) = respond(stream) {
+                        tracing::debug!(%err, "metrics request failed");
+                    }
+                }
+                Err(err) => tracing::debug!(%err, "metrics connection failed"),
+            }
+        }
+    });
+}
+
+fn respond(mut stream: TcpStream) -> std::io::Result<()> {
+    let mut request_line = String::new();
+    BufReader::new(&stream).read_line(&mut request_line)?;
+    let path = request_line.split_whitespace().nth(1).unwrap_or("");
+    let (status, body) = if path == "/metrics" {
+        ("200 OK", render())
+    } else {
+        ("404 Not Found", String::new())
+    };
+    stream.write_all(
+        format!(
+            "HTTP/1.1 {status}\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+        .as_bytes(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The contract file calls itself the single source of truth for metric
+    /// names, but nothing in this crate validated against it, which is how six of
+    /// its entries came to describe a design this forester does not have.
+    ///
+    /// Asserts a SUBSET, not equality: the k8s monitoring repo also validates
+    /// against this file, so entries we do not serve must stay listed rather than
+    /// be deleted from under it.
+    #[test]
+    fn contract_covers_served_names() {
+        let contract = include_str!("../metrics-contract.json");
+        let parsed: serde_json::Value = serde_json::from_str(contract).expect("contract is JSON");
+        let listed: Vec<&str> = parsed["metrics"]
+            .as_array()
+            .expect("metrics is an array")
+            .iter()
+            .map(|metric| metric["name"].as_str().expect("name is a string"))
+            .collect();
+
+        for served in names::ALL {
+            assert!(
+                listed.contains(served),
+                "served metric {served} is absent from metrics-contract.json"
+            );
+        }
+    }
+
+    #[test]
+    fn render_emits_labels_and_types() {
+        set_queue("treeAbc", 42, 500);
+        let out = render();
+        assert!(out.contains("# TYPE queue_length gauge"));
+        assert!(out.contains(r#"queue_length{tree_pubkey="treeAbc",tree_type="nullifier"} 42"#));
+        assert!(out.contains(r#"queue_capacity{tree_pubkey="treeAbc",tree_type="nullifier"} 500"#));
+    }
+
+    #[test]
+    fn balance_is_reported_in_sol_not_lamports() {
+        set_sol_balance("payerAbc", 2_500_000_000);
+        assert!(render().contains(r#"forester_sol_balance{pubkey="payerAbc"} 2.5"#));
+    }
+
+    #[test]
+    fn failures_accumulate_per_reason() {
+        count_failure("metrics-test-reason");
+        count_failure("metrics-test-reason");
+        let out = render();
+        assert!(out.contains("# TYPE forester_transactions_failed_total counter"));
+        assert!(
+            out.contains(r#"forester_transactions_failed_total{reason="metrics-test-reason"} 2"#),
+            "counter did not accumulate:\n{out}"
+        );
+    }
+
+    #[test]
+    fn label_values_are_escaped() {
+        assert_eq!(escape(r#"a"b\c"#), r#"a\"b\\c"#);
+    }
+}

--- a/forester/src/metrics.rs
+++ b/forester/src/metrics.rs
@@ -45,6 +45,9 @@ fn registry() -> &'static Mutex<Registry> {
 pub mod names {
     pub const QUEUE_LENGTH: &str = "queue_length";
     pub const QUEUE_CAPACITY: &str = "queue_capacity";
+    pub const QUEUE_ZKP_BATCH_SIZE: &str = "queue_zkp_batch_size";
+    pub const QUEUE_ZKP_BATCHES_READY: &str = "queue_zkp_batches_ready";
+    pub const QUEUE_ZKP_BATCHES_APPLIED: &str = "queue_zkp_batches_applied";
     pub const LAST_RUN_TIMESTAMP: &str = "forester_last_run_timestamp";
     pub const SOL_BALANCE: &str = "forester_sol_balance";
     pub const TRANSACTIONS_FAILED: &str = "forester_transactions_failed_total";
@@ -55,6 +58,9 @@ pub mod names {
     pub const ALL: &[&str] = &[
         QUEUE_LENGTH,
         QUEUE_CAPACITY,
+        QUEUE_ZKP_BATCH_SIZE,
+        QUEUE_ZKP_BATCHES_READY,
+        QUEUE_ZKP_BATCHES_APPLIED,
         LAST_RUN_TIMESTAMP,
         SOL_BALANCE,
         TRANSACTIONS_FAILED,
@@ -95,6 +101,36 @@ pub fn set_queue(tree_pubkey: &str, length: u64, capacity: u64) {
         &mut registry.gauges,
         names::QUEUE_CAPACITY,
         (tags, capacity as f64),
+    );
+}
+
+/// Record how the pending batch decomposes into zkp batches.
+///
+/// `queue_length` alone cannot answer "how much work is outstanding": the
+/// forester proves and submits a zkp batch at a time, so the unit of work is
+/// `zkp_batch_size` leaves. Publishing the size and both batch counts lets a
+/// dashboard show depth in leaves and in batches without hardcoding the size,
+/// which is on-chain configuration and can change.
+///
+/// `ready` is what still has to be proved and submitted; `applied` is what
+/// already has been for this batch.
+pub fn set_zkp_batches(tree_pubkey: &str, zkp_batch_size: u64, ready: u64, applied: u64) {
+    let tags = labels(&[("tree_type", "nullifier"), ("tree_pubkey", tree_pubkey)]);
+    let mut registry = registry().lock().expect("metrics registry poisoned");
+    set(
+        &mut registry.gauges,
+        names::QUEUE_ZKP_BATCH_SIZE,
+        (tags.clone(), zkp_batch_size as f64),
+    );
+    set(
+        &mut registry.gauges,
+        names::QUEUE_ZKP_BATCHES_READY,
+        (tags.clone(), ready as f64),
+    );
+    set(
+        &mut registry.gauges,
+        names::QUEUE_ZKP_BATCHES_APPLIED,
+        (tags, applied as f64),
     );
 }
 
@@ -317,6 +353,24 @@ mod tests {
         assert!(out.contains("# TYPE queue_length gauge"));
         assert!(out.contains(r#"queue_length{tree_pubkey="treeAbc",tree_type="nullifier"} 42"#));
         assert!(out.contains(r#"queue_capacity{tree_pubkey="treeAbc",tree_type="nullifier"} 500"#));
+    }
+
+    /// The dashboard shows queue depth in leaves and in batches. The batch size
+    /// is on-chain configuration, so it is published rather than hardcoded --
+    /// a dashboard dividing by a stale constant would quietly show the wrong
+    /// amount of outstanding work.
+    #[test]
+    fn zkp_batch_gauges_carry_size_and_both_counts() {
+        set_zkp_batches("treeZkp", 250, 3, 7);
+        let out = render();
+        assert!(out.contains("# TYPE queue_zkp_batches_ready gauge"));
+        assert!(out
+            .contains(r#"queue_zkp_batch_size{tree_pubkey="treeZkp",tree_type="nullifier"} 250"#));
+        assert!(out
+            .contains(r#"queue_zkp_batches_ready{tree_pubkey="treeZkp",tree_type="nullifier"} 3"#));
+        assert!(out.contains(
+            r#"queue_zkp_batches_applied{tree_pubkey="treeZkp",tree_type="nullifier"} 7"#
+        ));
     }
 
     #[test]

--- a/forester/src/run.rs
+++ b/forester/src/run.rs
@@ -227,10 +227,16 @@ fn report_queue_and_balance(rpc_url: &str, member: &Keypair, tree: Pubkey) {
                 snapshot.pending_queued,
                 snapshot.batch_capacity,
             );
-            crate::metrics::set_indexer_proof_count(
+            // Was published as forester_indexer_proof_count{metric="ready_zkp_batches"}:
+            // a queue statistic riding on an indexer metric, and the `metric`
+            // label is not one of the forester's CloudWatch dimensions, so it
+            // was dropped at the edge. These have their own names now, and the
+            // existing `^queue_.*$` selector picks them up unchanged.
+            crate::metrics::set_zkp_batches(
                 &tree_label,
-                "ready_zkp_batches",
+                snapshot.zkp_batch_size,
                 snapshot.ready,
+                snapshot.already_applied,
             );
         }
         Err(err) => tracing::debug!(%err, "metrics: tree snapshot unavailable"),

--- a/forester/src/run.rs
+++ b/forester/src/run.rs
@@ -190,6 +190,7 @@ pub fn run(config: &ForesterConfig, opts: RunOptions) -> Result<()> {
                 bail!("{not_ready}");
             }
         };
+        crate::metrics::count_batches_submitted(&opts.tree.to_string(), submitted);
         submitted_total += submitted;
 
         if !opts.watch {

--- a/forester/src/run.rs
+++ b/forester/src/run.rs
@@ -15,15 +15,16 @@
 //! checks `old_root == current root`, so submission is strictly sequential;
 //! proving could be parallelised (see PR #89) as a follow-up.
 
-use std::{env, fmt, thread, time::Duration};
+use std::{fmt, thread, time::Duration};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, Result};
 use num_bigint::BigUint;
 use num_traits::Num;
 use solana_commitment_config::CommitmentConfig;
 use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_rpc_client::rpc_client::RpcClient;
+use solana_signer::Signer;
 use zolana_client::{BatchAddressAppendInputs, ProofCompressed, ProverClient};
 use zolana_hasher::{hash_chain::create_hash_chain_from_array, Poseidon};
 use zolana_interface::instruction::{BatchUpdateNullifierTreeData, CompressedProof};
@@ -32,7 +33,10 @@ use zolana_tree::TreeAccount;
 
 type ReferenceNullifierTree = IndexedMerkleTree<Poseidon, usize>;
 
-use crate::forest::{batch_update_nullifier_tree_once, ForestParams};
+use crate::{
+    config::ForesterConfig,
+    forest::{batch_update_nullifier_tree_once, ForestParams},
+};
 use zolana_api::{BlockingZolanaApi, SerializablePubkey, PAGE_LIMIT};
 
 /// BN254 scalar field modulus minus one: the nullifier tree's initial
@@ -70,6 +74,8 @@ struct TreeSnapshot {
     next_index: u64,
     height: u32,
     zkp_batch_size: u64,
+    /// Elements one full batch holds: the denominator for queue fill.
+    batch_capacity: u64,
     already_applied: u64,
     ready: u64,
     pending_queued: u64,
@@ -123,30 +129,33 @@ fn indexed_value_shortage(
     }
 }
 
-/// Drain ready nullifier zkp-batches for `opts.tree`. Reads `RPC_URL`,
-/// `PROVER_URL`, `PHOTON_URL`, and `PAYER` (forester keypair) from the
-/// environment. Must run on a thread with no Tokio runtime — the prover and
-/// photon clients use `reqwest::blocking`.
-pub fn run(opts: RunOptions) -> Result<()> {
-    let rpc_url = env::var("RPC_URL").context("RPC_URL is not set")?;
-    let photon_url = env::var("PHOTON_URL").context("PHOTON_URL is not set")?;
-    let photon = BlockingZolanaApi::new(photon_url);
+/// Drain ready nullifier zkp-batches for `opts.tree`. Endpoints and credentials
+/// come from `config`, resolved at the process boundary. Must run on a thread with
+/// no Tokio runtime — the prover and photon clients use `reqwest::blocking`.
+pub fn run(config: &ForesterConfig, opts: RunOptions) -> Result<()> {
+    let rpc_url = config.rpc_url.clone();
+    let photon = BlockingZolanaApi::new(config.photon_url.clone());
 
     if opts.dry_run {
         return check_once(&rpc_url, &photon, opts.tree);
     }
 
-    let prover_url = env::var("PROVER_URL").context("PROVER_URL is not set")?;
+    let prover_url = config.require_prover_url()?.to_string();
     let settings = opts
         .settings
         .ok_or_else(|| anyhow!("--settings (forester smart-account) is required to submit"))?;
-    let member = forester_keypair()?;
+    let member = config.signer()?;
     let prover = ProverClient::new(prover_url);
 
     tracing::info!(tree = %opts.tree, "forester run: draining nullifier queue");
 
     let mut submitted_total: u64 = 0;
     loop {
+        // Liveness. Without this, "is the forester running?" is only answerable
+        // by reading logs.
+        crate::metrics::mark_run();
+        report_queue_and_balance(&rpc_url, &member, opts.tree);
+
         let remaining = opts
             .max_batches
             .map(|max| max.saturating_sub(submitted_total));
@@ -168,6 +177,7 @@ pub fn run(opts: RunOptions) -> Result<()> {
         let submitted = match outcome {
             DrainOutcome::Drained(submitted) => submitted,
             DrainOutcome::NotReady(not_ready) => {
+                crate::metrics::count_failure("photon_index_not_ready");
                 if opts.watch {
                     tracing::warn!(
                         %not_ready,
@@ -194,6 +204,46 @@ pub fn run(opts: RunOptions) -> Result<()> {
     Ok(())
 }
 
+/// Publish queue depth, queue capacity, and payer balance for this iteration.
+///
+/// Metrics are observability: a failure here is logged and skipped rather than
+/// propagated, so a metrics problem can never stop the queue draining.
+///
+/// This re-reads the tree account that `drain_once` will read again, costing one
+/// extra `getAccountInfo` per poll interval. That is deliberate: reporting from
+/// inside the drain path would skip publication on exactly the iterations that
+/// fail, which are the ones worth observing. At a seconds-scale poll interval the
+/// duplicate read is negligible next to proving.
+fn report_queue_and_balance(rpc_url: &str, member: &Keypair, tree: Pubkey) {
+    let tree_label = tree.to_string();
+    match read_snapshot(rpc_url, tree) {
+        Ok(snapshot) => {
+            // `pending_queued` counts elements inserted into the pending batch, so
+            // the denominator is that batch's element capacity. Both come from the
+            // same batch, which makes length/capacity a fill ratio in [0, 1].
+            crate::metrics::set_queue(
+                &tree_label,
+                snapshot.pending_queued,
+                snapshot.batch_capacity,
+            );
+            crate::metrics::set_indexer_proof_count(
+                &tree_label,
+                "ready_zkp_batches",
+                snapshot.ready,
+            );
+        }
+        Err(err) => tracing::debug!(%err, "metrics: tree snapshot unavailable"),
+    }
+
+    let rpc = RpcClient::new(rpc_url.to_string());
+    match rpc.get_balance(&member.pubkey()) {
+        Ok(lamports) => {
+            crate::metrics::set_sol_balance(&member.pubkey().to_string(), lamports);
+        }
+        Err(err) => tracing::debug!(%err, "metrics: payer balance unavailable"),
+    }
+}
+
 /// Read the nullifier tree's batch state and the ready zkp-batches' hash chains.
 fn read_snapshot(rpc_url: &str, tree: Pubkey) -> Result<TreeSnapshot> {
     let rpc = RpcClient::new_with_commitment(rpc_url.to_string(), CommitmentConfig::confirmed());
@@ -214,6 +264,7 @@ fn read_snapshot(rpc_url: &str, tree: Pubkey) -> Result<TreeSnapshot> {
 
     let pending = metadata.queue_batches.pending_batch_index as usize;
     let zkp_batch_size = metadata.queue_batches.zkp_batch_size;
+    let batch_capacity = metadata.queue_batches.batch_size;
     let batch = *metadata
         .queue_batches
         .batches
@@ -238,6 +289,7 @@ fn read_snapshot(rpc_url: &str, tree: Pubkey) -> Result<TreeSnapshot> {
         next_index: metadata.next_index,
         height: metadata.height,
         zkp_batch_size,
+        batch_capacity,
         already_applied,
         ready,
         pending_queued,
@@ -588,14 +640,6 @@ fn path_to_biguint(path: Vec<[u8; 32]>) -> Vec<BigUint> {
     path.into_iter()
         .map(|node| BigUint::from_bytes_be(&node))
         .collect()
-}
-
-/// Resolve the forester signing keypair from `PAYER` (a JSON byte array, as in
-/// `info`). Required for `run`: the update must be signed by the tree's
-/// configured forester authority.
-fn forester_keypair() -> Result<Keypair> {
-    let payer = env::var("PAYER").context("PAYER is not set (forester signing keypair)")?;
-    crate::parse_payer_keypair(&payer)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The forester runs unobserved. Liveness, whether the queue is draining, and whether it can still pay fees are answerable today only by reading CloudWatch logs. The fee-payer balance is the one that fails silently in production: the forester simply stops being able to submit.

`GET /metrics` on `--metrics-address`, Prometheus text format:

| metric | type | purpose |
| --- | --- | --- |
| `forester_last_run_timestamp` | gauge | liveness; the alert is staleness |
| `forester_sol_balance` | gauge | fee capacity, before it reaches zero |
| `queue_length` / `queue_capacity` | gauge | fill of the pending batch |
| `forester_transactions_failed_total` | counter | bucketed by reason |
| `forester_batches_submitted_total` | counter | work completed, per tree |
| `forester_indexer_response_time_seconds` | gauge | photon latency |
| `forester_indexer_proof_count` | gauge | ready zkp-batches |

Liveness and failures alone let a forester that loops without ever submitting look healthy, so `forester_batches_submitted_total` reports work completed. The contract's `forester_transactions_processed_total` is `epoch`-keyed, so rather than serve it with the label dropped, this adds a tree-keyed counter matching the dimensions `queue_length` already uses. Extending the contract is additive; the reasoning is recorded in its new `notes` field.

No new dependency. The forester is a small synchronous binary that pulls neither tokio nor hyper — its clients use `reqwest::blocking` and panic inside an async runtime. A `std::net::TcpListener` on a background thread avoids changing the binary's runtime model in order to expose seven gauges.

Every metrics failure is logged at debug and skipped rather than propagated, and a bind failure leaves the forester running without an endpoint. Reporting cannot break draining.

Six contract metrics are deliberately not served: `forester_epoch_detected`, `forester_epoch_registered`, `registered_foresters`, and three `epoch`-labelled transaction metrics. They describe the upstream Light Protocol epoch/registry design; this forester submits through a smart-account vault and has no epoch concept, so there is nothing to report. A gauge that is permanently zero reads as healthy data, which is worse than an absent one.

The contract file is left intact, and `contract_covers_served_names` asserts a subset rather than equality, because the k8s monitoring repo validates against the same file. Nothing in this crate validated against that file before, which is how six entries came to describe a design the forester does not have.

`RPC_URL`, `PHOTON_URL`, `PROVER_URL` and `PAYER` were read with `env::var` from inside `run` and `info`. Three costs: a missing variable surfaced partway through an operation, sometimes after network calls had been made; the same variable was read with different strictness in different places, with `PROVER_URL` required by `run` and optional in `info`; and neither entry point could be exercised without mutating process environment, so neither had unit tests.

`ForesterConfig::from_env()` resolves them once in `main`. `PAYER` is held unparsed, so a caller that never signs does not materialise key bytes. `start`, which does no work, no longer demands endpoints it never uses.

`forester.yml` ran `cargo check` only, so unit tests were compiled and never executed. It now runs `cargo test -p forester`.

Verification: `cargo fmt --all -- --check`, `./tools/check-test-hygiene.sh`, `cargo-machete`, `RUSTFLAGS="-D warnings" cargo check -p forester --all-targets` and `cargo clippy -p forester --all-targets` all clean; `cargo test -p forester` 20 passed, previously 8. The endpoint was exercised over a real socket: valid exposition text, 404 on unknown paths, counter accumulating per reason, balance reported in SOL rather than lamports. `forester start` with no environment succeeds; `forester info` with none fails with `RPC_URL is not set`.

Two follow-ups left out deliberately: a signer abstraction, since `PAYER` as a JSON byte array in the environment is a mainnet blocker and wants a remote or KMS signer; and decomposing `run()` at 695 lines, which is not worth doing while also changing behaviour.
