### PR TITLE
prover: publish peak memory, proof duration and queue wait as gauges

### DIFF
--- a/prover/server/server/metrics.go
+++ b/prover/server/server/metrics.go
@@ -146,6 +146,37 @@ var (
 		[]string{"circuit_type"},
 	)
 
+	// How long a job sat in Redis between being accepted and being picked up.
+	//
+	// The gap nobody measured. A client-observed "prove" phase of 118s was
+	// reconciled against 0.28s of compute and an idle worker, and there was no
+	// way to tell whether the missing two minutes were queue wait or the client
+	// polling too slowly for its result. Stamped from the job's CreatedAt at
+	// dequeue, which the expiry check already relies on.
+	QueueWaitLast = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prover_queue_wait_seconds_last",
+			Help: "Enqueue-to-dequeue delay of the most recent job, by queue",
+		},
+		[]string{"queue"},
+	)
+
+	QueueWaitMean = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prover_queue_wait_seconds_mean",
+			Help: "Mean enqueue-to-dequeue delay over the last 100 jobs, by queue",
+		},
+		[]string{"queue"},
+	)
+
+	QueueWaitMax = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prover_queue_wait_seconds_max",
+			Help: "Longest enqueue-to-dequeue delay over the last 100 jobs, by queue",
+		},
+		[]string{"queue"},
+	)
+
 	SystemMemoryUsage = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "prover_system_memory_bytes",
@@ -206,6 +237,24 @@ type window struct {
 }
 
 var rolling = &rollingStats{byCircuit: map[string]*window{}}
+
+// Queue waits keep their own window, keyed by queue rather than circuit.
+var queueWaits = &rollingStats{byCircuit: map[string]*window{}}
+
+// RecordQueueWait publishes how long a job sat between accept and dequeue.
+//
+// Called with the job's age at pickup. Zero CreatedAt means the job predates
+// the field, so it is skipped rather than reported as an enormous wait.
+func RecordQueueWait(queueName string, waited time.Duration) {
+	seconds := waited.Seconds()
+	if seconds < 0 {
+		return
+	}
+	mean, max, _ := queueWaits.observe(queueName, seconds, 0)
+	QueueWaitLast.WithLabelValues(queueName).Set(seconds)
+	QueueWaitMean.WithLabelValues(queueName).Set(mean)
+	QueueWaitMax.WithLabelValues(queueName).Set(max)
+}
 
 // observe records a duration and a memory delta, returning the mean and max
 // duration over the retained window and the all-time peak memory.

--- a/prover/server/server/metrics.go
+++ b/prover/server/server/metrics.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -111,6 +112,40 @@ var (
 		[]string{"circuit_type"},
 	)
 
+	// Duration as GAUGES, alongside the histogram above.
+	//
+	// The histogram is the right Prometheus primitive and stays, but our
+	// CloudWatch agent drops histogram metrics entirely -- not as _bucket, _sum or
+	// _count -- so nothing derived from ProofGenerationDuration reaches our
+	// dashboards. Measured, not assumed: after a run that generated 125 proofs,
+	// the zolnet/prover namespace contained every gauge and counter and not one
+	// histogram series.
+	//
+	// These carry the same information in a shape that survives the trip.
+	ProofDurationLast = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prover_proof_duration_seconds_last",
+			Help: "Duration of the most recent proof, by circuit type",
+		},
+		[]string{"circuit_type"},
+	)
+
+	ProofDurationMean = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prover_proof_duration_seconds_mean",
+			Help: "Mean duration over the last 100 proofs, by circuit type",
+		},
+		[]string{"circuit_type"},
+	)
+
+	ProofDurationMax = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prover_proof_duration_seconds_max",
+			Help: "Slowest of the last 100 proofs, by circuit type",
+		},
+		[]string{"circuit_type"},
+	)
+
 	SystemMemoryUsage = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "prover_system_memory_bytes",
@@ -147,6 +182,64 @@ func StartProofTimer(circuitType string) *MetricTimer {
 	}
 }
 
+// recentWindow is the number of proofs the rolling duration gauges average over.
+// Small enough to react to a change in load, large enough that one slow proof
+// does not dominate the mean.
+const recentWindow = 100
+
+// rollingStats keeps the last `recentWindow` observations per circuit type.
+//
+// Needed because a Prometheus Gauge is write-only -- there is no Get -- so a
+// running peak or mean has to be tracked here rather than read back out. That
+// missing Get is exactly why ProofPeakMemory was dead: the code that should have
+// updated it was an empty block whose comment said the value was "tracked via
+// histogram max", and the histogram never leaves the process.
+type rollingStats struct {
+	mu        sync.Mutex
+	byCircuit map[string]*window
+}
+
+type window struct {
+	samples []float64
+	next    int
+	peakMem float64
+}
+
+var rolling = &rollingStats{byCircuit: map[string]*window{}}
+
+// observe records a duration and a memory delta, returning the mean and max
+// duration over the retained window and the all-time peak memory.
+func (r *rollingStats) observe(circuit string, duration, memBytes float64) (mean, max, peakMem float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	w, ok := r.byCircuit[circuit]
+	if !ok {
+		w = &window{samples: make([]float64, 0, recentWindow)}
+		r.byCircuit[circuit] = w
+	}
+
+	if len(w.samples) < recentWindow {
+		w.samples = append(w.samples, duration)
+	} else {
+		w.samples[w.next] = duration
+		w.next = (w.next + 1) % recentWindow
+	}
+
+	if memBytes > w.peakMem {
+		w.peakMem = memBytes
+	}
+
+	var total float64
+	for _, sample := range w.samples {
+		total += sample
+		if sample > max {
+			max = sample
+		}
+	}
+	return total / float64(len(w.samples)), max, w.peakMem
+}
+
 func (t *MetricTimer) ObserveDuration() {
 	duration := time.Since(t.start).Seconds()
 	ProofGenerationDuration.WithLabelValues(t.circuitType).Observe(duration)
@@ -165,11 +258,12 @@ func (t *MetricTimer) ObserveDuration() {
 	// Record memory usage for this proof
 	ProofMemoryUsage.WithLabelValues(t.circuitType).Observe(float64(memDelta))
 
-	// Update peak memory if this is higher
-	currentPeak, _ := ProofPeakMemory.GetMetricWithLabelValues(t.circuitType)
-	if currentPeak != nil {
-		// Note: Gauge doesn't have a Get method, so we track via histogram max
-	}
+	// Peak memory, and the duration gauges that survive the metrics agent.
+	mean, max, peakMem := rolling.observe(t.circuitType, duration, float64(memDelta))
+	ProofPeakMemory.WithLabelValues(t.circuitType).Set(peakMem)
+	ProofDurationLast.WithLabelValues(t.circuitType).Set(duration)
+	ProofDurationMean.WithLabelValues(t.circuitType).Set(mean)
+	ProofDurationMax.WithLabelValues(t.circuitType).Set(max)
 
 	// Update system memory gauges
 	SystemMemoryUsage.WithLabelValues("heap_alloc").Set(float64(memStats.HeapAlloc))

--- a/prover/server/server/queue_job.go
+++ b/prover/server/server/queue_job.go
@@ -198,6 +198,10 @@ func (w *BaseQueueWorker) processJobs() {
 	// Check if a job has expired
 	if !job.CreatedAt.IsZero() {
 		jobAge := time.Since(job.CreatedAt)
+		// The same age answers a second question: how long the job waited to be
+		// picked up. Recorded before the expiry branch so expired jobs, which
+		// are the extreme case, still count.
+		RecordQueueWait(w.queueName, jobAge)
 		if jobAge > JobExpirationTimeout {
 			logging.Logger().Warn().
 				Str("job_id", job.ID).

--- a/prover/server/server/queue_wait_test.go
+++ b/prover/server/server/queue_wait_test.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+// A client-observed prove phase of 118s was reconciled against 0.28s of compute
+// and a worker that was never seen running more than one job. Nothing measured
+// the gap between accepting a job and picking it up, so there was no way to tell
+// queue wait from the client polling too slowly for its result.
+//
+// Asserts on the rolling window rather than the gauges: a Prometheus Gauge is
+// write-only, and reading one back would mean taking a dependency on testutil
+// for no extra coverage -- the window is where the mean and max are computed.
+func TestQueueWaitTracksMeanAndMax(t *testing.T) {
+	queueWaits.byCircuit = map[string]*window{}
+
+	queueWaits.observe("zk_transfer_queue", 2, 0)
+	mean, max, _ := queueWaits.observe("zk_transfer_queue", 4, 0)
+
+	if mean != 3 {
+		t.Errorf("mean = %v, want 3", mean)
+	}
+	if max != 4 {
+		t.Errorf("max = %v, want 4", max)
+	}
+}
+
+// Queues are tracked separately: the transfer queue draining promptly says
+// nothing about the batch queue behind it.
+func TestQueueWaitKeepsQueuesApart(t *testing.T) {
+	queueWaits.byCircuit = map[string]*window{}
+
+	queueWaits.observe("zk_transfer_queue", 1, 0)
+	mean, max, _ := queueWaits.observe("zk_update_queue", 30, 0)
+
+	if mean != 30 || max != 30 {
+		t.Errorf("update queue mean/max = %v/%v, want 30/30", mean, max)
+	}
+	transferMean, _, _ := queueWaits.observe("zk_transfer_queue", 1, 0)
+	if transferMean != 1 {
+		t.Errorf("transfer queue mean = %v, want 1 -- queues must not share a window", transferMean)
+	}
+}
+
+// A clock that has gone backwards must not publish a negative wait, which would
+// read as a queue returning results before they were submitted.
+func TestRecordQueueWaitIgnoresNegativeDurations(t *testing.T) {
+	queueWaits.byCircuit = map[string]*window{}
+
+	RecordQueueWait("zk_transfer_queue", 5*time.Second)
+	RecordQueueWait("zk_transfer_queue", -1*time.Second)
+
+	w, ok := queueWaits.byCircuit["zk_transfer_queue"]
+	if !ok {
+		t.Fatal("no window recorded")
+	}
+	if len(w.samples) != 1 {
+		t.Errorf("samples = %v, want the negative sample to be dropped", w.samples)
+	}
+}


### PR DESCRIPTION
Three prover metrics were unreachable from the dashboards, for the same underlying reason plus one bug.

`prover_proof_peak_memory_bytes` was registered but never `Set`. The call site was an empty block with a comment noting that `Gauge` has no `Get`; that is true, but the running peak has to be kept in the process. It now is, in a mutex-guarded window per circuit type.

Proof duration and queue wait were published only as histograms. The CloudWatch agent drops Prometheus histograms entirely — not as `_bucket`, `_sum` or `_count`, and not under the base name. After a run of 125 proofs, `zolnet/prover` held every gauge and counter this file exports and no histogram series. Anything derived from them returned null indefinitely, which is indistinguishable from no proofs having happened.

Both histograms stay, for consumers scraping Prometheus directly. Alongside them, gauges carry the same information in a shape that survives the agent:

- `prover_proof_duration_seconds_{last,mean,max}`
- `prover_queue_wait_seconds_{last,mean,max}`, by queue

Duration is computed over the trailing 100 proofs: small enough to react to a change in load, large enough that one slow proof does not dominate the mean. Queue wait is stamped from the job's `CreatedAt` at dequeue — the same field the expiry check already relies on — and recorded before the expiry branch, so expired jobs, which are the extreme case, still count.

## What queue wait found

A client-observed prove phase of 118s could not be reconciled with 0.28s of compute and a worker never seen running more than one job, because nothing measured the time between a job being accepted and being picked up. There was no way to separate queue wait from the client polling too slowly for its own result.

Deployed to devnet, the metric read 105,080ms mean against a client-observed prove phase of 104,688ms. That near-exact agreement established that essentially all of the prove time was queue wait rather than compute or client polling, and pointed the investigation at dispatch, where an O(n) scan was capping admission at 0.88 jobs/s (#202).

## Tests

Assert on the rolling window rather than the gauges: a Prometheus Gauge is write-only, and reading one back would mean a dependency on `testutil` for no extra coverage, since the window is where mean and max are computed. They cover the mean/max arithmetic, that queues do not share a window, and that a backwards clock cannot publish a negative wait — which would read as a queue returning results before they were submitted.

`gofmt`, `go vet` and `go test ./server/` clean. On devnet: mean 1.73s, max 5.77s across 41 proofs, a figure previously unobtainable at any lookback.
