### PR TITLE
indexer: read the newest block instead of aggregating over all of them

### DIFF
--- a/services/photon/src/common/indexer_context.rs
+++ b/services/photon/src/common/indexer_context.rs
@@ -1,5 +1,5 @@
 use crate::{api::error::PhotonApiError, dao::generated::blocks, migration::Expr};
-use sea_orm::{DatabaseConnection, EntityTrait, FromQueryResult, QuerySelect};
+use sea_orm::{DatabaseConnection, EntityTrait, FromQueryResult, QueryOrder, QuerySelect, Select};
 
 use zolana_indexer_api::Context;
 
@@ -14,11 +14,33 @@ struct SlotModel {
     slot: i64,
 }
 
-pub async fn extract(conn: &DatabaseConnection) -> Result<Context, PhotonApiError> {
-    let context = blocks::Entity::find()
+/// Reads the newest block, rather than each column's maximum separately.
+///
+/// Every rings method calls this to stamp its response, so it runs on more or
+/// less every request. It used to ask for `MAX(block_time), MAX(slot)` in one
+/// query: `slot` is the primary key and would answer from `pk_blocks` alone,
+/// but `block_time` has no index, and two aggregates over different columns
+/// cannot both be served by an index scan -- so Postgres scanned the whole
+/// `blocks` table, every time, holding a pool connection while it did.
+///
+/// Measured on devnet: 1.0-1.7s per call, rising to 2.2-2.4s an hour later as
+/// the table grew, and it was the *only* statement in the slow-query log. It
+/// pinned photon's connection pool flat at its ceiling and drove ALB target
+/// response time to 2s while photon itself sat at 6% CPU.
+///
+/// Ordering by the primary key and taking one row is a backward index scan.
+/// It also returns a coherent pair -- one real block's slot and time -- where
+/// two independent maxima could report a slot and a time from different blocks.
+fn latest_block() -> Select<blocks::Entity> {
+    blocks::Entity::find()
         .select_only()
-        .column_as(Expr::col(blocks::Column::BlockTime).max(), "block_time")
-        .column_as(Expr::col(blocks::Column::Slot).max(), "slot")
+        .column(blocks::Column::BlockTime)
+        .column(blocks::Column::Slot)
+        .order_by_desc(blocks::Column::Slot)
+}
+
+pub async fn extract(conn: &DatabaseConnection) -> Result<Context, PhotonApiError> {
+    let context = latest_block()
         .into_model::<ContextModel>()
         .one(conn)
         .await?
@@ -48,4 +70,30 @@ pub async fn extract_slot(conn: &DatabaseConnection) -> Result<u64, PhotonApiErr
             model.slot
         ))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::{DatabaseBackend, QueryTrait};
+
+    // This query runs on nearly every API response, so its plan matters more
+    // than its shape. Aggregating over `block_time`, which has no index, made it
+    // scan the whole `blocks` table -- 2.4s per call on devnet, and growing with
+    // the table. Asserting on the generated SQL is what keeps a later "just add
+    // MAX back, it reads better" from quietly reinstating a full scan.
+    #[test]
+    fn the_context_query_walks_the_primary_key_instead_of_aggregating() {
+        let sql = latest_block().build(DatabaseBackend::Postgres).to_string();
+
+        assert!(
+            !sql.contains("MAX"),
+            "context query must not aggregate -- MAX over the unindexed \
+             block_time forces a sequential scan: {sql}"
+        );
+        assert!(
+            sql.contains(r#"ORDER BY "blocks"."slot" DESC"#),
+            "context query must walk the pk_blocks index backwards: {sql}"
+        );
+    }
 }

--- a/services/photon/src/common/indexer_context.rs
+++ b/services/photon/src/common/indexer_context.rs
@@ -15,22 +15,6 @@ struct SlotModel {
 }
 
 /// Reads the newest block, rather than each column's maximum separately.
-///
-/// Every rings method calls this to stamp its response, so it runs on more or
-/// less every request. It used to ask for `MAX(block_time), MAX(slot)` in one
-/// query: `slot` is the primary key and would answer from `pk_blocks` alone,
-/// but `block_time` has no index, and two aggregates over different columns
-/// cannot both be served by an index scan -- so Postgres scanned the whole
-/// `blocks` table, every time, holding a pool connection while it did.
-///
-/// Measured on devnet: 1.0-1.7s per call, rising to 2.2-2.4s an hour later as
-/// the table grew, and it was the *only* statement in the slow-query log. It
-/// pinned photon's connection pool flat at its ceiling and drove ALB target
-/// response time to 2s while photon itself sat at 6% CPU.
-///
-/// Ordering by the primary key and taking one row is a backward index scan.
-/// It also returns a coherent pair -- one real block's slot and time -- where
-/// two independent maxima could report a slot and a time from different blocks.
 fn latest_block() -> Select<blocks::Entity> {
     blocks::Entity::find()
         .select_only()

--- a/services/photon/src/common/indexer_context.rs
+++ b/services/photon/src/common/indexer_context.rs
@@ -61,11 +61,6 @@ mod tests {
     use super::*;
     use sea_orm::{DatabaseBackend, QueryTrait};
 
-    // This query runs on nearly every API response, so its plan matters more
-    // than its shape. Aggregating over `block_time`, which has no index, made it
-    // scan the whole `blocks` table -- 2.4s per call on devnet, and growing with
-    // the table. Asserting on the generated SQL is what keeps a later "just add
-    // MAX back, it reads better" from quietly reinstating a full scan.
     #[test]
     fn the_context_query_walks_the_primary_key_instead_of_aggregating() {
         let sql = latest_block().build(DatabaseBackend::Postgres).to_string();


### PR DESCRIPTION
Stacked on `indexer/cursor-watermark` (#205).

`indexer_context::extract` stamps every rings response with the indexer's position, so it runs on more or less every request. It asked for both maxima in one query:

```sql
SELECT MAX("block_time"), MAX("slot") FROM "blocks"
```

`slot` is the primary key and would have been answered from `pk_blocks` alone. `block_time` has no index, and two aggregates over different columns cannot both be served by an index scan, so Postgres scanned the entire `blocks` table on every API call, holding a pool connection while it did.

It was the only statement in the devnet slow-query log.

| when | per call |
|---|---|
| during an 80-worker run | 1.0–1.7s |
| an hour later, at 8 workers | 2.2–2.4s |

The cost tracks the size of `blocks`, not the load, so it degrades on its own as the chain advances. The lighter run was the slower one.

Every individual signal said healthy: ALB with zero 5xx, zero rejected connections and zero target connection errors; WAF allowing everything; photon with no error logs at 6% CPU; RDS at 0.2ms read latency with a negligible disk queue.

Two signals told the truth. `TargetResponseTime` read 2.0s average and 12.7s max, against 0.0009s when idle. `DatabaseConnections` sat pinned flat at 43.0, average exactly equal to maximum, for fifteen minutes — a pool at its ceiling, not a pool under load. Low CPU with high response time means waiting, not working. Clients timed out mid-body and reported the indexer as unavailable: 619 failures in one run with nothing actually failing anywhere.

The fix orders by the primary key and takes one row, a backward scan of `pk_blocks`. It also returns a coherent pair — one real block's slot and time — where two independent maxima could in principle report a slot from one block and a time from another.

`extract_slot` is untouched. A lone `MAX` over the primary key is rewritten by Postgres into exactly this index scan, which is why it never appeared in the slow-query log.

Devnet, 8 workers, same wallets, only photon changed between the two runs:

| p50 | before | after |
|---|---|---|
| sync | 7,497ms | 2,097ms |
| prove | 1,399ms | 972ms |
| confirm | 903ms | 260ms |
| total | 11,118ms | 4,509ms |
| throughput | 0.706 tps | 1.53 tps |

Slow-query log after deploy: zero entries, and zero occurrences of the `MAX` query.

One detail makes this conservative rather than flattering: reported wallet depth fell from 9,570ms to 3,396ms across those runs. Those are the same wallets with strictly more history than before, so the workload got heavier.

The test asserts on generated SQL, which is unusual and deliberate. Both queries return the same values, so no behavioural test can tell them apart — the difference is entirely in the plan. The point is to stop a later rewrite from quietly reinstating the scan because `MAX` reads more naturally.
