### PR TITLE
sdk: resume the proofless scan, type indexer failures, and stop unbounded proof polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9843,6 +9843,7 @@ dependencies = [
  "solana-loader-v3-interface 8.0.1",
  "solana-message",
  "solana-pubkey 4.2.0",
+ "solana-rpc-client-api",
  "solana-signer",
  "solana-transaction",
  "swap-program",

--- a/program-libs/interface/src/error.rs
+++ b/program-libs/interface/src/error.rs
@@ -20,19 +20,6 @@ pub enum InterfaceError {
 }
 
 /// Declares the error enum and its reverse lookup from one list.
-///
-/// A client sees only a number -- `custom program error: 0x1b60` -- so naming
-/// it needs a code-to-variant map. Maintaining that map by hand is how 0x1b60
-/// got called `StaleNullifierRoot` for a day: it is 7008,
-/// `TransactProofVerificationFailed`, while `StaleNullifierRoot` is 7015. The
-/// wrong name came from reading a `TreeError` conversion instead of this table
-/// and survived into three commit messages because nothing checked it.
-///
-/// Generating both directions from one list means a new variant cannot be
-/// added without `from_code` learning it. A derive macro (strum's `EnumIter`)
-/// would do the same, but this crate compiles into the on-chain program and
-/// keeps its dependency list to what the program needs; a `macro_rules!` costs
-/// nothing at all.
 macro_rules! shielded_pool_errors {
     ($(
         $(#[$attr:meta])*
@@ -202,11 +189,6 @@ mod tests {
     use super::{ShieldedPoolError, ShieldedPoolError::*};
 
     /// Every pinned code must map back to the variant it came from.
-    ///
-    /// `expected_code` below is exhaustive with no wildcard, so a new variant
-    /// stops this file compiling until it is listed there -- and because the
-    /// enum and `from_code` are generated from one list, the lookup learns it
-    /// at the same moment. This asserts the two really do agree.
     #[test]
     fn every_code_maps_back_to_its_variant() {
         for error in [

--- a/program-libs/interface/src/error.rs
+++ b/program-libs/interface/src/error.rs
@@ -19,14 +19,52 @@ pub enum InterfaceError {
     AlreadyInitialized,
 }
 
-/// Program errors surfaced on-chain as `ProgramError::Custom(code)`.
+/// Declares the error enum and its reverse lookup from one list.
 ///
-/// The discriminants below are the on-chain error codes for this program
-/// version. `error_codes_are_stable` pins the mapping so intentional ABI
-/// changes are explicit.
-#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
-#[repr(u32)]
-pub enum ShieldedPoolError {
+/// A client sees only a number -- `custom program error: 0x1b60` -- so naming
+/// it needs a code-to-variant map. Maintaining that map by hand is how 0x1b60
+/// got called `StaleNullifierRoot` for a day: it is 7008,
+/// `TransactProofVerificationFailed`, while `StaleNullifierRoot` is 7015. The
+/// wrong name came from reading a `TreeError` conversion instead of this table
+/// and survived into three commit messages because nothing checked it.
+///
+/// Generating both directions from one list means a new variant cannot be
+/// added without `from_code` learning it. A derive macro (strum's `EnumIter`)
+/// would do the same, but this crate compiles into the on-chain program and
+/// keeps its dependency list to what the program needs; a `macro_rules!` costs
+/// nothing at all.
+macro_rules! shielded_pool_errors {
+    ($(
+        $(#[$attr:meta])*
+        $variant:ident = $code:literal,
+    )*) => {
+        /// Program errors surfaced on-chain as `ProgramError::Custom(code)`.
+        ///
+        /// The discriminants below are the on-chain error codes for this program
+        /// version. `error_codes_are_stable` pins the mapping so intentional ABI
+        /// changes are explicit.
+        #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+        #[repr(u32)]
+        pub enum ShieldedPoolError {
+            $(
+                $(#[$attr])*
+                $variant = $code,
+            )*
+        }
+
+        impl ShieldedPoolError {
+            /// Recovers the variant from the code a failed transaction reports.
+            pub fn from_code(code: u32) -> Option<Self> {
+                match code {
+                    $($code => Some(Self::$variant),)*
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+shielded_pool_errors! {
     #[error("invalid instruction data")]
     InvalidInstructionData = 7000,
     #[error("pool tree accounts are invalid")]
@@ -162,6 +200,49 @@ impl From<TreeError> for ShieldedPoolError {
 #[cfg(test)]
 mod tests {
     use super::{ShieldedPoolError, ShieldedPoolError::*};
+
+    /// Every pinned code must map back to the variant it came from.
+    ///
+    /// `expected_code` below is exhaustive with no wildcard, so a new variant
+    /// stops this file compiling until it is listed there -- and because the
+    /// enum and `from_code` are generated from one list, the lookup learns it
+    /// at the same moment. This asserts the two really do agree.
+    #[test]
+    fn every_code_maps_back_to_its_variant() {
+        for error in [
+            InvalidInstructionData,
+            TransactProofVerificationFailed,
+            StaleNullifierRoot,
+            NullifierTreeUpdateFailed,
+            RingPaused,
+        ] {
+            let code = error as u32;
+            assert_eq!(
+                ShieldedPoolError::from_code(code),
+                Some(error),
+                "code {code} did not map back"
+            );
+        }
+
+        // The two that were confused for each other, spelled out: 0x1b60 is
+        // proof verification, not a stale root.
+        assert_eq!(
+            ShieldedPoolError::from_code(0x1b60),
+            Some(TransactProofVerificationFailed)
+        );
+        assert_eq!(
+            ShieldedPoolError::from_code(0x1b67),
+            Some(StaleNullifierRoot)
+        );
+    }
+
+    /// A code the program never emits has no name, and inventing one would be
+    /// worse than reporting the number.
+    #[test]
+    fn an_unknown_code_has_no_variant() {
+        assert_eq!(ShieldedPoolError::from_code(1), None);
+        assert_eq!(ShieldedPoolError::from_code(7020), None, "7020 is retired");
+    }
 
     /// Pin every on-chain error code for this program version.
     #[test]

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -211,13 +211,20 @@ impl<R: Rpc> ZolanaClient<R> {
             .prove_transact(proof_inputs, &spend_proofs, &dummy_proofs)
     }
 
+    /// Fetches the blockhash itself, after proving rather than before.
+    ///
+    /// Callers used to fetch one and hand it in, which put a multi-second proof
+    /// between the blockhash and the send. Under load that window exceeded the
+    /// blockhash lifetime and the transaction was rejected at submission,
+    /// having already paid for the sync and the proof: an 80-worker run lost
+    /// 297 of 337 transfers to "Blockhash not found".
+    ///
     /// `R: Sync` because the two proof fetches below share the indexer across
     /// scoped threads.
     pub fn finish_submission_unsigned_sync(
         &self,
         signed: &SignedPrivateTransaction,
         fee_payer: Pubkey,
-        recent_blockhash: Hash,
     ) -> Result<SolanaTransaction, ClientError>
     where
         R: Sync,
@@ -261,6 +268,9 @@ impl<R: Rpc> ZolanaClient<R> {
             self.blocking_prover().prove_transfer(inputs)?
         };
         let proof = ProofCompressed::try_from(proof)?.to_transact_proof();
+        // Last thing before building, so the blockhash is as young as it can be
+        // when the transaction reaches the cluster.
+        let (recent_blockhash, _) = self.rpc().get_latest_blockhash()?;
         build_unsigned_solana_transaction(
             ComputeBudgetConfig {
                 cu_limit: self.cu_limit,

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -211,33 +211,49 @@ impl<R: Rpc> ZolanaClient<R> {
             .prove_transact(proof_inputs, &spend_proofs, &dummy_proofs)
     }
 
+    /// `R: Sync` because the two proof fetches below share the indexer across
+    /// scoped threads.
     pub fn finish_submission_unsigned_sync(
         &self,
         signed: &SignedPrivateTransaction,
         fee_payer: Pubkey,
         recent_blockhash: Hash,
-    ) -> Result<SolanaTransaction, ClientError> {
+    ) -> Result<SolanaTransaction, ClientError>
+    where
+        R: Sync,
+    {
         validate_fee_payer_pubkey(&signed.transaction.payer, fee_payer)?;
         let owner_signers = signed.transaction.owner_signer_pubkeys()?;
         let commitments = signed.transaction.input_utxo_hashes()?;
-        let spend_proofs = {
-            let _t = crate::timing::Phase::start("fetch_spend_proofs", 0);
-            fetch_spend_proofs(
-                self.blocking_indexer(),
-                signed.input_tree,
-                &commitments,
-                None,
-            )?
-        };
-        let dummy_proofs = {
-            let _t = crate::timing::Phase::start("fetch_dummy_nullifier_proofs", 0);
-            fetch_dummy_nullifier_proofs(
-                self.blocking_indexer(),
-                signed.input_tree,
-                &signed.transaction,
-                None,
-            )?
-        };
+        // Two independent indexer round trips (317ms and 114ms on devnet) that
+        // ran back to back. Nothing links them: different methods, and neither
+        // consumes the other's output.
+        let (spend_proofs, dummy_proofs) = std::thread::scope(|scope| {
+            let spend = scope.spawn(|| {
+                let _t = crate::timing::Phase::start("fetch_spend_proofs", 0);
+                fetch_spend_proofs(
+                    self.blocking_indexer(),
+                    signed.input_tree,
+                    &commitments,
+                    None,
+                )
+            });
+            let dummy = scope.spawn(|| {
+                let _t = crate::timing::Phase::start("fetch_dummy_nullifier_proofs", 0);
+                fetch_dummy_nullifier_proofs(
+                    self.blocking_indexer(),
+                    signed.input_tree,
+                    &signed.transaction,
+                    None,
+                )
+            });
+            (spend.join(), dummy.join())
+        });
+        // A panic here is a bug in proof assembly, not an unreachable indexer.
+        let spend_proofs =
+            spend_proofs.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
+        let dummy_proofs =
+            dummy_proofs.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
         let assembled = assemble(signed.transaction.clone(), &spend_proofs, &dummy_proofs)?;
         let ProverInputs::Eddsa(inputs) = &assembled.prover_inputs;
         let proof = {

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -220,21 +220,30 @@ impl<R: Rpc> ZolanaClient<R> {
         validate_fee_payer_pubkey(&signed.transaction.payer, fee_payer)?;
         let owner_signers = signed.transaction.owner_signer_pubkeys()?;
         let commitments = signed.transaction.input_utxo_hashes()?;
-        let spend_proofs = fetch_spend_proofs(
-            self.blocking_indexer(),
-            signed.input_tree,
-            &commitments,
-            None,
-        )?;
-        let dummy_proofs = fetch_dummy_nullifier_proofs(
-            self.blocking_indexer(),
-            signed.input_tree,
-            &signed.transaction,
-            None,
-        )?;
+        let spend_proofs = {
+            let _t = crate::timing::Phase::start("fetch_spend_proofs", 0);
+            fetch_spend_proofs(
+                self.blocking_indexer(),
+                signed.input_tree,
+                &commitments,
+                None,
+            )?
+        };
+        let dummy_proofs = {
+            let _t = crate::timing::Phase::start("fetch_dummy_nullifier_proofs", 0);
+            fetch_dummy_nullifier_proofs(
+                self.blocking_indexer(),
+                signed.input_tree,
+                &signed.transaction,
+                None,
+            )?
+        };
         let assembled = assemble(signed.transaction.clone(), &spend_proofs, &dummy_proofs)?;
         let ProverInputs::Eddsa(inputs) = &assembled.prover_inputs;
-        let proof = self.blocking_prover().prove_transfer(inputs)?;
+        let proof = {
+            let _t = crate::timing::Phase::start("prove_transfer", 0);
+            self.blocking_prover().prove_transfer(inputs)?
+        };
         let proof = ProofCompressed::try_from(proof)?.to_transact_proof();
         build_unsigned_solana_transaction(
             ComputeBudgetConfig {

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -51,9 +51,6 @@ pub struct SignedPrivateTransaction {
     pub input_tree: Address,
 }
 
-/// Compute-unit ceiling a private transaction is submitted with unless the
-/// caller overrides it. A shielded `Transact` verifies a Groth16 proof on-chain,
-/// which does not fit inside the default per-instruction budget.
 pub const DEFAULT_TRANSACT_CU_LIMIT: u32 = 300_000;
 
 /// Unified client for private transaction proving and submission helpers.
@@ -212,15 +209,6 @@ impl<R: Rpc> ZolanaClient<R> {
     }
 
     /// Fetches the blockhash itself, after proving rather than before.
-    ///
-    /// Callers used to fetch one and hand it in, which put a multi-second proof
-    /// between the blockhash and the send. Under load that window exceeded the
-    /// blockhash lifetime and the transaction was rejected at submission,
-    /// having already paid for the sync and the proof: an 80-worker run lost
-    /// 297 of 337 transfers to "Blockhash not found".
-    ///
-    /// `R: Sync` because the two proof fetches below share the indexer across
-    /// scoped threads.
     pub fn finish_submission_unsigned_sync(
         &self,
         signed: &SignedPrivateTransaction,
@@ -232,9 +220,6 @@ impl<R: Rpc> ZolanaClient<R> {
         validate_fee_payer_pubkey(&signed.transaction.payer, fee_payer)?;
         let owner_signers = signed.transaction.owner_signer_pubkeys()?;
         let commitments = signed.transaction.input_utxo_hashes()?;
-        // Two independent indexer round trips (317ms and 114ms on devnet) that
-        // ran back to back. Nothing links them: different methods, and neither
-        // consumes the other's output.
         let (spend_proofs, dummy_proofs) = std::thread::scope(|scope| {
             let spend = scope.spawn(|| {
                 let _t = crate::timing::Phase::start("fetch_spend_proofs", 0);
@@ -256,7 +241,6 @@ impl<R: Rpc> ZolanaClient<R> {
             });
             (spend.join(), dummy.join())
         });
-        // A panic here is a bug in proof assembly, not an unreachable indexer.
         let spend_proofs =
             spend_proofs.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
         let dummy_proofs =
@@ -268,8 +252,6 @@ impl<R: Rpc> ZolanaClient<R> {
             self.blocking_prover().prove_transfer(inputs)?
         };
         let proof = ProofCompressed::try_from(proof)?.to_transact_proof();
-        // Last thing before building, so the blockhash is as young as it can be
-        // when the transaction reaches the cluster.
         let (recent_blockhash, _) = self.rpc().get_latest_blockhash()?;
         build_unsigned_solana_transaction(
             ComputeBudgetConfig {

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -230,13 +230,6 @@ pub enum ClientError {
 
     /// The indexer could not answer, for a reason that may not persist.
     /// Acted on by `Rpc::should_retry` during the confirmation poll.
-    ///
-    /// `reason` is what callers should branch on. `detail` is for humans and
-    /// carries the transport's own wording, which is often not what it looks
-    /// like: reqwest renders a body-read timeout as "error decoding response
-    /// body", which reads like a deserialization bug and is not one. Deciding
-    /// anything by searching that text is how a load generator ended up
-    /// classifying throttling with `message.contains("429")`.
     #[error("indexer temporarily unavailable: {reason} ({detail})")]
     IndexerUnavailable { reason: Unavailable, detail: String },
 
@@ -274,13 +267,6 @@ pub enum ClientError {
 
 impl ClientError {
     /// The on-chain program error code, when the chain rejected the transaction.
-    ///
-    /// Solana already models this: the RPC error carries a `TransactionError`,
-    /// which carries an `InstructionError::Custom(u32)`. Callers should read
-    /// that rather than the rendered message -- a load generator grouped
-    /// failures by the first 160 characters of the string, and the code sits at
-    /// roughly character 160, so a run reporting 10748 failures said nothing
-    /// about what any of them were.
     pub fn program_error_code(&self) -> Option<u32> {
         use solana_instruction::error::InstructionError;
         use solana_rpc_client_api::client_error::TransactionError;
@@ -295,22 +281,8 @@ impl ClientError {
     }
 }
 
-/// Why an indexer request failed, in a form callers can match on.
-///
-/// Exists so that nothing has to inspect an error message to decide what to do.
-/// The load generator used to separate throttling from real failure with
-/// `message.contains("429") || message.contains("rate")`, which counts a
-/// signature containing "429" as a rate limit and the word "generate" as one
-/// too, while missing a 503 entirely.
-///
-/// Every variant is retryable today. That is worth stating rather than
-/// assuming: the set is explicit, so adding a reason that is *not* retryable
-/// forces `should_retry` to be revisited instead of silently inheriting
-/// "retry anything unavailable".
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum Unavailable {
-    /// Includes a timeout while reading the response body, which the transport
-    /// renders as "error decoding response body".
     #[error("request timed out")]
     Timeout,
 

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -272,6 +272,29 @@ pub enum ClientError {
     DepositSenderNotSigner { sender: [u8; 32] },
 }
 
+impl ClientError {
+    /// The on-chain program error code, when the chain rejected the transaction.
+    ///
+    /// Solana already models this: the RPC error carries a `TransactionError`,
+    /// which carries an `InstructionError::Custom(u32)`. Callers should read
+    /// that rather than the rendered message -- a load generator grouped
+    /// failures by the first 160 characters of the string, and the code sits at
+    /// roughly character 160, so a run reporting 10748 failures said nothing
+    /// about what any of them were.
+    pub fn program_error_code(&self) -> Option<u32> {
+        use solana_instruction::error::InstructionError;
+        use solana_rpc_client_api::client_error::TransactionError;
+
+        let Self::SolanaRpcTransaction { source, .. } = self else {
+            return None;
+        };
+        match source.get_transaction_error()? {
+            TransactionError::InstructionError(_, InstructionError::Custom(code)) => Some(code),
+            _ => None,
+        }
+    }
+}
+
 /// Why an indexer request failed, in a form callers can match on.
 ///
 /// Exists so that nothing has to inspect an error message to decide what to do.

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -228,10 +228,17 @@ pub enum ClientError {
     #[error("indexer error: {0}")]
     Indexer(String),
 
-    /// The indexer answered with a rate-limit or internal JSON-RPC error.
+    /// The indexer could not answer, for a reason that may not persist.
     /// Acted on by `Rpc::should_retry` during the confirmation poll.
-    #[error("indexer temporarily unavailable: {0}")]
-    IndexerUnavailable(String),
+    ///
+    /// `reason` is what callers should branch on. `detail` is for humans and
+    /// carries the transport's own wording, which is often not what it looks
+    /// like: reqwest renders a body-read timeout as "error decoding response
+    /// body", which reads like a deserialization bug and is not one. Deciding
+    /// anything by searching that text is how a load generator ended up
+    /// classifying throttling with `message.contains("429")`.
+    #[error("indexer temporarily unavailable: {reason} ({detail})")]
+    IndexerUnavailable { reason: Unavailable, detail: String },
 
     #[error("rpc backend does not implement method `{0}`")]
     UnsupportedRpcMethod(&'static str),
@@ -263,4 +270,36 @@ pub enum ClientError {
 
     #[error("SOL deposit funding account {sender:?} must be the signing authority")]
     DepositSenderNotSigner { sender: [u8; 32] },
+}
+
+/// Why an indexer request failed, in a form callers can match on.
+///
+/// Exists so that nothing has to inspect an error message to decide what to do.
+/// The load generator used to separate throttling from real failure with
+/// `message.contains("429") || message.contains("rate")`, which counts a
+/// signature containing "429" as a rate limit and the word "generate" as one
+/// too, while missing a 503 entirely.
+///
+/// Every variant is retryable today. That is worth stating rather than
+/// assuming: the set is explicit, so adding a reason that is *not* retryable
+/// forces `should_retry` to be revisited instead of silently inheriting
+/// "retry anything unavailable".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum Unavailable {
+    /// Includes a timeout while reading the response body, which the transport
+    /// renders as "error decoding response body".
+    #[error("request timed out")]
+    Timeout,
+
+    #[error("could not connect")]
+    Connect,
+
+    #[error("rate limited")]
+    RateLimited,
+
+    #[error("server error {status}")]
+    ServerError { status: u16 },
+
+    #[error("indexer reported an internal error")]
+    JsonRpcInternal,
 }

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -17,7 +17,7 @@ use zolana_keypair::{constants::P256_PUBKEY_LEN, P256Pubkey};
 use zolana_transaction::instructions::transact::SppProofInputs;
 
 use crate::{
-    error::ClientError,
+    error::{ClientError, Unavailable},
     prover::{transact::SpendProof, ProverClient},
     retry::IndexerRpcConfig,
     rpc::{
@@ -203,7 +203,7 @@ impl AsyncZolanaIndexer {
 
 impl Rpc for ZolanaIndexer {
     fn should_retry(&self, error: &ClientError) -> bool {
-        matches!(error, ClientError::IndexerUnavailable(_))
+        matches!(error, ClientError::IndexerUnavailable { .. })
     }
 
     fn get_encrypted_utxos_by_tags(
@@ -407,7 +407,7 @@ impl Rpc for ZolanaIndexer {
 #[async_trait]
 impl AsyncRpc for AsyncZolanaIndexer {
     fn should_retry(&self, error: &ClientError) -> bool {
-        matches!(error, ClientError::IndexerUnavailable(_))
+        matches!(error, ClientError::IndexerUnavailable { .. })
     }
 
     async fn get_encrypted_utxos_by_tags(
@@ -603,15 +603,27 @@ impl AsyncRpc for AsyncZolanaIndexer {
 /// retried and the caller is handed the last one it saw rather than a bare
 /// timeout.
 fn indexer_error(error: zolana_api::ApiError) -> ClientError {
-    let message = error.to_string();
+    let detail = error.to_string();
+    let unavailable = |reason| ClientError::IndexerUnavailable {
+        reason,
+        detail: detail.clone(),
+    };
     match error {
-        zolana_api::ApiError::Request(error) if error.is_timeout() || error.is_connect() => {
-            ClientError::IndexerUnavailable(message)
+        zolana_api::ApiError::Request(ref error) if error.is_timeout() => {
+            unavailable(Unavailable::Timeout)
+        }
+        zolana_api::ApiError::Request(ref error) if error.is_connect() => {
+            unavailable(Unavailable::Connect)
         }
         zolana_api::ApiError::Response { status, .. }
-            if status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error() =>
+            if status == reqwest::StatusCode::TOO_MANY_REQUESTS =>
         {
-            ClientError::IndexerUnavailable(message)
+            unavailable(Unavailable::RateLimited)
+        }
+        zolana_api::ApiError::Response { status, .. } if status.is_server_error() => {
+            unavailable(Unavailable::ServerError {
+                status: status.as_u16(),
+            })
         }
         zolana_api::ApiError::JsonRpc {
             method,
@@ -621,8 +633,8 @@ fn indexer_error(error: zolana_api::ApiError) -> ClientError {
         zolana_api::ApiError::JsonRpc {
             code: Some(JSON_RPC_INTERNAL_ERROR),
             ..
-        } => ClientError::IndexerUnavailable(message),
-        _ => ClientError::Indexer(message),
+        } => unavailable(Unavailable::JsonRpcInternal),
+        _ => ClientError::Indexer(detail),
     }
 }
 
@@ -1233,14 +1245,26 @@ mod tests {
             status: reqwest::StatusCode::TOO_MANY_REQUESTS,
             body: "retry later".to_string(),
         });
-        assert!(matches!(rate_limit, ClientError::IndexerUnavailable(_)));
+        assert!(matches!(
+            rate_limit,
+            ClientError::IndexerUnavailable {
+                reason: Unavailable::RateLimited,
+                ..
+            }
+        ));
 
         let internal_error = indexer_error(zolana_api::ApiError::JsonRpc {
             method: "get_shielded_transactions_by_signature",
             code: Some(-32603),
             message: Some("Internal error".to_string()),
         });
-        assert!(matches!(internal_error, ClientError::IndexerUnavailable(_)));
+        assert!(matches!(
+            internal_error,
+            ClientError::IndexerUnavailable {
+                reason: Unavailable::JsonRpcInternal,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -11,6 +11,7 @@
 //! - `solana-rpc`: concrete Solana RPC adapters
 //! - `client`: `indexer-api` + `solana-rpc`
 
+#[cfg(feature = "indexer-api")]
 pub mod client;
 pub mod error;
 #[cfg(feature = "indexer-api")]

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -25,7 +25,7 @@ pub mod timing;
 
 #[cfg(feature = "indexer-api")]
 pub use client::{SignedPrivateTransaction, ZolanaClient, DEFAULT_TRANSACT_CU_LIMIT};
-pub use error::ClientError;
+pub use error::{ClientError, Unavailable};
 #[cfg(feature = "indexer-api")]
 pub use indexer::{AsyncZolanaIndexer, ZolanaIndexer};
 pub use prover::{

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -11,7 +11,6 @@
 //! - `solana-rpc`: concrete Solana RPC adapters
 //! - `client`: `indexer-api` + `solana-rpc`
 
-#[cfg(feature = "indexer-api")]
 pub mod client;
 pub mod error;
 #[cfg(feature = "indexer-api")]
@@ -21,6 +20,7 @@ pub mod retry;
 pub mod rpc;
 #[cfg(feature = "solana-rpc")]
 pub mod solana_rpc;
+pub mod timing;
 
 #[cfg(feature = "indexer-api")]
 pub use client::{SignedPrivateTransaction, ZolanaClient, DEFAULT_TRANSACT_CU_LIMIT};

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -260,11 +260,25 @@ impl ProverClient {
         // used to be `.max(1)` and `sleep_secs`, which put a hard 1s floor on
         // every proof: a 270ms proof measured 3.3s end to end, essentially all
         // of it spent asleep between polls.
+        // The backoff ceiling is deliberately left to `poll_interval_secs` rather than
+        // clamped to something tighter.
+        //
+        // Tightening it to 250ms looks like an obvious win -- a finished proof then
+        // waits at most a quarter second to be collected -- and it measurably is not.
+        // Two 8-worker load tests, identical apart from this ceiling:
+        //
+        //     ceiling 1s     prove mean 2025ms   1.14 tps
+        //     ceiling 250ms  prove mean 3632ms   0.92 tps
+        //
+        // sync, send, and confirm were unchanged across the pair, so the regression is
+        // isolated to proving. Polling four times as hard contends with the prover's
+        // own queue rather than shortening the wait. Poll often enough to avoid the
+        // whole-second floor, then get out of the way.
         let poll_cap_ms = self
             .async_poll
             .poll_interval_secs
             .saturating_mul(1_000)
-            .clamp(INITIAL_POLL_MS, MAX_POLL_INTERVAL_MS);
+            .max(INITIAL_POLL_MS);
         let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
         let mut waited_ms = 0u64;
         let mut interval_ms = INITIAL_POLL_MS;
@@ -345,16 +359,6 @@ impl ProverClient {
 /// second, so the first poll should land almost immediately; the cost of being
 /// early is one cheap GET.
 const INITIAL_POLL_MS: u64 = 25;
-
-/// Ceiling on the gap between status polls.
-///
-/// An unbounded doubling trades the old bug for a smaller version of itself:
-/// with a 1s ceiling a proof that lands just after a poll waits up to another
-/// second. Under an 8-worker load test that showed as a 2025ms mean prove phase
-/// while the prover reported 0.267s of compute throughout, so the overshoot was
-/// most of what remained. 250ms bounds the wasted wait to a quarter second and
-/// still costs only about ten cheap status GETs for a 2s proof.
-const MAX_POLL_INTERVAL_MS: u64 = 250;
 
 /// Next gap in the backoff, doubling up to `cap_ms`.
 ///
@@ -496,7 +500,7 @@ impl AsyncProverClient {
             .async_poll
             .poll_interval_secs
             .saturating_mul(1_000)
-            .clamp(INITIAL_POLL_MS, MAX_POLL_INTERVAL_MS);
+            .max(INITIAL_POLL_MS);
         let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
         let mut waited_ms = 0u64;
         let mut interval_ms = INITIAL_POLL_MS;

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -205,6 +205,7 @@ impl ProverClient {
 
     fn send(&self, body: String) -> Result<Proof, ClientError> {
         let url = format!("{}{}", self.server_address, PROVE_PATH);
+        crate::timing::note(0, "prover_request_bytes", body.len());
         let mut attempt = 0;
         let response = loop {
             attempt += 1;
@@ -255,14 +256,24 @@ impl ProverClient {
     /// Poll the async job status endpoint until the queued proof completes.
     fn poll_async(&self, job_id: &str) -> Result<Proof, ClientError> {
         let url = format!("{}/prove/status?job_id={}", self.server_address, job_id);
-        let poll_interval = self.async_poll.poll_interval_secs.max(1);
-        let max_wait = self.async_poll.max_wait_secs;
-        let mut waited = 0u64;
+        // The configured interval caps the backoff rather than setting it. This
+        // used to be `.max(1)` and `sleep_secs`, which put a hard 1s floor on
+        // every proof: a 270ms proof measured 3.3s end to end, essentially all
+        // of it spent asleep between polls.
+        let poll_cap_ms = self
+            .async_poll
+            .poll_interval_secs
+            .saturating_mul(1_000)
+            .max(INITIAL_POLL_MS);
+        let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
+        let mut waited_ms = 0u64;
+        let mut interval_ms = INITIAL_POLL_MS;
         loop {
             let response = match self.http.get(&url).send() {
                 Ok(response) => response,
                 Err(_) => {
-                    wait_or_timeout(job_id, &mut waited, max_wait, poll_interval)?;
+                    wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                    interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
             };
@@ -277,14 +288,16 @@ impl ProverClient {
                 )));
             }
             if status.is_server_error() {
-                wait_or_timeout(job_id, &mut waited, max_wait, poll_interval)?;
+                wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 continue;
             }
 
             let text = match response.text() {
                 Ok(text) => text,
                 Err(_) => {
-                    wait_or_timeout(job_id, &mut waited, max_wait, poll_interval)?;
+                    wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                    interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
             };
@@ -305,7 +318,8 @@ impl ProverClient {
                 }
                 // queued / processing / unknown: keep polling until the bound.
                 _ => {
-                    wait_or_timeout(job_id, &mut waited, max_wait, poll_interval)?;
+                    wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                    interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 }
             }
         }
@@ -327,22 +341,38 @@ impl ProverClient {
     }
 }
 
+/// First gap between status polls. A transfer proof completes in well under a
+/// second, so the first poll should land almost immediately; the cost of being
+/// early is one cheap GET.
+const INITIAL_POLL_MS: u64 = 25;
+
+/// Next gap in the backoff, doubling up to `cap_ms`.
+///
+/// The configured poll interval is the CEILING, not a fixed period: a proof that
+/// finishes in 270ms should not wait a full second to be collected, but a proof
+/// that takes a minute should not be polled 2400 times either.
+fn next_poll_interval_ms(current_ms: u64, cap_ms: u64) -> u64 {
+    current_ms
+        .saturating_mul(2)
+        .min(cap_ms.max(INITIAL_POLL_MS))
+}
+
 fn wait_or_timeout(
     job_id: &str,
-    waited: &mut u64,
-    max_wait: u64,
-    poll_interval: u64,
+    waited_ms: &mut u64,
+    max_wait_ms: u64,
+    poll_interval_ms: u64,
 ) -> Result<(), ClientError> {
-    if *waited >= max_wait {
-        let waited_secs = *waited;
+    if *waited_ms >= max_wait_ms {
+        let waited_secs = *waited_ms / 1_000;
         return Err(ClientError::ProverServer(format!(
             "async proof timed out after {waited_secs}s (job {job_id})"
         )));
     }
-    let remaining = max_wait.saturating_sub(*waited);
-    let sleep_secs = poll_interval.min(remaining);
-    sleep(Duration::from_secs(sleep_secs));
-    *waited = (*waited).saturating_add(sleep_secs);
+    let remaining = max_wait_ms.saturating_sub(*waited_ms);
+    let sleep_ms = poll_interval_ms.min(remaining);
+    sleep(Duration::from_millis(sleep_ms));
+    *waited_ms = (*waited_ms).saturating_add(sleep_ms);
     Ok(())
 }
 
@@ -742,6 +772,64 @@ mod tests {
         assert_eq!(
             prover_start_command("zolana", 3001, Some("  ")),
             "zolana dev prover start --prover-port 3001"
+        );
+    }
+
+    /// The prover is queue-backed: `/prove` returns a job handle and the proof
+    /// is collected by polling. The gap between polls used to be
+    /// `Duration::from_secs(poll_interval.max(1))`, so a proof the server
+    /// finished in 270ms was not collected for a further second or more --
+    /// measured on devnet as 3.3s end to end for 270ms of proving, which made
+    /// the prover call the largest phase of a transfer for no real reason.
+    ///
+    /// Asserts wall-clock rather than the sleep arithmetic, because the bug was
+    /// only visible as latency.
+    #[test]
+    fn a_proof_ready_on_the_first_poll_is_not_held_for_a_whole_second() {
+        let server = MockServer::respond_with(vec![
+            MockResponse::json(202, json!({ "job_id": "job-1", "status": "queued" })),
+            MockResponse::json(
+                200,
+                json!({
+                    "status": "completed",
+                    "result": { "proof": gnark_proof(), "proof_duration_ms": 7 },
+                }),
+            ),
+        ]);
+        let started = std::time::Instant::now();
+        queued_prover_client(server.url())
+            .send("{}".to_string())
+            .expect("queued proof should complete");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "collecting a ready proof took {elapsed:?}; the poll interval is a \
+             ceiling, not a floor"
+        );
+    }
+
+    /// The configured interval bounds the backoff instead of fixing it, so a
+    /// long proof still settles into infrequent polling.
+    #[test]
+    fn poll_backoff_doubles_up_to_the_configured_ceiling() {
+        let cap = 1_000;
+        let mut interval = INITIAL_POLL_MS;
+        let mut seen = vec![interval];
+        for _ in 0..8 {
+            interval = next_poll_interval_ms(interval, cap);
+            seen.push(interval);
+        }
+        assert_eq!(seen[0], 25, "first poll lands almost immediately");
+        assert_eq!(&seen[1..4], &[50, 100, 200]);
+        assert_eq!(
+            *seen.last().expect("non-empty"),
+            cap,
+            "backoff settles at the configured interval"
+        );
+        assert!(
+            seen.windows(2).all(|w| w[1] >= w[0]),
+            "backoff is monotonic"
         );
     }
 

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -264,7 +264,7 @@ impl ProverClient {
             .async_poll
             .poll_interval_secs
             .saturating_mul(1_000)
-            .max(INITIAL_POLL_MS);
+            .clamp(INITIAL_POLL_MS, MAX_POLL_INTERVAL_MS);
         let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
         let mut waited_ms = 0u64;
         let mut interval_ms = INITIAL_POLL_MS;
@@ -345,6 +345,16 @@ impl ProverClient {
 /// second, so the first poll should land almost immediately; the cost of being
 /// early is one cheap GET.
 const INITIAL_POLL_MS: u64 = 25;
+
+/// Ceiling on the gap between status polls.
+///
+/// An unbounded doubling trades the old bug for a smaller version of itself:
+/// with a 1s ceiling a proof that lands just after a poll waits up to another
+/// second. Under an 8-worker load test that showed as a 2025ms mean prove phase
+/// while the prover reported 0.267s of compute throughout, so the overshoot was
+/// most of what remained. 250ms bounds the wasted wait to a quarter second and
+/// still costs only about ten cheap status GETs for a 2s proof.
+const MAX_POLL_INTERVAL_MS: u64 = 250;
 
 /// Next gap in the backoff, doubling up to `cap_ms`.
 ///
@@ -482,14 +492,20 @@ impl AsyncProverClient {
 
     async fn poll_async(&self, job_id: &str) -> Result<Proof, ClientError> {
         let url = format!("{}/prove/status?job_id={}", self.server_address, job_id);
-        let poll_interval = self.async_poll.poll_interval_secs.max(1);
-        let max_wait = self.async_poll.max_wait_secs;
-        let mut waited = 0u64;
+        let poll_cap_ms = self
+            .async_poll
+            .poll_interval_secs
+            .saturating_mul(1_000)
+            .clamp(INITIAL_POLL_MS, MAX_POLL_INTERVAL_MS);
+        let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
+        let mut waited_ms = 0u64;
+        let mut interval_ms = INITIAL_POLL_MS;
         loop {
             let response = match self.http.get(&url).send().await {
                 Ok(response) => response,
                 Err(_) => {
-                    async_wait_or_timeout(job_id, &mut waited, max_wait, poll_interval).await?;
+                    async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                    interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
             };
@@ -504,14 +520,16 @@ impl AsyncProverClient {
                 )));
             }
             if status.is_server_error() {
-                async_wait_or_timeout(job_id, &mut waited, max_wait, poll_interval).await?;
+                async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 continue;
             }
 
             let text = match response.text().await {
                 Ok(text) => text,
                 Err(_) => {
-                    async_wait_or_timeout(job_id, &mut waited, max_wait, poll_interval).await?;
+                    async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                    interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
             };
@@ -529,7 +547,8 @@ impl AsyncProverClient {
                     )));
                 }
                 _ => {
-                    async_wait_or_timeout(job_id, &mut waited, max_wait, poll_interval).await?;
+                    async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                    interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 }
             }
         }
@@ -538,20 +557,20 @@ impl AsyncProverClient {
 
 async fn async_wait_or_timeout(
     job_id: &str,
-    waited: &mut u64,
-    max_wait: u64,
-    poll_interval: u64,
+    waited_ms: &mut u64,
+    max_wait_ms: u64,
+    poll_interval_ms: u64,
 ) -> Result<(), ClientError> {
-    if *waited >= max_wait {
-        let waited_secs = *waited;
+    if *waited_ms >= max_wait_ms {
+        let waited_secs = *waited_ms / 1_000;
         return Err(ClientError::ProverServer(format!(
             "async proof timed out after {waited_secs}s (job {job_id})"
         )));
     }
-    let remaining = max_wait.saturating_sub(*waited);
-    let sleep_secs = poll_interval.min(remaining);
-    async_sleep(Duration::from_secs(sleep_secs)).await;
-    *waited = (*waited).saturating_add(sleep_secs);
+    let remaining = max_wait_ms.saturating_sub(*waited_ms);
+    let sleep_ms = poll_interval_ms.min(remaining);
+    async_sleep(Duration::from_millis(sleep_ms)).await;
+    *waited_ms = (*waited_ms).saturating_add(sleep_ms);
     Ok(())
 }
 

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -4,7 +4,7 @@ use std::{
     process::Command,
     sync::atomic::{AtomicBool, Ordering},
     thread::sleep,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use tokio::time::sleep as async_sleep;
@@ -65,6 +65,14 @@ const PROVE_RETRY_BACKOFF_SECS: u64 = 2;
 // well before this.
 const PROVE_REQUEST_TIMEOUT_SECS: u64 = 600;
 const PROVE_CONNECT_TIMEOUT_SECS: u64 = 10;
+/// Per-request bound on a `/prove/status` poll.
+///
+/// The status endpoint reads one Redis key and returns; it is not the request
+/// that 600s was sized for. Sharing the prove timeout let a single hung poll
+/// block a worker for ten minutes, and since the poll loop retries, the delays
+/// stacked: a 220-worker run whose proofs had all finished or been reaped sat
+/// wedged for over half an hour, every worker parked inside a status GET.
+const STATUS_POLL_TIMEOUT_SECS: u64 = 30;
 /// Polling cadence and ceiling for async (queued) proofs. Redis-backed provers
 /// queue batch, transfer, and merge proofs and return a job handle immediately
 /// instead of blocking; the client then polls the status endpoint until the
@@ -78,7 +86,13 @@ const PROVE_CONNECT_TIMEOUT_SECS: u64 = 10;
 pub struct AsyncPollConfig {
     /// Seconds between `/prove/status` polls (floored at 1 so it can't spin).
     pub poll_interval_secs: u64,
-    /// Max seconds to wait for a queued proof before returning a timeout error.
+    /// Wall-clock seconds to wait for a queued proof before returning a timeout
+    /// error.
+    ///
+    /// Wall clock, measured from the first poll. It used to be a running total
+    /// of time *slept*, which bounds nothing: the time inside each request did
+    /// not count, so with a 600s request timeout this "1200s" ceiling permitted
+    /// well over a day of waiting.
     pub max_wait_secs: u64,
 }
 
@@ -279,14 +293,19 @@ impl ProverClient {
             .poll_interval_secs
             .saturating_mul(1_000)
             .max(INITIAL_POLL_MS);
-        let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
-        let mut waited_ms = 0u64;
+        let max_wait = Duration::from_secs(self.async_poll.max_wait_secs);
+        let started = Instant::now();
         let mut interval_ms = INITIAL_POLL_MS;
         loop {
-            let response = match self.http.get(&url).send() {
+            let response = match self
+                .http
+                .get(&url)
+                .timeout(Duration::from_secs(STATUS_POLL_TIMEOUT_SECS))
+                .send()
+            {
                 Ok(response) => response,
                 Err(_) => {
-                    wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                    wait_or_timeout(job_id, started, max_wait, interval_ms)?;
                     interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
@@ -302,7 +321,7 @@ impl ProverClient {
                 )));
             }
             if status.is_server_error() {
-                wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                wait_or_timeout(job_id, started, max_wait, interval_ms)?;
                 interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 continue;
             }
@@ -310,7 +329,7 @@ impl ProverClient {
             let text = match response.text() {
                 Ok(text) => text,
                 Err(_) => {
-                    wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                    wait_or_timeout(job_id, started, max_wait, interval_ms)?;
                     interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
@@ -332,7 +351,7 @@ impl ProverClient {
                 }
                 // queued / processing / unknown: keep polling until the bound.
                 _ => {
-                    wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                    wait_or_timeout(job_id, started, max_wait, interval_ms)?;
                     interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 }
             }
@@ -371,22 +390,40 @@ fn next_poll_interval_ms(current_ms: u64, cap_ms: u64) -> u64 {
         .min(cap_ms.max(INITIAL_POLL_MS))
 }
 
+/// How long is left before the deadline, or `Err` if it has passed.
+///
+/// Shared by the blocking and async poll loops so one definition of "expired"
+/// covers both. `started`/`max_wait` are wall clock: the previous version added
+/// up only the sleeps, which meant time spent inside a request was free and the
+/// ceiling bounded nothing.
+fn remaining_before_deadline(
+    job_id: &str,
+    started: Instant,
+    max_wait: Duration,
+    poll_interval_ms: u64,
+) -> Result<Duration, ClientError> {
+    let elapsed = started.elapsed();
+    let Some(remaining) = max_wait.checked_sub(elapsed) else {
+        return Err(ClientError::ProverServer(format!(
+            "async proof timed out after {}s (job {job_id})",
+            elapsed.as_secs()
+        )));
+    };
+    Ok(Duration::from_millis(poll_interval_ms).min(remaining))
+}
+
 fn wait_or_timeout(
     job_id: &str,
-    waited_ms: &mut u64,
-    max_wait_ms: u64,
+    started: Instant,
+    max_wait: Duration,
     poll_interval_ms: u64,
 ) -> Result<(), ClientError> {
-    if *waited_ms >= max_wait_ms {
-        let waited_secs = *waited_ms / 1_000;
-        return Err(ClientError::ProverServer(format!(
-            "async proof timed out after {waited_secs}s (job {job_id})"
-        )));
-    }
-    let remaining = max_wait_ms.saturating_sub(*waited_ms);
-    let sleep_ms = poll_interval_ms.min(remaining);
-    sleep(Duration::from_millis(sleep_ms));
-    *waited_ms = (*waited_ms).saturating_add(sleep_ms);
+    sleep(remaining_before_deadline(
+        job_id,
+        started,
+        max_wait,
+        poll_interval_ms,
+    )?);
     Ok(())
 }
 
@@ -501,14 +538,20 @@ impl AsyncProverClient {
             .poll_interval_secs
             .saturating_mul(1_000)
             .max(INITIAL_POLL_MS);
-        let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
-        let mut waited_ms = 0u64;
+        let max_wait = Duration::from_secs(self.async_poll.max_wait_secs);
+        let started = Instant::now();
         let mut interval_ms = INITIAL_POLL_MS;
         loop {
-            let response = match self.http.get(&url).send().await {
+            let response = match self
+                .http
+                .get(&url)
+                .timeout(Duration::from_secs(STATUS_POLL_TIMEOUT_SECS))
+                .send()
+                .await
+            {
                 Ok(response) => response,
                 Err(_) => {
-                    async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                    async_wait_or_timeout(job_id, started, max_wait, interval_ms).await?;
                     interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
@@ -524,7 +567,7 @@ impl AsyncProverClient {
                 )));
             }
             if status.is_server_error() {
-                async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                async_wait_or_timeout(job_id, started, max_wait, interval_ms).await?;
                 interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 continue;
             }
@@ -532,7 +575,7 @@ impl AsyncProverClient {
             let text = match response.text().await {
                 Ok(text) => text,
                 Err(_) => {
-                    async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                    async_wait_or_timeout(job_id, started, max_wait, interval_ms).await?;
                     interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
@@ -551,7 +594,7 @@ impl AsyncProverClient {
                     )));
                 }
                 _ => {
-                    async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                    async_wait_or_timeout(job_id, started, max_wait, interval_ms).await?;
                     interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 }
             }
@@ -561,20 +604,17 @@ impl AsyncProverClient {
 
 async fn async_wait_or_timeout(
     job_id: &str,
-    waited_ms: &mut u64,
-    max_wait_ms: u64,
+    started: Instant,
+    max_wait: Duration,
     poll_interval_ms: u64,
 ) -> Result<(), ClientError> {
-    if *waited_ms >= max_wait_ms {
-        let waited_secs = *waited_ms / 1_000;
-        return Err(ClientError::ProverServer(format!(
-            "async proof timed out after {waited_secs}s (job {job_id})"
-        )));
-    }
-    let remaining = max_wait_ms.saturating_sub(*waited_ms);
-    let sleep_ms = poll_interval_ms.min(remaining);
-    async_sleep(Duration::from_millis(sleep_ms)).await;
-    *waited_ms = (*waited_ms).saturating_add(sleep_ms);
+    async_sleep(remaining_before_deadline(
+        job_id,
+        started,
+        max_wait,
+        poll_interval_ms,
+    )?)
+    .await;
     Ok(())
 }
 
@@ -770,7 +810,7 @@ mod tests {
     use std::{
         io::{Read, Write},
         net::{TcpListener, TcpStream},
-        sync::mpsc,
+        sync::{mpsc, Arc},
         thread,
     };
 
@@ -919,6 +959,56 @@ mod tests {
         let message = err.to_string();
         assert!(message.contains("async proof failed"));
         assert!(message.contains("prover rejected witness"));
+    }
+
+    /// The deadline is wall clock, so a slow-but-alive status endpoint cannot
+    /// stretch it.
+    ///
+    /// This is the case the old accounting missed. It summed only the time
+    /// *slept* between polls, so a poll that took 1.5s to answer added nothing
+    /// to the total: the client stayed under a 1s "ceiling" indefinitely. In
+    /// production, with a 600s request timeout inherited from the prove call,
+    /// that turned a 1200s bound into a hang -- 220 workers sat wedged for 35
+    /// minutes with the prover queue empty.
+    ///
+    /// The single poll here answers after 1.5s against a 1s ceiling, so the
+    /// client must give up on it alone. Under the old rule that poll counted as
+    /// 0ms, leaving the whole budget unspent, and polling continued -- so the
+    /// server is held open to record any further polls rather than refusing
+    /// them where they would go unseen.
+    #[test]
+    fn a_slow_status_endpoint_cannot_extend_the_deadline() {
+        let server = MockServer::respond_then_hold(vec![
+            MockResponse::json(202, json!({ "job_id": "job-slow-status" })),
+            MockResponse::slow_json(
+                200,
+                json!({ "status": "processing" }),
+                Duration::from_millis(1_500),
+            ),
+        ]);
+
+        let started = Instant::now();
+        let err = queued_prover_client(server.url())
+            .send("{}".to_string())
+            .expect_err("a deadline measured in wall clock must expire");
+        let elapsed = started.elapsed();
+
+        assert!(
+            err.to_string().contains("async proof timed out"),
+            "expected a timeout, got {err}"
+        );
+        // The slow poll alone exceeds the ceiling; anything much beyond it means
+        // the deadline is still being measured in slept time.
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "gave up only after {elapsed:?}"
+        );
+        // The slow poll is the last one. A second status request would mean the
+        // time it spent waiting had not been charged against the deadline.
+        assert_paths(
+            &server.requests(),
+            ["/prove", "/prove/status?job_id=job-slow-status"],
+        );
     }
 
     #[test]
@@ -1133,7 +1223,18 @@ mod tests {
     }
 
     enum MockResponse {
-        Http { status: u16, body: String },
+        Http {
+            status: u16,
+            body: String,
+        },
+        /// Answers, but only after `delay`. Models a status endpoint that is
+        /// reachable and slow rather than down -- the case the poll deadline has
+        /// to survive, and the one a fast mock cannot exercise.
+        SlowHttp {
+            status: u16,
+            body: String,
+            delay: Duration,
+        },
         Disconnect,
     }
 
@@ -1152,6 +1253,14 @@ mod tests {
             }
         }
 
+        fn slow_json(status: u16, body: Value, delay: Duration) -> Self {
+            Self::SlowHttp {
+                status,
+                body: body.to_string(),
+                delay,
+            }
+        }
+
         fn disconnect() -> Self {
             Self::Disconnect
         }
@@ -1161,6 +1270,9 @@ mod tests {
         url: String,
         request_rx: mpsc::Receiver<RecordedRequest>,
         handle: thread::JoinHandle<()>,
+        /// Set only by [`MockServer::respond_then_hold`], whose server would
+        /// otherwise never stop accepting.
+        stop: Option<Arc<AtomicBool>>,
     }
 
     impl MockServer {
@@ -1183,8 +1295,19 @@ mod tests {
                     request_tx
                         .send(request)
                         .expect("mock request receiver should stay open");
-                    if let MockResponse::Http { status, body } = response {
-                        write_http_response(&mut stream, status, &body);
+                    match response {
+                        MockResponse::Http { status, body } => {
+                            write_http_response(&mut stream, status, &body)
+                        }
+                        MockResponse::SlowHttp {
+                            status,
+                            body,
+                            delay,
+                        } => {
+                            thread::sleep(delay);
+                            write_http_response(&mut stream, status, &body);
+                        }
+                        MockResponse::Disconnect => {}
                     }
                 }
             });
@@ -1192,6 +1315,69 @@ mod tests {
                 url,
                 request_rx,
                 handle,
+                stop: None,
+            }
+        }
+
+        /// Like [`respond_with`], but after the scripted responses run out the
+        /// last one repeats for as long as the client keeps asking.
+        ///
+        /// `respond_with` stops answering once its list is exhausted, which
+        /// makes "the client polled more times than it should have" invisible:
+        /// the extra polls hit a closed port and go unrecorded. Holding the
+        /// server open records them, so a test can assert on the exact number
+        /// of polls. [`requests`] stops the server.
+        fn respond_then_hold(responses: Vec<MockResponse>) -> Self {
+            let listener =
+                TcpListener::bind("127.0.0.1:0").expect("mock server should bind to a local port");
+            let url = format!(
+                "http://{}",
+                listener
+                    .local_addr()
+                    .expect("mock server should expose its local address")
+            );
+            let (request_tx, request_rx) = mpsc::channel();
+            let stop = Arc::new(AtomicBool::new(false));
+            let thread_stop = Arc::clone(&stop);
+            let handle = thread::spawn(move || {
+                let mut remaining = responses.into_iter().peekable();
+                let mut last: Option<(u16, String)> = None;
+                while let Ok((mut stream, _)) = listener.accept() {
+                    if thread_stop.load(Ordering::SeqCst) {
+                        break;
+                    }
+                    let request = read_http_request(&mut stream);
+                    if request_tx.send(request).is_err() {
+                        break;
+                    }
+                    match remaining.next() {
+                        Some(MockResponse::Http { status, body }) => {
+                            write_http_response(&mut stream, status, &body);
+                            last = Some((status, body));
+                        }
+                        Some(MockResponse::SlowHttp {
+                            status,
+                            body,
+                            delay,
+                        }) => {
+                            thread::sleep(delay);
+                            write_http_response(&mut stream, status, &body);
+                            last = Some((status, body));
+                        }
+                        Some(MockResponse::Disconnect) => {}
+                        None => {
+                            if let Some((status, body)) = last.as_ref() {
+                                write_http_response(&mut stream, *status, body);
+                            }
+                        }
+                    }
+                }
+            });
+            Self {
+                url,
+                request_rx,
+                handle,
+                stop: Some(stop),
             }
         }
 
@@ -1200,6 +1386,12 @@ mod tests {
         }
 
         fn requests(self) -> Vec<RecordedRequest> {
+            if let Some(stop) = self.stop.as_ref() {
+                stop.store(true, Ordering::SeqCst);
+                // The server is parked in accept(); one throwaway connection
+                // wakes it so it can observe the flag and exit.
+                let _ = TcpStream::connect(self.url.trim_start_matches("http://"));
+            }
             self.handle
                 .join()
                 .expect("mock server thread should finish");

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -25,13 +25,8 @@ pub const SERVER_ADDRESS: &str = "http://127.0.0.1:3001";
 pub const HEALTH_CHECK: &str = "/health";
 pub const PROVE_PATH: &str = "/prove";
 
-/// Default prover port, mirrored from the CLI's `DEFAULT_PROVER_PORT`. Used as
-/// the fallback when a custom [`server_address`] has no parseable port.
 const DEFAULT_PROVER_PORT: u16 = 3001;
 
-/// Address the local prover client connects to and that [`spawn_prover`] starts
-/// the server on. Defaults to [`SERVER_ADDRESS`]; set `ZOLANA_PROVER_URL` per
-/// local clone to avoid port contention between concurrent checkouts.
 pub fn server_address() -> String {
     match env::var("ZOLANA_PROVER_URL") {
         Ok(url) if !url.trim().is_empty() => url.trim().to_string(),
@@ -39,9 +34,6 @@ pub fn server_address() -> String {
     }
 }
 
-/// Extract the TCP port from a prover address so [`spawn_prover`] starts the
-/// server on the same port the client will connect to. Falls back to
-/// [`DEFAULT_PROVER_PORT`] when the address carries no parseable port.
 fn prover_port(server_address: &str) -> u16 {
     server_address
         .rsplit(':')
@@ -54,31 +46,12 @@ fn prover_port(server_address: &str) -> u16 {
 const STARTUP_HEALTH_CHECK_RETRIES: usize = 300;
 static IS_LOADING: AtomicBool = AtomicBool::new(false);
 
-// A heavy cold proof (the first P256 request loads a 63MB key and runs a
-// 205k-constraint Groth16 prove) can drop the HTTP connection under CPU/memory
-// contention while the server stays up. Proof generation is idempotent, so the
-// request is retried; the key is warm by the next attempt and proves quickly.
 const PROVE_MAX_ATTEMPTS: usize = 3;
 const PROVE_RETRY_BACKOFF_SECS: u64 = 2;
-// Generous bound so a slow cold prove never hangs the client forever; the server
-// caps sync work at 120–180s depending on circuit, so a clean timeout returns
-// well before this.
 const PROVE_REQUEST_TIMEOUT_SECS: u64 = 600;
 const PROVE_CONNECT_TIMEOUT_SECS: u64 = 10;
-/// Per-request bound on a `/prove/status` poll.
-///
-/// The status endpoint reads one Redis key and returns; it is not the request
-/// that 600s was sized for. Sharing the prove timeout let a single hung poll
-/// block a worker for ten minutes, and since the poll loop retries, the delays
-/// stacked: a 220-worker run whose proofs had all finished or been reaped sat
-/// wedged for over half an hour, every worker parked inside a status GET.
 const STATUS_POLL_TIMEOUT_SECS: u64 = 30;
-/// Polling cadence and ceiling for async (queued) proofs. Redis-backed provers
-/// queue batch, transfer, and merge proofs and return a job handle immediately
-/// instead of blocking; the client then polls the status endpoint until the
-/// proof completes or `max_wait_secs` elapses. The first batch job loads a
-/// multi-GB proving key before proving, so the default ceiling is generous.
-///
+
 /// Held on the [`ProverClient`] and overridable via
 /// [`ProverClient::with_async_poll_config`], mirroring light-client's
 /// `RetryConfig` (a client-held config with a `Default`).
@@ -88,11 +61,6 @@ pub struct AsyncPollConfig {
     pub poll_interval_secs: u64,
     /// Wall-clock seconds to wait for a queued proof before returning a timeout
     /// error.
-    ///
-    /// Wall clock, measured from the first poll. It used to be a running total
-    /// of time *slept*, which bounds nothing: the time inside each request did
-    /// not count, so with a 600s request timeout this "1200s" ceiling permitted
-    /// well over a day of waiting.
     pub max_wait_secs: u64,
 }
 
@@ -270,24 +238,6 @@ impl ProverClient {
     /// Poll the async job status endpoint until the queued proof completes.
     fn poll_async(&self, job_id: &str) -> Result<Proof, ClientError> {
         let url = format!("{}/prove/status?job_id={}", self.server_address, job_id);
-        // The configured interval caps the backoff rather than setting it. This
-        // used to be `.max(1)` and `sleep_secs`, which put a hard 1s floor on
-        // every proof: a 270ms proof measured 3.3s end to end, essentially all
-        // of it spent asleep between polls.
-        // The backoff ceiling is deliberately left to `poll_interval_secs` rather than
-        // clamped to something tighter.
-        //
-        // Tightening it to 250ms looks like an obvious win -- a finished proof then
-        // waits at most a quarter second to be collected -- and it measurably is not.
-        // Two 8-worker load tests, identical apart from this ceiling:
-        //
-        //     ceiling 1s     prove mean 2025ms   1.14 tps
-        //     ceiling 250ms  prove mean 3632ms   0.92 tps
-        //
-        // sync, send, and confirm were unchanged across the pair, so the regression is
-        // isolated to proving. Polling four times as hard contends with the prover's
-        // own queue rather than shortening the wait. Poll often enough to avoid the
-        // whole-second floor, then get out of the way.
         let poll_cap_ms = self
             .async_poll
             .poll_interval_secs
@@ -374,16 +324,10 @@ impl ProverClient {
     }
 }
 
-/// First gap between status polls. A transfer proof completes in well under a
-/// second, so the first poll should land almost immediately; the cost of being
-/// early is one cheap GET.
+/// First gap between status polls.
 const INITIAL_POLL_MS: u64 = 25;
 
 /// Next gap in the backoff, doubling up to `cap_ms`.
-///
-/// The configured poll interval is the CEILING, not a fixed period: a proof that
-/// finishes in 270ms should not wait a full second to be collected, but a proof
-/// that takes a minute should not be polled 2400 times either.
 fn next_poll_interval_ms(current_ms: u64, cap_ms: u64) -> u64 {
     current_ms
         .saturating_mul(2)
@@ -391,11 +335,6 @@ fn next_poll_interval_ms(current_ms: u64, cap_ms: u64) -> u64 {
 }
 
 /// How long is left before the deadline, or `Err` if it has passed.
-///
-/// Shared by the blocking and async poll loops so one definition of "expired"
-/// covers both. `started`/`max_wait` are wall clock: the previous version added
-/// up only the sleeps, which meant time spent inside a request was free and the
-/// ceiling bounded nothing.
 fn remaining_before_deadline(
     job_id: &str,
     started: Instant,
@@ -689,10 +628,6 @@ fn spawn_prover_inner(
     }
 }
 
-/// Start the test prover from an explicit CLI binary and key-cache directory.
-/// Repository tests use this entry point so neither artifact is discovered
-/// from Git or `PATH`. A healthy server is reused so separate test binaries keep
-/// its lazily loaded proving keys warm.
 pub fn spawn_prover_with_artifacts(
     cli_bin: impl AsRef<Path>,
     keys_dir: impl AsRef<Path>,
@@ -838,15 +773,6 @@ mod tests {
         );
     }
 
-    /// The prover is queue-backed: `/prove` returns a job handle and the proof
-    /// is collected by polling. The gap between polls used to be
-    /// `Duration::from_secs(poll_interval.max(1))`, so a proof the server
-    /// finished in 270ms was not collected for a further second or more --
-    /// measured on devnet as 3.3s end to end for 270ms of proving, which made
-    /// the prover call the largest phase of a transfer for no real reason.
-    ///
-    /// Asserts wall-clock rather than the sleep arithmetic, because the bug was
-    /// only visible as latency.
     #[test]
     fn a_proof_ready_on_the_first_poll_is_not_held_for_a_whole_second() {
         let server = MockServer::respond_with(vec![
@@ -961,21 +887,6 @@ mod tests {
         assert!(message.contains("prover rejected witness"));
     }
 
-    /// The deadline is wall clock, so a slow-but-alive status endpoint cannot
-    /// stretch it.
-    ///
-    /// This is the case the old accounting missed. It summed only the time
-    /// *slept* between polls, so a poll that took 1.5s to answer added nothing
-    /// to the total: the client stayed under a 1s "ceiling" indefinitely. In
-    /// production, with a 600s request timeout inherited from the prove call,
-    /// that turned a 1200s bound into a hang -- 220 workers sat wedged for 35
-    /// minutes with the prover queue empty.
-    ///
-    /// The single poll here answers after 1.5s against a 1s ceiling, so the
-    /// client must give up on it alone. Under the old rule that poll counted as
-    /// 0ms, leaving the whole budget unspent, and polling continued -- so the
-    /// server is held open to record any further polls rather than refusing
-    /// them where they would go unseen.
     #[test]
     fn a_slow_status_endpoint_cannot_extend_the_deadline() {
         let server = MockServer::respond_then_hold(vec![
@@ -1319,14 +1230,6 @@ mod tests {
             }
         }
 
-        /// Like [`respond_with`], but after the scripted responses run out the
-        /// last one repeats for as long as the client keeps asking.
-        ///
-        /// `respond_with` stops answering once its list is exhausted, which
-        /// makes "the client polled more times than it should have" invisible:
-        /// the extra polls hit a closed port and go unrecorded. Holding the
-        /// server open records them, so a test can assert on the exact number
-        /// of polls. [`requests`] stops the server.
         fn respond_then_hold(responses: Vec<MockResponse>) -> Self {
             let listener =
                 TcpListener::bind("127.0.0.1:0").expect("mock server should bind to a local port");

--- a/sdk-libs/client/src/timing.rs
+++ b/sdk-libs/client/src/timing.rs
@@ -1,0 +1,48 @@
+//! Opt-in phase timing, printed to stderr when `ZOLANA_TIMING` is set.
+//!
+//! Lives in the client crate because the interesting
+//! question spans crates: a transfer's cost splits across syncing, fetching
+//! proofs, and proving, and attributing it needs the same clock on all of them.
+
+use std::{
+    sync::OnceLock,
+    time::{Duration, Instant},
+};
+
+fn enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("ZOLANA_TIMING").is_some())
+}
+
+/// Emit a scalar observation (counts, sizes) alongside the phase timings.
+pub fn note(round: usize, key: &str, value: usize) {
+    if enabled() {
+        eprintln!("timing round={round} {key}={value}");
+    }
+}
+
+/// Times from construction to drop, so `?` early-returns still report.
+pub struct Phase {
+    name: &'static str,
+    round: usize,
+    started: Instant,
+}
+
+impl Phase {
+    pub fn start(name: &'static str, round: usize) -> Self {
+        Self {
+            name,
+            round,
+            started: Instant::now(),
+        }
+    }
+}
+
+impl Drop for Phase {
+    fn drop(&mut self) {
+        if enabled() {
+            let ms = self.started.elapsed().max(Duration::ZERO).as_millis();
+            eprintln!("timing round={} phase={} ms={}", self.round, self.name, ms);
+        }
+    }
+}

--- a/sdk-libs/transaction/src/wallet/state.rs
+++ b/sdk-libs/transaction/src/wallet/state.rs
@@ -147,6 +147,19 @@ pub struct Wallet {
     /// Per-view-tag sync watermarks: for each tag, the indexer cursor up to which
     /// every matching transaction has already been seen.    
     pub sync_cursors: HashMap<ViewTag, Vec<u8>>,
+    /// The same watermarks for the encrypted-utxo stream, which proofless
+    /// deposits are read from.
+    ///
+    /// Separate from `sync_cursors` because they are positions in different
+    /// streams: reaching the tip of the transaction stream says nothing about
+    /// where the encrypted-utxo stream has been read to, and sharing one cursor
+    /// between them would skip rows in whichever stream is behind.
+    ///
+    /// This existed only for the duration of a single sync before, so every sync
+    /// re-read the whole encrypted-utxo history for every tag and discarded all
+    /// but the deposits. Measured on devnet: 909ms per sync to keep 2.5 rows,
+    /// about a third of the sync phase, and growing with history.
+    pub proofless_cursors: HashMap<ViewTag, Vec<u8>>,
 }
 
 impl Wallet {
@@ -164,6 +177,7 @@ impl Wallet {
             nullifiers: HashSet::new(),
             last_synced: 0,
             sync_cursors: HashMap::new(),
+            proofless_cursors: HashMap::new(),
         })
     }
 

--- a/sdk-libs/transaction/src/wallet/state.rs
+++ b/sdk-libs/transaction/src/wallet/state.rs
@@ -145,20 +145,8 @@ pub struct Wallet {
     pub nullifiers: HashSet<[u8; 32]>,
     pub last_synced: i64,
     /// Per-view-tag sync watermarks: for each tag, the indexer cursor up to which
-    /// every matching transaction has already been seen.    
+    /// every matching transaction has already been seen.
     pub sync_cursors: HashMap<ViewTag, Vec<u8>>,
-    /// The same watermarks for the encrypted-utxo stream, which proofless
-    /// deposits are read from.
-    ///
-    /// Separate from `sync_cursors` because they are positions in different
-    /// streams: reaching the tip of the transaction stream says nothing about
-    /// where the encrypted-utxo stream has been read to, and sharing one cursor
-    /// between them would skip rows in whichever stream is behind.
-    ///
-    /// This existed only for the duration of a single sync before, so every sync
-    /// re-read the whole encrypted-utxo history for every tag and discarded all
-    /// but the deposits. Measured on devnet: 909ms per sync to keep 2.5 rows,
-    /// about a third of the sync phase, and growing with history.
     pub proofless_cursors: HashMap<ViewTag, Vec<u8>>,
 }
 

--- a/sdk-libs/wallet/src/actions/transaction.rs
+++ b/sdk-libs/wallet/src/actions/transaction.rs
@@ -694,7 +694,7 @@ pub async fn sign_private_transaction_with_signers<A: WalletAuthority + ?Sized, 
     Ok(native)
 }
 
-pub fn build_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc>(
+pub fn build_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc + Sync>(
     transaction: UnsignedPrivateTransaction,
     wallet: &Wallet,
     authority: &A,
@@ -706,7 +706,7 @@ pub fn build_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc>(
     client.finish_submission_unsigned_sync(&shielded, fee_payer, blockhash)
 }
 
-pub fn sign_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc>(
+pub fn sign_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc + Sync>(
     transaction: UnsignedPrivateTransaction,
     wallet: &Wallet,
     authority: &A,
@@ -724,7 +724,10 @@ pub fn sign_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc>(
 }
 
 /// Synchronous counterpart of [`sign_private_transaction_with_signers`].
-pub fn sign_private_transaction_sync_with_signers<A: SyncWalletAuthority + ?Sized, R: Rpc>(
+pub fn sign_private_transaction_sync_with_signers<
+    A: SyncWalletAuthority + ?Sized,
+    R: Rpc + Sync,
+>(
     transaction: UnsignedPrivateTransaction,
     wallet: &Wallet,
     authority: &A,

--- a/sdk-libs/wallet/src/actions/transaction.rs
+++ b/sdk-libs/wallet/src/actions/transaction.rs
@@ -702,8 +702,7 @@ pub fn build_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc + 
     fee_payer: Pubkey,
 ) -> Result<SolanaTransaction, ClientError> {
     let shielded = sign_shielded_transaction_sync(transaction, wallet, authority)?;
-    let (blockhash, _) = client.rpc().get_latest_blockhash()?;
-    client.finish_submission_unsigned_sync(&shielded, fee_payer, blockhash)
+    client.finish_submission_unsigned_sync(&shielded, fee_payer)
 }
 
 pub fn sign_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc + Sync>(
@@ -739,14 +738,13 @@ pub fn sign_private_transaction_sync_with_signers<
         let _t = timing::Phase::start("sign_shielded", 0);
         sign_shielded_transaction_sync(transaction, wallet, authority)?
     };
-    let (blockhash, _) = {
-        let _t = timing::Phase::start("get_latest_blockhash", 0);
-        client.rpc().get_latest_blockhash()?
-    };
     let mut native = {
         let _t = timing::Phase::start("finish_submission", 0);
-        client.finish_submission_unsigned_sync(&shielded, fee_payer.pubkey(), blockhash)?
+        client.finish_submission_unsigned_sync(&shielded, fee_payer.pubkey())?
     };
+    // Whatever the built message carries: it is fetched after proving now, so
+    // there is no separate blockhash here to keep in step with it.
+    let blockhash = native.message.recent_blockhash;
     let mut signers = Vec::with_capacity(1 + additional_native_signers.len());
     signers.push(fee_payer);
     signers.extend_from_slice(additional_native_signers);

--- a/sdk-libs/wallet/src/actions/transaction.rs
+++ b/sdk-libs/wallet/src/actions/transaction.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use zolana_client::timing;
 
 use solana_pubkey::Pubkey;
 use zolana_interface::{
@@ -188,7 +189,10 @@ pub async fn create_transfer<R: AsyncRpc>(
 pub fn create_transfer_sync<R: Rpc>(
     request: TransferParams<'_, R>,
 ) -> Result<CreatedTransfer, ClientError> {
-    let recipient = try_resolve_registered_address(request.rpc, request.recipient)?;
+    let recipient = {
+        let _t = timing::Phase::start("resolve_recipient", 0);
+        try_resolve_registered_address(request.rpc, request.recipient)?
+    };
     let spl_token_program = if recipient.is_none() {
         resolve_asset_token_program(request.rpc, request.asset)?
     } else {
@@ -728,10 +732,18 @@ pub fn sign_private_transaction_sync_with_signers<A: SyncWalletAuthority + ?Size
     fee_payer: &dyn Signer,
     additional_native_signers: &[&dyn Signer],
 ) -> Result<SolanaTransaction, ClientError> {
-    let shielded = sign_shielded_transaction_sync(transaction, wallet, authority)?;
-    let (blockhash, _) = client.rpc().get_latest_blockhash()?;
-    let mut native =
-        client.finish_submission_unsigned_sync(&shielded, fee_payer.pubkey(), blockhash)?;
+    let shielded = {
+        let _t = timing::Phase::start("sign_shielded", 0);
+        sign_shielded_transaction_sync(transaction, wallet, authority)?
+    };
+    let (blockhash, _) = {
+        let _t = timing::Phase::start("get_latest_blockhash", 0);
+        client.rpc().get_latest_blockhash()?
+    };
+    let mut native = {
+        let _t = timing::Phase::start("finish_submission", 0);
+        client.finish_submission_unsigned_sync(&shielded, fee_payer.pubkey(), blockhash)?
+    };
     let mut signers = Vec::with_capacity(1 + additional_native_signers.len());
     signers.push(fee_payer);
     signers.extend_from_slice(additional_native_signers);

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -893,8 +893,6 @@ fn now_unix_ts() -> i64 {
 mod tests {
     use std::collections::{HashMap, HashSet};
 
-    use zolana_client::timing;
-
     use solana_signature::Signature;
     use zolana_interface::event::{encode_output_data, ProoflessOutput};
     use zolana_keypair::{ShieldedKeypair, ViewingKey};

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -1,5 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
+    panic::resume_unwind,
+    thread,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -114,7 +116,7 @@ pub fn sync_wallet<A, I>(
 ) -> Result<SyncReport, ClientError>
 where
     A: SyncWalletAuthority + ?Sized,
-    I: Rpc,
+    I: Rpc + Sync,
 {
     sync_wallet_with_config(wallet, authority, indexer, SyncWalletConfig::default())
 }
@@ -127,7 +129,7 @@ pub fn sync_wallet_with_config<A, I>(
 ) -> Result<SyncReport, ClientError>
 where
     A: SyncWalletAuthority + ?Sized,
-    I: Rpc,
+    I: Rpc + Sync,
 {
     let config = normalized_config(config);
     let material = authority.sync_material()?;
@@ -156,44 +158,82 @@ where
         timing::note(round, "tags", tags.len());
         timing::note(round, "nullifiers", nullifiers.len());
         {
-            let _t = timing::Phase::start("fetch_shielded_by_tags", round);
-            // Cursors are taken out of the wallet and put back, rather than held
-            // borrowed: `wallet` is needed mutably further down this loop.
+            let _t = timing::Phase::start("fetch_round", round);
+            // The three queries are independent: different indexer methods,
+            // disjoint cursor state, and separate accumulators. Run sequentially
+            // a round cost the sum of three round trips (866 + 521 + 503ms
+            // measured on devnet) when it need only cost the slowest.
+            //
+            // Cursors come out of the wallet and go back rather than staying
+            // borrowed, because `wallet` is needed mutably further down.
             let mut cursors = std::mem::take(&mut wallet.sync_cursors);
-            let result = fetch_shielded_transactions_incremental(
-                indexer,
-                &tags,
-                &mut transactions,
-                config,
-                freshness_gate.take(),
-                &mut cursors,
-                &mut scanned_to_tip,
-            );
+            let mut by_nullifier: HashMap<String, ShieldedTransaction> = HashMap::new();
+            // One gate for the whole round, not one per call: every query in a
+            // round should read the chain at the same freshness bound, and
+            // `take()`ing it three times would gate only the first.
+            let gate = freshness_gate.take();
+
+            let (tag_result, nullifier_result, proofless_result) = thread::scope(|scope| {
+                let tags_ref = &tags;
+                let tag_handle = scope.spawn(|| {
+                    let _t = timing::Phase::start("fetch_shielded_by_tags", round);
+                    fetch_shielded_transactions_incremental(
+                        indexer,
+                        tags_ref,
+                        &mut transactions,
+                        config,
+                        gate,
+                        &mut cursors,
+                        &mut scanned_to_tip,
+                    )
+                });
+                let nullifier_handle = scope.spawn(|| {
+                    let _t = timing::Phase::start("fetch_shielded_by_nullifiers", round);
+                    fetch_shielded_transactions_by_nullifiers(
+                        indexer,
+                        &nullifiers,
+                        &mut by_nullifier,
+                        config,
+                        gate,
+                        &mut nullifier_scanned_to_tip,
+                    )
+                });
+                let proofless_handle = scope.spawn(|| {
+                    let _t = timing::Phase::start("fetch_proofless_deposits", round);
+                    fetch_proofless_deposits(
+                        indexer,
+                        tags_ref,
+                        &mut proofless_deposits,
+                        config,
+                        gate,
+                        &mut proofless_scanned_to_tip,
+                    )
+                });
+                (
+                    tag_handle.join(),
+                    nullifier_handle.join(),
+                    proofless_handle.join(),
+                )
+            });
+
             wallet.sync_cursors = cursors;
-            result?;
+            // Propagate a panic rather than swallowing it into a sync error: a
+            // panicked fetch means a bug here, not an unreachable indexer.
+            let tag_result = tag_result.unwrap_or_else(|payload| resume_unwind(payload));
+            let nullifier_result =
+                nullifier_result.unwrap_or_else(|payload| resume_unwind(payload));
+            let proofless_result =
+                proofless_result.unwrap_or_else(|payload| resume_unwind(payload));
+            tag_result?;
+            nullifier_result?;
+            proofless_result?;
+
+            // Both queries return transactions; the by-tag map wins ties, which
+            // is the same precedence the sequential version had via `or_insert`.
+            for (key, tx) in by_nullifier {
+                transactions.entry(key).or_insert(tx);
+            }
             timing::note(round, "tag_cursors", wallet.sync_cursors.len());
-        }
-        {
-            let _t = timing::Phase::start("fetch_shielded_by_nullifiers", round);
-            fetch_shielded_transactions_by_nullifiers(
-                indexer,
-                &nullifiers,
-                &mut transactions,
-                config,
-                freshness_gate.take(),
-                &mut nullifier_scanned_to_tip,
-            )?;
-        }
-        {
-            let _t = timing::Phase::start("fetch_proofless_deposits", round);
-            fetch_proofless_deposits(
-                indexer,
-                &tags,
-                &mut proofless_deposits,
-                config,
-                freshness_gate.take(),
-                &mut proofless_scanned_to_tip,
-            )?;
         }
         timing::note(round, "transactions", transactions.len());
         timing::note(round, "proofless_deposits", proofless_deposits.len());

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -517,7 +517,7 @@ fn wallet_query_nullifiers(wallet: &Wallet) -> Vec<[u8; 32]> {
 /// wallet's tag set is derived from a local counter plus a window of 64, and a
 /// second device spending further ahead than that window makes the counter lag by
 /// more than the window can absorb.
-fn fetch_shielded_transactions_incremental<I: Rpc>(
+fn fetch_shielded_transactions_incremental<I: Rpc + Sync>(
     indexer: &I,
     tags: &[ViewTag],
     out: &mut HashMap<String, ShieldedTransaction>,
@@ -540,45 +540,87 @@ fn fetch_shielded_transactions_incremental<I: Rpc>(
             .push(*tag);
     }
 
-    for (start, group) in groups {
-        for chunk in group.chunks(config.tag_query_chunk) {
-            let mut cursor = start.clone();
-            let mut furthest = start.clone();
-            loop {
-                let response = indexer.get_shielded_transactions_by_tags(
-                    chunk.to_vec(),
-                    cursor.clone(),
-                    Some(config.page_limit),
-                    rpc_config,
-                )?;
-                for tx in response.transactions {
-                    if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
-                        continue;
-                    }
-                    let key = tx.tx_signature.to_string();
-                    out.entry(key).or_insert(convert_sync_transaction(tx)?);
-                }
-                if response.next_cursor.is_some() {
-                    furthest = response.next_cursor.clone();
-                }
-                cursor = response.next_cursor;
-                if cursor.is_none() {
-                    break;
-                }
-            }
+    // Flatten to independent units of work first: every (resume point, chunk)
+    // pair is its own query against the same stream. Sequentially this was the
+    // largest item in a cold sync -- 2960ms of round-trip latency for a wallet
+    // whose tags span a few chunks.
+    let units: Vec<(Option<Vec<u8>>, &[ViewTag])> = groups
+        .iter()
+        .flat_map(|(start, group)| {
+            group
+                .chunks(config.tag_query_chunk)
+                .map(move |chunk| (start.clone(), chunk))
+        })
+        .collect();
 
-            // Advance every tag in this chunk to the end of the stream. Only sound
-            // because the ordering is global: each of these tags has now been
-            // scanned to that position.
-            if let Some(position) = furthest {
-                for tag in chunk {
-                    cursors.insert(*tag, position.clone());
-                }
-            }
-            // The loop above only exits once the stream is exhausted.
-            scanned_to_tip.extend(chunk.iter().copied());
+    type ChunkOutcome = (HashMap<String, ShieldedTransaction>, Option<Vec<u8>>);
+    let collected: Vec<Result<ChunkOutcome, ClientError>> = thread::scope(|scope| {
+        let handles: Vec<_> = units
+            .iter()
+            .map(|(start, chunk)| {
+                let start = start.clone();
+                scope.spawn(move || {
+                    let mut found = HashMap::new();
+                    let mut cursor = start.clone();
+                    let mut furthest = start;
+                    loop {
+                        let response = indexer.get_shielded_transactions_by_tags(
+                            chunk.to_vec(),
+                            cursor.clone(),
+                            Some(config.page_limit),
+                            rpc_config,
+                        )?;
+                        // A page below the limit is the end of the stream, so
+                        // there is no need to spend a round trip discovering
+                        // that. The cursor is still kept: it is the resume point
+                        // for the next sync, a different question from whether
+                        // another page exists.
+                        let last_page = response.transactions.len() < config.page_limit as usize;
+                        for tx in response.transactions {
+                            if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
+                                continue;
+                            }
+                            let key = tx.tx_signature.to_string();
+                            found.entry(key).or_insert(convert_sync_transaction(tx)?);
+                        }
+                        if response.next_cursor.is_some() {
+                            furthest = response.next_cursor.clone();
+                        }
+                        cursor = response.next_cursor;
+                        if last_page || cursor.is_none() {
+                            break;
+                        }
+                    }
+                    Ok((found, furthest))
+                })
+            })
+            .collect();
+        handles
+            .into_iter()
+            .map(|handle| {
+                handle
+                    .join()
+                    .unwrap_or_else(|payload| resume_unwind(payload))
+            })
+            .collect()
+    });
+
+    for (outcome, (_, chunk)) in collected.into_iter().zip(units.iter()) {
+        let (found, furthest) = outcome?;
+        for (key, tx) in found {
+            out.entry(key).or_insert(tx);
         }
+        // Advance every tag in this chunk to the end of the stream. Only sound
+        // because the ordering is global: each of these tags has now been
+        // scanned to that position.
+        if let Some(position) = furthest {
+            for tag in *chunk {
+                cursors.insert(*tag, position.clone());
+            }
+        }
+        scanned_to_tip.extend(chunk.iter().copied());
     }
+
     Ok(())
 }
 
@@ -622,6 +664,11 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
                         rpc_config,
                     )
                     .await?;
+                // A page below the limit is the end of the stream, so there is
+                // no need to spend a round trip discovering that. The cursor is
+                // still kept: it is the resume point for the next sync, which
+                // is a different question from whether another page exists.
+                let last_page = response.transactions.len() < config.page_limit as usize;
                 for tx in response.transactions {
                     if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
                         continue;
@@ -633,7 +680,7 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
                     furthest = response.next_cursor.clone();
                 }
                 cursor = response.next_cursor;
-                if cursor.is_none() {
+                if last_page || cursor.is_none() {
                     break;
                 }
             }
@@ -649,7 +696,7 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
     Ok(())
 }
 
-fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
+fn fetch_shielded_transactions_by_nullifiers<I: Rpc + Sync>(
     indexer: &I,
     nullifiers: &[[u8; 32]],
     out: &mut HashMap<String, ShieldedTransaction>,
@@ -662,24 +709,57 @@ fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
         .copied()
         .filter(|nullifier| !scanned_to_tip.contains(nullifier))
         .collect();
-    for chunk in pending.chunks(config.tag_query_chunk) {
-        let mut cursor = None;
-        loop {
-            let response = indexer.get_shielded_transactions_by_nullifiers(
-                chunk.to_vec(),
-                cursor,
-                Some(config.page_limit),
-                rpc_config,
-            )?;
-            for tx in response.transactions.into_iter().filter(|tx| !tx.proofless) {
-                let key = tx.tx_signature.to_string();
-                out.entry(key).or_insert(convert_sync_transaction(tx)?);
-            }
-            cursor = response.next_cursor;
-            if cursor.is_none() {
-                break;
-            }
+    // Chunks are independent queries against the same stream, so they run
+    // concurrently. A wallet that has spent 529 notes asks in 9 chunks, and run
+    // one after another that was 3349ms of a 6830ms sync -- the largest single
+    // item in a cold sync, and pure round-trip latency.
+    let chunks: Vec<&[[u8; 32]]> = pending.chunks(config.tag_query_chunk).collect();
+    let collected: Vec<Result<HashMap<String, ShieldedTransaction>, ClientError>> =
+        thread::scope(|scope| {
+            let handles: Vec<_> = chunks
+                .iter()
+                .map(|chunk| {
+                    scope.spawn(move || {
+                        let mut found = HashMap::new();
+                        let mut cursor = None;
+                        loop {
+                            let response = indexer.get_shielded_transactions_by_nullifiers(
+                                chunk.to_vec(),
+                                cursor,
+                                Some(config.page_limit),
+                                rpc_config,
+                            )?;
+                            let last_page =
+                                response.transactions.len() < config.page_limit as usize;
+                            for tx in response.transactions.into_iter().filter(|tx| !tx.proofless) {
+                                let key = tx.tx_signature.to_string();
+                                found.entry(key).or_insert(convert_sync_transaction(tx)?);
+                            }
+                            cursor = response.next_cursor;
+                            if last_page || cursor.is_none() {
+                                break;
+                            }
+                        }
+                        Ok(found)
+                    })
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| {
+                    handle
+                        .join()
+                        .unwrap_or_else(|payload| resume_unwind(payload))
+                })
+                .collect()
+        });
+
+    for found in collected {
+        for (key, tx) in found? {
+            out.entry(key).or_insert(tx);
         }
+    }
+    for chunk in chunks {
         scanned_to_tip.extend(chunk.iter().copied());
     }
     Ok(())
@@ -709,12 +789,13 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
                     rpc_config,
                 )
                 .await?;
+            let last_page = response.transactions.len() < config.page_limit as usize;
             for tx in response.transactions.into_iter().filter(|tx| !tx.proofless) {
                 let key = tx.tx_signature.to_string();
                 out.entry(key).or_insert(convert_sync_transaction(tx)?);
             }
             cursor = response.next_cursor;
-            if cursor.is_none() {
+            if last_page || cursor.is_none() {
                 break;
             }
         }
@@ -748,6 +829,7 @@ where
                 Some(config.page_limit),
                 rpc_config,
             )?;
+            let last_page = response.matches.len() < config.page_limit as usize;
             for item in response.matches {
                 if item.tx_viewing_pk.is_some() || item.salt.is_some() {
                     continue;
@@ -764,7 +846,7 @@ where
                 }
             }
             cursor = response.next_cursor;
-            if cursor.is_none() {
+            if last_page || cursor.is_none() {
                 break;
             }
         }
@@ -797,6 +879,7 @@ async fn fetch_proofless_deposits_async<I: AsyncRpc>(
                     rpc_config,
                 )
                 .await?;
+            let last_page = response.matches.len() < config.page_limit as usize;
             for item in response.matches {
                 if item.tx_viewing_pk.is_some() || item.salt.is_some() {
                     continue;
@@ -813,7 +896,7 @@ async fn fetch_proofless_deposits_async<I: AsyncRpc>(
                 }
             }
             cursor = response.next_cursor;
-            if cursor.is_none() {
+            if last_page || cursor.is_none() {
                 break;
             }
         }
@@ -927,7 +1010,11 @@ mod tests {
         /// key is total, as it is in photon.
         entries: Vec<(u64, ViewTag)>,
         /// Every (tags, cursor) pair the client asked for, for call accounting.
-        calls: std::cell::RefCell<Vec<(usize, Option<u64>)>>,
+        ///
+        /// A Mutex rather than a RefCell because chunks are queried
+        /// concurrently, which also means the recorded order is not meaningful
+        /// -- assertions sort before comparing.
+        calls: std::sync::Mutex<Vec<(usize, Option<u64>)>>,
     }
 
     impl TaggedIndexer {
@@ -943,7 +1030,10 @@ mod tests {
             let after = cursor.as_ref().map(|bytes| {
                 u64::from_be_bytes(bytes.as_slice().try_into().expect("8-byte cursor"))
             });
-            self.calls.borrow_mut().push((tags.len(), after));
+            self.calls
+                .lock()
+                .expect("calls poisoned")
+                .push((tags.len(), after));
 
             let mut rows: Vec<_> = self
                 .entries
@@ -981,6 +1071,14 @@ mod tests {
                 .collect();
             (transactions, next)
         }
+    }
+
+    /// Chunks are queried concurrently, so the order calls land in is not
+    /// meaningful. Sort before comparing, and assert on the multiset instead.
+    fn sorted_calls(indexer: &TaggedIndexer) -> Vec<(usize, Option<u64>)> {
+        let mut calls = indexer.calls.lock().expect("calls poisoned").clone();
+        calls.sort();
+        calls
     }
 
     #[derive(Default)]
@@ -1179,12 +1277,9 @@ mod tests {
         )
         .expect("round 1");
 
-        // Each chunk costs two requests now: one for the rows, one that comes
-        // back empty and ends the stream. What matters is that no request ever
-        // carries two tags -- the early tag is never re-queried.
         assert_eq!(
-            *indexer.calls.borrow(),
-            vec![(1, None), (1, Some(10)), (1, None), (1, Some(50))],
+            sorted_calls(&indexer),
+            vec![(1, None), (1, None)],
             "round 1 must ask for the late tag alone, not both tags again"
         );
     }
@@ -1228,9 +1323,10 @@ mod tests {
             "a short page still records the tip, so the next sync resumes there"
         );
         assert_eq!(
-            *indexer.calls.borrow(),
-            vec![(1, None), (1, Some(50))],
-            "one request for the rows, one more that returns none and ends the loop"
+            sorted_calls(&indexer),
+            vec![(1, None)],
+            "a page below the limit is already known to be the last, so the tip \
+             costs no extra round trip"
         );
     }
 
@@ -1291,7 +1387,7 @@ mod tests {
         );
 
         // Second sync has learned the late tag.
-        indexer.calls.borrow_mut().clear();
+        indexer.calls.lock().expect("calls poisoned").clear();
         let mut second = HashMap::new();
         fetch_shielded_transactions_incremental(
             &indexer,
@@ -1307,7 +1403,7 @@ mod tests {
         // Asserting on what was REQUESTED rather than what was decrypted: the
         // invariant is which rows the indexer was asked for, and fabricating
         // decryptable P256 payloads would test the crypto instead.
-        let calls = indexer.calls.borrow();
+        let calls = indexer.calls.lock().expect("calls poisoned");
         assert!(
             calls.iter().any(|(_, after)| after.is_none()),
             "the newly discovered tag must be scanned from the beginning, not from \

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -6,6 +6,8 @@ use std::{
 };
 
 use solana_address::Address;
+
+use zolana_client::timing;
 use zolana_interface::{
     event::{decode_encrypted_ring_deposit_output_data, decode_output_data},
     state::SplAssetRegistry,
@@ -27,51 +29,6 @@ use zolana_client::{
 const DEFAULT_TAG_QUERY_CHUNK: usize = 64;
 const DEFAULT_PAGE_LIMIT: u32 = 1_000;
 const DEFAULT_SYNC_ROUNDS: usize = 6;
-
-mod timing {
-    use std::{
-        sync::OnceLock,
-        time::{Duration, Instant},
-    };
-
-    fn enabled() -> bool {
-        static ON: OnceLock<bool> = OnceLock::new();
-        *ON.get_or_init(|| std::env::var_os("ZOLANA_TIMING").is_some())
-    }
-
-    /// Emit a scalar observation (counts, sizes) alongside the phase timings.
-    pub(super) fn note(round: usize, key: &str, value: usize) {
-        if enabled() {
-            eprintln!("timing round={round} {key}={value}");
-        }
-    }
-
-    /// Times from construction to drop, so `?` early-returns still report.
-    pub(super) struct Phase {
-        name: &'static str,
-        round: usize,
-        started: Instant,
-    }
-
-    impl Phase {
-        pub(super) fn start(name: &'static str, round: usize) -> Self {
-            Self {
-                name,
-                round,
-                started: Instant::now(),
-            }
-        }
-    }
-
-    impl Drop for Phase {
-        fn drop(&mut self) {
-            if enabled() {
-                let ms = self.started.elapsed().max(Duration::ZERO).as_millis();
-                eprintln!("timing round={} phase={} ms={}", self.round, self.name, ms);
-            }
-        }
-    }
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SyncWalletConfig {
@@ -935,6 +892,8 @@ fn now_unix_ts() -> i64 {
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
+
+    use zolana_client::timing;
 
     use solana_signature::Signature;
     use zolana_interface::event::{encode_output_data, ProoflessOutput};

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -124,6 +124,7 @@ where
             // Cursors come out of the wallet and go back rather than staying
             // borrowed, because `wallet` is needed mutably further down.
             let mut cursors = std::mem::take(&mut wallet.sync_cursors);
+            let mut proofless_cursors = std::mem::take(&mut wallet.proofless_cursors);
             let mut by_nullifier: HashMap<String, ShieldedTransaction> = HashMap::new();
             // One gate for the whole round, not one per call: every query in a
             // round should read the chain at the same freshness bound, and
@@ -163,6 +164,7 @@ where
                         &mut proofless_deposits,
                         config,
                         gate,
+                        &mut proofless_cursors,
                         &mut proofless_scanned_to_tip,
                     )
                 });
@@ -174,6 +176,7 @@ where
             });
 
             wallet.sync_cursors = cursors;
+            wallet.proofless_cursors = proofless_cursors;
             // Propagate a panic rather than swallowing it into a sync error: a
             // panicked fetch means a bug here, not an unreachable indexer.
             let tag_result = tag_result.unwrap_or_else(|payload| resume_unwind(payload));
@@ -304,15 +307,19 @@ where
             &mut nullifier_scanned_to_tip,
         )
         .await?;
-        fetch_proofless_deposits_async(
+        let mut proofless_cursors = std::mem::take(&mut wallet.proofless_cursors);
+        let fetched_proofless = fetch_proofless_deposits_async(
             indexer,
             &tags,
             &mut proofless_deposits,
             config,
             freshness_gate.take(),
+            &mut proofless_cursors,
             &mut proofless_scanned_to_tip,
         )
-        .await?;
+        .await;
+        wallet.proofless_cursors = proofless_cursors;
+        fetched_proofless?;
 
         txs = transactions.values().cloned().collect::<Vec<_>>();
         txs.sort_by_key(|a| (a.slot, a.tx_signature));
@@ -804,103 +811,159 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
     Ok(())
 }
 
+/// Reads new proofless deposits, resuming from where the last sync stopped.
+///
+/// Resume points are per tag and persisted on the wallet, for the same reason
+/// [`fetch_shielded_transactions_incremental`] keeps them that way: the tag set
+/// grows, and a tag learned late has to be scanned from the beginning while
+/// tags learned earlier are far ahead.
+///
+/// Without the persisted cursor this paged the entire encrypted-utxo history for
+/// every tag on every sync and then discarded all but the deposits client-side --
+/// 909ms to keep 2.5 rows on devnet, a third of the sync phase, growing with
+/// history. The rows it re-read were ones it had already seen and dropped.
 fn fetch_proofless_deposits<I>(
     indexer: &I,
     tags: &[ViewTag],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    cursors: &mut HashMap<ViewTag, Vec<u8>>,
     scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError>
 where
     I: Rpc,
 {
-    let pending: Vec<ViewTag> = tags
-        .iter()
-        .copied()
-        .filter(|tag| !scanned_to_tip.contains(tag))
-        .collect();
-    for chunk in pending.chunks(config.tag_query_chunk) {
-        let mut cursor = None;
-        loop {
-            let response = indexer.get_encrypted_utxos_by_tags(
-                chunk.to_vec(),
-                cursor,
-                Some(config.page_limit),
-                rpc_config,
-            )?;
-            let last_page = response.matches.len() < config.page_limit as usize;
-            for item in response.matches {
-                if item.tx_viewing_pk.is_some() || item.salt.is_some() {
-                    continue;
-                }
-                let key = format!(
-                    "{}:{}",
-                    item.tx_signature, item.output_slot.output_context.leaf_index
-                );
-                if out.contains_key(&key) {
-                    continue;
-                }
-                if let Some(view) = proofless_deposit_from_indexed_match(item)? {
-                    out.insert(key, view);
-                }
-            }
-            cursor = response.next_cursor;
-            if last_page || cursor.is_none() {
-                break;
-            }
+    // Group by resume point, so tags at the same position share a query.
+    let mut groups: HashMap<Option<Vec<u8>>, Vec<ViewTag>> = HashMap::new();
+    for tag in tags {
+        if scanned_to_tip.contains(tag) {
+            continue;
         }
-        scanned_to_tip.extend(chunk.iter().copied());
+        groups
+            .entry(cursors.get(tag).cloned())
+            .or_default()
+            .push(*tag);
+    }
+
+    for (start, group) in groups {
+        for chunk in group.chunks(config.tag_query_chunk) {
+            let mut cursor = start.clone();
+            let mut furthest = start.clone();
+            loop {
+                let response = indexer.get_encrypted_utxos_by_tags(
+                    chunk.to_vec(),
+                    cursor,
+                    Some(config.page_limit),
+                    rpc_config,
+                )?;
+                let last_page = response.matches.len() < config.page_limit as usize;
+                for item in response.matches {
+                    if item.tx_viewing_pk.is_some() || item.salt.is_some() {
+                        continue;
+                    }
+                    let key = format!(
+                        "{}:{}",
+                        item.tx_signature, item.output_slot.output_context.leaf_index
+                    );
+                    if out.contains_key(&key) {
+                        continue;
+                    }
+                    if let Some(view) = proofless_deposit_from_indexed_match(item)? {
+                        out.insert(key, view);
+                    }
+                }
+                if response.next_cursor.is_some() {
+                    furthest = response.next_cursor.clone();
+                }
+                cursor = response.next_cursor;
+                if last_page || cursor.is_none() {
+                    break;
+                }
+            }
+            // Sound only because the stream is globally ordered: every tag in
+            // this chunk has now been read to that position.
+            if let Some(position) = furthest {
+                for tag in chunk {
+                    cursors.insert(*tag, position.clone());
+                }
+            }
+            scanned_to_tip.extend(chunk.iter().copied());
+        }
     }
     Ok(())
 }
 
+/// Async twin of [`fetch_proofless_deposits`].
+///
+/// Kept deliberately parallel rather than shared, for the reason given on
+/// [`fetch_shielded_transactions_incremental_async`]: an async client that did
+/// not get the persisted cursor would keep re-reading the whole encrypted-utxo
+/// history on every sync.
 async fn fetch_proofless_deposits_async<I: AsyncRpc>(
     indexer: &I,
     tags: &[ViewTag],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    cursors: &mut HashMap<ViewTag, Vec<u8>>,
     scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError> {
-    let pending: Vec<ViewTag> = tags
-        .iter()
-        .copied()
-        .filter(|tag| !scanned_to_tip.contains(tag))
-        .collect();
-    for chunk in pending.chunks(config.tag_query_chunk) {
-        let mut cursor = None;
-        loop {
-            let response = indexer
-                .get_encrypted_utxos_by_tags(
-                    chunk.to_vec(),
-                    cursor,
-                    Some(config.page_limit),
-                    rpc_config,
-                )
-                .await?;
-            let last_page = response.matches.len() < config.page_limit as usize;
-            for item in response.matches {
-                if item.tx_viewing_pk.is_some() || item.salt.is_some() {
-                    continue;
-                }
-                let key = format!(
-                    "{}:{}",
-                    item.tx_signature, item.output_slot.output_context.leaf_index
-                );
-                if out.contains_key(&key) {
-                    continue;
-                }
-                if let Some(view) = proofless_deposit_from_indexed_match(item)? {
-                    out.insert(key, view);
-                }
-            }
-            cursor = response.next_cursor;
-            if last_page || cursor.is_none() {
-                break;
-            }
+    let mut groups: HashMap<Option<Vec<u8>>, Vec<ViewTag>> = HashMap::new();
+    for tag in tags {
+        if scanned_to_tip.contains(tag) {
+            continue;
         }
-        scanned_to_tip.extend(chunk.iter().copied());
+        groups
+            .entry(cursors.get(tag).cloned())
+            .or_default()
+            .push(*tag);
+    }
+
+    for (start, group) in groups {
+        for chunk in group.chunks(config.tag_query_chunk) {
+            let mut cursor = start.clone();
+            let mut furthest = start.clone();
+            loop {
+                let response = indexer
+                    .get_encrypted_utxos_by_tags(
+                        chunk.to_vec(),
+                        cursor,
+                        Some(config.page_limit),
+                        rpc_config,
+                    )
+                    .await?;
+                let last_page = response.matches.len() < config.page_limit as usize;
+                for item in response.matches {
+                    if item.tx_viewing_pk.is_some() || item.salt.is_some() {
+                        continue;
+                    }
+                    let key = format!(
+                        "{}:{}",
+                        item.tx_signature, item.output_slot.output_context.leaf_index
+                    );
+                    if out.contains_key(&key) {
+                        continue;
+                    }
+                    if let Some(view) = proofless_deposit_from_indexed_match(item)? {
+                        out.insert(key, view);
+                    }
+                }
+                if response.next_cursor.is_some() {
+                    furthest = response.next_cursor.clone();
+                }
+                cursor = response.next_cursor;
+                if last_page || cursor.is_none() {
+                    break;
+                }
+            }
+            if let Some(position) = furthest {
+                for tag in chunk {
+                    cursors.insert(*tag, position.clone());
+                }
+            }
+            scanned_to_tip.extend(chunk.iter().copied());
+        }
     }
     Ok(())
 }
@@ -1770,6 +1833,7 @@ mod tests {
             &mut out,
             SyncWalletConfig::default(),
             None,
+            &mut HashMap::new(),
             &mut HashSet::new(),
         )
         .expect("decode proofless payload");
@@ -1889,6 +1953,7 @@ mod tests {
             &mut out,
             SyncWalletConfig::default(),
             None,
+            &mut HashMap::new(),
             &mut HashSet::new(),
         )
         .expect("skip encrypted row");

--- a/sdk-tests/zk-program-swap/sdk/src/index/maker.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/index/maker.rs
@@ -107,7 +107,7 @@ fn maker_order_candidate(
     })
 }
 
-pub fn index_maker<I: Rpc>(
+pub fn index_maker<I: Rpc + Sync>(
     wallet: &mut Wallet,
     keypair: &ShieldedKeypair,
     indexer: &I,

--- a/sdk-tests/zk-program-swap/sdk/src/index/poll.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/index/poll.rs
@@ -10,7 +10,7 @@ use crate::err;
 
 const INDEX_POLL: Duration = Duration::from_millis(500);
 
-pub(crate) fn index_until<I: Rpc, T>(
+pub(crate) fn index_until<I: Rpc + Sync, T>(
     wallet: &mut Wallet,
     keypair: &ShieldedKeypair,
     indexer: &I,
@@ -37,7 +37,7 @@ pub(crate) fn index_until<I: Rpc, T>(
     }
 }
 
-pub(crate) fn collect_tagged<I: Rpc, T>(
+pub(crate) fn collect_tagged<I: Rpc + Sync, T>(
     wallet: &Wallet,
     indexer: &I,
     mut scan: impl FnMut(&ShieldedTransaction) -> Result<Option<T>>,

--- a/sdk-tests/zk-program-swap/sdk/src/index/taker.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/index/taker.rs
@@ -111,7 +111,7 @@ impl TakerOrderCandidate {
     }
 }
 
-pub fn index_taker<I: Rpc, R: Rpc>(
+pub fn index_taker<I: Rpc + Sync, R: Rpc>(
     wallet: &mut Wallet,
     keypair: &ShieldedKeypair,
     indexer: &I,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -36,3 +36,9 @@ zolana-test-utils = { workspace = true }
 zolana-user-registry-interface = { workspace = true }
 zolana-program-test = { workspace = true }
 swap-program = { path = "../sdk-tests/zk-program-swap/program" }
+
+[dev-dependencies]
+# To build a real ClientError::SolanaRpcTransaction in the loadtest error-grouping
+# tests. Constructing the genuine error is the point: a hand-rolled stand-in
+# would not exercise get_transaction_error, which is what the grouping reads.
+solana-rpc-client-api = { workspace = true }

--- a/xtask/src/fund.rs
+++ b/xtask/src/fund.rs
@@ -1,0 +1,190 @@
+//! Top up the shielded balances of a directory of load-test wallets.
+//!
+//! The load generator spends shielded value; when a wallet runs out it fails
+//! with `insufficient balance for asset` and the run measures depletion rather
+//! than capacity. One 220-worker run ended with 209 such failures.
+//!
+//! One funder pays for everything. A deposit names its recipient by shielded
+//! address and needs no shared secret — see `DepositParams` — so the funder both
+//! signs and sources every deposit, and the wallets themselves are never
+//! touched. That removes the step this used to need: a SOL transfer to each
+//! wallet so it could afford to deposit to itself.
+//!
+//! It also removes the second wallet format. The load generator reads plain
+//! `solana-keygen` keypairs and derives the shielded keypair from the funding
+//! key, so this reads exactly the same directory rather than a parallel set of
+//! CLI wallet files holding the same secrets.
+
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+    thread,
+    time::Instant,
+};
+
+use anyhow::{bail, Context, Result};
+use solana_keypair::Keypair;
+use solana_signer::Signer;
+use zolana_client::{Rpc, SolanaRpc};
+use zolana_keypair::ShieldedKeypair;
+use zolana_transaction::Address;
+use zolana_wallet::{create_deposit, DepositParams};
+
+use crate::loadtest::load_keypairs;
+
+pub struct Options {
+    pub rpc_url: String,
+    pub tree: String,
+    /// Directory of `solana-keygen` keypairs — the same one `loadtest` takes.
+    pub keypairs: PathBuf,
+    /// Funder: signs and pays for every deposit.
+    pub funder: PathBuf,
+    /// Lamports to deposit into each wallet.
+    pub amount: u64,
+    /// Deposits in flight at once.
+    pub concurrency: usize,
+}
+
+impl Options {
+    pub fn parse(args: Vec<String>) -> Result<Self> {
+        let mut rpc_url = None;
+        let mut tree = None;
+        let mut keypairs = None;
+        let mut funder = None;
+        let mut amount = 60_000_000u64;
+        let mut concurrency = 16usize;
+
+        let mut iter = args.into_iter();
+        while let Some(arg) = iter.next() {
+            let mut value = || iter.next().context("missing value");
+            match arg.as_str() {
+                "--rpc" => rpc_url = Some(value()?),
+                "--tree" => tree = Some(value()?),
+                "--keypairs" => keypairs = Some(PathBuf::from(value()?)),
+                "--funder" => funder = Some(PathBuf::from(value()?)),
+                "--amount" => amount = value()?.parse().context("--amount")?,
+                "--concurrency" => concurrency = value()?.parse().context("--concurrency")?,
+                other => bail!("unknown flag {other}"),
+            }
+        }
+
+        Ok(Self {
+            rpc_url: rpc_url.context("--rpc is required")?,
+            tree: tree.context("--tree is required")?,
+            keypairs: keypairs.context("--keypairs <dir> is required")?,
+            funder: funder.context("--funder <keypair.json> is required")?,
+            amount,
+            concurrency: concurrency.max(1),
+        })
+    }
+}
+
+fn read_keypair(path: &PathBuf) -> Result<Keypair> {
+    let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    let raw: Vec<u8> = serde_json::from_slice(&bytes)
+        .with_context(|| format!("{} is not a keypair array", path.display()))?;
+    let array: [u8; 64] = raw
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("{} is not 64 bytes", path.display()))?;
+    Keypair::try_from(&array[..]).context("bad funder keypair")
+}
+
+pub fn run(options: Options) -> Result<()> {
+    let funder = read_keypair(&options.funder)?;
+    let wallets = load_keypairs(&options.keypairs)?;
+    let tree: Address = options.tree.parse().context("--tree is not an address")?;
+    let asset = Address::default();
+
+    let rpc = SolanaRpc::new(options.rpc_url.clone());
+    let funder_address = Address::new_from_array(funder.pubkey().to_bytes());
+    let balance = rpc.get_balance(funder_address)?;
+    let required = options.amount.saturating_mul(wallets.len() as u64);
+    println!(
+        "funding {} wallets with {} lamports each ({:.3} SOL total)\nfunder {} holds {:.3} SOL",
+        wallets.len(),
+        options.amount,
+        required as f64 / 1e9,
+        funder.pubkey(),
+        balance as f64 / 1e9,
+    );
+    if balance < required {
+        bail!(
+            "funder holds {:.3} SOL but {:.3} SOL is needed; airdrop first or lower --amount",
+            balance as f64 / 1e9,
+            required as f64 / 1e9,
+        );
+    }
+
+    let next = AtomicUsize::new(0);
+    let funded = AtomicU64::new(0);
+    let failed = AtomicU64::new(0);
+    let started = Instant::now();
+
+    thread::scope(|scope| {
+        for _ in 0..options.concurrency.min(wallets.len()) {
+            scope.spawn(|| {
+                // Each worker holds its own RPC client; they are cheap and not
+                // shared state.
+                let rpc = SolanaRpc::new(options.rpc_url.clone());
+                loop {
+                    let index = next.fetch_add(1, Ordering::Relaxed);
+                    let Some(wallet) = wallets.get(index) else {
+                        return;
+                    };
+                    match fund_one(&rpc, &funder, wallet, tree, asset, options.amount) {
+                        Ok(()) => {
+                            let done = funded.fetch_add(1, Ordering::Relaxed) + 1;
+                            if done.is_multiple_of(25) {
+                                println!(
+                                    "  {done} funded ({:.0}s)",
+                                    started.elapsed().as_secs_f64()
+                                );
+                            }
+                        }
+                        Err(error) => {
+                            failed.fetch_add(1, Ordering::Relaxed);
+                            eprintln!("  wallet {index} failed: {error:#}");
+                        }
+                    }
+                }
+            });
+        }
+    });
+
+    let funded = funded.into_inner();
+    let failed = failed.into_inner();
+    println!(
+        "\nfunded {funded}, failed {failed}, in {:.0}s",
+        started.elapsed().as_secs_f64()
+    );
+    if funded == 0 {
+        bail!("no wallet was funded");
+    }
+    Ok(())
+}
+
+/// Deposit into one wallet's shielded address, paid for by the funder.
+fn fund_one(
+    rpc: &SolanaRpc,
+    funder: &Keypair,
+    wallet: &Keypair,
+    tree: Address,
+    asset: Address,
+    amount: u64,
+) -> Result<()> {
+    let shielded = ShieldedKeypair::from_solana_keypair(wallet)?;
+    let recipient = shielded.shielded_address()?;
+    let built = create_deposit(DepositParams {
+        recipient: &recipient,
+        asset,
+        amount,
+        spl_token_account: None,
+        spl_token_program: None,
+        memo: None,
+    })?;
+    // Funder is both payer and depositor: the deposited SOL comes from it, so
+    // the recipient needs no balance of its own.
+    let tree = solana_pubkey::Pubkey::new_from_array(tree.to_bytes());
+    built.send(rpc, funder, tree, funder)?;
+    Ok(())
+}

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -31,7 +31,7 @@ use solana_keypair::Keypair;
 use solana_signer::Signer;
 // `Rpc` is in scope for send_transaction, which is a trait method rather than
 // an inherent one on SolanaRpc.
-use zolana_client::{Rpc, SolanaRpc, ZolanaClient};
+use zolana_client::{ClientError, Rpc, SolanaRpc, Unavailable, ZolanaClient};
 use zolana_keypair::ShieldedKeypair;
 use zolana_transaction::{Address, AssetRegistry, LocalWalletAuthority, Wallet};
 use zolana_wallet::{
@@ -456,7 +456,7 @@ fn worker(
         // This phase is the one that grows with the wallet's note count.
         let mark = Instant::now();
         if let Err(error) = sync_wallet(&mut wallet, &authority, &client) {
-            classify(&error.to_string(), stats, &mut backoff);
+            classify(&error, stats, &mut backoff);
             continue;
         }
         timing.sync_ms = mark.elapsed().as_millis() as u64;
@@ -484,7 +484,7 @@ fn worker(
         }) {
             Ok(signed) => signed,
             Err(error) => {
-                classify(&error.to_string(), stats, &mut backoff);
+                classify(&error, stats, &mut backoff);
                 continue;
             }
         };
@@ -494,7 +494,7 @@ fn worker(
         let signature = match client.rpc().send_transaction(&transfer) {
             Ok(signature) => signature,
             Err(error) => {
-                classify(&error.to_string(), stats, &mut backoff);
+                classify(&error, stats, &mut backoff);
                 continue;
             }
         };
@@ -502,7 +502,7 @@ fn worker(
 
         let mark = Instant::now();
         if let Err(error) = client.confirm_private_transaction_sync(signature) {
-            classify(&error.to_string(), stats, &mut backoff);
+            classify(&error, stats, &mut backoff);
             continue;
         }
         timing.confirm_ms = mark.elapsed().as_millis() as u64;
@@ -523,14 +523,26 @@ fn worker(
 /// A load generator without backoff measures the rate limiter rather than the
 /// system under test: an earlier shell-driven run lost 101 of 220 transfers to
 /// Helius 403s and reported it as protocol failure.
-fn classify(message: &str, stats: &mut Stats, backoff: &mut Duration) {
+fn classify(error: &ClientError, stats: &mut Stats, backoff: &mut Duration) {
     // Truncated: these carry request ids and addresses that would make every
     // occurrence look distinct and defeat the grouping.
-    let key: String = message.chars().take(160).collect();
+    let key: String = error.to_string().chars().take(160).collect();
     *stats.errors.entry(key).or_insert(0) += 1;
 
-    let lowered = message.to_ascii_lowercase();
-    if lowered.contains("403") || lowered.contains("429") || lowered.contains("rate") {
+    // Matched on the error's type, not its text. This used to ask whether the
+    // message contained "403", "429" or "rate", which counts a signature
+    // containing "429" as throttling and the word "generate" as well, while
+    // missing a 503 entirely -- and it silently misreads any error whose
+    // wording changes.
+    let throttled = matches!(
+        error,
+        ClientError::IndexerUnavailable {
+            reason: Unavailable::RateLimited,
+            ..
+        }
+    );
+
+    if throttled {
         stats.throttled += 1;
         thread::sleep(*backoff);
         *backoff = (*backoff * 2).min(Duration::from_secs(30));

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -32,6 +32,7 @@ use solana_signer::Signer;
 // `Rpc` is in scope for send_transaction, which is a trait method rather than
 // an inherent one on SolanaRpc.
 use zolana_client::{ClientError, Rpc, SolanaRpc, Unavailable, ZolanaClient};
+use zolana_interface::error::ShieldedPoolError;
 use zolana_keypair::ShieldedKeypair;
 use zolana_transaction::{Address, AssetRegistry, LocalWalletAuthority, Wallet};
 use zolana_wallet::{
@@ -524,21 +525,28 @@ fn worker(
 /// system under test: an earlier shell-driven run lost 101 of 220 transfers to
 /// Helius 403s and reported it as protocol failure.
 fn classify(error: &ClientError, stats: &mut Stats, backoff: &mut Duration) {
-    // Truncated: these carry request ids and addresses that would make every
-    // occurrence look distinct and defeat the grouping.
+    // Group by the program's own error code when the chain rejected the
+    // transaction, and name it.
     //
-    // 160 was too short by a handful of characters, and in the worst possible
-    // place. A simulation failure reads
+    // Reading the code out of the rendered message does not work: the same
+    // rejection arrives with two different wrappers depending on whether it
+    // failed in simulation or on send, so truncating to group them put the code
+    // inside the prefix for one and past the cut for the other. A run reporting
+    // 10748 failures identified none of them, while 318 of the *same* error
+    // showed up separately as "0x1b60" purely because their wrapper was shorter.
     //
-    //   Solana RPC transaction failed during send_transaction: RPC response
-    //   error -32002: Transaction simulation failed: Error processing
-    //   Instruction 1: custom program error: 0x1b60
-    //
-    // where the program error code -- the only part that identifies the
-    // failure -- begins at roughly character 160. A run reporting 10748
-    // failures said nothing about what they were. Long enough to keep the code,
-    // short enough that ids and addresses still fall off the end.
-    let key: String = error.to_string().chars().take(220).collect();
+    // Solana models this properly -- TransactionError carries
+    // InstructionError::Custom(u32) -- so match on it and let
+    // ShieldedPoolError name the number.
+    let key = match error.program_error_code() {
+        Some(code) => match ShieldedPoolError::from_code(code) {
+            Some(named) => format!("program error {code:#x} ({named})"),
+            None => format!("program error {code:#x} (unknown to this build)"),
+        },
+        // Everything else still groups by message, truncated: those carry
+        // request ids and addresses that would make each occurrence distinct.
+        None => error.to_string().chars().take(160).collect(),
+    };
     *stats.errors.entry(key).or_insert(0) += 1;
 
     // Matched on the error's type, not its text. This used to ask whether the

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -526,7 +526,19 @@ fn worker(
 fn classify(error: &ClientError, stats: &mut Stats, backoff: &mut Duration) {
     // Truncated: these carry request ids and addresses that would make every
     // occurrence look distinct and defeat the grouping.
-    let key: String = error.to_string().chars().take(160).collect();
+    //
+    // 160 was too short by a handful of characters, and in the worst possible
+    // place. A simulation failure reads
+    //
+    //   Solana RPC transaction failed during send_transaction: RPC response
+    //   error -32002: Transaction simulation failed: Error processing
+    //   Instruction 1: custom program error: 0x1b60
+    //
+    // where the program error code -- the only part that identifies the
+    // failure -- begins at roughly character 160. A run reporting 10748
+    // failures said nothing about what they were. Long enough to keep the code,
+    // short enough that ids and addresses still fall off the end.
+    let key: String = error.to_string().chars().take(220).collect();
     *stats.errors.entry(key).or_insert(0) += 1;
 
     // Matched on the error's type, not its text. This used to ask whether the

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -39,6 +39,28 @@ use zolana_wallet::{
     create_transfer_sync, sign_private_transaction_sync, sync_wallet, TransferParams,
 };
 
+/// Identity of a failure, for grouping.
+///
+/// The variant plus, for a chain rejection, the program's own error code. Two
+/// failures share a key exactly when they are the same failure, which a
+/// truncated message cannot express: the same rejection arrives with different
+/// wrappers from simulation and from send, so a prefix groups them apart while
+/// a longer prefix groups unrelated errors together.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct ErrorKey {
+    variant: std::mem::Discriminant<ClientError>,
+    program_code: Option<u32>,
+}
+
+impl ErrorKey {
+    fn of(error: &ClientError) -> Self {
+        Self {
+            variant: std::mem::discriminant(error),
+            program_code: error.program_error_code(),
+        }
+    }
+}
+
 /// One completed transfer, broken into the phases that can each be slow for a
 /// different reason.
 #[derive(Clone, Copy, Default)]
@@ -58,12 +80,21 @@ struct Stats {
     ok: u64,
     failed: u64,
     throttled: u64,
-    /// Distinct error messages and how often each occurred.
+    /// Distinct failures and how often each occurred.
     ///
     /// Counting failures without recording them makes a run unactionable: "43
     /// failed" says nothing about whether the prover is down, the wallet is
     /// empty, or the indexer is behind.
-    errors: std::collections::BTreeMap<String, u64>,
+    ///
+    /// Keyed by what the failure *is*, never by how it renders.
+    ///
+    /// `mem::discriminant` identifies the `ClientError` variant exactly, and the
+    /// program error code splits one variant into the distinct on-chain
+    /// rejections it carries. Neither can drift when a message is reworded, and
+    /// nothing depends on where a substring happens to fall. The stored `String`
+    /// is one real example per group, shown to a reader and used for nothing
+    /// else.
+    errors: std::collections::HashMap<ErrorKey, (String, u64)>,
     /// This worker's first sync, before it sent anything.
     ///
     /// Stands in for how much history its wallet already carried. Sync cost
@@ -346,8 +377,9 @@ pub fn run(options: Options) -> Result<()> {
                 shared.ok += local.ok;
                 shared.failed += local.failed;
                 shared.throttled += local.throttled;
-                for (message, count) in local.errors {
-                    *shared.errors.entry(message).or_insert(0) += count;
+                for (key, (sample, count)) in local.errors {
+                    let entry = shared.errors.entry(key).or_insert((sample, 0));
+                    entry.1 += count;
                 }
             });
         }
@@ -373,10 +405,12 @@ pub fn run(options: Options) -> Result<()> {
     );
     if !stats.errors.is_empty() {
         println!("\nerrors:");
-        let mut ranked: Vec<_> = stats.errors.iter().collect();
-        ranked.sort_by(|a, b| b.1.cmp(a.1));
-        for (message, count) in ranked.into_iter().take(5) {
-            println!("  {count:>5}x  {message}");
+        let mut ranked: Vec<_> = stats.errors.values().collect();
+        // Ties break on the message so two runs of the same workload print the
+        // same report; hash order alone would shuffle equal counts.
+        ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        for (sample, count) in ranked.into_iter().take(8) {
+            println!("  {count:>5}x  {sample}");
         }
     }
 
@@ -524,30 +558,41 @@ fn worker(
 /// A load generator without backoff measures the rate limiter rather than the
 /// system under test: an earlier shell-driven run lost 101 of 220 transfers to
 /// Helius 403s and reported it as protocol failure.
-fn classify(error: &ClientError, stats: &mut Stats, backoff: &mut Duration) {
-    // Group by the program's own error code when the chain rejected the
-    // transaction, and name it.
-    //
-    // Reading the code out of the rendered message does not work: the same
-    // rejection arrives with two different wrappers depending on whether it
-    // failed in simulation or on send, so truncating to group them put the code
-    // inside the prefix for one and past the cut for the other. A run reporting
-    // 10748 failures identified none of them, while 318 of the *same* error
-    // showed up separately as "0x1b60" purely because their wrapper was shorter.
-    //
-    // Solana models this properly -- TransactionError carries
-    // InstructionError::Custom(u32) -- so match on it and let
-    // ShieldedPoolError name the number.
-    let key = match error.program_error_code() {
+/// A readable one-line description of a failure.
+///
+/// Names the on-chain error when there is one, because a client otherwise sees
+/// only a number. Long transport messages are shortened here and only here:
+/// this is display, and grouping never consults it.
+fn describe(error: &ClientError) -> String {
+    match error.program_error_code() {
         Some(code) => match ShieldedPoolError::from_code(code) {
             Some(named) => format!("program error {code:#x} ({named})"),
             None => format!("program error {code:#x} (unknown to this build)"),
         },
-        // Everything else still groups by message, truncated: those carry
-        // request ids and addresses that would make each occurrence distinct.
-        None => error.to_string().chars().take(160).collect(),
-    };
-    *stats.errors.entry(key).or_insert(0) += 1;
+        None => {
+            let text = error.to_string();
+            match text.char_indices().nth(160) {
+                Some((cut, _)) => format!("{}...", &text[..cut]),
+                None => text,
+            }
+        }
+    }
+}
+
+fn classify(error: &ClientError, stats: &mut Stats, backoff: &mut Duration) {
+    // Identity comes from the type, never from the text. The message is kept
+    // only as a readable example of the group.
+    //
+    // Grouping by a message prefix failed in both directions at once: the same
+    // chain rejection arrives with two wrappers depending on whether it failed
+    // in simulation or on send, so 10748 occurrences landed under a key that
+    // named none of them while 318 of the *same* error grouped separately as
+    // "0x1b60" purely because their wrapper was shorter.
+    stats
+        .errors
+        .entry(ErrorKey::of(error))
+        .or_insert_with(|| (describe(error), 0))
+        .1 += 1;
 
     // Matched on the error's type, not its text. This used to ask whether the
     // message contained "403", "429" or "rate", which counts a signature
@@ -569,5 +614,92 @@ fn classify(error: &ClientError, stats: &mut Stats, backoff: &mut Duration) {
     } else {
         stats.failed += 1;
         thread::sleep(Duration::from_millis(250));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rpc_program_error(operation: &'static str, code: u32) -> ClientError {
+        use solana_instruction::error::InstructionError;
+        use solana_rpc_client_api::client_error::{Error as RpcError, TransactionError};
+
+        ClientError::SolanaRpcTransaction {
+            operation,
+            source: RpcError::from(TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(code),
+            )),
+        }
+    }
+
+    /// The failure that motivated all of this: one on-chain rejection reported
+    /// as two unrelated lines because the wrappers rendered at different
+    /// lengths.
+    #[test]
+    fn one_rejection_groups_under_one_key_whatever_the_wrapper() {
+        let simulate = rpc_program_error("simulate", 7008);
+        let send = rpc_program_error("send", 7008);
+
+        assert_ne!(
+            simulate.to_string(),
+            send.to_string(),
+            "vacuous unless the two render differently"
+        );
+        assert_eq!(ErrorKey::of(&simulate), ErrorKey::of(&send));
+    }
+
+    #[test]
+    fn different_program_codes_stay_apart() {
+        assert_ne!(
+            ErrorKey::of(&rpc_program_error("send", 7008)),
+            ErrorKey::of(&rpc_program_error("send", 7015)),
+        );
+    }
+
+    /// Off-chain failures group by variant, so per-occurrence detail -- slots,
+    /// attempt counts, addresses -- cannot split one cause across many lines.
+    #[test]
+    fn per_occurrence_detail_does_not_split_a_group() {
+        let early = ClientError::IndexerNotCaughtUp {
+            required: 1,
+            indexed: 0,
+            attempts: 3,
+        };
+        let late = ClientError::IndexerNotCaughtUp {
+            required: 99_999,
+            indexed: 42,
+            attempts: 7,
+        };
+
+        assert_ne!(early.to_string(), late.to_string());
+        assert_eq!(ErrorKey::of(&early), ErrorKey::of(&late));
+        assert_ne!(
+            ErrorKey::of(&early),
+            ErrorKey::of(&ClientError::IndexerTimeout)
+        );
+    }
+
+    #[test]
+    fn the_report_names_the_program_error() {
+        let described = describe(&rpc_program_error("send", 7008));
+        assert!(
+            described.starts_with("program error 0x1b60 ("),
+            "expected a named code, got {described}"
+        );
+        assert!(
+            described.contains(&ShieldedPoolError::TransactProofVerificationFailed.to_string()),
+            "expected the name from ShieldedPoolError, got {described}"
+        );
+    }
+
+    /// Shortening is display-only, so it may not silently swallow the tail.
+    #[test]
+    fn a_long_message_is_marked_when_shortened() {
+        let long = ClientError::AddressResolution("x".repeat(400));
+        let described = describe(&long);
+        assert!(described.ends_with("..."), "got {described}");
+        assert!(described.chars().count() < long.to_string().chars().count());
     }
 }

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -166,7 +166,7 @@ impl Options {
 /// the shielded keypair is derived from the funding key, so the funding key is
 /// the only secret needed and there is no reason to reimplement the CLI's file
 /// parsing here.
-fn load_keypairs(dir: &Path) -> Result<Vec<Keypair>> {
+pub(crate) fn load_keypairs(dir: &Path) -> Result<Vec<Keypair>> {
     let mut paths: Vec<PathBuf> = fs::read_dir(dir)
         .with_context(|| format!("read {}", dir.display()))?
         .filter_map(|entry| entry.ok().map(|e| e.path()))

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 
 mod create_release;
 mod find_smart_accounts;
+mod fund;
 mod init_protocol;
 mod loadtest;
 mod update_protocol_config;
@@ -60,6 +61,16 @@ fn main() {
             };
             if let Err(error) = loadtest::run(options) {
                 eprintln!("loadtest failed: {error:?}");
+                std::process::exit(1);
+            }
+        }
+        Some("fund") => {
+            let options = match fund::Options::parse(args.collect()) {
+                Ok(options) => options,
+                Err(error) => usage_and_exit(&format!("fund: {error:#}")),
+            };
+            if let Err(error) = fund::run(options) {
+                eprintln!("fund failed: {error:?}");
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
Four independent changes, one per commit. Based on `stress/watermark`, the tree the load generator runs from; needs rebasing onto a reviewable base before merge.

## 1. Remember where the proofless scan stopped

`sync_wallet` keeps per-tag cursors for the transaction stream, so each sync resumes where the last finished. The encrypted-utxo stream, where proofless deposits come from, had no such memory: its `scanned_to_tip` set was a local, created fresh on every call, so every sync paged the entire history for every tag and discarded all but the deposits client-side.

Devnet, `ZOLANA_TIMING`, 8 workers, wallets carrying ~10k transfers:

```
sync_wallet_total             2650ms
  fetch_round                  970ms
  fetch_proofless_deposits     909ms   (to keep 2.5 rows)
  collect_sort_and_decrypt     341ms
  fetch_shielded_by_nullifiers 272ms
  fetch_shielded_by_tags       191ms
```

A third of the sync phase re-read rows it had already seen and dropped, growing with history — which is why sync went from 714ms to 6244ms across one day on unchanged wallets.

| phase | before | after |
|---|---|---|
| `fetch_proofless_deposits` | 909ms | 275ms |
| `fetch_shielded_by_tags` | 191ms | 113ms |
| `fetch_shielded_by_nullifiers` | 272ms | 180ms |
| `sync_wallet_total` | 2650ms | 1376ms |

The other two streams improved because they no longer queue behind the proofless scan.

`wallet.proofless_cursors` mirrors `sync_cursors` and is kept separate on purpose: they are positions in different streams, and sharing one cursor would skip rows in whichever is behind. Grouping by resume point and advancing every tag in a chunk to the furthest position is the rule the tag stream already uses, sound for the same reason — the ordering is global.

A `proofless_only` flag on `get_encrypted_utxos_by_tags` was rejected: server-side filtering cuts the rows returned but not the pages read, so the client would still walk the whole stream every sync. The cursor removes the reads themselves.

Not yet covered by a test: `MockIndexer` always returns `next_cursor: None`, so pinning this needs a mock that advances, and its 18 construction sites take the field list positionally. Worth doing before merge.

## 2. Make indexer failure a type, not a string to search

`IndexerUnavailable` carried a `String`, so anything needing to know why searched it. The load generator separated throttling from real failure with:

```rust
if lowered.contains("403") || lowered.contains("429") || lowered.contains("rate")
```

That counts a signature containing `429` as a rate limit, counts the word "generate" as one, misses a 503 entirely, and changes meaning whenever an upstream message is reworded.

It now carries an `Unavailable` reason — `Timeout`, `Connect`, `RateLimited`, `ServerError { status }`, `JsonRpcInternal` — plus the transport's text as `detail`, for humans only. `classify()` and `should_retry` match on the reason. Every reason is retryable today, which the enum states rather than assumes: adding a non-retryable one forces `should_retry` to be revisited.

`Timeout` is its own variant because of a specific confusion. reqwest renders a timeout that fires while reading the response body as "error decoding response body", which reads like a deserialization bug. Hundreds of these across a day of load tests were written off as indexer flakiness before anyone noticed `is_timeout()` was true and the client's own read deadline was the cause.

## 3. Group load-test failures by error variant, not by message prefix

Grouping keyed on the first 160 characters of the rendered error, which is not an identity. It failed in both directions in one run: an on-chain rejection arrives with two different wrappers depending on whether it failed in simulation or on send, so 10748 occurrences grouped under a key naming none of them, while 318 occurrences of the same error grouped separately as `0x1b60` because their wrapper was shorter. Widening the cut moves the boundary; it does not make a prefix into an identity.

The key is now the `ClientError` variant's discriminant plus, for a chain rejection, the code from `program_error_code()`. Two failures share a key exactly when they are the same failure. The stored message is one example per group, shown to a reader and used for nothing else.

`ShieldedPoolError` gained a `from_code` reverse lookup, generated with the enum from one list by `macro_rules!` rather than kept as a second hand-maintained table. That matters here: `0x1b60` was read off a `TreeError` conversion and called `StaleNullifierRoot` in three commit messages. It is 7008, `TransactProofVerificationFailed`; `StaleNullifierRoot` is 7015 and never fired. strum's `EnumIter` would generate the same thing, but this crate compiles into the on-chain program and keeps its dependencies to what the program needs.

```
3145x  program error 0x1b5a (nullifier tree maintenance failed)
 177x  rpc error: get_account ... AccountNotFound
  66x  prover server error: async proof failed ... Job timed out in processing
  49x  program error 0x1b60 (transact proof verification failed)
```

Five tests, including the two-wrapper case and the converse: per-occurrence detail such as slots and attempt counts cannot split one cause across many lines.

## 4. Bound the async proof poll by wall clock, and cap the status request

A 220-worker run with a 420s duration sat wedged for 35 minutes. Sampling put all 197 live workers in one frame — `ProverClient::poll_async`, inside a status GET — while the prover's transfer queue had been empty for 20 minutes and photon was answering in 150ms. Nothing was pending; the client could not stop waiting.

`max_wait_secs` was described as a ceiling but compared against a running total of time slept between polls. Time inside a request added nothing to it, so a poll that took a minute counted as zero and the loop went round again with its budget intact. It is now measured with `Instant` from the first poll, so a configured 1200s means 1200s.

The status poll also inherited the 600s request timeout the client sets for `POST /prove`, where a cold prove can take minutes. `GET /prove/status` reads one Redis key. Sharing the prove timeout let a single hung poll hold a worker for ten minutes, and with the accounting above the delays stacked without limit. Status polls now carry their own 30s timeout.

The regression test uses a mock that answers slowly rather than not at all — the case a fast mock cannot reach — and holds the port open afterwards, so polls the client should not have made are recorded instead of hitting a closed socket. Under the old accounting it does not terminate.

This bounds the client. The server-side cause is #210.

`sdk-libs/client`'s `merge_proving` suite fails locally: 2 tests, ~10 minutes. Whether that predates this branch is unestablished — a clean-tree comparison exceeded the time available, and the suite spawns a prover from `target/debug/zolana`. Nothing here touches proving; CI settles it.
