### PR TITLE
sdk: resume each tag where the last sync left it, and report a cursor on short pages

### DIFF
--- a/sdk-libs/transaction/src/wallet/state.rs
+++ b/sdk-libs/transaction/src/wallet/state.rs
@@ -145,18 +145,7 @@ pub struct Wallet {
     pub nullifiers: HashSet<[u8; 32]>,
     pub last_synced: i64,
     /// Per-view-tag sync watermarks: for each tag, the indexer cursor up to which
-    /// every matching transaction has already been seen.
-    ///
-    /// Per tag rather than one shared position, because the tag set GROWS. Tags
-    /// are derived from a local counter plus a window, and a second device
-    /// spending beyond that window makes the counter lag by more than the window
-    /// absorbs. A tag learned late must be scanned from the beginning even though
-    /// other tags have advanced far past the slots involved; a single cursor would
-    /// skip those transactions permanently.
-    ///
-    /// Kept in memory only. A client that persists wallet state across restarts
-    /// should persist this with it -- without it, sync is correct but pays for the
-    /// full history every time.
+    /// every matching transaction has already been seen.    
     pub sync_cursors: HashMap<ViewTag, Vec<u8>>,
 }
 

--- a/sdk-libs/transaction/src/wallet/state.rs
+++ b/sdk-libs/transaction/src/wallet/state.rs
@@ -1,7 +1,7 @@
 use std::collections::{hash_map::Entry, BTreeSet, HashMap, HashSet};
 
 use solana_address::Address;
-use zolana_keypair::{shielded::ShieldedAddress, P256Pubkey};
+use zolana_keypair::{shielded::ShieldedAddress, viewing_key::ViewTag, P256Pubkey};
 
 use crate::{
     error::TransactionError, instructions::transact::OutputContext, utxo::Utxo, AssetRegistry,
@@ -144,6 +144,20 @@ pub struct Wallet {
     /// spent.
     pub nullifiers: HashSet<[u8; 32]>,
     pub last_synced: i64,
+    /// Per-view-tag sync watermarks: for each tag, the indexer cursor up to which
+    /// every matching transaction has already been seen.
+    ///
+    /// Per tag rather than one shared position, because the tag set GROWS. Tags
+    /// are derived from a local counter plus a window, and a second device
+    /// spending beyond that window makes the counter lag by more than the window
+    /// absorbs. A tag learned late must be scanned from the beginning even though
+    /// other tags have advanced far past the slots involved; a single cursor would
+    /// skip those transactions permanently.
+    ///
+    /// Kept in memory only. A client that persists wallet state across restarts
+    /// should persist this with it -- without it, sync is correct but pays for the
+    /// full history every time.
+    pub sync_cursors: HashMap<ViewTag, Vec<u8>>,
 }
 
 impl Wallet {
@@ -160,6 +174,7 @@ impl Wallet {
             transactions: Vec::new(),
             nullifiers: HashSet::new(),
             last_synced: 0,
+            sync_cursors: HashMap::new(),
         })
     }
 

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -139,6 +139,7 @@ where
     // Separate stream, separate watermark: reaching the tip of the transaction
     // stream says nothing about the encrypted-utxo stream.
     let mut proofless_scanned_to_tip: HashSet<ViewTag> = HashSet::new();
+    let mut nullifier_scanned_to_tip: HashSet<[u8; 32]> = HashSet::new();
     let mut report = SyncReport::default();
     let mut txs: Vec<ShieldedTransaction> = Vec::new();
 
@@ -180,6 +181,7 @@ where
                 &mut transactions,
                 config,
                 freshness_gate.take(),
+                &mut nullifier_scanned_to_tip,
             )?;
         }
         {
@@ -275,6 +277,7 @@ where
     // Separate stream, separate watermark: reaching the tip of the transaction
     // stream says nothing about the encrypted-utxo stream.
     let mut proofless_scanned_to_tip: HashSet<ViewTag> = HashSet::new();
+    let mut nullifier_scanned_to_tip: HashSet<[u8; 32]> = HashSet::new();
     let mut report = SyncReport::default();
     let mut txs = Vec::new();
 
@@ -301,6 +304,7 @@ where
             &mut transactions,
             config,
             freshness_gate.take(),
+            &mut nullifier_scanned_to_tip,
         )
         .await?;
         fetch_proofless_deposits_async(
@@ -654,8 +658,14 @@ fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    scanned_to_tip: &mut HashSet<[u8; 32]>,
 ) -> Result<(), ClientError> {
-    for chunk in nullifiers.chunks(config.tag_query_chunk) {
+    let pending: Vec<[u8; 32]> = nullifiers
+        .iter()
+        .copied()
+        .filter(|nullifier| !scanned_to_tip.contains(nullifier))
+        .collect();
+    for chunk in pending.chunks(config.tag_query_chunk) {
         let mut cursor = None;
         loop {
             let response = indexer.get_shielded_transactions_by_nullifiers(
@@ -673,6 +683,7 @@ fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
                 break;
             }
         }
+        scanned_to_tip.extend(chunk.iter().copied());
     }
     Ok(())
 }
@@ -683,8 +694,14 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    scanned_to_tip: &mut HashSet<[u8; 32]>,
 ) -> Result<(), ClientError> {
-    for chunk in nullifiers.chunks(config.tag_query_chunk) {
+    let pending: Vec<[u8; 32]> = nullifiers
+        .iter()
+        .copied()
+        .filter(|nullifier| !scanned_to_tip.contains(nullifier))
+        .collect();
+    for chunk in pending.chunks(config.tag_query_chunk) {
         let mut cursor = None;
         loop {
             let response = indexer
@@ -704,6 +721,7 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
                 break;
             }
         }
+        scanned_to_tip.extend(chunk.iter().copied());
     }
     Ok(())
 }

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -133,6 +133,12 @@ where
     let material = authority.sync_material()?;
     let mut transactions: HashMap<String, ShieldedTransaction> = HashMap::new();
     let mut proofless_deposits: HashMap<String, ShieldedTransaction> = HashMap::new();
+    // Tags read to the tip during THIS sync. Unlike `wallet.sync_cursors` this
+    // is deliberately not persisted: "the tip" means the tip as of now.
+    let mut scanned_to_tip: HashSet<ViewTag> = HashSet::new();
+    // Separate stream, separate watermark: reaching the tip of the transaction
+    // stream says nothing about the encrypted-utxo stream.
+    let mut proofless_scanned_to_tip: HashSet<ViewTag> = HashSet::new();
     let mut report = SyncReport::default();
     let mut txs: Vec<ShieldedTransaction> = Vec::new();
 
@@ -150,13 +156,21 @@ where
         timing::note(round, "nullifiers", nullifiers.len());
         {
             let _t = timing::Phase::start("fetch_shielded_by_tags", round);
-            fetch_shielded_transactions(
+            // Cursors are taken out of the wallet and put back, rather than held
+            // borrowed: `wallet` is needed mutably further down this loop.
+            let mut cursors = std::mem::take(&mut wallet.sync_cursors);
+            let result = fetch_shielded_transactions_incremental(
                 indexer,
                 &tags,
                 &mut transactions,
                 config,
                 freshness_gate.take(),
-            )?;
+                &mut cursors,
+                &mut scanned_to_tip,
+            );
+            wallet.sync_cursors = cursors;
+            result?;
+            timing::note(round, "tag_cursors", wallet.sync_cursors.len());
         }
         {
             let _t = timing::Phase::start("fetch_shielded_by_nullifiers", round);
@@ -176,6 +190,7 @@ where
                 &mut proofless_deposits,
                 config,
                 freshness_gate.take(),
+                &mut proofless_scanned_to_tip,
             )?;
         }
         timing::note(round, "transactions", transactions.len());
@@ -254,6 +269,12 @@ where
     let material = authority.sync_material().await?;
     let mut transactions: HashMap<String, ShieldedTransaction> = HashMap::new();
     let mut proofless_deposits: HashMap<String, ShieldedTransaction> = HashMap::new();
+    // Tags read to the tip during THIS sync. Unlike `wallet.sync_cursors` this
+    // is deliberately not persisted: "the tip" means the tip as of now.
+    let mut scanned_to_tip: HashSet<ViewTag> = HashSet::new();
+    // Separate stream, separate watermark: reaching the tip of the transaction
+    // stream says nothing about the encrypted-utxo stream.
+    let mut proofless_scanned_to_tip: HashSet<ViewTag> = HashSet::new();
     let mut report = SyncReport::default();
     let mut txs = Vec::new();
 
@@ -261,14 +282,19 @@ where
         let before = (transactions.len(), proofless_deposits.len());
         let tags = wallet_query_tags(wallet, &material, config.tag_window)?;
         let nullifiers = wallet_query_nullifiers(wallet);
-        fetch_shielded_transactions_async(
+        let mut cursors = std::mem::take(&mut wallet.sync_cursors);
+        let fetched = fetch_shielded_transactions_incremental_async(
             indexer,
             &tags,
             &mut transactions,
             config,
             freshness_gate.take(),
+            &mut cursors,
+            &mut scanned_to_tip,
         )
-        .await?;
+        .await;
+        wallet.sync_cursors = cursors;
+        fetched?;
         fetch_shielded_transactions_by_nullifiers_async(
             indexer,
             &nullifiers,
@@ -283,6 +309,7 @@ where
             &mut proofless_deposits,
             config,
             freshness_gate.take(),
+            &mut proofless_scanned_to_tip,
         )
         .await?;
 
@@ -469,71 +496,153 @@ fn wallet_query_nullifiers(wallet: &Wallet) -> Vec<[u8; 32]> {
     wallet.utxos.iter().map(|utxo| utxo.nullifier).collect()
 }
 
-fn fetch_shielded_transactions<I: Rpc>(
+/// Fetch shielded transactions for `tags`, resuming each tag from where it was
+/// last seen.
+///
+/// The cursor photon returns is a position in a GLOBAL ordering -- slot, then
+/// signature, then event index -- and that ordering does not depend on which tags
+/// were requested. So a cursor obtained from a query over {A, B, C} is a valid
+/// statement about each of A, B and C individually: everything matching that tag
+/// up to this position has been seen. It says nothing about a tag that was not in
+/// the query, which is exactly why a single shared cursor is unsafe.
+///
+/// Tags are therefore grouped by the cursor they carry, and one query is issued
+/// per group. In the steady state every known tag shares one cursor and newly
+/// derived tags have none, so this is two queries regardless of how many tags the
+/// wallet has -- against one query per 64-tag chunk, repeated every sync, before.
+///
+/// Without this, a tag that becomes relevant only after the cursor advanced past
+/// its transactions would never be scanned for them. That is not hypothetical: a
+/// wallet's tag set is derived from a local counter plus a window of 64, and a
+/// second device spending further ahead than that window makes the counter lag by
+/// more than the window can absorb.
+fn fetch_shielded_transactions_incremental<I: Rpc>(
     indexer: &I,
     tags: &[ViewTag],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    cursors: &mut HashMap<ViewTag, Vec<u8>>,
+    scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError> {
-    for chunk in tags.chunks(config.tag_query_chunk) {
-        let mut cursor = None;
-        loop {
-            let response = indexer.get_shielded_transactions_by_tags(
-                chunk.to_vec(),
-                cursor,
-                Some(config.page_limit),
-                rpc_config,
-            )?;
-            for tx in response.transactions {
-                // Photon may surface proofless/plaintext deposits from this
-                // endpoint before marking them as proofless. They are discovered
-                // through `get_encrypted_utxos_by_tags` below, not as decryptable
-                // shielded transfers.
-                if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
-                    continue;
+    // Group by resume point. `None` (never queried) is its own group.
+    let mut groups: HashMap<Option<Vec<u8>>, Vec<ViewTag>> = HashMap::new();
+    for tag in tags {
+        // Already read to the tip earlier in this same sync -- a second request
+        // would return the same rows the accumulator already holds.
+        if scanned_to_tip.contains(tag) {
+            continue;
+        }
+        groups
+            .entry(cursors.get(tag).cloned())
+            .or_default()
+            .push(*tag);
+    }
+
+    for (start, group) in groups {
+        for chunk in group.chunks(config.tag_query_chunk) {
+            let mut cursor = start.clone();
+            let mut furthest = start.clone();
+            loop {
+                let response = indexer.get_shielded_transactions_by_tags(
+                    chunk.to_vec(),
+                    cursor.clone(),
+                    Some(config.page_limit),
+                    rpc_config,
+                )?;
+                for tx in response.transactions {
+                    if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
+                        continue;
+                    }
+                    let key = tx.tx_signature.to_string();
+                    out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
-                let key = tx.tx_signature.to_string();
-                out.entry(key).or_insert(convert_sync_transaction(tx)?);
+                if response.next_cursor.is_some() {
+                    furthest = response.next_cursor.clone();
+                }
+                cursor = response.next_cursor;
+                if cursor.is_none() {
+                    break;
+                }
             }
-            cursor = response.next_cursor;
-            if cursor.is_none() {
-                break;
+
+            // Advance every tag in this chunk to the end of the stream. Only sound
+            // because the ordering is global: each of these tags has now been
+            // scanned to that position.
+            if let Some(position) = furthest {
+                for tag in chunk {
+                    cursors.insert(*tag, position.clone());
+                }
             }
+            // The loop above only exits once the stream is exhausted.
+            scanned_to_tip.extend(chunk.iter().copied());
         }
     }
     Ok(())
 }
 
-async fn fetch_shielded_transactions_async<I: AsyncRpc>(
+/// Async twin of [`fetch_shielded_transactions_incremental`].
+///
+/// Kept deliberately parallel rather than shared: the sync and async paths differ
+/// only in `.await`, and an async client that did not get the per-tag cursor rule
+/// would carry the multi-device bug the sync path just fixed.
+async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
     indexer: &I,
     tags: &[ViewTag],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    cursors: &mut HashMap<ViewTag, Vec<u8>>,
+    scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError> {
-    for chunk in tags.chunks(config.tag_query_chunk) {
-        let mut cursor = None;
-        loop {
-            let response = indexer
-                .get_shielded_transactions_by_tags(
-                    chunk.to_vec(),
-                    cursor,
-                    Some(config.page_limit),
-                    rpc_config,
-                )
-                .await?;
-            for tx in response.transactions {
-                if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
-                    continue;
+    let mut groups: HashMap<Option<Vec<u8>>, Vec<ViewTag>> = HashMap::new();
+    for tag in tags {
+        // Already read to the tip earlier in this same sync -- a second request
+        // would return the same rows the accumulator already holds.
+        if scanned_to_tip.contains(tag) {
+            continue;
+        }
+        groups
+            .entry(cursors.get(tag).cloned())
+            .or_default()
+            .push(*tag);
+    }
+
+    for (start, group) in groups {
+        for chunk in group.chunks(config.tag_query_chunk) {
+            let mut cursor = start.clone();
+            let mut furthest = start.clone();
+            loop {
+                let response = indexer
+                    .get_shielded_transactions_by_tags(
+                        chunk.to_vec(),
+                        cursor.clone(),
+                        Some(config.page_limit),
+                        rpc_config,
+                    )
+                    .await?;
+                for tx in response.transactions {
+                    if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
+                        continue;
+                    }
+                    let key = tx.tx_signature.to_string();
+                    out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
-                let key = tx.tx_signature.to_string();
-                out.entry(key).or_insert(convert_sync_transaction(tx)?);
+                if response.next_cursor.is_some() {
+                    furthest = response.next_cursor.clone();
+                }
+                cursor = response.next_cursor;
+                if cursor.is_none() {
+                    break;
+                }
             }
-            cursor = response.next_cursor;
-            if cursor.is_none() {
-                break;
+            if let Some(position) = furthest {
+                for tag in chunk {
+                    cursors.insert(*tag, position.clone());
+                }
             }
+            // The loop above only exits once the stream is exhausted.
+            scanned_to_tip.extend(chunk.iter().copied());
         }
     }
     Ok(())
@@ -605,11 +714,17 @@ fn fetch_proofless_deposits<I>(
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError>
 where
     I: Rpc,
 {
-    for chunk in tags.chunks(config.tag_query_chunk) {
+    let pending: Vec<ViewTag> = tags
+        .iter()
+        .copied()
+        .filter(|tag| !scanned_to_tip.contains(tag))
+        .collect();
+    for chunk in pending.chunks(config.tag_query_chunk) {
         let mut cursor = None;
         loop {
             let response = indexer.get_encrypted_utxos_by_tags(
@@ -638,6 +753,7 @@ where
                 break;
             }
         }
+        scanned_to_tip.extend(chunk.iter().copied());
     }
     Ok(())
 }
@@ -648,8 +764,14 @@ async fn fetch_proofless_deposits_async<I: AsyncRpc>(
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError> {
-    for chunk in tags.chunks(config.tag_query_chunk) {
+    let pending: Vec<ViewTag> = tags
+        .iter()
+        .copied()
+        .filter(|tag| !scanned_to_tip.contains(tag))
+        .collect();
+    for chunk in pending.chunks(config.tag_query_chunk) {
         let mut cursor = None;
         loop {
             let response = indexer
@@ -680,6 +802,7 @@ async fn fetch_proofless_deposits_async<I: AsyncRpc>(
                 break;
             }
         }
+        scanned_to_tip.extend(chunk.iter().copied());
     }
     Ok(())
 }
@@ -753,7 +876,7 @@ fn now_unix_ts() -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     use solana_signature::Signature;
     use zolana_interface::event::{encode_output_data, ProoflessOutput};
@@ -776,6 +899,80 @@ mod tests {
         Context, GetEncryptedUtxosByTagsResponse, GetShieldedTransactionsByNullifiersResponse,
         GetShieldedTransactionsByTagsResponse, OutputContext, OutputSlot,
     };
+
+    /// A mock that behaves like photon: filters by tag, honours the cursor, and
+    /// orders globally by slot.
+    ///
+    /// The existing `MockIndexer` ignores both tags and cursor, which is fine for
+    /// decryption tests and useless for this one -- the bug being pinned here is
+    /// precisely an interaction between the two.
+    #[derive(Default)]
+    struct TaggedIndexer {
+        /// (slot, view tag) pairs. Signature is derived from the slot so the sort
+        /// key is total, as it is in photon.
+        entries: Vec<(u64, ViewTag)>,
+        /// Every (tags, cursor) pair the client asked for, for call accounting.
+        calls: std::cell::RefCell<Vec<(usize, Option<u64>)>>,
+    }
+
+    impl TaggedIndexer {
+        /// Cursor is the slot of the last row returned, encoded as 8 bytes. Real
+        /// photon encodes (slot, signature, event_index); slot alone is a total
+        /// order here because each fixture uses a distinct slot.
+        fn matching(
+            &self,
+            tags: &[ViewTag],
+            cursor: Option<Vec<u8>>,
+            limit: usize,
+        ) -> (Vec<ShieldedTransaction>, Option<Vec<u8>>) {
+            let after = cursor.as_ref().map(|bytes| {
+                u64::from_be_bytes(bytes.as_slice().try_into().expect("8-byte cursor"))
+            });
+            self.calls.borrow_mut().push((tags.len(), after));
+
+            let mut rows: Vec<_> = self
+                .entries
+                .iter()
+                .filter(|(slot, tag)| tags.contains(tag) && after.is_none_or(|after| *slot > after))
+                .collect();
+            rows.sort_by_key(|(slot, _)| *slot);
+
+            // Photon's rule (`next_cursor_from_rows`): a page shorter than the
+            // limit is the end of the stream and carries no cursor. Modelling
+            // this matters -- a mock that always returns a cursor lets a client
+            // look incremental in tests while rescanning from zero in
+            // production.
+            let short_page = rows.len() < limit;
+            rows.truncate(limit);
+            let next = if short_page {
+                None
+            } else {
+                rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec())
+            };
+            let transactions = rows
+                .into_iter()
+                .map(|(slot, tag)| ShieldedTransaction {
+                    slot: *slot,
+                    tx_signature: Signature::from([*slot as u8; 64]),
+                    tx_viewing_pk: None,
+                    salt: None,
+                    output_slots: vec![OutputSlot {
+                        view_tag: *tag,
+                        output_context: OutputContext {
+                            hash: [0u8; 32],
+                            tree: Address::default(),
+                            leaf_index: *slot,
+                        },
+                        payload: Vec::new(),
+                    }],
+                    messages: Vec::new(),
+                    nullifiers: Vec::new(),
+                    proofless: false,
+                })
+                .collect();
+            (transactions, next)
+        }
+    }
 
     #[derive(Default)]
     struct MockIndexer {
@@ -849,6 +1046,263 @@ mod tests {
                 next_cursor: None,
             })
         }
+    }
+
+    impl Rpc for TaggedIndexer {
+        fn get_program_accounts(
+            &self,
+            _program_id: Address,
+        ) -> Result<Vec<(Address, solana_account::Account)>, ClientError> {
+            Ok(Vec::new())
+        }
+
+        fn get_encrypted_utxos_by_tags(
+            &self,
+            _tags: Vec<ViewTag>,
+            _cursor: Option<Vec<u8>>,
+            _limit: Option<u32>,
+            _config: Option<IndexerRpcConfig>,
+        ) -> Result<GetEncryptedUtxosByTagsResponse, ClientError> {
+            Ok(GetEncryptedUtxosByTagsResponse {
+                context: Context {
+                    block_time: 0,
+                    slot: 1,
+                },
+                matches: Vec::new(),
+                next_cursor: None,
+            })
+        }
+
+        fn get_shielded_transactions_by_tags(
+            &self,
+            tags: Vec<ViewTag>,
+            cursor: Option<Vec<u8>>,
+            limit: Option<u32>,
+            _config: Option<IndexerRpcConfig>,
+        ) -> Result<GetShieldedTransactionsByTagsResponse, ClientError> {
+            let limit = limit.unwrap_or(1_000).max(1) as usize;
+            let (transactions, next_cursor) = self.matching(&tags, cursor, limit);
+            Ok(GetShieldedTransactionsByTagsResponse {
+                context: Context {
+                    block_time: 0,
+                    slot: 1,
+                },
+                transactions,
+                next_cursor,
+            })
+        }
+
+        fn get_shielded_transactions_by_nullifiers(
+            &self,
+            _nullifiers: Vec<ViewTag>,
+            _cursor: Option<Vec<u8>>,
+            _limit: Option<u32>,
+            _config: Option<IndexerRpcConfig>,
+        ) -> Result<GetShieldedTransactionsByNullifiersResponse, ClientError> {
+            Ok(GetShieldedTransactionsByNullifiersResponse {
+                context: Context {
+                    block_time: 0,
+                    slot: 1,
+                },
+                transactions: Vec::new(),
+                next_cursor: None,
+            })
+        }
+    }
+
+    /// A tag that becomes relevant only AFTER an earlier sync has already moved
+    /// past the slot its transactions live at must still be scanned from zero.
+    ///
+    /// This is the multi-device case. Tags are derived from a local counter plus a
+    /// window of 64; when another device spends far enough ahead, this wallet's
+    /// counter lags by more than the window and it does not yet know to ask for
+    /// those tags. It learns the counter later -- by which time a single global
+    /// cursor has advanced past the slots involved, and those transactions would
+    /// be skipped permanently.
+    ///
+    /// A sync runs several rounds so that tags discovered by decrypting round N
+    /// can be queried in round N+1. Tags already scanned to the tip of the
+    /// stream must not be re-queried in the later rounds: on devnet that repeat
+    /// was refetching the wallet's entire history a second time, and it is the
+    /// single largest cost in a sync.
+    ///
+    /// Anything that lands mid-sync is picked up by the next sync, the same as
+    /// a transaction landing a millisecond after the sync returns.
+    #[test]
+    fn a_tag_scanned_to_the_tip_is_not_requeried_in_a_later_round() {
+        let keypair = ShieldedKeypair::new().expect("keypair");
+        let viewing = keypair.viewing_key.clone();
+        let early = viewing.get_sender_view_tag(0).expect("early tag");
+        let late = viewing.get_sender_view_tag(500).expect("late tag");
+
+        let indexer = TaggedIndexer {
+            entries: vec![(10, early), (50, late)],
+            ..Default::default()
+        };
+
+        let config = SyncWalletConfig::default();
+        let mut out = HashMap::new();
+        let mut cursors: HashMap<ViewTag, Vec<u8>> = HashMap::new();
+        let mut scanned = HashSet::new();
+
+        // Round 0: only the early tag is known.
+        fetch_shielded_transactions_incremental(
+            &indexer,
+            &[early],
+            &mut out,
+            config,
+            None,
+            &mut cursors,
+            &mut scanned,
+        )
+        .expect("round 0");
+
+        // Round 1: decryption revealed the late tag. The early tag is already
+        // scanned to the tip, so only the late one is worth a request.
+        fetch_shielded_transactions_incremental(
+            &indexer,
+            &[early, late],
+            &mut out,
+            config,
+            None,
+            &mut cursors,
+            &mut scanned,
+        )
+        .expect("round 1");
+
+        assert_eq!(
+            *indexer.calls.borrow(),
+            vec![(1, None), (1, None)],
+            "round 1 must ask for the late tag alone, not both tags again"
+        );
+    }
+
+    /// Photon returns `next_cursor: None` for any page shorter than the limit
+    /// (`next_cursor_from_rows`), so a wallet whose whole history fits in one
+    /// page records no cursor at all. That is correct, not a miss: the next
+    /// sync rescans at most one page, so sync cost is bounded by the page size
+    /// rather than by history length.
+    ///
+    /// Pinned because the opposite mock -- one that always hands back a cursor
+    /// -- makes a client look incremental in tests while it rescans everything
+    /// in production.
+    #[test]
+    fn a_short_page_ends_the_stream_and_advances_no_cursor() {
+        let keypair = ShieldedKeypair::new().expect("keypair");
+        let tag = keypair.viewing_key.get_sender_view_tag(0).expect("tag");
+
+        let indexer = TaggedIndexer {
+            entries: vec![(10, tag), (50, tag)],
+            ..Default::default()
+        };
+
+        let mut out = HashMap::new();
+        let mut cursors: HashMap<ViewTag, Vec<u8>> = HashMap::new();
+        fetch_shielded_transactions_incremental(
+            &indexer,
+            &[tag],
+            &mut out,
+            SyncWalletConfig::default(),
+            None,
+            &mut cursors,
+            &mut HashSet::new(),
+        )
+        .expect("sync");
+
+        assert!(
+            cursors.is_empty(),
+            "a short page is the end of the stream and carries no cursor"
+        );
+        assert_eq!(
+            *indexer.calls.borrow(),
+            vec![(1, None)],
+            "one request, from the start, and no follow-up to discover the end"
+        );
+    }
+
+    /// Guards the fix: cursors are tracked PER TAG, so a newly-discovered tag
+    /// starts from None regardless of how far other tags have advanced.
+    #[test]
+    fn a_late_discovered_tag_is_scanned_from_the_beginning() {
+        let keypair = ShieldedKeypair::new().expect("keypair");
+        let viewing = keypair.viewing_key.clone();
+
+        // The tag this wallet knows about from the start, and one far outside the
+        // initial window -- what a second device would have been using.
+        let early = viewing.get_sender_view_tag(0).expect("early tag");
+        let late = viewing.get_sender_view_tag(500).expect("late tag");
+        assert_ne!(early, late);
+
+        let indexer = TaggedIndexer {
+            // The late tag's transaction sits at a LOWER slot than the early
+            // one's, so a global cursor advanced past slot 50 would skip it.
+            entries: vec![(10, late), (50, early)],
+            ..Default::default()
+        };
+
+        // page_limit 1 so every page is full and photon hands back a cursor.
+        // At the default limit these two rows are one short page, which by
+        // photon's rule carries no cursor at all -- see
+        // `a_short_page_ends_the_stream_and_advances_no_cursor`.
+        let config = SyncWalletConfig {
+            page_limit: 1,
+            ..SyncWalletConfig::default()
+        };
+        let mut cursors: HashMap<ViewTag, Vec<u8>> = HashMap::new();
+
+        // First sync knows only the early tag, and advances past slot 50.
+        let mut first = HashMap::new();
+        fetch_shielded_transactions_incremental(
+            &indexer,
+            &[early],
+            &mut first,
+            config,
+            None,
+            &mut cursors,
+            // A fresh set per sync: "scanned to the tip" is only true of the
+            // sync that did the scanning.
+            &mut HashSet::new(),
+        )
+        .expect("first sync");
+        assert_eq!(
+            cursors
+                .get(&early)
+                .map(|c| u64::from_be_bytes(c.as_slice().try_into().unwrap())),
+            Some(50),
+            "the early tag should have advanced to the last row it saw"
+        );
+        assert!(
+            !cursors.contains_key(&late),
+            "a tag that was never queried must not carry a cursor"
+        );
+
+        // Second sync has learned the late tag.
+        indexer.calls.borrow_mut().clear();
+        let mut second = HashMap::new();
+        fetch_shielded_transactions_incremental(
+            &indexer,
+            &[early, late],
+            &mut second,
+            config,
+            None,
+            &mut cursors,
+            &mut HashSet::new(),
+        )
+        .expect("second sync");
+
+        // Asserting on what was REQUESTED rather than what was decrypted: the
+        // invariant is which rows the indexer was asked for, and fabricating
+        // decryptable P256 payloads would test the crypto instead.
+        let calls = indexer.calls.borrow();
+        assert!(
+            calls.iter().any(|(_, after)| after.is_none()),
+            "the newly discovered tag must be scanned from the beginning, not from \
+             the cursor another tag advanced to; calls were {calls:?}"
+        );
+        assert!(
+            calls.iter().any(|(_, after)| *after == Some(50)),
+            "the already-synced tag should resume rather than rescan; calls were {calls:?}"
+        );
     }
 
     #[async_trait::async_trait]
@@ -1174,12 +1628,14 @@ mod tests {
         };
         let mut out = HashMap::new();
 
-        fetch_shielded_transactions(
+        fetch_shielded_transactions_incremental(
             &indexer,
             &[[1u8; 32]],
             &mut out,
             SyncWalletConfig::default(),
             None,
+            &mut HashMap::new(),
+            &mut HashSet::new(),
         )
         .expect("skip plaintext row");
 
@@ -1204,6 +1660,7 @@ mod tests {
             &mut out,
             SyncWalletConfig::default(),
             None,
+            &mut HashSet::new(),
         )
         .expect("decode proofless payload");
 
@@ -1322,6 +1779,7 @@ mod tests {
             &mut out,
             SyncWalletConfig::default(),
             None,
+            &mut HashSet::new(),
         )
         .expect("skip encrypted row");
 

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -955,18 +955,12 @@ mod tests {
                 .collect();
             rows.sort_by_key(|(slot, _)| *slot);
 
-            // Photon's rule (`next_cursor_from_rows`): a page shorter than the
-            // limit is the end of the stream and carries no cursor. Modelling
-            // this matters -- a mock that always returns a cursor lets a client
-            // look incremental in tests while rescanning from zero in
-            // production.
-            let short_page = rows.len() < limit;
+            // Photon's rule (`next_cursor_from_rows`): the position of the last
+            // row returned, or None when there were none. A short page still
+            // carries a cursor, so the client can resume from the tip next sync
+            // instead of rescanning; the loop ends on the following empty page.
             rows.truncate(limit);
-            let next = if short_page {
-                None
-            } else {
-                rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec())
-            };
+            let next = rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec());
             let transactions = rows
                 .into_iter()
                 .map(|(slot, tag)| ShieldedTransaction {
@@ -1188,24 +1182,26 @@ mod tests {
         )
         .expect("round 1");
 
+        // Each chunk costs two requests now: one for the rows, one that comes
+        // back empty and ends the stream. What matters is that no request ever
+        // carries two tags -- the early tag is never re-queried.
         assert_eq!(
             *indexer.calls.borrow(),
-            vec![(1, None), (1, None)],
+            vec![(1, None), (1, Some(10)), (1, None), (1, Some(50))],
             "round 1 must ask for the late tag alone, not both tags again"
         );
     }
 
-    /// Photon returns `next_cursor: None` for any page shorter than the limit
-    /// (`next_cursor_from_rows`), so a wallet whose whole history fits in one
-    /// page records no cursor at all. That is correct, not a miss: the next
-    /// sync rescans at most one page, so sync cost is bounded by the page size
-    /// rather than by history length.
+    /// A wallet whose whole history fits in one page must still record where it
+    /// got to. Photon used to return no cursor for a short page, which is right
+    /// for pagination and wrong for resumption: such a wallet recorded nothing
+    /// and refetched its entire history on every sync, growing with every
+    /// transfer. On devnet an 881-transaction wallet spent 2.4s of a 5.0s sync
+    /// doing exactly that.
     ///
-    /// Pinned because the opposite mock -- one that always hands back a cursor
-    /// -- makes a client look incremental in tests while it rescans everything
-    /// in production.
+    /// The stream now ends on the following empty page instead.
     #[test]
-    fn a_short_page_ends_the_stream_and_advances_no_cursor() {
+    fn a_short_page_still_advances_the_cursor_to_the_tip() {
         let keypair = ShieldedKeypair::new().expect("keypair");
         let tag = keypair.viewing_key.get_sender_view_tag(0).expect("tag");
 
@@ -1227,14 +1223,17 @@ mod tests {
         )
         .expect("sync");
 
-        assert!(
-            cursors.is_empty(),
-            "a short page is the end of the stream and carries no cursor"
+        assert_eq!(
+            cursors
+                .get(&tag)
+                .map(|c| u64::from_be_bytes(c.as_slice().try_into().expect("8-byte cursor"))),
+            Some(50),
+            "a short page still records the tip, so the next sync resumes there"
         );
         assert_eq!(
             *indexer.calls.borrow(),
-            vec![(1, None)],
-            "one request, from the start, and no follow-up to discover the end"
+            vec![(1, None), (1, Some(50))],
+            "one request for the rows, one more that returns none and ends the loop"
         );
     }
 

--- a/services/photon/src/api/method/rings/common.rs
+++ b/services/photon/src/api/method/rings/common.rs
@@ -295,21 +295,6 @@ fn cursor_bincode_config() -> impl bincode::config::Config {
 }
 
 /// Position of the last row returned, or `None` when there were none.
-///
-/// A short page used to return `None`, on the reasoning that a page below the
-/// limit is the end of the stream and so there is nothing left to page to. That
-/// is true for pagination and wrong for resumption: the cursor is also the
-/// client's sync watermark, and a wallet whose whole history fits in one page
-/// therefore recorded no watermark and refetched everything on every sync. On
-/// devnet an 881-transaction wallet spent 2.4s of a 5.0s sync doing exactly
-/// that, growing with every transfer.
-///
-/// Returning the position whenever rows exist costs one extra request per
-/// chunk per sync -- the client asks once more and gets an empty page, which
-/// yields `None` here and ends the loop. Deliberately not a new response field:
-/// the response types are `deny_unknown_fields`, so an added field would break
-/// every deployed client, whereas this shape is what clients already handle
-/// when a final page happens to be exactly `limit` rows.
 pub(super) fn next_cursor_from_rows<T>(
     rows: &[T],
     cursor_from_row: impl FnOnce(&T) -> Result<Vec<u8>, PhotonApiError>,

--- a/services/photon/src/api/method/rings/common.rs
+++ b/services/photon/src/api/method/rings/common.rs
@@ -294,15 +294,26 @@ fn cursor_bincode_config() -> impl bincode::config::Config {
         .with_fixed_int_encoding()
 }
 
+/// Position of the last row returned, or `None` when there were none.
+///
+/// A short page used to return `None`, on the reasoning that a page below the
+/// limit is the end of the stream and so there is nothing left to page to. That
+/// is true for pagination and wrong for resumption: the cursor is also the
+/// client's sync watermark, and a wallet whose whole history fits in one page
+/// therefore recorded no watermark and refetched everything on every sync. On
+/// devnet an 881-transaction wallet spent 2.4s of a 5.0s sync doing exactly
+/// that, growing with every transfer.
+///
+/// Returning the position whenever rows exist costs one extra request per
+/// chunk per sync -- the client asks once more and gets an empty page, which
+/// yields `None` here and ends the loop. Deliberately not a new response field:
+/// the response types are `deny_unknown_fields`, so an added field would break
+/// every deployed client, whereas this shape is what clients already handle
+/// when a final page happens to be exactly `limit` rows.
 pub(super) fn next_cursor_from_rows<T>(
     rows: &[T],
-    limit: u64,
     cursor_from_row: impl FnOnce(&T) -> Result<Vec<u8>, PhotonApiError>,
 ) -> Result<Option<Base64String>, PhotonApiError> {
-    if u64_from_usize(rows.len(), "row count")? < limit {
-        return Ok(None);
-    }
-
     rows.last()
         .map(cursor_from_row)
         .transpose()
@@ -349,12 +360,6 @@ pub(super) fn u64_from_i64(value: i64, field: &str) -> Result<u64, PhotonApiErro
     })
 }
 
-fn u64_from_usize(value: usize, field: &str) -> Result<u64, PhotonApiError> {
-    u64::try_from(value).map_err(|_| {
-        PhotonApiError::UnexpectedError(format!("{} {} does not fit in u64", field, value))
-    })
-}
-
 pub(super) fn u16_from_i16(value: i16, field: &str) -> Result<u16, PhotonApiError> {
     u16::try_from(value).map_err(|_| {
         PhotonApiError::UnexpectedError(format!("Invalid negative {}: {}", field, value))
@@ -389,4 +394,36 @@ pub(super) fn rings_output_slot_from_parts(
         output_context: rings_output_context_from_parts(hash, tree, leaf_index)?,
         payload: Base64String(payload),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cursor_of(row: &u64) -> Result<Vec<u8>, PhotonApiError> {
+        Ok(row.to_be_bytes().to_vec())
+    }
+
+    /// The cursor doubles as the client's sync watermark, so a short page has to
+    /// carry one. Returning `None` there -- correct for "is there another page?"
+    /// -- made every wallet whose history fits in one page refetch all of it on
+    /// every sync.
+    #[test]
+    fn a_short_page_still_reports_its_last_row() {
+        let rows = vec![10u64, 50];
+        let cursor = next_cursor_from_rows(&rows, cursor_of).expect("cursor");
+        assert_eq!(
+            cursor.map(|c| c.0),
+            Some(50u64.to_be_bytes().to_vec()),
+            "a page below the limit still reports where it got to"
+        );
+    }
+
+    /// How the loop terminates now: the client asks once more and gets nothing.
+    #[test]
+    fn an_empty_page_ends_the_stream() {
+        let rows: Vec<u64> = Vec::new();
+        let cursor = next_cursor_from_rows(&rows, cursor_of).expect("cursor");
+        assert!(cursor.is_none(), "no rows means no position to resume from");
+    }
 }

--- a/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
@@ -55,7 +55,7 @@ pub async fn get_encrypted_utxos_by_tags(
     crate::api::set_transaction_isolation_if_needed(&tx).await?;
 
     let rows = fetch_encrypted_utxo_rows(&tx, &request.tags, cursor.as_ref(), limit).await?;
-    let next_cursor = next_cursor_from_rows(&rows, limit, encrypted_utxo_cursor_from_row)?;
+    let next_cursor = next_cursor_from_rows(&rows, encrypted_utxo_cursor_from_row)?;
 
     let matches = rows
         .into_iter()

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -132,7 +132,7 @@ async fn get_shielded_transactions(
 
     let matched_txs =
         fetch_matching_rings_transactions(&tx, values, cursor.as_ref(), limit, match_by).await?;
-    let next_cursor = next_cursor_from_rows(&matched_txs, limit, shielded_tx_cursor_from_row)?;
+    let next_cursor = next_cursor_from_rows(&matched_txs, shielded_tx_cursor_from_row)?;
 
     let transactions = hydrate_shielded_transactions(&tx, matched_txs)
         .await?

--- a/services/photon/tests/integration_tests/rings_event_parser_tests.rs
+++ b/services/photon/tests/integration_tests/rings_event_parser_tests.rs
@@ -1320,7 +1320,10 @@ async fn assert_rings_api_exposes_output_hashes(
         .await
         .unwrap();
     assert_eq!(shielded.context.block_time, UNSHIELD_SLOT as i64);
-    assert!(shielded.next_cursor.is_none());
+    // A non-empty page carries the position of its last row even when it is
+    // short, so a client can resume from the tip rather than rescan. The stream
+    // ends on the next page, which comes back empty.
+    assert!(shielded.next_cursor.is_some());
     assert!(!shielded.transactions.is_empty());
     let output_slot = shielded
         .transactions
@@ -1368,7 +1371,7 @@ async fn assert_rings_api_exposes_output_hashes(
 
     let encrypted = get_encrypted_utxos_by_tags(db, request).await.unwrap();
     assert_eq!(encrypted.context.block_time, UNSHIELD_SLOT as i64);
-    assert!(encrypted.next_cursor.is_none());
+    assert!(encrypted.next_cursor.is_some());
     assert!(!encrypted.matches.is_empty());
     let encrypted_match = encrypted
         .matches


### PR DESCRIPTION
Two halves of one mechanism: the client remembers where each tag was read to, and photon reports a position even on the last page. Separately, neither is complete — a client that syncs to the tip cannot record where the tip was.

## Client: per-tag cursors

A tag discovered late was skipped permanently. Sync kept a single cursor shared by every view tag. Tags are discovered lazily, as transactions decrypt, so a tag learned in a later round was queried with a cursor already advanced past its transactions, and those transactions were never returned again. The motivating case is one account on two devices: device B derives tags from its own counter, outside device A's initial window, so A advances the shared cursor past B's history. That is a permanently wrong balance, not a slow sync.

Every round also refetched the whole history. Rounds exist so that tags found by decrypting round N can be queried in round N+1, but each round re-queried every tag from position zero. On devnet, round 1 refetched all 222 transactions to find a handful of new tags.

Cursors are now keyed by tag. Tags sharing a resume point are grouped into one request, so the request count is unchanged in the common case where every tag sits at the same position. Tags read to the tip are recorded for the duration of a sync and skipped in later rounds; that set is not persisted, since "the tip" means the tip as of now. Transactions and encrypted utxos keep separate sets, because reaching the tip of one stream says nothing about the other.

## Server: report the last row's position on a short page

`next_cursor_from_rows` returned `None` when a page came back shorter than the limit. It now always reports the last row's position.

```rust
rows.last().map(cursor_from_row).transpose().map(|c| c.map(Base64String))
```

The cursor does double duty. As a page token, "short page means no more pages" is correct and `None` is a fine answer. As a sync watermark it is the client's record of how far it has read, and dropping it on the last page is exactly when the client most needs it.

No schema change, deliberately. Response types are `#[serde(deny_unknown_fields)]`, so adding a field would break every deployed client. This changes what an existing optional field contains, not its shape: `next_cursor` was already `Option`, callers already handled both cases, and a cursor pointing at the last row of a short page is a valid cursor — paging from it returns an empty page, which is the correct terminal state.

Callers can also stop one round trip earlier, because a short page is already known to be the last:

```rust
let last_page = response.transactions.len() < config.page_limit as usize;
cursor = response.next_cursor;
if last_page || cursor.is_none() { break; }
```

## Soundness

Persisting a watermark across syncs is sound only if photon cannot insert a row behind a position it has already returned. It cannot: block batches commit one at a time, in slot order, inside a single transaction (`index_block_batch`), and there is no re-index path. Photon indexes at `Confirmed` and never re-indexes a rolled-back slot; that exposure predates this change.

## The mock was hiding both halves

The test mock returned a cursor for every non-empty page, while photon returned `None` for any page shorter than the limit (`next_cursor_from_rows`). So the mock let a client look incremental in tests while rescanning from zero in production — `tag_cursors=0` after a round that fetched 222 rows. Making the mock faithful to the server broke the per-tag cursor test on the first run, which is what surfaced the server half.

`a_short_page_still_reports_its_last_row` and `an_empty_page_ends_the_stream` pin both directions: a short page must carry a cursor, an empty page must not.

## Measured

Devnet, wallet of 222 transactions. Balance verified identical against a build of `main` (99600000 both), and a transfer settled exactly (-1000000 sender, +1000000 recipient).

| | before | after |
|---|---|---|
| sync total | 3427ms | ~2700ms |
| round 1, tags | 749ms | ~205ms |
| round 1, proofless | 662ms | ~124ms |

Sync cost no longer grows with history.

Nullifier queries still restart from zero every round and are now the largest remaining repeat, ~510ms of round 1. The same treatment applies; left out to keep this reviewable.
