### PR TITLE
indexer: report the last row's position even on a short page

### DIFF
--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -955,18 +955,12 @@ mod tests {
                 .collect();
             rows.sort_by_key(|(slot, _)| *slot);
 
-            // Photon's rule (`next_cursor_from_rows`): a page shorter than the
-            // limit is the end of the stream and carries no cursor. Modelling
-            // this matters -- a mock that always returns a cursor lets a client
-            // look incremental in tests while rescanning from zero in
-            // production.
-            let short_page = rows.len() < limit;
+            // Photon's rule (`next_cursor_from_rows`): the position of the last
+            // row returned, or None when there were none. A short page still
+            // carries a cursor, so the client can resume from the tip next sync
+            // instead of rescanning; the loop ends on the following empty page.
             rows.truncate(limit);
-            let next = if short_page {
-                None
-            } else {
-                rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec())
-            };
+            let next = rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec());
             let transactions = rows
                 .into_iter()
                 .map(|(slot, tag)| ShieldedTransaction {
@@ -1188,24 +1182,26 @@ mod tests {
         )
         .expect("round 1");
 
+        // Each chunk costs two requests now: one for the rows, one that comes
+        // back empty and ends the stream. What matters is that no request ever
+        // carries two tags -- the early tag is never re-queried.
         assert_eq!(
             *indexer.calls.borrow(),
-            vec![(1, None), (1, None)],
+            vec![(1, None), (1, Some(10)), (1, None), (1, Some(50))],
             "round 1 must ask for the late tag alone, not both tags again"
         );
     }
 
-    /// Photon returns `next_cursor: None` for any page shorter than the limit
-    /// (`next_cursor_from_rows`), so a wallet whose whole history fits in one
-    /// page records no cursor at all. That is correct, not a miss: the next
-    /// sync rescans at most one page, so sync cost is bounded by the page size
-    /// rather than by history length.
+    /// A wallet whose whole history fits in one page must still record where it
+    /// got to. Photon used to return no cursor for a short page, which is right
+    /// for pagination and wrong for resumption: such a wallet recorded nothing
+    /// and refetched its entire history on every sync, growing with every
+    /// transfer. On devnet an 881-transaction wallet spent 2.4s of a 5.0s sync
+    /// doing exactly that.
     ///
-    /// Pinned because the opposite mock -- one that always hands back a cursor
-    /// -- makes a client look incremental in tests while it rescans everything
-    /// in production.
+    /// The stream now ends on the following empty page instead.
     #[test]
-    fn a_short_page_ends_the_stream_and_advances_no_cursor() {
+    fn a_short_page_still_advances_the_cursor_to_the_tip() {
         let keypair = ShieldedKeypair::new().expect("keypair");
         let tag = keypair.viewing_key.get_sender_view_tag(0).expect("tag");
 
@@ -1227,14 +1223,17 @@ mod tests {
         )
         .expect("sync");
 
-        assert!(
-            cursors.is_empty(),
-            "a short page is the end of the stream and carries no cursor"
+        assert_eq!(
+            cursors
+                .get(&tag)
+                .map(|c| u64::from_be_bytes(c.as_slice().try_into().expect("8-byte cursor"))),
+            Some(50),
+            "a short page still records the tip, so the next sync resumes there"
         );
         assert_eq!(
             *indexer.calls.borrow(),
-            vec![(1, None)],
-            "one request, from the start, and no follow-up to discover the end"
+            vec![(1, None), (1, Some(50))],
+            "one request for the rows, one more that returns none and ends the loop"
         );
     }
 

--- a/services/photon/src/api/method/rings/common.rs
+++ b/services/photon/src/api/method/rings/common.rs
@@ -294,15 +294,26 @@ fn cursor_bincode_config() -> impl bincode::config::Config {
         .with_fixed_int_encoding()
 }
 
+/// Position of the last row returned, or `None` when there were none.
+///
+/// A short page used to return `None`, on the reasoning that a page below the
+/// limit is the end of the stream and so there is nothing left to page to. That
+/// is true for pagination and wrong for resumption: the cursor is also the
+/// client's sync watermark, and a wallet whose whole history fits in one page
+/// therefore recorded no watermark and refetched everything on every sync. On
+/// devnet an 881-transaction wallet spent 2.4s of a 5.0s sync doing exactly
+/// that, growing with every transfer.
+///
+/// Returning the position whenever rows exist costs one extra request per
+/// chunk per sync -- the client asks once more and gets an empty page, which
+/// yields `None` here and ends the loop. Deliberately not a new response field:
+/// the response types are `deny_unknown_fields`, so an added field would break
+/// every deployed client, whereas this shape is what clients already handle
+/// when a final page happens to be exactly `limit` rows.
 pub(super) fn next_cursor_from_rows<T>(
     rows: &[T],
-    limit: u64,
     cursor_from_row: impl FnOnce(&T) -> Result<Vec<u8>, PhotonApiError>,
 ) -> Result<Option<Base64String>, PhotonApiError> {
-    if u64_from_usize(rows.len(), "row count")? < limit {
-        return Ok(None);
-    }
-
     rows.last()
         .map(cursor_from_row)
         .transpose()
@@ -349,12 +360,6 @@ pub(super) fn u64_from_i64(value: i64, field: &str) -> Result<u64, PhotonApiErro
     })
 }
 
-fn u64_from_usize(value: usize, field: &str) -> Result<u64, PhotonApiError> {
-    u64::try_from(value).map_err(|_| {
-        PhotonApiError::UnexpectedError(format!("{} {} does not fit in u64", field, value))
-    })
-}
-
 pub(super) fn u16_from_i16(value: i16, field: &str) -> Result<u16, PhotonApiError> {
     u16::try_from(value).map_err(|_| {
         PhotonApiError::UnexpectedError(format!("Invalid negative {}: {}", field, value))
@@ -389,4 +394,36 @@ pub(super) fn rings_output_slot_from_parts(
         output_context: rings_output_context_from_parts(hash, tree, leaf_index)?,
         payload: Base64String(payload),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cursor_of(row: &u64) -> Result<Vec<u8>, PhotonApiError> {
+        Ok(row.to_be_bytes().to_vec())
+    }
+
+    /// The cursor doubles as the client's sync watermark, so a short page has to
+    /// carry one. Returning `None` there -- correct for "is there another page?"
+    /// -- made every wallet whose history fits in one page refetch all of it on
+    /// every sync.
+    #[test]
+    fn a_short_page_still_reports_its_last_row() {
+        let rows = vec![10u64, 50];
+        let cursor = next_cursor_from_rows(&rows, cursor_of).expect("cursor");
+        assert_eq!(
+            cursor.map(|c| c.0),
+            Some(50u64.to_be_bytes().to_vec()),
+            "a page below the limit still reports where it got to"
+        );
+    }
+
+    /// How the loop terminates now: the client asks once more and gets nothing.
+    #[test]
+    fn an_empty_page_ends_the_stream() {
+        let rows: Vec<u64> = Vec::new();
+        let cursor = next_cursor_from_rows(&rows, cursor_of).expect("cursor");
+        assert!(cursor.is_none(), "no rows means no position to resume from");
+    }
 }

--- a/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
@@ -55,7 +55,7 @@ pub async fn get_encrypted_utxos_by_tags(
     crate::api::set_transaction_isolation_if_needed(&tx).await?;
 
     let rows = fetch_encrypted_utxo_rows(&tx, &request.tags, cursor.as_ref(), limit).await?;
-    let next_cursor = next_cursor_from_rows(&rows, limit, encrypted_utxo_cursor_from_row)?;
+    let next_cursor = next_cursor_from_rows(&rows, encrypted_utxo_cursor_from_row)?;
 
     let matches = rows
         .into_iter()

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -132,7 +132,7 @@ async fn get_shielded_transactions(
 
     let matched_txs =
         fetch_matching_rings_transactions(&tx, values, cursor.as_ref(), limit, match_by).await?;
-    let next_cursor = next_cursor_from_rows(&matched_txs, limit, shielded_tx_cursor_from_row)?;
+    let next_cursor = next_cursor_from_rows(&matched_txs, shielded_tx_cursor_from_row)?;
 
     let transactions = hydrate_shielded_transactions(&tx, matched_txs)
         .await?

--- a/services/photon/tests/integration_tests/rings_event_parser_tests.rs
+++ b/services/photon/tests/integration_tests/rings_event_parser_tests.rs
@@ -1320,7 +1320,10 @@ async fn assert_rings_api_exposes_output_hashes(
         .await
         .unwrap();
     assert_eq!(shielded.context.block_time, UNSHIELD_SLOT as i64);
-    assert!(shielded.next_cursor.is_none());
+    // A non-empty page carries the position of its last row even when it is
+    // short, so a client can resume from the tip rather than rescan. The stream
+    // ends on the next page, which comes back empty.
+    assert!(shielded.next_cursor.is_some());
     assert!(!shielded.transactions.is_empty());
     let output_slot = shielded
         .transactions
@@ -1368,7 +1371,7 @@ async fn assert_rings_api_exposes_output_hashes(
 
     let encrypted = get_encrypted_utxos_by_tags(db, request).await.unwrap();
     assert_eq!(encrypted.context.block_time, UNSHIELD_SLOT as i64);
-    assert!(encrypted.next_cursor.is_none());
+    assert!(encrypted.next_cursor.is_some());
     assert!(!encrypted.matches.is_empty());
     let encrypted_match = encrypted
         .matches


### PR DESCRIPTION
Stacked on `sdk/incremental-sync` (#198).

`next_cursor_from_rows` returned `None` when a page came back shorter than the limit. It now always reports the last row's position.

```rust
rows.last().map(cursor_from_row).transpose().map(|c| c.map(Base64String))
```

The cursor does double duty. As a page token, "short page means no more pages" is correct and `None` is a fine answer. As a sync watermark it is the client's record of how far it has read, and dropping it on the last page is exactly when the client most needs it. The effect was that a client syncing to the tip could not remember where the tip was: next sync it re-read from its previous position, and the cost of a sync grew with total history rather than with what had arrived since.

No schema change, deliberately. Response types are `#[serde(deny_unknown_fields)]`, so adding a field would break every deployed client. This changes what an existing optional field contains, not its shape: `next_cursor` was already `Option`, callers already handled both cases, and a cursor pointing at the last row of a short page is a valid cursor — paging from it returns an empty page, which is the correct terminal state.

Callers can stop one round trip earlier, because a short page is already known to be the last:

```rust
let last_page = response.transactions.len() < config.page_limit as usize;
cursor = response.next_cursor;
if last_page || cursor.is_none() { break; }
```

The cursor is kept for the next sync; only the extra end-of-stream request goes away.

`a_short_page_still_reports_its_last_row` and `an_empty_page_ends_the_stream` pin both halves: a short page must carry a cursor, an empty page must not.

How the gap survived: the client-side mock always returned a cursor, while photon returned `None` on short pages. Making the mock faithful to the server made the guard test fail immediately.
