### PR TITLE
feat(cli): load release accounts with local programs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -98,6 +98,11 @@ zolana dev start --local --sbf-program <ID> target/deploy/<program>.so
 Passing any explicit `--sbf-program` also implies local mode. Override the
 release download host with `ZOLANA_RELEASE_URL`.
 
+Add `--release-accounts` when testing local program binaries against the
+release's initialized protocol config, asset counter, and canonical default
+tree. Local prover, Photon, and program binaries remain selected; only the
+account-snapshot bundle is downloaded and loaded.
+
 Maintainers publish the release with
 `just release <tag> --upload --prerelease` (omit the flags for a dry run that only
 stages assets and regenerates the lockfile). It builds the programs, the host +

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -229,6 +229,12 @@ pub(crate) struct TestValidatorOptions {
     )]
     pub(crate) local: bool,
 
+    #[arg(
+        long,
+        help = "Load the pinned release's initialized accounts with local programs"
+    )]
+    pub(crate) release_accounts: bool,
+
     #[arg(long, help = "Stop the local validator environment")]
     pub(crate) stop: bool,
 
@@ -706,6 +712,12 @@ impl TestValidatorOptions {
         !self.local && self.sbf_programs.is_empty() && self.upgradeable_programs.is_empty()
     }
 
+    /// The normal release rail always includes its initialized accounts. Local
+    /// program tests opt in explicitly when they need release-style state.
+    pub(crate) fn use_release_accounts(&self) -> bool {
+        self.use_release() || self.release_accounts
+    }
+
     pub(crate) fn sbf_program_specs(&self) -> Vec<ProgramSpec> {
         self.sbf_programs
             .chunks_exact(2)
@@ -928,14 +940,16 @@ mod tests {
     }
 
     #[test]
-    fn use_release_reflects_local_flag_and_explicit_programs() {
+    fn release_selection_separates_accounts_from_programs() {
         let default = parse_validator(&[]);
         assert!(default.use_release());
+        assert!(default.use_release_accounts());
         assert!(!default.local);
 
         let local = parse_validator(&["--local"]);
         assert!(local.local);
         assert!(!local.use_release());
+        assert!(!local.use_release_accounts());
 
         let explicit_program = parse_validator(&[
             "--sbf-program",
@@ -943,6 +957,16 @@ mod tests {
             "target/deploy/pool.so",
         ]);
         assert!(!explicit_program.use_release());
+        assert!(!explicit_program.use_release_accounts());
+
+        let release_accounts = parse_validator(&[
+            "--release-accounts",
+            "--sbf-program",
+            "Pool111111111111111111111111111111111111111",
+            "target/deploy/pool.so",
+        ]);
+        assert!(!release_accounts.use_release());
+        assert!(release_accounts.use_release_accounts());
     }
 
     #[test]

--- a/cli/src/localnet.rs
+++ b/cli/src/localnet.rs
@@ -25,27 +25,37 @@ pub(crate) fn run_test_validator(mut opts: TestValidatorOptions) -> Result<()> {
     stop_test_validator(opts.rpc_port);
     thread::sleep(Duration::from_secs(1));
 
-    // Default rail: fetch version-pinned programs, initialized account snapshots,
-    // and helper binaries from the release. `--local` (or explicit --sbf-program)
-    // keeps the fully-local artifacts used by dev and CI. Release programs and
-    // snapshots are folded into `opts` so the arg builders keep a single source.
-    let release = if opts.use_release() {
+    // Default rail: fetch every artifact from the pinned release. A local-program
+    // rail can opt into only the initialized account snapshot, so it exercises
+    // canonical protocol/tree state without replacing local SBF binaries.
+    let use_release = opts.use_release();
+    let use_release_accounts = opts.use_release_accounts();
+    let release = if use_release || use_release_accounts {
         Some(Release::load()?)
     } else {
         None
     };
-    if let Some(release) = &release {
+    if use_release {
+        let release = release
+            .as_ref()
+            .expect("release is loaded when release artifacts are enabled");
         println!("Using release {} artifacts", release.tag());
         for spec in release.program_specs()? {
             opts.sbf_programs.push(spec.address);
             opts.sbf_programs.push(spec.path);
         }
+    }
+    if use_release_accounts {
+        let release = release
+            .as_ref()
+            .expect("release is loaded when release accounts are enabled");
+        println!("Using release {} initialized accounts", release.tag());
         opts.account_dirs
             .push(path_string(&release.accounts_dir()?)?);
     }
 
     let mut validator = if opts.use_surfpool_backend() {
-        let surfpool = match &release {
+        let surfpool = match release.as_ref().filter(|_| use_release) {
             Some(release) => release.surfpool_binary()?,
             None => find_binary(&["SURFPOOL_BIN"], &["target/tools/surfpool"], &["surfpool"])?,
         };
@@ -82,7 +92,7 @@ pub(crate) fn run_test_validator(mut opts: TestValidatorOptions) -> Result<()> {
     })?;
 
     if !opts.skip_prover {
-        let prover_binary = match &release {
+        let prover_binary = match release.as_ref().filter(|_| use_release) {
             Some(release) => Some(release.prover_binary()?),
             None => None,
         };
@@ -96,7 +106,7 @@ pub(crate) fn run_test_validator(mut opts: TestValidatorOptions) -> Result<()> {
     }
 
     if opts.with_photon {
-        let photon_binary = match &release {
+        let photon_binary = match release.as_ref().filter(|_| use_release) {
             Some(release) => Some(release.photon_binary()?),
             None => None,
         };


### PR DESCRIPTION
## Summary
- Add `zolana dev start --release-accounts`.
- Load pinned release account snapshots while retaining local programs and services.
- Preserve existing release and fully local behavior.

## Test plan
- [x] `cargo test -p zolana-cli release_selection_separates_accounts_from_programs`