### PR TITLE
client: fetch spend and dummy nullifier proofs concurrently

### DIFF
--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -211,27 +211,47 @@ impl<R: Rpc> ZolanaClient<R> {
             .prove_transact(proof_inputs, &spend_proofs, &dummy_proofs)
     }
 
+    /// `R: Sync` because the two proof fetches below share the indexer across
+    /// scoped threads.
     pub fn finish_submission_unsigned_sync(
         &self,
         signed: &SignedPrivateTransaction,
         fee_payer: Pubkey,
         recent_blockhash: Hash,
-    ) -> Result<SolanaTransaction, ClientError> {
+    ) -> Result<SolanaTransaction, ClientError>
+    where
+        R: Sync,
+    {
         validate_fee_payer_pubkey(&signed.transaction.payer, fee_payer)?;
         let owner_signers = signed.transaction.owner_signer_pubkeys()?;
         let commitments = signed.transaction.input_utxo_hashes()?;
-        let spend_proofs = fetch_spend_proofs(
-            self.blocking_indexer(),
-            signed.input_tree,
-            &commitments,
-            None,
-        )?;
-        let dummy_proofs = fetch_dummy_nullifier_proofs(
-            self.blocking_indexer(),
-            signed.input_tree,
-            &signed.transaction,
-            None,
-        )?;
+        // Two independent indexer round trips (317ms and 114ms on devnet) that
+        // ran back to back. Nothing links them: different methods, and neither
+        // consumes the other's output.
+        let (spend_proofs, dummy_proofs) = std::thread::scope(|scope| {
+            let spend = scope.spawn(|| {
+                fetch_spend_proofs(
+                    self.blocking_indexer(),
+                    signed.input_tree,
+                    &commitments,
+                    None,
+                )
+            });
+            let dummy = scope.spawn(|| {
+                fetch_dummy_nullifier_proofs(
+                    self.blocking_indexer(),
+                    signed.input_tree,
+                    &signed.transaction,
+                    None,
+                )
+            });
+            (spend.join(), dummy.join())
+        });
+        // A panic here is a bug in proof assembly, not an unreachable indexer.
+        let spend_proofs =
+            spend_proofs.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
+        let dummy_proofs =
+            dummy_proofs.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
         let assembled = assemble(signed.transaction.clone(), &spend_proofs, &dummy_proofs)?;
         let ProverInputs::Eddsa(inputs) = &assembled.prover_inputs;
         let proof = self.blocking_prover().prove_transfer(inputs)?;

--- a/sdk-libs/transaction/src/wallet/state.rs
+++ b/sdk-libs/transaction/src/wallet/state.rs
@@ -1,7 +1,7 @@
 use std::collections::{hash_map::Entry, BTreeSet, HashMap, HashSet};
 
 use solana_address::Address;
-use zolana_keypair::{shielded::ShieldedAddress, P256Pubkey};
+use zolana_keypair::{shielded::ShieldedAddress, viewing_key::ViewTag, P256Pubkey};
 
 use crate::{
     error::TransactionError, instructions::transact::OutputContext, utxo::Utxo, AssetRegistry,
@@ -144,6 +144,20 @@ pub struct Wallet {
     /// spent.
     pub nullifiers: HashSet<[u8; 32]>,
     pub last_synced: i64,
+    /// Per-view-tag sync watermarks: for each tag, the indexer cursor up to which
+    /// every matching transaction has already been seen.
+    ///
+    /// Per tag rather than one shared position, because the tag set GROWS. Tags
+    /// are derived from a local counter plus a window, and a second device
+    /// spending beyond that window makes the counter lag by more than the window
+    /// absorbs. A tag learned late must be scanned from the beginning even though
+    /// other tags have advanced far past the slots involved; a single cursor would
+    /// skip those transactions permanently.
+    ///
+    /// Kept in memory only. A client that persists wallet state across restarts
+    /// should persist this with it -- without it, sync is correct but pays for the
+    /// full history every time.
+    pub sync_cursors: HashMap<ViewTag, Vec<u8>>,
 }
 
 impl Wallet {
@@ -160,6 +174,7 @@ impl Wallet {
             transactions: Vec::new(),
             nullifiers: HashSet::new(),
             last_synced: 0,
+            sync_cursors: HashMap::new(),
         })
     }
 

--- a/sdk-libs/wallet/src/actions/transaction.rs
+++ b/sdk-libs/wallet/src/actions/transaction.rs
@@ -690,7 +690,7 @@ pub async fn sign_private_transaction_with_signers<A: WalletAuthority + ?Sized, 
     Ok(native)
 }
 
-pub fn build_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc>(
+pub fn build_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc + Sync>(
     transaction: UnsignedPrivateTransaction,
     wallet: &Wallet,
     authority: &A,
@@ -702,7 +702,7 @@ pub fn build_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc>(
     client.finish_submission_unsigned_sync(&shielded, fee_payer, blockhash)
 }
 
-pub fn sign_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc>(
+pub fn sign_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc + Sync>(
     transaction: UnsignedPrivateTransaction,
     wallet: &Wallet,
     authority: &A,
@@ -720,7 +720,10 @@ pub fn sign_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc>(
 }
 
 /// Synchronous counterpart of [`sign_private_transaction_with_signers`].
-pub fn sign_private_transaction_sync_with_signers<A: SyncWalletAuthority + ?Sized, R: Rpc>(
+pub fn sign_private_transaction_sync_with_signers<
+    A: SyncWalletAuthority + ?Sized,
+    R: Rpc + Sync,
+>(
     transaction: UnsignedPrivateTransaction,
     wallet: &Wallet,
     authority: &A,

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -139,6 +139,7 @@ where
     // Separate stream, separate watermark: reaching the tip of the transaction
     // stream says nothing about the encrypted-utxo stream.
     let mut proofless_scanned_to_tip: HashSet<ViewTag> = HashSet::new();
+    let mut nullifier_scanned_to_tip: HashSet<[u8; 32]> = HashSet::new();
     let mut report = SyncReport::default();
     let mut txs: Vec<ShieldedTransaction> = Vec::new();
 
@@ -180,6 +181,7 @@ where
                 &mut transactions,
                 config,
                 freshness_gate.take(),
+                &mut nullifier_scanned_to_tip,
             )?;
         }
         {
@@ -275,6 +277,7 @@ where
     // Separate stream, separate watermark: reaching the tip of the transaction
     // stream says nothing about the encrypted-utxo stream.
     let mut proofless_scanned_to_tip: HashSet<ViewTag> = HashSet::new();
+    let mut nullifier_scanned_to_tip: HashSet<[u8; 32]> = HashSet::new();
     let mut report = SyncReport::default();
     let mut txs = Vec::new();
 
@@ -301,6 +304,7 @@ where
             &mut transactions,
             config,
             freshness_gate.take(),
+            &mut nullifier_scanned_to_tip,
         )
         .await?;
         fetch_proofless_deposits_async(
@@ -654,8 +658,14 @@ fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    scanned_to_tip: &mut HashSet<[u8; 32]>,
 ) -> Result<(), ClientError> {
-    for chunk in nullifiers.chunks(config.tag_query_chunk) {
+    let pending: Vec<[u8; 32]> = nullifiers
+        .iter()
+        .copied()
+        .filter(|nullifier| !scanned_to_tip.contains(nullifier))
+        .collect();
+    for chunk in pending.chunks(config.tag_query_chunk) {
         let mut cursor = None;
         loop {
             let response = indexer.get_shielded_transactions_by_nullifiers(
@@ -673,6 +683,7 @@ fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
                 break;
             }
         }
+        scanned_to_tip.extend(chunk.iter().copied());
     }
     Ok(())
 }
@@ -683,8 +694,14 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    scanned_to_tip: &mut HashSet<[u8; 32]>,
 ) -> Result<(), ClientError> {
-    for chunk in nullifiers.chunks(config.tag_query_chunk) {
+    let pending: Vec<[u8; 32]> = nullifiers
+        .iter()
+        .copied()
+        .filter(|nullifier| !scanned_to_tip.contains(nullifier))
+        .collect();
+    for chunk in pending.chunks(config.tag_query_chunk) {
         let mut cursor = None;
         loop {
             let response = indexer
@@ -704,6 +721,7 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
                 break;
             }
         }
+        scanned_to_tip.extend(chunk.iter().copied());
     }
     Ok(())
 }

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -133,6 +133,12 @@ where
     let material = authority.sync_material()?;
     let mut transactions: HashMap<String, ShieldedTransaction> = HashMap::new();
     let mut proofless_deposits: HashMap<String, ShieldedTransaction> = HashMap::new();
+    // Tags read to the tip during THIS sync. Unlike `wallet.sync_cursors` this
+    // is deliberately not persisted: "the tip" means the tip as of now.
+    let mut scanned_to_tip: HashSet<ViewTag> = HashSet::new();
+    // Separate stream, separate watermark: reaching the tip of the transaction
+    // stream says nothing about the encrypted-utxo stream.
+    let mut proofless_scanned_to_tip: HashSet<ViewTag> = HashSet::new();
     let mut report = SyncReport::default();
     let mut txs: Vec<ShieldedTransaction> = Vec::new();
 
@@ -150,13 +156,21 @@ where
         timing::note(round, "nullifiers", nullifiers.len());
         {
             let _t = timing::Phase::start("fetch_shielded_by_tags", round);
-            fetch_shielded_transactions(
+            // Cursors are taken out of the wallet and put back, rather than held
+            // borrowed: `wallet` is needed mutably further down this loop.
+            let mut cursors = std::mem::take(&mut wallet.sync_cursors);
+            let result = fetch_shielded_transactions_incremental(
                 indexer,
                 &tags,
                 &mut transactions,
                 config,
                 freshness_gate.take(),
-            )?;
+                &mut cursors,
+                &mut scanned_to_tip,
+            );
+            wallet.sync_cursors = cursors;
+            result?;
+            timing::note(round, "tag_cursors", wallet.sync_cursors.len());
         }
         {
             let _t = timing::Phase::start("fetch_shielded_by_nullifiers", round);
@@ -176,6 +190,7 @@ where
                 &mut proofless_deposits,
                 config,
                 freshness_gate.take(),
+                &mut proofless_scanned_to_tip,
             )?;
         }
         timing::note(round, "transactions", transactions.len());
@@ -254,6 +269,12 @@ where
     let material = authority.sync_material().await?;
     let mut transactions: HashMap<String, ShieldedTransaction> = HashMap::new();
     let mut proofless_deposits: HashMap<String, ShieldedTransaction> = HashMap::new();
+    // Tags read to the tip during THIS sync. Unlike `wallet.sync_cursors` this
+    // is deliberately not persisted: "the tip" means the tip as of now.
+    let mut scanned_to_tip: HashSet<ViewTag> = HashSet::new();
+    // Separate stream, separate watermark: reaching the tip of the transaction
+    // stream says nothing about the encrypted-utxo stream.
+    let mut proofless_scanned_to_tip: HashSet<ViewTag> = HashSet::new();
     let mut report = SyncReport::default();
     let mut txs = Vec::new();
 
@@ -261,14 +282,19 @@ where
         let before = (transactions.len(), proofless_deposits.len());
         let tags = wallet_query_tags(wallet, &material, config.tag_window)?;
         let nullifiers = wallet_query_nullifiers(wallet);
-        fetch_shielded_transactions_async(
+        let mut cursors = std::mem::take(&mut wallet.sync_cursors);
+        let fetched = fetch_shielded_transactions_incremental_async(
             indexer,
             &tags,
             &mut transactions,
             config,
             freshness_gate.take(),
+            &mut cursors,
+            &mut scanned_to_tip,
         )
-        .await?;
+        .await;
+        wallet.sync_cursors = cursors;
+        fetched?;
         fetch_shielded_transactions_by_nullifiers_async(
             indexer,
             &nullifiers,
@@ -283,6 +309,7 @@ where
             &mut proofless_deposits,
             config,
             freshness_gate.take(),
+            &mut proofless_scanned_to_tip,
         )
         .await?;
 
@@ -469,71 +496,153 @@ fn wallet_query_nullifiers(wallet: &Wallet) -> Vec<[u8; 32]> {
     wallet.utxos.iter().map(|utxo| utxo.nullifier).collect()
 }
 
-fn fetch_shielded_transactions<I: Rpc>(
+/// Fetch shielded transactions for `tags`, resuming each tag from where it was
+/// last seen.
+///
+/// The cursor photon returns is a position in a GLOBAL ordering -- slot, then
+/// signature, then event index -- and that ordering does not depend on which tags
+/// were requested. So a cursor obtained from a query over {A, B, C} is a valid
+/// statement about each of A, B and C individually: everything matching that tag
+/// up to this position has been seen. It says nothing about a tag that was not in
+/// the query, which is exactly why a single shared cursor is unsafe.
+///
+/// Tags are therefore grouped by the cursor they carry, and one query is issued
+/// per group. In the steady state every known tag shares one cursor and newly
+/// derived tags have none, so this is two queries regardless of how many tags the
+/// wallet has -- against one query per 64-tag chunk, repeated every sync, before.
+///
+/// Without this, a tag that becomes relevant only after the cursor advanced past
+/// its transactions would never be scanned for them. That is not hypothetical: a
+/// wallet's tag set is derived from a local counter plus a window of 64, and a
+/// second device spending further ahead than that window makes the counter lag by
+/// more than the window can absorb.
+fn fetch_shielded_transactions_incremental<I: Rpc>(
     indexer: &I,
     tags: &[ViewTag],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    cursors: &mut HashMap<ViewTag, Vec<u8>>,
+    scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError> {
-    for chunk in tags.chunks(config.tag_query_chunk) {
-        let mut cursor = None;
-        loop {
-            let response = indexer.get_shielded_transactions_by_tags(
-                chunk.to_vec(),
-                cursor,
-                Some(config.page_limit),
-                rpc_config,
-            )?;
-            for tx in response.transactions {
-                // Photon may surface proofless/plaintext deposits from this
-                // endpoint before marking them as proofless. They are discovered
-                // through `get_encrypted_utxos_by_tags` below, not as decryptable
-                // shielded transfers.
-                if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
-                    continue;
+    // Group by resume point. `None` (never queried) is its own group.
+    let mut groups: HashMap<Option<Vec<u8>>, Vec<ViewTag>> = HashMap::new();
+    for tag in tags {
+        // Already read to the tip earlier in this same sync -- a second request
+        // would return the same rows the accumulator already holds.
+        if scanned_to_tip.contains(tag) {
+            continue;
+        }
+        groups
+            .entry(cursors.get(tag).cloned())
+            .or_default()
+            .push(*tag);
+    }
+
+    for (start, group) in groups {
+        for chunk in group.chunks(config.tag_query_chunk) {
+            let mut cursor = start.clone();
+            let mut furthest = start.clone();
+            loop {
+                let response = indexer.get_shielded_transactions_by_tags(
+                    chunk.to_vec(),
+                    cursor.clone(),
+                    Some(config.page_limit),
+                    rpc_config,
+                )?;
+                for tx in response.transactions {
+                    if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
+                        continue;
+                    }
+                    let key = tx.tx_signature.to_string();
+                    out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
-                let key = tx.tx_signature.to_string();
-                out.entry(key).or_insert(convert_sync_transaction(tx)?);
+                if response.next_cursor.is_some() {
+                    furthest = response.next_cursor.clone();
+                }
+                cursor = response.next_cursor;
+                if cursor.is_none() {
+                    break;
+                }
             }
-            cursor = response.next_cursor;
-            if cursor.is_none() {
-                break;
+
+            // Advance every tag in this chunk to the end of the stream. Only sound
+            // because the ordering is global: each of these tags has now been
+            // scanned to that position.
+            if let Some(position) = furthest {
+                for tag in chunk {
+                    cursors.insert(*tag, position.clone());
+                }
             }
+            // The loop above only exits once the stream is exhausted.
+            scanned_to_tip.extend(chunk.iter().copied());
         }
     }
     Ok(())
 }
 
-async fn fetch_shielded_transactions_async<I: AsyncRpc>(
+/// Async twin of [`fetch_shielded_transactions_incremental`].
+///
+/// Kept deliberately parallel rather than shared: the sync and async paths differ
+/// only in `.await`, and an async client that did not get the per-tag cursor rule
+/// would carry the multi-device bug the sync path just fixed.
+async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
     indexer: &I,
     tags: &[ViewTag],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    cursors: &mut HashMap<ViewTag, Vec<u8>>,
+    scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError> {
-    for chunk in tags.chunks(config.tag_query_chunk) {
-        let mut cursor = None;
-        loop {
-            let response = indexer
-                .get_shielded_transactions_by_tags(
-                    chunk.to_vec(),
-                    cursor,
-                    Some(config.page_limit),
-                    rpc_config,
-                )
-                .await?;
-            for tx in response.transactions {
-                if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
-                    continue;
+    let mut groups: HashMap<Option<Vec<u8>>, Vec<ViewTag>> = HashMap::new();
+    for tag in tags {
+        // Already read to the tip earlier in this same sync -- a second request
+        // would return the same rows the accumulator already holds.
+        if scanned_to_tip.contains(tag) {
+            continue;
+        }
+        groups
+            .entry(cursors.get(tag).cloned())
+            .or_default()
+            .push(*tag);
+    }
+
+    for (start, group) in groups {
+        for chunk in group.chunks(config.tag_query_chunk) {
+            let mut cursor = start.clone();
+            let mut furthest = start.clone();
+            loop {
+                let response = indexer
+                    .get_shielded_transactions_by_tags(
+                        chunk.to_vec(),
+                        cursor.clone(),
+                        Some(config.page_limit),
+                        rpc_config,
+                    )
+                    .await?;
+                for tx in response.transactions {
+                    if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
+                        continue;
+                    }
+                    let key = tx.tx_signature.to_string();
+                    out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
-                let key = tx.tx_signature.to_string();
-                out.entry(key).or_insert(convert_sync_transaction(tx)?);
+                if response.next_cursor.is_some() {
+                    furthest = response.next_cursor.clone();
+                }
+                cursor = response.next_cursor;
+                if cursor.is_none() {
+                    break;
+                }
             }
-            cursor = response.next_cursor;
-            if cursor.is_none() {
-                break;
+            if let Some(position) = furthest {
+                for tag in chunk {
+                    cursors.insert(*tag, position.clone());
+                }
             }
+            // The loop above only exits once the stream is exhausted.
+            scanned_to_tip.extend(chunk.iter().copied());
         }
     }
     Ok(())
@@ -605,11 +714,17 @@ fn fetch_proofless_deposits<I>(
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError>
 where
     I: Rpc,
 {
-    for chunk in tags.chunks(config.tag_query_chunk) {
+    let pending: Vec<ViewTag> = tags
+        .iter()
+        .copied()
+        .filter(|tag| !scanned_to_tip.contains(tag))
+        .collect();
+    for chunk in pending.chunks(config.tag_query_chunk) {
         let mut cursor = None;
         loop {
             let response = indexer.get_encrypted_utxos_by_tags(
@@ -638,6 +753,7 @@ where
                 break;
             }
         }
+        scanned_to_tip.extend(chunk.iter().copied());
     }
     Ok(())
 }
@@ -648,8 +764,14 @@ async fn fetch_proofless_deposits_async<I: AsyncRpc>(
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError> {
-    for chunk in tags.chunks(config.tag_query_chunk) {
+    let pending: Vec<ViewTag> = tags
+        .iter()
+        .copied()
+        .filter(|tag| !scanned_to_tip.contains(tag))
+        .collect();
+    for chunk in pending.chunks(config.tag_query_chunk) {
         let mut cursor = None;
         loop {
             let response = indexer
@@ -680,6 +802,7 @@ async fn fetch_proofless_deposits_async<I: AsyncRpc>(
                 break;
             }
         }
+        scanned_to_tip.extend(chunk.iter().copied());
     }
     Ok(())
 }
@@ -753,7 +876,7 @@ fn now_unix_ts() -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     use solana_signature::Signature;
     use zolana_interface::event::{encode_output_data, ProoflessOutput};
@@ -776,6 +899,80 @@ mod tests {
         Context, GetEncryptedUtxosByTagsResponse, GetShieldedTransactionsByNullifiersResponse,
         GetShieldedTransactionsByTagsResponse, OutputContext, OutputSlot,
     };
+
+    /// A mock that behaves like photon: filters by tag, honours the cursor, and
+    /// orders globally by slot.
+    ///
+    /// The existing `MockIndexer` ignores both tags and cursor, which is fine for
+    /// decryption tests and useless for this one -- the bug being pinned here is
+    /// precisely an interaction between the two.
+    #[derive(Default)]
+    struct TaggedIndexer {
+        /// (slot, view tag) pairs. Signature is derived from the slot so the sort
+        /// key is total, as it is in photon.
+        entries: Vec<(u64, ViewTag)>,
+        /// Every (tags, cursor) pair the client asked for, for call accounting.
+        calls: std::cell::RefCell<Vec<(usize, Option<u64>)>>,
+    }
+
+    impl TaggedIndexer {
+        /// Cursor is the slot of the last row returned, encoded as 8 bytes. Real
+        /// photon encodes (slot, signature, event_index); slot alone is a total
+        /// order here because each fixture uses a distinct slot.
+        fn matching(
+            &self,
+            tags: &[ViewTag],
+            cursor: Option<Vec<u8>>,
+            limit: usize,
+        ) -> (Vec<ShieldedTransaction>, Option<Vec<u8>>) {
+            let after = cursor.as_ref().map(|bytes| {
+                u64::from_be_bytes(bytes.as_slice().try_into().expect("8-byte cursor"))
+            });
+            self.calls.borrow_mut().push((tags.len(), after));
+
+            let mut rows: Vec<_> = self
+                .entries
+                .iter()
+                .filter(|(slot, tag)| tags.contains(tag) && after.is_none_or(|after| *slot > after))
+                .collect();
+            rows.sort_by_key(|(slot, _)| *slot);
+
+            // Photon's rule (`next_cursor_from_rows`): a page shorter than the
+            // limit is the end of the stream and carries no cursor. Modelling
+            // this matters -- a mock that always returns a cursor lets a client
+            // look incremental in tests while rescanning from zero in
+            // production.
+            let short_page = rows.len() < limit;
+            rows.truncate(limit);
+            let next = if short_page {
+                None
+            } else {
+                rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec())
+            };
+            let transactions = rows
+                .into_iter()
+                .map(|(slot, tag)| ShieldedTransaction {
+                    slot: *slot,
+                    tx_signature: Signature::from([*slot as u8; 64]),
+                    tx_viewing_pk: None,
+                    salt: None,
+                    output_slots: vec![OutputSlot {
+                        view_tag: *tag,
+                        output_context: OutputContext {
+                            hash: [0u8; 32],
+                            tree: Address::default(),
+                            leaf_index: *slot,
+                        },
+                        payload: Vec::new(),
+                    }],
+                    messages: Vec::new(),
+                    nullifiers: Vec::new(),
+                    proofless: false,
+                })
+                .collect();
+            (transactions, next)
+        }
+    }
 
     #[derive(Default)]
     struct MockIndexer {
@@ -849,6 +1046,263 @@ mod tests {
                 next_cursor: None,
             })
         }
+    }
+
+    impl Rpc for TaggedIndexer {
+        fn get_program_accounts(
+            &self,
+            _program_id: Address,
+        ) -> Result<Vec<(Address, solana_account::Account)>, ClientError> {
+            Ok(Vec::new())
+        }
+
+        fn get_encrypted_utxos_by_tags(
+            &self,
+            _tags: Vec<ViewTag>,
+            _cursor: Option<Vec<u8>>,
+            _limit: Option<u32>,
+            _config: Option<IndexerRpcConfig>,
+        ) -> Result<GetEncryptedUtxosByTagsResponse, ClientError> {
+            Ok(GetEncryptedUtxosByTagsResponse {
+                context: Context {
+                    block_time: 0,
+                    slot: 1,
+                },
+                matches: Vec::new(),
+                next_cursor: None,
+            })
+        }
+
+        fn get_shielded_transactions_by_tags(
+            &self,
+            tags: Vec<ViewTag>,
+            cursor: Option<Vec<u8>>,
+            limit: Option<u32>,
+            _config: Option<IndexerRpcConfig>,
+        ) -> Result<GetShieldedTransactionsByTagsResponse, ClientError> {
+            let limit = limit.unwrap_or(1_000).max(1) as usize;
+            let (transactions, next_cursor) = self.matching(&tags, cursor, limit);
+            Ok(GetShieldedTransactionsByTagsResponse {
+                context: Context {
+                    block_time: 0,
+                    slot: 1,
+                },
+                transactions,
+                next_cursor,
+            })
+        }
+
+        fn get_shielded_transactions_by_nullifiers(
+            &self,
+            _nullifiers: Vec<ViewTag>,
+            _cursor: Option<Vec<u8>>,
+            _limit: Option<u32>,
+            _config: Option<IndexerRpcConfig>,
+        ) -> Result<GetShieldedTransactionsByNullifiersResponse, ClientError> {
+            Ok(GetShieldedTransactionsByNullifiersResponse {
+                context: Context {
+                    block_time: 0,
+                    slot: 1,
+                },
+                transactions: Vec::new(),
+                next_cursor: None,
+            })
+        }
+    }
+
+    /// A tag that becomes relevant only AFTER an earlier sync has already moved
+    /// past the slot its transactions live at must still be scanned from zero.
+    ///
+    /// This is the multi-device case. Tags are derived from a local counter plus a
+    /// window of 64; when another device spends far enough ahead, this wallet's
+    /// counter lags by more than the window and it does not yet know to ask for
+    /// those tags. It learns the counter later -- by which time a single global
+    /// cursor has advanced past the slots involved, and those transactions would
+    /// be skipped permanently.
+    ///
+    /// A sync runs several rounds so that tags discovered by decrypting round N
+    /// can be queried in round N+1. Tags already scanned to the tip of the
+    /// stream must not be re-queried in the later rounds: on devnet that repeat
+    /// was refetching the wallet's entire history a second time, and it is the
+    /// single largest cost in a sync.
+    ///
+    /// Anything that lands mid-sync is picked up by the next sync, the same as
+    /// a transaction landing a millisecond after the sync returns.
+    #[test]
+    fn a_tag_scanned_to_the_tip_is_not_requeried_in_a_later_round() {
+        let keypair = ShieldedKeypair::new().expect("keypair");
+        let viewing = keypair.viewing_key.clone();
+        let early = viewing.get_sender_view_tag(0).expect("early tag");
+        let late = viewing.get_sender_view_tag(500).expect("late tag");
+
+        let indexer = TaggedIndexer {
+            entries: vec![(10, early), (50, late)],
+            ..Default::default()
+        };
+
+        let config = SyncWalletConfig::default();
+        let mut out = HashMap::new();
+        let mut cursors: HashMap<ViewTag, Vec<u8>> = HashMap::new();
+        let mut scanned = HashSet::new();
+
+        // Round 0: only the early tag is known.
+        fetch_shielded_transactions_incremental(
+            &indexer,
+            &[early],
+            &mut out,
+            config,
+            None,
+            &mut cursors,
+            &mut scanned,
+        )
+        .expect("round 0");
+
+        // Round 1: decryption revealed the late tag. The early tag is already
+        // scanned to the tip, so only the late one is worth a request.
+        fetch_shielded_transactions_incremental(
+            &indexer,
+            &[early, late],
+            &mut out,
+            config,
+            None,
+            &mut cursors,
+            &mut scanned,
+        )
+        .expect("round 1");
+
+        assert_eq!(
+            *indexer.calls.borrow(),
+            vec![(1, None), (1, None)],
+            "round 1 must ask for the late tag alone, not both tags again"
+        );
+    }
+
+    /// Photon returns `next_cursor: None` for any page shorter than the limit
+    /// (`next_cursor_from_rows`), so a wallet whose whole history fits in one
+    /// page records no cursor at all. That is correct, not a miss: the next
+    /// sync rescans at most one page, so sync cost is bounded by the page size
+    /// rather than by history length.
+    ///
+    /// Pinned because the opposite mock -- one that always hands back a cursor
+    /// -- makes a client look incremental in tests while it rescans everything
+    /// in production.
+    #[test]
+    fn a_short_page_ends_the_stream_and_advances_no_cursor() {
+        let keypair = ShieldedKeypair::new().expect("keypair");
+        let tag = keypair.viewing_key.get_sender_view_tag(0).expect("tag");
+
+        let indexer = TaggedIndexer {
+            entries: vec![(10, tag), (50, tag)],
+            ..Default::default()
+        };
+
+        let mut out = HashMap::new();
+        let mut cursors: HashMap<ViewTag, Vec<u8>> = HashMap::new();
+        fetch_shielded_transactions_incremental(
+            &indexer,
+            &[tag],
+            &mut out,
+            SyncWalletConfig::default(),
+            None,
+            &mut cursors,
+            &mut HashSet::new(),
+        )
+        .expect("sync");
+
+        assert!(
+            cursors.is_empty(),
+            "a short page is the end of the stream and carries no cursor"
+        );
+        assert_eq!(
+            *indexer.calls.borrow(),
+            vec![(1, None)],
+            "one request, from the start, and no follow-up to discover the end"
+        );
+    }
+
+    /// Guards the fix: cursors are tracked PER TAG, so a newly-discovered tag
+    /// starts from None regardless of how far other tags have advanced.
+    #[test]
+    fn a_late_discovered_tag_is_scanned_from_the_beginning() {
+        let keypair = ShieldedKeypair::new().expect("keypair");
+        let viewing = keypair.viewing_key.clone();
+
+        // The tag this wallet knows about from the start, and one far outside the
+        // initial window -- what a second device would have been using.
+        let early = viewing.get_sender_view_tag(0).expect("early tag");
+        let late = viewing.get_sender_view_tag(500).expect("late tag");
+        assert_ne!(early, late);
+
+        let indexer = TaggedIndexer {
+            // The late tag's transaction sits at a LOWER slot than the early
+            // one's, so a global cursor advanced past slot 50 would skip it.
+            entries: vec![(10, late), (50, early)],
+            ..Default::default()
+        };
+
+        // page_limit 1 so every page is full and photon hands back a cursor.
+        // At the default limit these two rows are one short page, which by
+        // photon's rule carries no cursor at all -- see
+        // `a_short_page_ends_the_stream_and_advances_no_cursor`.
+        let config = SyncWalletConfig {
+            page_limit: 1,
+            ..SyncWalletConfig::default()
+        };
+        let mut cursors: HashMap<ViewTag, Vec<u8>> = HashMap::new();
+
+        // First sync knows only the early tag, and advances past slot 50.
+        let mut first = HashMap::new();
+        fetch_shielded_transactions_incremental(
+            &indexer,
+            &[early],
+            &mut first,
+            config,
+            None,
+            &mut cursors,
+            // A fresh set per sync: "scanned to the tip" is only true of the
+            // sync that did the scanning.
+            &mut HashSet::new(),
+        )
+        .expect("first sync");
+        assert_eq!(
+            cursors
+                .get(&early)
+                .map(|c| u64::from_be_bytes(c.as_slice().try_into().unwrap())),
+            Some(50),
+            "the early tag should have advanced to the last row it saw"
+        );
+        assert!(
+            !cursors.contains_key(&late),
+            "a tag that was never queried must not carry a cursor"
+        );
+
+        // Second sync has learned the late tag.
+        indexer.calls.borrow_mut().clear();
+        let mut second = HashMap::new();
+        fetch_shielded_transactions_incremental(
+            &indexer,
+            &[early, late],
+            &mut second,
+            config,
+            None,
+            &mut cursors,
+            &mut HashSet::new(),
+        )
+        .expect("second sync");
+
+        // Asserting on what was REQUESTED rather than what was decrypted: the
+        // invariant is which rows the indexer was asked for, and fabricating
+        // decryptable P256 payloads would test the crypto instead.
+        let calls = indexer.calls.borrow();
+        assert!(
+            calls.iter().any(|(_, after)| after.is_none()),
+            "the newly discovered tag must be scanned from the beginning, not from \
+             the cursor another tag advanced to; calls were {calls:?}"
+        );
+        assert!(
+            calls.iter().any(|(_, after)| *after == Some(50)),
+            "the already-synced tag should resume rather than rescan; calls were {calls:?}"
+        );
     }
 
     #[async_trait::async_trait]
@@ -1174,12 +1628,14 @@ mod tests {
         };
         let mut out = HashMap::new();
 
-        fetch_shielded_transactions(
+        fetch_shielded_transactions_incremental(
             &indexer,
             &[[1u8; 32]],
             &mut out,
             SyncWalletConfig::default(),
             None,
+            &mut HashMap::new(),
+            &mut HashSet::new(),
         )
         .expect("skip plaintext row");
 
@@ -1204,6 +1660,7 @@ mod tests {
             &mut out,
             SyncWalletConfig::default(),
             None,
+            &mut HashSet::new(),
         )
         .expect("decode proofless payload");
 
@@ -1322,6 +1779,7 @@ mod tests {
             &mut out,
             SyncWalletConfig::default(),
             None,
+            &mut HashSet::new(),
         )
         .expect("skip encrypted row");
 

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -1,5 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
+    panic::resume_unwind,
+    thread,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -114,7 +116,7 @@ pub fn sync_wallet<A, I>(
 ) -> Result<SyncReport, ClientError>
 where
     A: SyncWalletAuthority + ?Sized,
-    I: Rpc,
+    I: Rpc + Sync,
 {
     sync_wallet_with_config(wallet, authority, indexer, SyncWalletConfig::default())
 }
@@ -127,7 +129,7 @@ pub fn sync_wallet_with_config<A, I>(
 ) -> Result<SyncReport, ClientError>
 where
     A: SyncWalletAuthority + ?Sized,
-    I: Rpc,
+    I: Rpc + Sync,
 {
     let config = normalized_config(config);
     let material = authority.sync_material()?;
@@ -156,44 +158,82 @@ where
         timing::note(round, "tags", tags.len());
         timing::note(round, "nullifiers", nullifiers.len());
         {
-            let _t = timing::Phase::start("fetch_shielded_by_tags", round);
-            // Cursors are taken out of the wallet and put back, rather than held
-            // borrowed: `wallet` is needed mutably further down this loop.
+            let _t = timing::Phase::start("fetch_round", round);
+            // The three queries are independent: different indexer methods,
+            // disjoint cursor state, and separate accumulators. Run sequentially
+            // a round cost the sum of three round trips (866 + 521 + 503ms
+            // measured on devnet) when it need only cost the slowest.
+            //
+            // Cursors come out of the wallet and go back rather than staying
+            // borrowed, because `wallet` is needed mutably further down.
             let mut cursors = std::mem::take(&mut wallet.sync_cursors);
-            let result = fetch_shielded_transactions_incremental(
-                indexer,
-                &tags,
-                &mut transactions,
-                config,
-                freshness_gate.take(),
-                &mut cursors,
-                &mut scanned_to_tip,
-            );
+            let mut by_nullifier: HashMap<String, ShieldedTransaction> = HashMap::new();
+            // One gate for the whole round, not one per call: every query in a
+            // round should read the chain at the same freshness bound, and
+            // `take()`ing it three times would gate only the first.
+            let gate = freshness_gate.take();
+
+            let (tag_result, nullifier_result, proofless_result) = thread::scope(|scope| {
+                let tags_ref = &tags;
+                let tag_handle = scope.spawn(|| {
+                    let _t = timing::Phase::start("fetch_shielded_by_tags", round);
+                    fetch_shielded_transactions_incremental(
+                        indexer,
+                        tags_ref,
+                        &mut transactions,
+                        config,
+                        gate,
+                        &mut cursors,
+                        &mut scanned_to_tip,
+                    )
+                });
+                let nullifier_handle = scope.spawn(|| {
+                    let _t = timing::Phase::start("fetch_shielded_by_nullifiers", round);
+                    fetch_shielded_transactions_by_nullifiers(
+                        indexer,
+                        &nullifiers,
+                        &mut by_nullifier,
+                        config,
+                        gate,
+                        &mut nullifier_scanned_to_tip,
+                    )
+                });
+                let proofless_handle = scope.spawn(|| {
+                    let _t = timing::Phase::start("fetch_proofless_deposits", round);
+                    fetch_proofless_deposits(
+                        indexer,
+                        tags_ref,
+                        &mut proofless_deposits,
+                        config,
+                        gate,
+                        &mut proofless_scanned_to_tip,
+                    )
+                });
+                (
+                    tag_handle.join(),
+                    nullifier_handle.join(),
+                    proofless_handle.join(),
+                )
+            });
+
             wallet.sync_cursors = cursors;
-            result?;
+            // Propagate a panic rather than swallowing it into a sync error: a
+            // panicked fetch means a bug here, not an unreachable indexer.
+            let tag_result = tag_result.unwrap_or_else(|payload| resume_unwind(payload));
+            let nullifier_result =
+                nullifier_result.unwrap_or_else(|payload| resume_unwind(payload));
+            let proofless_result =
+                proofless_result.unwrap_or_else(|payload| resume_unwind(payload));
+            tag_result?;
+            nullifier_result?;
+            proofless_result?;
+
+            // Both queries return transactions; the by-tag map wins ties, which
+            // is the same precedence the sequential version had via `or_insert`.
+            for (key, tx) in by_nullifier {
+                transactions.entry(key).or_insert(tx);
+            }
             timing::note(round, "tag_cursors", wallet.sync_cursors.len());
-        }
-        {
-            let _t = timing::Phase::start("fetch_shielded_by_nullifiers", round);
-            fetch_shielded_transactions_by_nullifiers(
-                indexer,
-                &nullifiers,
-                &mut transactions,
-                config,
-                freshness_gate.take(),
-                &mut nullifier_scanned_to_tip,
-            )?;
-        }
-        {
-            let _t = timing::Phase::start("fetch_proofless_deposits", round);
-            fetch_proofless_deposits(
-                indexer,
-                &tags,
-                &mut proofless_deposits,
-                config,
-                freshness_gate.take(),
-                &mut proofless_scanned_to_tip,
-            )?;
         }
         timing::note(round, "transactions", transactions.len());
         timing::note(round, "proofless_deposits", proofless_deposits.len());

--- a/sdk-tests/zk-program-swap/sdk/src/index/maker.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/index/maker.rs
@@ -107,7 +107,7 @@ fn maker_order_candidate(
     })
 }
 
-pub fn index_maker<I: Rpc>(
+pub fn index_maker<I: Rpc + Sync>(
     wallet: &mut Wallet,
     keypair: &ShieldedKeypair,
     indexer: &I,

--- a/sdk-tests/zk-program-swap/sdk/src/index/poll.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/index/poll.rs
@@ -10,7 +10,7 @@ use crate::err;
 
 const INDEX_POLL: Duration = Duration::from_millis(500);
 
-pub(crate) fn index_until<I: Rpc, T>(
+pub(crate) fn index_until<I: Rpc + Sync, T>(
     wallet: &mut Wallet,
     keypair: &ShieldedKeypair,
     indexer: &I,
@@ -37,7 +37,7 @@ pub(crate) fn index_until<I: Rpc, T>(
     }
 }
 
-pub(crate) fn collect_tagged<I: Rpc, T>(
+pub(crate) fn collect_tagged<I: Rpc + Sync, T>(
     wallet: &Wallet,
     indexer: &I,
     mut scan: impl FnMut(&ShieldedTransaction) -> Result<Option<T>>,

--- a/sdk-tests/zk-program-swap/sdk/src/index/taker.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/index/taker.rs
@@ -111,7 +111,7 @@ impl TakerOrderCandidate {
     }
 }
 
-pub fn index_taker<I: Rpc, R: Rpc>(
+pub fn index_taker<I: Rpc + Sync, R: Rpc>(
     wallet: &mut Wallet,
     keypair: &ShieldedKeypair,
     indexer: &I,


### PR DESCRIPTION
Two independent indexer round trips that ran back to back: different methods, neither consuming the other's output. 317ms and 114ms on devnet, so the pair cost 431ms where it need only cost 317ms.

Needs `R: Sync` on the submission path since the scoped threads share the indexer, widened through the two signing entry points that call it.

Same caveat as #200: a single-client latency win, not a throughput win.