### PR TITLE
sdk: run independent indexer round trips concurrently

### DIFF
--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -1,5 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
+    panic::resume_unwind,
+    thread,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -114,7 +116,7 @@ pub fn sync_wallet<A, I>(
 ) -> Result<SyncReport, ClientError>
 where
     A: SyncWalletAuthority + ?Sized,
-    I: Rpc,
+    I: Rpc + Sync,
 {
     sync_wallet_with_config(wallet, authority, indexer, SyncWalletConfig::default())
 }
@@ -127,7 +129,7 @@ pub fn sync_wallet_with_config<A, I>(
 ) -> Result<SyncReport, ClientError>
 where
     A: SyncWalletAuthority + ?Sized,
-    I: Rpc,
+    I: Rpc + Sync,
 {
     let config = normalized_config(config);
     let material = authority.sync_material()?;
@@ -156,44 +158,82 @@ where
         timing::note(round, "tags", tags.len());
         timing::note(round, "nullifiers", nullifiers.len());
         {
-            let _t = timing::Phase::start("fetch_shielded_by_tags", round);
-            // Cursors are taken out of the wallet and put back, rather than held
-            // borrowed: `wallet` is needed mutably further down this loop.
+            let _t = timing::Phase::start("fetch_round", round);
+            // The three queries are independent: different indexer methods,
+            // disjoint cursor state, and separate accumulators. Run sequentially
+            // a round cost the sum of three round trips (866 + 521 + 503ms
+            // measured on devnet) when it need only cost the slowest.
+            //
+            // Cursors come out of the wallet and go back rather than staying
+            // borrowed, because `wallet` is needed mutably further down.
             let mut cursors = std::mem::take(&mut wallet.sync_cursors);
-            let result = fetch_shielded_transactions_incremental(
-                indexer,
-                &tags,
-                &mut transactions,
-                config,
-                freshness_gate.take(),
-                &mut cursors,
-                &mut scanned_to_tip,
-            );
+            let mut by_nullifier: HashMap<String, ShieldedTransaction> = HashMap::new();
+            // One gate for the whole round, not one per call: every query in a
+            // round should read the chain at the same freshness bound, and
+            // `take()`ing it three times would gate only the first.
+            let gate = freshness_gate.take();
+
+            let (tag_result, nullifier_result, proofless_result) = thread::scope(|scope| {
+                let tags_ref = &tags;
+                let tag_handle = scope.spawn(|| {
+                    let _t = timing::Phase::start("fetch_shielded_by_tags", round);
+                    fetch_shielded_transactions_incremental(
+                        indexer,
+                        tags_ref,
+                        &mut transactions,
+                        config,
+                        gate,
+                        &mut cursors,
+                        &mut scanned_to_tip,
+                    )
+                });
+                let nullifier_handle = scope.spawn(|| {
+                    let _t = timing::Phase::start("fetch_shielded_by_nullifiers", round);
+                    fetch_shielded_transactions_by_nullifiers(
+                        indexer,
+                        &nullifiers,
+                        &mut by_nullifier,
+                        config,
+                        gate,
+                        &mut nullifier_scanned_to_tip,
+                    )
+                });
+                let proofless_handle = scope.spawn(|| {
+                    let _t = timing::Phase::start("fetch_proofless_deposits", round);
+                    fetch_proofless_deposits(
+                        indexer,
+                        tags_ref,
+                        &mut proofless_deposits,
+                        config,
+                        gate,
+                        &mut proofless_scanned_to_tip,
+                    )
+                });
+                (
+                    tag_handle.join(),
+                    nullifier_handle.join(),
+                    proofless_handle.join(),
+                )
+            });
+
             wallet.sync_cursors = cursors;
-            result?;
+            // Propagate a panic rather than swallowing it into a sync error: a
+            // panicked fetch means a bug here, not an unreachable indexer.
+            let tag_result = tag_result.unwrap_or_else(|payload| resume_unwind(payload));
+            let nullifier_result =
+                nullifier_result.unwrap_or_else(|payload| resume_unwind(payload));
+            let proofless_result =
+                proofless_result.unwrap_or_else(|payload| resume_unwind(payload));
+            tag_result?;
+            nullifier_result?;
+            proofless_result?;
+
+            // Both queries return transactions; the by-tag map wins ties, which
+            // is the same precedence the sequential version had via `or_insert`.
+            for (key, tx) in by_nullifier {
+                transactions.entry(key).or_insert(tx);
+            }
             timing::note(round, "tag_cursors", wallet.sync_cursors.len());
-        }
-        {
-            let _t = timing::Phase::start("fetch_shielded_by_nullifiers", round);
-            fetch_shielded_transactions_by_nullifiers(
-                indexer,
-                &nullifiers,
-                &mut transactions,
-                config,
-                freshness_gate.take(),
-                &mut nullifier_scanned_to_tip,
-            )?;
-        }
-        {
-            let _t = timing::Phase::start("fetch_proofless_deposits", round);
-            fetch_proofless_deposits(
-                indexer,
-                &tags,
-                &mut proofless_deposits,
-                config,
-                freshness_gate.take(),
-                &mut proofless_scanned_to_tip,
-            )?;
         }
         timing::note(round, "transactions", transactions.len());
         timing::note(round, "proofless_deposits", proofless_deposits.len());

--- a/sdk-tests/zk-program-swap/sdk/src/index/maker.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/index/maker.rs
@@ -107,7 +107,7 @@ fn maker_order_candidate(
     })
 }
 
-pub fn index_maker<I: Rpc>(
+pub fn index_maker<I: Rpc + Sync>(
     wallet: &mut Wallet,
     keypair: &ShieldedKeypair,
     indexer: &I,

--- a/sdk-tests/zk-program-swap/sdk/src/index/poll.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/index/poll.rs
@@ -10,7 +10,7 @@ use crate::err;
 
 const INDEX_POLL: Duration = Duration::from_millis(500);
 
-pub(crate) fn index_until<I: Rpc, T>(
+pub(crate) fn index_until<I: Rpc + Sync, T>(
     wallet: &mut Wallet,
     keypair: &ShieldedKeypair,
     indexer: &I,
@@ -37,7 +37,7 @@ pub(crate) fn index_until<I: Rpc, T>(
     }
 }
 
-pub(crate) fn collect_tagged<I: Rpc, T>(
+pub(crate) fn collect_tagged<I: Rpc + Sync, T>(
     wallet: &Wallet,
     indexer: &I,
     mut scan: impl FnMut(&ShieldedTransaction) -> Result<Option<T>>,

--- a/sdk-tests/zk-program-swap/sdk/src/index/taker.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/index/taker.rs
@@ -111,7 +111,7 @@ impl TakerOrderCandidate {
     }
 }
 
-pub fn index_taker<I: Rpc, R: Rpc>(
+pub fn index_taker<I: Rpc + Sync, R: Rpc>(
     wallet: &mut Wallet,
     keypair: &ShieldedKeypair,
     indexer: &I,


### PR DESCRIPTION
Two places where independent indexer round trips ran back to back. Same technique in both, same reason they were serial, same measured caveat.

## A sync round's three queries

A sync round issues three independent queries: by tag, by nullifier, and for proofless deposits. Different indexer methods, disjoint cursor state, separate accumulators. They ran one after another, so a round cost the sum of three round trips rather than the slowest.

Devnet, same wallet, single client:

```
round 0   866 + 0 + 404ms   -> 902ms
round 1   713 + 521 + 503ms -> 467ms
sync total          3374ms  -> 1762ms
```

The freshness gate is now taken once per round and shared by all three, rather than taken three times. That is also more correct: previously only the first query of the first round was gated at all, and the intent is that a round reads the chain at one freshness bound.

## Spend and dummy nullifier proofs

Two more independent round trips on the submission path: different methods, neither consuming the other's output. 317ms and 114ms on devnet, so the pair cost 431ms where it need only cost 317ms.

## Bounds and failure handling

Both require `Sync` on the shared indexer, since the scoped threads share it — `I: Rpc + Sync` widened through the swap SDK's polling helpers for the sync round, and `R: Sync` widened through the two signing entry points for the proof fetch.

A panicking fetch is resumed rather than folded into a sync error, because it indicates a bug here rather than an unreachable indexer.

## Caveat

Both are single-client latency wins, not throughput wins. Under a 16-worker load test, aggregate throughput did not improve — see #199 and the stress results. Worth taking for interactive wallet sync; neither will raise TPS.
