### PR TITLE
indexer: derive each proof's root index from its own tree

### DIFF
--- a/services/photon/src/api/method/rings/common.rs
+++ b/services/photon/src/api/method/rings/common.rs
@@ -179,7 +179,7 @@ pub(super) fn non_inclusion_proof_from_context(
     let root_seq = proof.root_seq.unwrap_or(0);
     let root_index = proof
         .root_seq
-        .map(|root_seq| root_index(root_seq, tree_info.root_history_capacity))
+        .map(|root_seq| root_index(root_seq, tree_kind, tree_info))
         .transpose()
         .map(|root_index| root_index.unwrap_or(0))?;
 
@@ -200,15 +200,51 @@ pub(super) fn non_inclusion_proof_from_context(
     })
 }
 
-/// Root index for the nullifier tree, where the sequence number *is* the
+/// Position of a root within its own tree's history ring.
+///
+/// Only the nullifier tree reaches here, and its sequence number *is* the
 /// chain's: it comes from `BatchAddressAppendEvent`, not from a local counter.
-/// The state tree has no such field in its event, which is why it reads the
-/// index from the tree account instead -- see [`state_root_index`].
-fn root_index(root_seq: u64, root_history_capacity: u64) -> Result<u16, PhotonApiError> {
-    let root_index = if root_history_capacity == 0 {
+/// The state tree has no such field in its event, so it reads its index from
+/// the tree account instead -- see `RootIndexCache`.
+///
+/// The capacity always comes from `tree_kind`, never from a value that happens
+/// to be in scope. The UTXO and nullifier trees share one account but keep
+/// separate histories of different sizes (200 and 120), so `root_seq % capacity`
+/// gives a different answer per tree, and the program reads that slot of the
+/// ring to check the root it was handed. A capacity from the wrong tree yields a
+/// valid-looking index pointing at the wrong root, which the program rejects as
+/// `InvalidRootIndex` -- surfacing to the client as `StaleNullifierRoot`,
+/// indistinguishable from a proof that genuinely expired. That is an expensive
+/// error to recognise: we spent an hour attributing exactly this code to prover
+/// latency before ruling this path out. Upstream photon shipped that bug by
+/// computing both proof kinds' indices from one capacity
+/// (helius-labs/photon@7113918); taking the capacity from `tree_kind` makes it
+/// unrepresentable here.
+///
+/// `tree_info` is cross-checked rather than used: it carries the *nullifier*
+/// tree's capacity, because both trees live in one account and that is the one
+/// `process_rings_tree_account` stores. Where it is comparable it must agree
+/// with the constant this binary was built against; a mismatch means the
+/// deployed tree is not the tree this code assumes, and guessing is worse than
+/// failing.
+fn root_index(
+    root_seq: u64,
+    tree_kind: RingsTreeKind,
+    tree_info: &TreeInfo,
+) -> Result<u16, PhotonApiError> {
+    let capacity = tree_kind.root_history_capacity();
+    if matches!(tree_kind, RingsTreeKind::Nullifier) && tree_info.root_history_capacity != capacity
+    {
+        return Err(PhotonApiError::UnexpectedError(format!(
+            "nullifier root history capacity is {} on chain but {} in this build",
+            tree_info.root_history_capacity, capacity
+        )));
+    }
+
+    let root_index = if capacity == 0 {
         0
     } else {
-        root_seq % root_history_capacity
+        root_seq % capacity
     };
     root_index.try_into().map_err(|_| {
         PhotonApiError::UnexpectedError(format!("Root index {} does not fit in u16", root_index))
@@ -410,5 +446,58 @@ mod tests {
         let rows: Vec<u64> = Vec::new();
         let cursor = next_cursor_from_rows(&rows, cursor_of).expect("cursor");
         assert!(cursor.is_none(), "no rows means no position to resume from");
+    }
+
+    fn tree_info_with(root_history_capacity: u64) -> TreeInfo {
+        TreeInfo {
+            tree: Default::default(),
+            queue: Default::default(),
+            height: 0,
+            root_history_capacity,
+            input_queue_zkp_batch_size: 0,
+        }
+    }
+
+    /// The two trees share an account but not a history size, so the same
+    /// `root_seq` lands at different ring positions for each. Getting this wrong
+    /// hands the program a plausible index pointing at the wrong root, which it
+    /// rejects as `InvalidRootIndex` -> `StaleNullifierRoot`, identical to a
+    /// proof that genuinely expired. Upstream photon shipped exactly that
+    /// (helius-labs/photon@7113918).
+    #[test]
+    fn each_tree_indexes_its_root_by_its_own_capacity() {
+        let nullifier_capacity = RingsTreeKind::Nullifier.root_history_capacity();
+        let state_capacity = RingsTreeKind::State.root_history_capacity();
+        assert_ne!(
+            nullifier_capacity, state_capacity,
+            "this test is only meaningful while the capacities differ"
+        );
+
+        // Chosen so the two capacities disagree about where it lands.
+        let root_seq = state_capacity + 5;
+        let info = tree_info_with(nullifier_capacity);
+
+        let nullifier = root_index(root_seq, RingsTreeKind::Nullifier, &info).expect("nullifier");
+        let state = root_index(root_seq, RingsTreeKind::State, &info).expect("state");
+
+        assert_eq!(nullifier as u64, root_seq % nullifier_capacity);
+        assert_eq!(state as u64, root_seq % state_capacity);
+        assert_ne!(
+            nullifier, state,
+            "a shared capacity would collapse these to one value -- the upstream bug"
+        );
+    }
+
+    /// A deployed tree that disagrees with the constant this binary was built
+    /// against means the assumption is wrong, and a computed index would be
+    /// quietly incorrect. Fail instead.
+    #[test]
+    fn a_tree_whose_capacity_disagrees_with_the_build_is_rejected() {
+        let info = tree_info_with(RingsTreeKind::Nullifier.root_history_capacity() + 1);
+        let result = root_index(7, RingsTreeKind::Nullifier, &info);
+        assert!(
+            result.is_err(),
+            "a capacity mismatch must fail loudly, not produce an index"
+        );
     }
 }


### PR DESCRIPTION
Prompted by [helius-labs/photon@7113918](https://github.com/helius-labs/photon/commit/71139185c47f571f1469ea5e493f950338c8ed07), which fixes this class of bug upstream. We do not have that bug; this makes not having it structural rather than accidental.

The UTXO and nullifier trees live in one account but keep separate root-history rings of different sizes:

```
utxo tree      200   (smt::ROOT_HISTORY_CAPACITY)
nullifier tree 120   (DEFAULT_ADDRESS_BATCH_ROOT_HISTORY_LEN)
```

A proof carries `root_index = root_seq % capacity`, and the program reads that slot of the ring to check the root it was handed. A capacity borrowed from the other tree produces a plausible index pointing at the wrong root. The program rejects it as `InvalidRootIndex`, which reaches the client as `ShieldedPoolError::StaleNullifierRoot` — identical to the error a proof gets when it genuinely expired.

Upstream hit this on mainnet: state tree capacity 60, address tree 120, giving `784 % 60 = 4` where `784 % 120 = 64` was wanted.

Our two call sites read the capacity from two unrelated places, and each happened to land on the right one:

| path | proof | capacity source | value |
|---|---|---|---|
| `merkle_proof_from_context` | utxo | `tree_kind.root_history_capacity()` (`State`) | 200 |
| `non_inclusion_proof_from_context` | nullifier | `tree_info.root_history_capacity` | 120 |

The second is 120 only because `process_rings_tree_account` populates `TreeInfo` from `nullifier_metadata` — both trees share an account and that is the one it stores. Correct, but by coincidence of construction: passing `tree_info` to a utxo proof, or storing the utxo capacity in that field, silently reintroduces upstream's bug.

Capacity now always comes from the proof's own `tree_kind`. `tree_info` is cross-checked rather than used: where it is comparable it must agree with the constant this binary was built against, and a mismatch returns an error rather than computing an index from an assumption already known to be wrong.

Two tests: that the two trees produce different indices for the same `root_seq`, which a shared capacity would collapse; and that a capacity mismatch fails loudly.

The reason to bother, given we were not broken, is that the symptom is unreadable. This exact error code was attributed to prover latency at high concurrency, and that diagnosis was correct — 843 came from proofs genuinely expiring while prove p50 sat at 15s. Two unrelated causes produce one indistinguishable symptom, so the one that can be made structurally impossible should be, leaving the remaining occurrences unambiguous.

Not included: proof staleness under load, where prove latency exceeds the 120-root nullifier window at high throughput. That needs lower prove latency, a larger root history, or slower root rotation, and is tracked separately.
