### PR TITLE
client: collect queued proofs on a sub-second backoff

### DIFF
--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -220,21 +220,30 @@ impl<R: Rpc> ZolanaClient<R> {
         validate_fee_payer_pubkey(&signed.transaction.payer, fee_payer)?;
         let owner_signers = signed.transaction.owner_signer_pubkeys()?;
         let commitments = signed.transaction.input_utxo_hashes()?;
-        let spend_proofs = fetch_spend_proofs(
-            self.blocking_indexer(),
-            signed.input_tree,
-            &commitments,
-            None,
-        )?;
-        let dummy_proofs = fetch_dummy_nullifier_proofs(
-            self.blocking_indexer(),
-            signed.input_tree,
-            &signed.transaction,
-            None,
-        )?;
+        let spend_proofs = {
+            let _t = crate::timing::Phase::start("fetch_spend_proofs", 0);
+            fetch_spend_proofs(
+                self.blocking_indexer(),
+                signed.input_tree,
+                &commitments,
+                None,
+            )?
+        };
+        let dummy_proofs = {
+            let _t = crate::timing::Phase::start("fetch_dummy_nullifier_proofs", 0);
+            fetch_dummy_nullifier_proofs(
+                self.blocking_indexer(),
+                signed.input_tree,
+                &signed.transaction,
+                None,
+            )?
+        };
         let assembled = assemble(signed.transaction.clone(), &spend_proofs, &dummy_proofs)?;
         let ProverInputs::Eddsa(inputs) = &assembled.prover_inputs;
-        let proof = self.blocking_prover().prove_transfer(inputs)?;
+        let proof = {
+            let _t = crate::timing::Phase::start("prove_transfer", 0);
+            self.blocking_prover().prove_transfer(inputs)?
+        };
         let proof = ProofCompressed::try_from(proof)?.to_transact_proof();
         build_unsigned_solana_transaction(
             ComputeBudgetConfig {

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -11,6 +11,7 @@
 //! - `solana-rpc`: concrete Solana RPC adapters
 //! - `client`: `indexer-api` + `solana-rpc`
 
+#[cfg(feature = "indexer-api")]
 pub mod client;
 pub mod error;
 #[cfg(feature = "indexer-api")]

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -11,7 +11,6 @@
 //! - `solana-rpc`: concrete Solana RPC adapters
 //! - `client`: `indexer-api` + `solana-rpc`
 
-#[cfg(feature = "indexer-api")]
 pub mod client;
 pub mod error;
 #[cfg(feature = "indexer-api")]
@@ -21,6 +20,7 @@ pub mod retry;
 pub mod rpc;
 #[cfg(feature = "solana-rpc")]
 pub mod solana_rpc;
+pub mod timing;
 
 #[cfg(feature = "indexer-api")]
 pub use client::{SignedPrivateTransaction, ZolanaClient, DEFAULT_TRANSACT_CU_LIMIT};

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -260,11 +260,25 @@ impl ProverClient {
         // used to be `.max(1)` and `sleep_secs`, which put a hard 1s floor on
         // every proof: a 270ms proof measured 3.3s end to end, essentially all
         // of it spent asleep between polls.
+        // The backoff ceiling is deliberately left to `poll_interval_secs` rather than
+        // clamped to something tighter.
+        //
+        // Tightening it to 250ms looks like an obvious win -- a finished proof then
+        // waits at most a quarter second to be collected -- and it measurably is not.
+        // Two 8-worker load tests, identical apart from this ceiling:
+        //
+        //     ceiling 1s     prove mean 2025ms   1.14 tps
+        //     ceiling 250ms  prove mean 3632ms   0.92 tps
+        //
+        // sync, send, and confirm were unchanged across the pair, so the regression is
+        // isolated to proving. Polling four times as hard contends with the prover's
+        // own queue rather than shortening the wait. Poll often enough to avoid the
+        // whole-second floor, then get out of the way.
         let poll_cap_ms = self
             .async_poll
             .poll_interval_secs
             .saturating_mul(1_000)
-            .clamp(INITIAL_POLL_MS, MAX_POLL_INTERVAL_MS);
+            .max(INITIAL_POLL_MS);
         let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
         let mut waited_ms = 0u64;
         let mut interval_ms = INITIAL_POLL_MS;
@@ -345,16 +359,6 @@ impl ProverClient {
 /// second, so the first poll should land almost immediately; the cost of being
 /// early is one cheap GET.
 const INITIAL_POLL_MS: u64 = 25;
-
-/// Ceiling on the gap between status polls.
-///
-/// An unbounded doubling trades the old bug for a smaller version of itself:
-/// with a 1s ceiling a proof that lands just after a poll waits up to another
-/// second. Under an 8-worker load test that showed as a 2025ms mean prove phase
-/// while the prover reported 0.267s of compute throughout, so the overshoot was
-/// most of what remained. 250ms bounds the wasted wait to a quarter second and
-/// still costs only about ten cheap status GETs for a 2s proof.
-const MAX_POLL_INTERVAL_MS: u64 = 250;
 
 /// Next gap in the backoff, doubling up to `cap_ms`.
 ///
@@ -496,7 +500,7 @@ impl AsyncProverClient {
             .async_poll
             .poll_interval_secs
             .saturating_mul(1_000)
-            .clamp(INITIAL_POLL_MS, MAX_POLL_INTERVAL_MS);
+            .max(INITIAL_POLL_MS);
         let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
         let mut waited_ms = 0u64;
         let mut interval_ms = INITIAL_POLL_MS;

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -205,6 +205,7 @@ impl ProverClient {
 
     fn send(&self, body: String) -> Result<Proof, ClientError> {
         let url = format!("{}{}", self.server_address, PROVE_PATH);
+        crate::timing::note(0, "prover_request_bytes", body.len());
         let mut attempt = 0;
         let response = loop {
             attempt += 1;
@@ -255,14 +256,24 @@ impl ProverClient {
     /// Poll the async job status endpoint until the queued proof completes.
     fn poll_async(&self, job_id: &str) -> Result<Proof, ClientError> {
         let url = format!("{}/prove/status?job_id={}", self.server_address, job_id);
-        let poll_interval = self.async_poll.poll_interval_secs.max(1);
-        let max_wait = self.async_poll.max_wait_secs;
-        let mut waited = 0u64;
+        // The configured interval caps the backoff rather than setting it. This
+        // used to be `.max(1)` and `sleep_secs`, which put a hard 1s floor on
+        // every proof: a 270ms proof measured 3.3s end to end, essentially all
+        // of it spent asleep between polls.
+        let poll_cap_ms = self
+            .async_poll
+            .poll_interval_secs
+            .saturating_mul(1_000)
+            .max(INITIAL_POLL_MS);
+        let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
+        let mut waited_ms = 0u64;
+        let mut interval_ms = INITIAL_POLL_MS;
         loop {
             let response = match self.http.get(&url).send() {
                 Ok(response) => response,
                 Err(_) => {
-                    wait_or_timeout(job_id, &mut waited, max_wait, poll_interval)?;
+                    wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                    interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
             };
@@ -277,14 +288,16 @@ impl ProverClient {
                 )));
             }
             if status.is_server_error() {
-                wait_or_timeout(job_id, &mut waited, max_wait, poll_interval)?;
+                wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 continue;
             }
 
             let text = match response.text() {
                 Ok(text) => text,
                 Err(_) => {
-                    wait_or_timeout(job_id, &mut waited, max_wait, poll_interval)?;
+                    wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                    interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
             };
@@ -305,7 +318,8 @@ impl ProverClient {
                 }
                 // queued / processing / unknown: keep polling until the bound.
                 _ => {
-                    wait_or_timeout(job_id, &mut waited, max_wait, poll_interval)?;
+                    wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                    interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 }
             }
         }
@@ -327,22 +341,38 @@ impl ProverClient {
     }
 }
 
+/// First gap between status polls. A transfer proof completes in well under a
+/// second, so the first poll should land almost immediately; the cost of being
+/// early is one cheap GET.
+const INITIAL_POLL_MS: u64 = 25;
+
+/// Next gap in the backoff, doubling up to `cap_ms`.
+///
+/// The configured poll interval is the CEILING, not a fixed period: a proof that
+/// finishes in 270ms should not wait a full second to be collected, but a proof
+/// that takes a minute should not be polled 2400 times either.
+fn next_poll_interval_ms(current_ms: u64, cap_ms: u64) -> u64 {
+    current_ms
+        .saturating_mul(2)
+        .min(cap_ms.max(INITIAL_POLL_MS))
+}
+
 fn wait_or_timeout(
     job_id: &str,
-    waited: &mut u64,
-    max_wait: u64,
-    poll_interval: u64,
+    waited_ms: &mut u64,
+    max_wait_ms: u64,
+    poll_interval_ms: u64,
 ) -> Result<(), ClientError> {
-    if *waited >= max_wait {
-        let waited_secs = *waited;
+    if *waited_ms >= max_wait_ms {
+        let waited_secs = *waited_ms / 1_000;
         return Err(ClientError::ProverServer(format!(
             "async proof timed out after {waited_secs}s (job {job_id})"
         )));
     }
-    let remaining = max_wait.saturating_sub(*waited);
-    let sleep_secs = poll_interval.min(remaining);
-    sleep(Duration::from_secs(sleep_secs));
-    *waited = (*waited).saturating_add(sleep_secs);
+    let remaining = max_wait_ms.saturating_sub(*waited_ms);
+    let sleep_ms = poll_interval_ms.min(remaining);
+    sleep(Duration::from_millis(sleep_ms));
+    *waited_ms = (*waited_ms).saturating_add(sleep_ms);
     Ok(())
 }
 
@@ -742,6 +772,64 @@ mod tests {
         assert_eq!(
             prover_start_command("zolana", 3001, Some("  ")),
             "zolana dev prover start --prover-port 3001"
+        );
+    }
+
+    /// The prover is queue-backed: `/prove` returns a job handle and the proof
+    /// is collected by polling. The gap between polls used to be
+    /// `Duration::from_secs(poll_interval.max(1))`, so a proof the server
+    /// finished in 270ms was not collected for a further second or more --
+    /// measured on devnet as 3.3s end to end for 270ms of proving, which made
+    /// the prover call the largest phase of a transfer for no real reason.
+    ///
+    /// Asserts wall-clock rather than the sleep arithmetic, because the bug was
+    /// only visible as latency.
+    #[test]
+    fn a_proof_ready_on_the_first_poll_is_not_held_for_a_whole_second() {
+        let server = MockServer::respond_with(vec![
+            MockResponse::json(202, json!({ "job_id": "job-1", "status": "queued" })),
+            MockResponse::json(
+                200,
+                json!({
+                    "status": "completed",
+                    "result": { "proof": gnark_proof(), "proof_duration_ms": 7 },
+                }),
+            ),
+        ]);
+        let started = std::time::Instant::now();
+        queued_prover_client(server.url())
+            .send("{}".to_string())
+            .expect("queued proof should complete");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "collecting a ready proof took {elapsed:?}; the poll interval is a \
+             ceiling, not a floor"
+        );
+    }
+
+    /// The configured interval bounds the backoff instead of fixing it, so a
+    /// long proof still settles into infrequent polling.
+    #[test]
+    fn poll_backoff_doubles_up_to_the_configured_ceiling() {
+        let cap = 1_000;
+        let mut interval = INITIAL_POLL_MS;
+        let mut seen = vec![interval];
+        for _ in 0..8 {
+            interval = next_poll_interval_ms(interval, cap);
+            seen.push(interval);
+        }
+        assert_eq!(seen[0], 25, "first poll lands almost immediately");
+        assert_eq!(&seen[1..4], &[50, 100, 200]);
+        assert_eq!(
+            *seen.last().expect("non-empty"),
+            cap,
+            "backoff settles at the configured interval"
+        );
+        assert!(
+            seen.windows(2).all(|w| w[1] >= w[0]),
+            "backoff is monotonic"
         );
     }
 

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -264,7 +264,7 @@ impl ProverClient {
             .async_poll
             .poll_interval_secs
             .saturating_mul(1_000)
-            .max(INITIAL_POLL_MS);
+            .clamp(INITIAL_POLL_MS, MAX_POLL_INTERVAL_MS);
         let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
         let mut waited_ms = 0u64;
         let mut interval_ms = INITIAL_POLL_MS;
@@ -345,6 +345,16 @@ impl ProverClient {
 /// second, so the first poll should land almost immediately; the cost of being
 /// early is one cheap GET.
 const INITIAL_POLL_MS: u64 = 25;
+
+/// Ceiling on the gap between status polls.
+///
+/// An unbounded doubling trades the old bug for a smaller version of itself:
+/// with a 1s ceiling a proof that lands just after a poll waits up to another
+/// second. Under an 8-worker load test that showed as a 2025ms mean prove phase
+/// while the prover reported 0.267s of compute throughout, so the overshoot was
+/// most of what remained. 250ms bounds the wasted wait to a quarter second and
+/// still costs only about ten cheap status GETs for a 2s proof.
+const MAX_POLL_INTERVAL_MS: u64 = 250;
 
 /// Next gap in the backoff, doubling up to `cap_ms`.
 ///
@@ -482,14 +492,20 @@ impl AsyncProverClient {
 
     async fn poll_async(&self, job_id: &str) -> Result<Proof, ClientError> {
         let url = format!("{}/prove/status?job_id={}", self.server_address, job_id);
-        let poll_interval = self.async_poll.poll_interval_secs.max(1);
-        let max_wait = self.async_poll.max_wait_secs;
-        let mut waited = 0u64;
+        let poll_cap_ms = self
+            .async_poll
+            .poll_interval_secs
+            .saturating_mul(1_000)
+            .clamp(INITIAL_POLL_MS, MAX_POLL_INTERVAL_MS);
+        let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
+        let mut waited_ms = 0u64;
+        let mut interval_ms = INITIAL_POLL_MS;
         loop {
             let response = match self.http.get(&url).send().await {
                 Ok(response) => response,
                 Err(_) => {
-                    async_wait_or_timeout(job_id, &mut waited, max_wait, poll_interval).await?;
+                    async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                    interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
             };
@@ -504,14 +520,16 @@ impl AsyncProverClient {
                 )));
             }
             if status.is_server_error() {
-                async_wait_or_timeout(job_id, &mut waited, max_wait, poll_interval).await?;
+                async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 continue;
             }
 
             let text = match response.text().await {
                 Ok(text) => text,
                 Err(_) => {
-                    async_wait_or_timeout(job_id, &mut waited, max_wait, poll_interval).await?;
+                    async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                    interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
             };
@@ -529,7 +547,8 @@ impl AsyncProverClient {
                     )));
                 }
                 _ => {
-                    async_wait_or_timeout(job_id, &mut waited, max_wait, poll_interval).await?;
+                    async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                    interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 }
             }
         }
@@ -538,20 +557,20 @@ impl AsyncProverClient {
 
 async fn async_wait_or_timeout(
     job_id: &str,
-    waited: &mut u64,
-    max_wait: u64,
-    poll_interval: u64,
+    waited_ms: &mut u64,
+    max_wait_ms: u64,
+    poll_interval_ms: u64,
 ) -> Result<(), ClientError> {
-    if *waited >= max_wait {
-        let waited_secs = *waited;
+    if *waited_ms >= max_wait_ms {
+        let waited_secs = *waited_ms / 1_000;
         return Err(ClientError::ProverServer(format!(
             "async proof timed out after {waited_secs}s (job {job_id})"
         )));
     }
-    let remaining = max_wait.saturating_sub(*waited);
-    let sleep_secs = poll_interval.min(remaining);
-    async_sleep(Duration::from_secs(sleep_secs)).await;
-    *waited = (*waited).saturating_add(sleep_secs);
+    let remaining = max_wait_ms.saturating_sub(*waited_ms);
+    let sleep_ms = poll_interval_ms.min(remaining);
+    async_sleep(Duration::from_millis(sleep_ms)).await;
+    *waited_ms = (*waited_ms).saturating_add(sleep_ms);
     Ok(())
 }
 

--- a/sdk-libs/client/src/timing.rs
+++ b/sdk-libs/client/src/timing.rs
@@ -1,0 +1,48 @@
+//! Opt-in phase timing, printed to stderr when `ZOLANA_TIMING` is set.
+//!
+//! Lives in the client crate because the interesting
+//! question spans crates: a transfer's cost splits across syncing, fetching
+//! proofs, and proving, and attributing it needs the same clock on all of them.
+
+use std::{
+    sync::OnceLock,
+    time::{Duration, Instant},
+};
+
+fn enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ZOLANA_TIMING").is_some())
+}
+
+/// Emit a scalar observation (counts, sizes) alongside the phase timings.
+pub fn note(round: usize, key: &str, value: usize) {
+    if enabled() {
+        eprintln!("timing round={round} {key}={value}");
+    }
+}
+
+/// Times from construction to drop, so `?` early-returns still report.
+pub struct Phase {
+    name: &'static str,
+    round: usize,
+    started: Instant,
+}
+
+impl Phase {
+    pub fn start(name: &'static str, round: usize) -> Self {
+        Self {
+            name,
+            round,
+            started: Instant::now(),
+        }
+    }
+}
+
+impl Drop for Phase {
+    fn drop(&mut self) {
+        if enabled() {
+            let ms = self.started.elapsed().max(Duration::ZERO).as_millis();
+            eprintln!("timing round={} phase={} ms={}", self.round, self.name, ms);
+        }
+    }
+}

--- a/sdk-libs/wallet/src/actions/transaction.rs
+++ b/sdk-libs/wallet/src/actions/transaction.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use zolana_client::timing;
 
 use solana_pubkey::Pubkey;
 use zolana_interface::{
@@ -188,7 +189,10 @@ pub async fn create_transfer<R: AsyncRpc>(
 pub fn create_transfer_sync<R: Rpc>(
     request: TransferParams<'_, R>,
 ) -> Result<CreatedTransfer, ClientError> {
-    let recipient = try_resolve_registered_address(request.rpc, request.recipient)?;
+    let recipient = {
+        let _t = timing::Phase::start("resolve_recipient", 0);
+        try_resolve_registered_address(request.rpc, request.recipient)?
+    };
     let spl_token_program = if recipient.is_none() {
         resolve_asset_token_program(request.rpc, request.asset)?
     } else {
@@ -728,10 +732,18 @@ pub fn sign_private_transaction_sync_with_signers<A: SyncWalletAuthority + ?Size
     fee_payer: &dyn Signer,
     additional_native_signers: &[&dyn Signer],
 ) -> Result<SolanaTransaction, ClientError> {
-    let shielded = sign_shielded_transaction_sync(transaction, wallet, authority)?;
-    let (blockhash, _) = client.rpc().get_latest_blockhash()?;
-    let mut native =
-        client.finish_submission_unsigned_sync(&shielded, fee_payer.pubkey(), blockhash)?;
+    let shielded = {
+        let _t = timing::Phase::start("sign_shielded", 0);
+        sign_shielded_transaction_sync(transaction, wallet, authority)?
+    };
+    let (blockhash, _) = {
+        let _t = timing::Phase::start("get_latest_blockhash", 0);
+        client.rpc().get_latest_blockhash()?
+    };
+    let mut native = {
+        let _t = timing::Phase::start("finish_submission", 0);
+        client.finish_submission_unsigned_sync(&shielded, fee_payer.pubkey(), blockhash)?
+    };
     let mut signers = Vec::with_capacity(1 + additional_native_signers.len());
     signers.push(fee_payer);
     signers.extend_from_slice(additional_native_signers);

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -4,6 +4,8 @@ use std::{
 };
 
 use solana_address::Address;
+
+use zolana_client::timing;
 use zolana_interface::{
     event::{decode_encrypted_ring_deposit_output_data, decode_output_data},
     state::SplAssetRegistry,
@@ -25,51 +27,6 @@ use zolana_client::{
 const DEFAULT_TAG_QUERY_CHUNK: usize = 64;
 const DEFAULT_PAGE_LIMIT: u32 = 1_000;
 const DEFAULT_SYNC_ROUNDS: usize = 6;
-
-mod timing {
-    use std::{
-        sync::OnceLock,
-        time::{Duration, Instant},
-    };
-
-    fn enabled() -> bool {
-        static ON: OnceLock<bool> = OnceLock::new();
-        *ON.get_or_init(|| std::env::var_os("ZOLANA_TIMING").is_some())
-    }
-
-    /// Emit a scalar observation (counts, sizes) alongside the phase timings.
-    pub(super) fn note(round: usize, key: &str, value: usize) {
-        if enabled() {
-            eprintln!("timing round={round} {key}={value}");
-        }
-    }
-
-    /// Times from construction to drop, so `?` early-returns still report.
-    pub(super) struct Phase {
-        name: &'static str,
-        round: usize,
-        started: Instant,
-    }
-
-    impl Phase {
-        pub(super) fn start(name: &'static str, round: usize) -> Self {
-            Self {
-                name,
-                round,
-                started: Instant::now(),
-            }
-        }
-    }
-
-    impl Drop for Phase {
-        fn drop(&mut self) {
-            if enabled() {
-                let ms = self.started.elapsed().max(Duration::ZERO).as_millis();
-                eprintln!("timing round={} phase={} ms={}", self.round, self.name, ms);
-            }
-        }
-    }
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SyncWalletConfig {
@@ -754,6 +711,8 @@ fn now_unix_ts() -> i64 {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+
+    use zolana_client::timing;
 
     use solana_signature::Signature;
     use zolana_interface::event::{encode_output_data, ProoflessOutput};

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -712,8 +712,6 @@ fn now_unix_ts() -> i64 {
 mod tests {
     use std::collections::HashMap;
 
-    use zolana_client::timing;
-
     use solana_signature::Signature;
     use zolana_interface::event::{encode_output_data, ProoflessOutput};
     use zolana_keypair::{ShieldedKeypair, ViewingKey};


### PR DESCRIPTION
A transfer's `prove` phase measured 3334ms on devnet. The prover's own instrumentation reported 0.27s mean and 0.28s max for the same circuit over the same period. Round-trip to the ALB is ~150ms and the request body is 12KB, so neither transport nor payload accounts for the gap.

The prover is queue-backed: `POST /prove` returns a job handle, and the proof is collected by polling `/prove/status`. The gap between polls was whole seconds, floored at one.

```rust
let poll_interval = self.async_poll.poll_interval_secs.max(1);
...
sleep(Duration::from_secs(sleep_secs));
```

The server finishes in 270ms and the client then sleeps a full second or more before collecting the result. Over 2.9s of every transfer was spent asleep.

The configured interval now caps the backoff instead of fixing it: the first poll is at 25ms, doubling up to `poll_interval_secs`. Fast proofs return promptly, slow ones still settle into infrequent polling, and `poll_interval_secs` keeps its meaning for anyone who set it to limit load.

Measured against deployed devnet, same wallet, same circuit, same 12KB request:

| | before | after |
|---|---|---|
| `prove_transfer` | 3334ms | 614ms, 577ms |

The phase breakdown that located it, behind `ZOLANA_TIMING`:

```
sync_wallet_total            2309ms
resolve_recipient            1174ms
sign_shielded                   4ms
get_latest_blockhash          270ms
fetch_spend_proofs            312ms
fetch_dummy_nullifier_proofs  114ms
prove_transfer               3334ms   (270ms of it proving)
```

This also bears on prover sizing. The prover was scaled to 16 vCPU to make transfers faster, which could not have helped: the work was finished in 270ms and the client was not collecting it. Across a 429-second eight-worker run the prover accumulated 89 seconds of compute in total, and `prover_active_jobs` read ~0 because a 0.27s job is rarely in flight when the 60s scrape lands.

Phase timing moves from a private module inside `wallet_sync` to the client crate: attributing a transfer's cost spans syncing, proof fetching and proving, and that needs one clock.

The regression test asserts wall-clock rather than the sleep arithmetic, since the bug was only ever visible as latency.

`resolve_recipient` at 1174ms, and the three further sequential round trips (`get_latest_blockhash`, `fetch_spend_proofs`, `fetch_dummy_nullifier_proofs`), are independent of each other and could overlap. Left out to keep this reviewable.
