### PR TITLE
sdk: require https for indexer and prover, and add a TypeScript loadtest

### DIFF
--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -28,7 +28,7 @@ pub(crate) fn run_transfer(opts: TransferOptions) -> Result<()> {
         network.sync.indexer_url.clone(),
         network.prover_url.clone(),
         Address::new_from_array(network.tree.to_bytes()),
-    );
+    )?;
     let recipient = parse_pubkey(&opts.to)?;
 
     let transfer = create_transfer_sync(TransferParams {
@@ -111,7 +111,7 @@ pub(crate) fn run_split(opts: SplitOptions) -> Result<()> {
         network.sync.indexer_url.clone(),
         network.prover_url.clone(),
         Address::new_from_array(network.tree.to_bytes()),
-    );
+    )?;
     let input = opts
         .input
         .as_deref()
@@ -183,7 +183,7 @@ pub(crate) fn run_merge(opts: MergeOptions) -> Result<()> {
         network.sync.indexer_url.clone(),
         network.prover_url.clone(),
         Address::new_from_array(tree.to_bytes()),
-    );
+    )?;
     // Submit only needs the owner's public identity plus the nullifier secret;
     // no signing/viewing/funding secret crosses the submit boundary.
     let material = MergeMaterial::from_keypair(&ctx.material.keypair);

--- a/cli/src/wallet_cli/withdraw.rs
+++ b/cli/src/wallet_cli/withdraw.rs
@@ -29,7 +29,7 @@ pub(crate) fn run_withdraw(opts: WithdrawOptions) -> Result<()> {
         network.sync.indexer_url.clone(),
         network.prover_url.clone(),
         Address::new_from_array(network.tree.to_bytes()),
-    );
+    )?;
     let recipient = parse_pubkey(&opts.to)?;
 
     // An SPL withdrawal settles into the recipient's associated token account,

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -7,6 +7,48 @@
 
 use std::{sync::OnceLock, thread::sleep, time::Duration};
 
+/// Reject a service URL that would carry shielded material in plaintext.
+///
+/// Mirrors the TypeScript SDK's `checkedServiceUrl`: https anywhere, http only
+/// to loopback, where there is no network to observe. Kept deliberately simple
+/// -- scheme and host, no dependency on a URL crate -- because the rule is
+/// about which wire the bytes cross, not about parsing.
+fn check_service_url(url: &str, field: &'static str) -> Result<(), ClientError> {
+    let insecure = || ClientError::InsecureServiceUrl {
+        field,
+        url: url.to_string(),
+    };
+
+    if url.starts_with("https://") {
+        return Ok(());
+    }
+    let Some(rest) = url.strip_prefix("http://") else {
+        return Err(insecure());
+    };
+    let host = rest
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default()
+        .rsplit_once(':')
+        .map_or(
+            rest.split(['/', '?', '#']).next().unwrap_or_default(),
+            |(host, _)| host,
+        );
+    let host = host.trim_end_matches('.');
+
+    let loopback = host == "localhost"
+        || host.ends_with(".localhost")
+        || host == "[::1]"
+        || host
+            .strip_prefix("127.")
+            .is_some_and(|tail| tail.split('.').count() == 3);
+    if loopback {
+        Ok(())
+    } else {
+        Err(insecure())
+    }
+}
+
 use async_trait::async_trait;
 use solana_account::Account;
 use solana_address::Address;
@@ -106,7 +148,37 @@ impl<R> ZolanaClient<R> {
     ///
     /// Blocking adapters are initialized on first blocking use so constructing
     /// an async client inside a Tokio runtime never creates a nested runtime.
+    ///
+    /// Both URLs must be https, or http to loopback. The indexer's response
+    /// says which UTXOs an identity owns and the prover's request carries the
+    /// witness, so in plaintext they hand a network observer exactly what a
+    /// shielded protocol exists to hide. Where the transport is already private
+    /// -- an indexer inside your own VPC, TLS terminated elsewhere -- use
+    /// [`Self::from_urls_allowing_insecure_http`], which is named so that
+    /// choice is greppable.
     pub fn from_urls(
+        rpc: R,
+        indexer_url: impl AsRef<str>,
+        prover_url: impl Into<String>,
+        output_tree: Address,
+    ) -> Result<Self, ClientError> {
+        let indexer_url = indexer_url.as_ref().to_string();
+        let prover_url = prover_url.into();
+        check_service_url(&indexer_url, "indexer_url")?;
+        check_service_url(&prover_url, "prover_url")?;
+        Ok(Self::from_urls_allowing_insecure_http(
+            rpc,
+            indexer_url,
+            prover_url,
+            output_tree,
+        ))
+    }
+
+    /// [`Self::from_urls`] without the transport check.
+    ///
+    /// Only for a network that is already private. On a public endpoint this
+    /// publishes the wallet's UTXO set and every proof witness in the clear.
+    pub fn from_urls_allowing_insecure_http(
         rpc: R,
         indexer_url: impl AsRef<str>,
         prover_url: impl Into<String>,
@@ -1247,11 +1319,80 @@ mod tests {
         types::SppProofInputUtxo,
     };
 
+    #[test]
+    fn from_urls_requires_https_off_loopback() {
+        // The indexer response is the wallet's UTXO set and the prover request
+        // is the witness. In plaintext to a remote host both are readable by
+        // anyone on the path, which is the privacy property itself.
+        let tree = Address::new_from_array([42u8; 32]);
+        for (indexer, prover) in [
+            ("http://indexer.example.com", "https://prover.example.com"),
+            ("https://indexer.example.com", "http://prover.example.com"),
+        ] {
+            assert!(
+                matches!(
+                    ZolanaClient::from_urls((), indexer, prover, tree),
+                    Err(ClientError::InsecureServiceUrl { .. })
+                ),
+                "expected {indexer} / {prover} to be rejected"
+            );
+        }
+
+        assert!(ZolanaClient::from_urls(
+            (),
+            "https://indexer.example.com",
+            "https://prover.example.com",
+            tree
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn loopback_http_is_allowed_but_lookalikes_are_not() {
+        // `127.` prefix matching has to mean the loopback block, not any host
+        // whose name merely starts with it.
+        let tree = Address::new_from_array([42u8; 32]);
+        for url in [
+            "http://127.0.0.1:8784",
+            "http://127.1.2.3:8784",
+            "http://localhost:8784",
+            "http://svc.localhost:8784",
+        ] {
+            assert!(
+                ZolanaClient::from_urls((), url, url, tree).is_ok(),
+                "expected {url} to be allowed"
+            );
+        }
+        for url in [
+            "http://127.0.0.1.evil.com:8784",
+            "http://localhost.evil.com:8784",
+            "http://notlocalhost:8784",
+        ] {
+            assert!(
+                ZolanaClient::from_urls((), url, url, tree).is_err(),
+                "expected {url} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn the_insecure_escape_hatch_is_explicit() {
+        let tree = Address::new_from_array([42u8; 32]);
+        let client = ZolanaClient::from_urls_allowing_insecure_http(
+            (),
+            "http://indexer.internal:8784",
+            "http://prover.internal:3001",
+            tree,
+        );
+        assert_eq!(client.output_tree(), tree);
+    }
+
     #[tokio::test]
     async fn from_urls_is_safe_inside_an_async_runtime() {
         let tree = Address::new_from_array([42u8; 32]);
         let client =
-            ZolanaClient::from_urls((), "http://127.0.0.1:8784", "http://127.0.0.1:3001", tree);
+            ZolanaClient::from_urls((), "http://127.0.0.1:8784", "http://127.0.0.1:3001", tree)
+                .expect("loopback http is allowed");
 
         assert_eq!(client.output_tree(), tree);
         assert!(

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -140,17 +140,6 @@ impl<R> ZolanaClient<R> {
     }
 
     /// Build both async and blocking service adapters from their URLs.
-    ///
-    /// Blocking adapters are initialized on first blocking use so constructing
-    /// an async client inside a Tokio runtime never creates a nested runtime.
-    ///
-    /// Both URLs must be https, or http to loopback. The indexer's response
-    /// says which UTXOs an identity owns and the prover's request carries the
-    /// witness, so in plaintext they hand a network observer exactly what a
-    /// shielded protocol exists to hide. Where the transport is already private
-    /// -- an indexer inside your own VPC, TLS terminated elsewhere -- use
-    /// [`Self::from_urls_allowing_insecure_http`], which is named so that
-    /// choice is greppable.
     pub fn from_urls(
         rpc: R,
         indexer_url: impl AsRef<str>,

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -8,11 +8,6 @@
 use std::{sync::OnceLock, thread::sleep, time::Duration};
 
 /// Reject a service URL that would carry shielded material in plaintext.
-///
-/// Mirrors the TypeScript SDK's `checkedServiceUrl`: https anywhere, http only
-/// to loopback, where there is no network to observe. Kept deliberately simple
-/// -- scheme and host, no dependency on a URL crate -- because the rule is
-/// about which wire the bytes cross, not about parsing.
 fn check_service_url(url: &str, field: &'static str) -> Result<(), ClientError> {
     let insecure = || ClientError::InsecureServiceUrl {
         field,

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -19,6 +19,16 @@ pub enum ClientError {
     #[error("hasher error: {0}")]
     Hasher(#[from] HasherError),
 
+    /// A service URL that would carry shielded material in plaintext.
+    ///
+    /// The indexer's response says which UTXOs an identity owns and the
+    /// prover's request carries the witness, so over plain http both are
+    /// readable by anyone on the path -- that is the protocol's privacy, not a
+    /// hardening detail. Use `from_urls_allowing_insecure_http` where the
+    /// transport is already private.
+    #[error("{field} must use https (or http to loopback): {url}")]
+    InsecureServiceUrl { field: &'static str, url: String },
+
     #[error("no supported circuit shape holds {n_in} inputs and {n_out} outputs")]
     UnsupportedShape { n_in: usize, n_out: usize },
 

--- a/sdk-libs/ts/bench/loadtest.ts
+++ b/sdk-libs/ts/bench/loadtest.ts
@@ -23,6 +23,7 @@
  *     --tree <address> --keypairs <dir> --duration 420
  */
 
+import { AsyncLocalStorage } from "node:async_hooks";
 import { readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -63,10 +64,32 @@ interface Options {
 interface Timing {
   readonly syncMs: number;
   readonly proveMs: number;
+  /** Of `proveMs`, time inside HTTP requests rather than local compute. */
+  readonly proveNetworkMs: number;
   readonly sendMs: number;
   readonly confirmMs: number;
   readonly totalMs: number;
 }
+
+/**
+ * Per-transfer HTTP time, so `prove` can be split into waiting on the indexer
+ * and prover versus computing locally.
+ *
+ * Workers run concurrently, so a single accumulator would blend them; the store
+ * is bound per transfer with `AsyncLocalStorage` and every fetch the SDK makes
+ * inside that transfer lands in the right bucket.
+ */
+const networkTime = new AsyncLocalStorage<{ ms: number }>();
+
+const timedFetch: typeof globalThis.fetch = async (input, init) => {
+  const started = Date.now();
+  try {
+    return await globalThis.fetch(input, init);
+  } finally {
+    const store = networkTime.getStore();
+    if (store !== undefined) store.ms += Date.now() - started;
+  }
+};
 
 interface Actor {
   readonly signer: KeyPairSigner;
@@ -190,16 +213,20 @@ async function transferOnce(
   await syncWallet({ client, wallet: from.wallet, authority: from.authority });
   const synced = Date.now();
 
-  // Proving happens inside the build: it requests the proof from the prover
-  // service, which is what the Rust harness times as `prove`.
-  const transaction = await buildTransferTransaction({
-    client,
-    wallet: from.wallet,
-    authority: from.authority,
-    feePayer: from.signer.address,
-    recipient: to.shieldedAddress,
-    amount,
-  });
+  // Proving happens inside the build: two indexer round-trips for the input
+  // merkle and dummy non-inclusion proofs, local assembly, then the prover
+  // call. The Rust harness brackets the same work, so the phases compare.
+  const proveNetwork = { ms: 0 };
+  const transaction = await networkTime.run(proveNetwork, () =>
+    buildTransferTransaction({
+      client,
+      wallet: from.wallet,
+      authority: from.authority,
+      feePayer: from.signer.address,
+      recipient: to.shieldedAddress,
+      amount,
+    }),
+  );
   const proved = Date.now();
 
   const signed = await signTransactionWithSigners([from.signer], transaction);
@@ -215,6 +242,7 @@ async function transferOnce(
   return {
     syncMs: synced - started,
     proveMs: proved - synced,
+    proveNetworkMs: proveNetwork.ms,
     sendMs: sent - proved,
     confirmMs: confirmed - sent,
     totalMs: confirmed - started,
@@ -254,6 +282,7 @@ async function main(): Promise<void> {
     // network in the clear -- and it is spelled out here rather than defaulted,
     // so it disappears the moment the certificate is issued.
     allowInsecureHttp: true,
+    fetch: timedFetch,
   });
   const actors = await loadActors(options.keypairs);
 
@@ -340,6 +369,17 @@ async function main(): Promise<void> {
     "prove",
     timings.map((timing) => timing.proveMs),
   );
+  // Splitting prove tells a client problem from a service one: `net` is time
+  // inside the indexer and prover requests, `local` is everything this process
+  // computes around them.
+  reportPhase(
+    "  net",
+    timings.map((timing) => timing.proveNetworkMs),
+  );
+  reportPhase(
+    "  local",
+    timings.map((timing) => timing.proveMs - timing.proveNetworkMs),
+  );
   reportPhase(
     "send",
     timings.map((timing) => timing.sendMs),
@@ -382,6 +422,7 @@ async function main(): Promise<void> {
           phases: {
             sync: timings.map((timing) => timing.syncMs),
             prove: timings.map((timing) => timing.proveMs),
+            proveNetwork: timings.map((timing) => timing.proveNetworkMs),
             send: timings.map((timing) => timing.sendMs),
             confirm: timings.map((timing) => timing.confirmMs),
             total: timings.map((timing) => timing.totalMs),

--- a/sdk-libs/ts/bench/loadtest.ts
+++ b/sdk-libs/ts/bench/loadtest.ts
@@ -1,0 +1,398 @@
+/**
+ * Sustained shielded transfers through the TypeScript SDK, reporting where the
+ * time goes.
+ *
+ * The Rust `xtask loadtest` measures the Rust client. That leaves the SDK most
+ * integrators actually use unmeasured, and a slow client is indistinguishable
+ * from a saturated backend if throughput is all you look at -- both just show
+ * low tps against healthy infrastructure. Running the same shape through both
+ * clients makes the difference visible.
+ *
+ * Deliberately mirrors `xtask/src/loadtest.rs`: same wallet-file format, same
+ * ring of transfers, same four phases, same 30s progress windows. Numbers are
+ * meant to be read side by side with it, so changes here should keep that true.
+ *
+ * The shielded key derivation matches `ShieldedKeypair::from_solana_keypair`
+ * (32-byte Ed25519 secret, account 0), so wallet directories funded by
+ * `xtask fund` work unchanged.
+ *
+ * Runs against `dist/`, so it measures the SDK as published rather than as
+ * sourced; `npm run loadtest` builds first.
+ *
+ *   npm run loadtest -- --rpc <url> --indexer <url> --prover <url> \
+ *     --tree <address> --keypairs <dir> --duration 420
+ */
+
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { ed25519 } from "@noble/curves/ed25519.js";
+import {
+  address,
+  createKeyPairSignerFromBytes,
+  getSignatureFromTransaction,
+  sendTransactionWithoutConfirmingFactory,
+  signTransactionWithSigners,
+  type Address,
+  type KeyPairSigner,
+  type Signature,
+} from "@solana/kit";
+
+import {
+  LocalWalletAuthority,
+  ShieldedKeypair,
+  Wallet,
+  buildTransferTransaction,
+  createZolanaClient,
+  syncWallet,
+  type Bytes32,
+} from "../dist/index.js";
+import type { ZolanaClient } from "../dist/client/client.js";
+
+interface Options {
+  readonly rpcUrl: string;
+  readonly indexerUrl: string;
+  readonly proverUrl: string;
+  readonly tree: Address;
+  readonly keypairs: string;
+  readonly durationSecs: number;
+  readonly amount: bigint;
+  readonly json: string | undefined;
+}
+
+interface Timing {
+  readonly syncMs: number;
+  readonly proveMs: number;
+  readonly sendMs: number;
+  readonly confirmMs: number;
+  readonly totalMs: number;
+}
+
+interface Actor {
+  readonly signer: KeyPairSigner;
+  readonly wallet: Wallet;
+  readonly authority: LocalWalletAuthority;
+  readonly shieldedAddress: ReturnType<ShieldedKeypair["shieldedAddress"]>;
+}
+
+const PROGRESS_INTERVAL_MS = 30_000;
+
+function usage(message: string): never {
+  console.error(`loadtest: ${message}
+
+usage: npm run loadtest -- --rpc <url> --indexer <url> --prover <url>
+                          --tree <address> --keypairs <dir>
+                          [--duration 300] [--amount 200000] [--json out.json]
+
+Worker count is the number of .json keypair files in --keypairs.`);
+  process.exit(2);
+}
+
+function parseOptions(argv: readonly string[]): Options {
+  const values = new Map<string, string>();
+  for (let i = 0; i < argv.length; i += 2) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === undefined || !flag.startsWith("--")) usage(`unexpected argument ${flag}`);
+    if (value === undefined) usage(`${flag} needs a value`);
+    values.set(flag.slice(2), value);
+  }
+  const required = (name: string): string => values.get(name) ?? usage(`--${name} is required`);
+
+  return {
+    rpcUrl: required("rpc"),
+    indexerUrl: required("indexer"),
+    proverUrl: required("prover"),
+    tree: address(required("tree")),
+    keypairs: required("keypairs"),
+    durationSecs: Number(values.get("duration") ?? 300),
+    amount: BigInt(values.get("amount") ?? 200_000),
+    json: values.get("json"),
+  };
+}
+
+/**
+ * Solana CLI keypair files: a JSON array of 64 bytes, secret then public. The
+ * first 32 are the seed both the signer and the shielded keypair derive from.
+ */
+async function loadActors(dir: string): Promise<Actor[]> {
+  const files = (await readdir(dir)).filter((name) => name.endsWith(".json")).sort();
+  if (files.length < 2) usage(`--keypairs ${dir} needs at least two keypair files`);
+
+  const actors: Actor[] = [];
+  for (const file of files) {
+    const raw = JSON.parse(await readFile(join(dir, file), "utf8")) as unknown;
+    if (!Array.isArray(raw) || raw.length !== 64) {
+      usage(`${file} is not a 64-byte Solana keypair array`);
+    }
+    const bytes = Uint8Array.from(raw as number[]);
+    const seed = bytes.slice(0, 32) as Bytes32;
+    const signer = await createKeyPairSignerFromBytes(
+      Uint8Array.of(...seed, ...ed25519.getPublicKey(seed)),
+    );
+    const keypair = ShieldedKeypair.fromEd25519(seed, 0);
+    actors.push({
+      signer,
+      wallet: new Wallet({ identity: keypair.shieldedAddress() }),
+      authority: new LocalWalletAuthority({ solanaPublicKey: signer.address, keypair }),
+      shieldedAddress: keypair.shieldedAddress(),
+    });
+  }
+  return actors;
+}
+
+/**
+ * Group failures by their SDK error code rather than message text. Messages
+ * carry addresses and request ids that would make every occurrence unique;
+ * `code`/`causeCode` are the SDK's own taxonomy and stay stable.
+ */
+function errorKey(error: unknown): string {
+  if (typeof error === "object" && error !== null) {
+    const { code, causeCode } = error as { code?: unknown; causeCode?: unknown };
+    if (typeof code === "string") {
+      return typeof causeCode === "string" ? `${code} / ${causeCode}` : code;
+    }
+  }
+  return error instanceof Error ? error.message.slice(0, 120) : String(error).slice(0, 120);
+}
+
+function percentile(sorted: readonly number[], fraction: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(sorted.length - 1, Math.floor(sorted.length * fraction));
+  return sorted[index] ?? 0;
+}
+
+function reportPhase(label: string, values: readonly number[]): void {
+  if (values.length === 0) {
+    console.log(`  ${label.padEnd(10)} no samples`);
+    return;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mean = sorted.reduce((sum, value) => sum + value, 0) / sorted.length;
+  const cell = (value: number) => `${Math.round(value)}ms`.padStart(9);
+  console.log(
+    `  ${label.padEnd(10)} p50${cell(percentile(sorted, 0.5))}  p95${cell(
+      percentile(sorted, 0.95),
+    )}  p99${cell(percentile(sorted, 0.99))}  max${cell(sorted[sorted.length - 1] ?? 0)}  mean${cell(
+      mean,
+    )}`,
+  );
+}
+
+async function transferOnce(
+  client: ZolanaClient,
+  from: Actor,
+  to: Actor,
+  amount: bigint,
+): Promise<Timing> {
+  const started = Date.now();
+
+  await syncWallet({ client, wallet: from.wallet, authority: from.authority });
+  const synced = Date.now();
+
+  // Proving happens inside the build: it requests the proof from the prover
+  // service, which is what the Rust harness times as `prove`.
+  const transaction = await buildTransferTransaction({
+    client,
+    wallet: from.wallet,
+    authority: from.authority,
+    feePayer: from.signer.address,
+    recipient: to.shieldedAddress,
+    amount,
+  });
+  const proved = Date.now();
+
+  const signed = await signTransactionWithSigners([from.signer], transaction);
+  const signature = getSignatureFromTransaction(signed);
+  await sendTransactionWithoutConfirmingFactory({ rpc: client.solanaRpc })(signed, {
+    commitment: client.commitment,
+  });
+  const sent = Date.now();
+
+  await confirm(client, signature);
+  const confirmed = Date.now();
+
+  return {
+    syncMs: synced - started,
+    proveMs: proved - synced,
+    sendMs: sent - proved,
+    confirmMs: confirmed - sent,
+    totalMs: confirmed - started,
+  };
+}
+
+async function confirm(client: ZolanaClient, signature: Signature): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const { value } = await client.solanaRpc
+      .getSignatureStatuses([signature], { searchTransactionHistory: true })
+      .send({ abortSignal: AbortSignal.timeout(5_000) });
+    const status = value[0];
+    if (status?.err !== null && status?.err !== undefined) {
+      throw new Error(`transaction failed: ${JSON.stringify(status.err)}`);
+    }
+    if (status?.confirmationStatus === "confirmed" || status?.confirmationStatus === "finalized") {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`transaction ${signature} not confirmed within 30s`);
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  // Before the wallets: deriving a shielded address hashes, and the Poseidon
+  // WASM module is loaded by `createZolanaClient`.
+  const client = await createZolanaClient({
+    solanaRpcUrl: options.rpcUrl,
+    indexerUrl: options.indexerUrl,
+    proverUrl: options.proverUrl,
+    tree: options.tree,
+    // Explicitly insecure, matching `xtask loadtest`: devnet's ALB has no
+    // certificate yet, so the indexer and prover are plain http. That is a real
+    // exposure -- the wallet's UTXO set and every proof witness cross the
+    // network in the clear -- and it is spelled out here rather than defaulted,
+    // so it disappears the moment the certificate is issued.
+    allowInsecureHttp: true,
+  });
+  const actors = await loadActors(options.keypairs);
+
+  console.log(
+    `loadtest: ${actors.length} workers, ${options.durationSecs}s, ${options.amount} lamports/transfer`,
+  );
+
+  const timings: Timing[] = [];
+  const errors = new Map<string, number>();
+  const warmupMs: number[] = [];
+  let ok = 0;
+  let failed = 0;
+
+  const startedAt = Date.now();
+  const deadline = startedAt + options.durationSecs * 1_000;
+  let nextProgress = startedAt + PROGRESS_INTERVAL_MS;
+  let lastOk = 0;
+
+  const progress = setInterval(() => {
+    const now = Date.now();
+    if (now < nextProgress) return;
+    const elapsed = (now - startedAt) / 1_000;
+    const window = (ok - lastOk) / ((now - nextProgress + PROGRESS_INTERVAL_MS) / 1_000);
+    console.log(
+      `  [${String(Math.round(elapsed)).padStart(5)}s] ${ok} ok, ${(ok / elapsed).toFixed(
+        2,
+      )} tps overall, ${window.toFixed(2)} tps last 30s`,
+    );
+    lastOk = ok;
+    nextProgress = now + PROGRESS_INTERVAL_MS;
+  }, 1_000);
+
+  // One loop per wallet, each sending to the next in a ring, so every transfer
+  // spends an input and produces a nullifier.
+  await Promise.all(
+    actors.map(async (from, index) => {
+      const to = actors[(index + 1) % actors.length];
+      if (to === undefined) return;
+
+      let first = true;
+      while (Date.now() < deadline) {
+        try {
+          const timing = await transferOnce(client, from, to, options.amount);
+          if (first) {
+            warmupMs.push(timing.syncMs);
+            first = false;
+          }
+          timings.push(timing);
+          ok += 1;
+        } catch (error) {
+          if (first) first = false;
+          const key = errorKey(error);
+          errors.set(key, (errors.get(key) ?? 0) + 1);
+          failed += 1;
+        }
+      }
+    }),
+  );
+
+  clearInterval(progress);
+
+  const elapsed = (Date.now() - startedAt) / 1_000;
+  console.log(`\n${"─".repeat(61)}`);
+  console.log(`ok ${ok}  failed ${failed}  in ${Math.round(elapsed)}s`);
+  console.log(
+    `throughput ${(ok / elapsed).toFixed(2)} transfers/sec (${((ok / elapsed) * 60).toFixed(
+      1,
+    )}/min)`,
+  );
+
+  if (errors.size > 0) {
+    console.log("\nerrors:");
+    for (const [key, count] of [...errors].sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${String(count).padStart(6)}x  ${key}`);
+    }
+  }
+
+  console.log("\nphase latency:");
+  reportPhase(
+    "sync",
+    timings.map((timing) => timing.syncMs),
+  );
+  reportPhase(
+    "prove",
+    timings.map((timing) => timing.proveMs),
+  );
+  reportPhase(
+    "send",
+    timings.map((timing) => timing.sendMs),
+  );
+  reportPhase(
+    "confirm",
+    timings.map((timing) => timing.confirmMs),
+  );
+  reportPhase(
+    "total",
+    timings.map((timing) => timing.totalMs),
+  );
+
+  if (warmupMs.length > 0) {
+    const mean = warmupMs.reduce((sum, value) => sum + value, 0) / warmupMs.length;
+    console.log(`\nwallet depth:`);
+    console.log(
+      `  first sync   mean ${Math.round(mean).toString().padStart(8)}ms   across ${
+        warmupMs.length
+      } wallets`,
+    );
+    console.log(
+      "  Sync cost scales with a wallet's history, and every run leaves more\n" +
+        "  behind on these wallets. Compare runs only at similar first-sync cost.",
+    );
+  }
+
+  if (options.json !== undefined) {
+    await writeFile(
+      options.json,
+      `${JSON.stringify(
+        {
+          client: "typescript",
+          workers: actors.length,
+          durationSecs: Math.round(elapsed),
+          ok,
+          failed,
+          tps: Number((ok / elapsed).toFixed(3)),
+          errors: Object.fromEntries(errors),
+          phases: {
+            sync: timings.map((timing) => timing.syncMs),
+            prove: timings.map((timing) => timing.proveMs),
+            send: timings.map((timing) => timing.sendMs),
+            confirm: timings.map((timing) => timing.confirmMs),
+            total: timings.map((timing) => timing.totalMs),
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    console.log(`\nwrote ${options.json}`);
+  }
+}
+
+await main();

--- a/sdk-libs/ts/package.json
+++ b/sdk-libs/ts/package.json
@@ -55,7 +55,8 @@
     "lint": "oxlint --deny-warnings src test api/test transaction/test wallet/test scripts",
     "test": "vitest run --exclude \"test/e2e/**\"",
     "test:e2e": "vitest run test/e2e",
-    "check": "npm run format:check && npm run lint && npm run typecheck && npm run test && npm run build"
+    "check": "npm run format:check && npm run lint && npm run typecheck && npm run test && npm run build",
+    "loadtest": "npm run build && node bench/loadtest.ts"
   },
   "dependencies": {
     "@lightprotocol/hasher.rs": "^0.2.1",

--- a/sdk-libs/ts/src/client/client.ts
+++ b/sdk-libs/ts/src/client/client.ts
@@ -89,6 +89,15 @@ export interface ZolanaClientConfig {
   readonly indexerConfig?: IndexerRpcConfig;
   readonly proverAsyncPoll?: AsyncPollConfig;
   readonly fetch?: typeof globalThis.fetch;
+  /**
+   * Permit plain http to non-loopback indexer and prover URLs.
+   *
+   * Off by default: in plaintext the indexer response reveals which UTXOs an
+   * identity owns and the prover request carries the witness, so the transport
+   * carries the protocol's privacy. Set this only where the network is already
+   * private, and never for a public endpoint.
+   */
+  readonly allowInsecureHttp?: boolean;
 }
 
 /** @internal */
@@ -142,8 +151,13 @@ export class ZolanaClient {
         ? {}
         : { solanaRpcSubscriptionsUrl: endpoints.solanaRpcSubscriptions }),
     });
-    const indexerUrl = checkedServiceUrl(endpoints.photon, endpoints.photonField);
-    const proverUrl = checkedServiceUrl(endpoints.prover, endpoints.proverField);
+    const allowInsecureHttp = input.allowInsecureHttp ?? false;
+    const indexerUrl = checkedServiceUrl(
+      endpoints.photon,
+      endpoints.photonField,
+      allowInsecureHttp,
+    );
+    const proverUrl = checkedServiceUrl(endpoints.prover, endpoints.proverField, allowInsecureHttp);
     let indexer: ZolanaIndexer;
     try {
       indexer = new ZolanaIndexer(
@@ -163,6 +177,7 @@ export class ZolanaClient {
     try {
       prover = new ProverClient({
         url: proverUrl,
+        allowInsecureHttp,
         ...(input.proverAsyncPoll === undefined ? {} : { asyncPoll: input.proverAsyncPoll }),
         ...(input.fetch === undefined ? {} : { fetch: input.fetch }),
       });

--- a/sdk-libs/ts/src/client/internal.ts
+++ b/sdk-libs/ts/src/client/internal.ts
@@ -32,7 +32,27 @@ const base58Encoder = getBase58Encoder();
 const base64Decoder = getBase64Decoder();
 const base64Encoder = getBase64Encoder();
 
-export function checkedServiceUrl(value: string | URL, field: string): URL {
+/**
+ * Service URLs must be https, or http to loopback.
+ *
+ * This is stricter than a general "prefer TLS" default because of what these
+ * two endpoints carry. The indexer's response says which UTXOs an identity
+ * owns, and the prover's request carries the witness. In plaintext both are
+ * readable by anyone on the path, which is the whole privacy property of a
+ * shielded protocol, not a hardening nicety. A tamperer can also feed altered
+ * merkle proofs or root indices and steer the client into proving against
+ * state it did not choose.
+ *
+ * `allowInsecureHttp` exists for deployments where the transport is already
+ * private -- an indexer inside your own VPC, a service mesh terminating TLS
+ * elsewhere. It is opt-in so that choice is deliberate and greppable rather
+ * than the silent default.
+ */
+export function checkedServiceUrl(
+  value: string | URL,
+  field: string,
+  allowInsecureHttp = false,
+): URL {
   let url: URL;
   try {
     url = new URL(value instanceof URL ? value.href : value);
@@ -45,8 +65,9 @@ export function checkedServiceUrl(value: string | URL, field: string): URL {
     hostname.endsWith(".localhost") ||
     hostname === "[::1]" ||
     /^127(?:\.\d{1,3}){3}$/u.test(hostname);
+  const httpAllowed = isLoopback || allowInsecureHttp;
   if (
-    (url.protocol !== "https:" && (url.protocol !== "http:" || !isLoopback)) ||
+    (url.protocol !== "https:" && (url.protocol !== "http:" || !httpAllowed)) ||
     url.username !== "" ||
     url.password !== "" ||
     url.hash !== ""

--- a/sdk-libs/ts/src/client/prover/client.ts
+++ b/sdk-libs/ts/src/client/prover/client.ts
@@ -26,20 +26,34 @@ const RETRY_DELAY_MS = 2_000n;
 /// Generous enough for a cold prove that first loads a 63MB proving key, so a
 /// clean server-side timeout still returns before it.
 const REQUEST_TIMEOUT_MS = 600_000;
-/// Floor on the status-poll interval so a misconfigured client cannot spin.
-const MIN_POLL_INTERVAL_MS = 1_000;
+/**
+ * First gap between status polls, doubling up to `pollIntervalCapMs`.
+ *
+ * Matches the Rust client's `INITIAL_POLL_MS`. A flat interval pays its full
+ * length on every proof: at 3s, a proof that finished in 1.3s still waited for
+ * the next tick, which was most of the TypeScript SDK's per-transfer latency and
+ * looked like slow local compute because sleeping burns no CPU and issues no
+ * request. Starting small and backing off keeps the common case tight without
+ * hammering the prover while a genuinely long proof runs.
+ */
+const INITIAL_POLL_INTERVAL_MS = 25;
 const PROVE_PATH = "/prove";
 
 /// Polling cadence and ceiling for queued (async) proofs. A Redis-backed prover
 /// returns a job handle instead of a proof, and the client polls
 /// `/prove/status` until it completes.
 export interface AsyncPollConfig {
-  readonly pollIntervalMs: number;
+  /**
+   * Ceiling for the gap between status polls. Polling starts at 25ms and
+   * doubles up to this, so a fast proof is noticed quickly and a slow one does
+   * not generate a request per 25ms for its whole duration.
+   */
+  readonly pollIntervalCapMs: number;
   readonly maxWaitMs: number;
 }
 
 const DEFAULT_ASYNC_POLL_CONFIG: AsyncPollConfig = Object.freeze({
-  pollIntervalMs: 3_000,
+  pollIntervalCapMs: 1_000,
   maxWaitMs: 1_200_000,
 });
 
@@ -151,7 +165,8 @@ export class ProverClient {
     const url = new URL(this.#url);
     url.pathname = url.pathname.replace(/\/prove$/u, "/prove/status");
     url.searchParams.set("job_id", jobId);
-    const interval = Math.max(MIN_POLL_INTERVAL_MS, this.#asyncPoll.pollIntervalMs);
+    const intervalCap = Math.max(INITIAL_POLL_INTERVAL_MS, this.#asyncPoll.pollIntervalCapMs);
+    let interval = INITIAL_POLL_INTERVAL_MS;
     const maxWaitMs = this.#asyncPoll.maxWaitMs;
     const deadline = Date.now() + maxWaitMs;
     const remainingMs = (): number => Math.max(0, deadline - Date.now());
@@ -165,6 +180,7 @@ export class ProverClient {
       if (remaining === 0) timeout();
       const sleepMs = Math.min(interval, remaining);
       await sleep(BigInt(sleepMs), { signal: signal.signal });
+      interval = Math.min(interval * 2, intervalCap);
     };
     for (;;) {
       // The Rust status GET inherits the shared client's request timeout, so a
@@ -367,11 +383,11 @@ function isObject(value: unknown): value is Record<string, unknown> {
 
 function asyncPollConfig(input: AsyncPollConfig | undefined): AsyncPollConfig {
   if (input === undefined) return DEFAULT_ASYNC_POLL_CONFIG;
-  for (const field of ["pollIntervalMs", "maxWaitMs"] as const) {
+  for (const field of ["pollIntervalCapMs", "maxWaitMs"] as const) {
     const value = input[field];
     if (!Number.isSafeInteger(value) || value <= 0) {
       throw new ClientError("CLIENT_INVALID_POLL_CONFIG", { details: { field } });
     }
   }
-  return Object.freeze({ pollIntervalMs: input.pollIntervalMs, maxWaitMs: input.maxWaitMs });
+  return Object.freeze({ pollIntervalCapMs: input.pollIntervalCapMs, maxWaitMs: input.maxWaitMs });
 }

--- a/sdk-libs/ts/src/client/prover/client.ts
+++ b/sdk-libs/ts/src/client/prover/client.ts
@@ -53,13 +53,15 @@ export class ProverClient {
       url: URL | string;
       fetch?: typeof globalThis.fetch;
       asyncPoll?: AsyncPollConfig;
+      /** See `ZolanaClientConfig.allowInsecureHttp`. */
+      allowInsecureHttp?: boolean;
     }>,
   ) {
     const candidate: unknown = input;
     if (typeof candidate !== "object" || candidate === null) {
       throw new ClientError("CLIENT_INVALID_CONFIG");
     }
-    const url = checkedServiceUrl(input.url, "url");
+    const url = checkedServiceUrl(input.url, "url", input.allowInsecureHttp ?? false);
     url.pathname = `${url.pathname.replace(/\/+$/u, "")}${PROVE_PATH}`;
     const fetchImplementation = input.fetch ?? globalThis.fetch;
     if (typeof fetchImplementation !== "function") {

--- a/sdk-libs/ts/src/transaction/wallet/state.ts
+++ b/sdk-libs/ts/src/transaction/wallet/state.ts
@@ -156,6 +156,33 @@ export class Wallet {
   #transactions: PrivateTransaction[] = [];
   #nullifiers = new Set<string>();
   #lastSynced = 0n;
+  /**
+   * Per-view-tag sync watermarks: for each tag, the indexer cursor up to which
+   * every matching transaction has already been seen. Mirrors Rust's
+   * `Wallet::sync_cursors`.
+   *
+   * Per tag rather than one shared position, because the tag set GROWS. Tags
+   * come from a local counter plus a window, and a second device spending
+   * beyond that window makes the counter lag by more than the window absorbs.
+   * A tag learned late must be scanned from the beginning even though other
+   * tags have advanced far past those slots, so a single cursor would skip
+   * those transactions permanently.
+   *
+   * In memory only. A client persisting wallet state across restarts should
+   * persist these too -- without them sync stays correct but pays for the full
+   * history every time.
+   */
+  #syncCursors = new Map<string, Uint8Array>();
+  /**
+   * The same watermarks for the encrypted-utxo stream that proofless deposits
+   * are read from. Mirrors Rust's `Wallet::proofless_cursors`.
+   *
+   * Separate from `#syncCursors` because they are positions in different
+   * streams: reaching the tip of the transaction stream says nothing about
+   * where the encrypted-utxo stream has been read to, and sharing one cursor
+   * would skip rows in whichever stream is behind.
+   */
+  #prooflessCursors = new Map<string, Uint8Array>();
 
   constructor(input: Readonly<{ identity: ShieldedAddress; registry?: AssetRegistry }>) {
     this.identity = input.identity;
@@ -174,6 +201,26 @@ export class Wallet {
   /** Timestamp the last completed sync was told to record, zero before the first. */
   get lastSynced(): bigint {
     return this.#lastSynced;
+  }
+
+  /**
+   * Cursor this tag's stream has been read to, or `undefined` for a tag never
+   * scanned -- which must start from the beginning, not from another tag's
+   * position.
+   *
+   * @internal
+   */
+  _syncCursor(stream: "transactions" | "proofless", tag: string): Uint8Array | undefined {
+    return this.#cursorsFor(stream).get(tag);
+  }
+
+  /** @internal */
+  _setSyncCursor(stream: "transactions" | "proofless", tag: string, cursor: Uint8Array): void {
+    this.#cursorsFor(stream).set(tag, Uint8Array.from(cursor));
+  }
+
+  #cursorsFor(stream: "transactions" | "proofless"): Map<string, Uint8Array> {
+    return stream === "transactions" ? this.#syncCursors : this.#prooflessCursors;
   }
 
   registerAsset(assetId: bigint, mint: Address): void {

--- a/sdk-libs/ts/src/wallet/sync.ts
+++ b/sdk-libs/ts/src/wallet/sync.ts
@@ -279,13 +279,16 @@ interface CollectByTagsInput {
   readonly pageLimit: number;
   readonly nextRpcConfig: () => IndexerRpcConfig;
   readonly out: Map<string, IndexedShieldedTransaction>;
+  /** Where this group of tags was read to last sync, or undefined for never. */
+  readonly from: Uint8Array | undefined;
 }
 
 async function collectShieldedTransactions(
   input: CollectByTagsInput,
   context?: RequestContext,
-): Promise<void> {
-  let cursor: Uint8Array | undefined;
+): Promise<Uint8Array | undefined> {
+  let cursor: Uint8Array | undefined = input.from;
+  let furthest: Uint8Array | undefined = input.from;
   const seenCursors = new Set<string>();
   do {
     const response = await input.indexer.getShieldedTransactionsByTags(
@@ -302,14 +305,19 @@ async function collectShieldedTransactions(
       if (!input.out.has(key)) input.out.set(key, transaction);
     }
     cursor = checkedNextCursor("getShieldedTransactionsByTags", response.nextCursor, seenCursors);
+    // Kept even on the last page: the resume point for the next sync is a
+    // different question from whether another page exists now.
+    if (cursor !== undefined) furthest = cursor;
   } while (cursor !== undefined);
+  return furthest;
 }
 
 async function collectProoflessDeposits(
   input: CollectByTagsInput,
   context?: RequestContext,
-): Promise<void> {
-  let cursor: Uint8Array | undefined;
+): Promise<Uint8Array | undefined> {
+  let cursor: Uint8Array | undefined = input.from;
+  let furthest: Uint8Array | undefined = input.from;
   const seenCursors = new Set<string>();
   do {
     const response = await input.indexer.getEncryptedUtxosByTags(
@@ -340,7 +348,9 @@ async function collectProoflessDeposits(
       );
     }
     cursor = checkedNextCursor("getEncryptedUtxosByTags", response.nextCursor, seenCursors);
+    if (cursor !== undefined) furthest = cursor;
   } while (cursor !== undefined);
+  return furthest;
 }
 
 interface CollectByNullifiersInput {
@@ -412,16 +422,42 @@ export async function syncWallet(
     const transactions = new Map<string, IndexedShieldedTransaction>();
     const deposits = new Map<string, IndexedShieldedTransaction>();
     const tags = walletQueryTags(input.wallet, material);
-    for (let offset = 0; offset < tags.length; offset += chunkSize) {
-      const chunk = tags.slice(offset, offset + chunkSize);
-      await collectShieldedTransactions(
-        { indexer: input.client, chunk, pageLimit, nextRpcConfig, out: transactions },
-        context,
-      );
-      await collectProoflessDeposits(
-        { indexer: input.client, chunk, pageLimit, nextRpcConfig, out: deposits },
-        context,
-      );
+    // Tags are grouped by where each was last read to, because a chunk can only
+    // carry one cursor. Mixing a tag at the tip with one learned this sync would
+    // resume the new tag from the old one's position and skip its history
+    // permanently -- which is why the watermarks are per tag, not per wallet.
+    // `undefined` (never queried) is its own group.
+    for (const stream of ["transactions", "proofless"] as const) {
+      const groups = new Map<string, { from: Uint8Array | undefined; tags: Bytes32[] }>();
+      for (const tag of tags) {
+        const from = input.wallet._syncCursor(stream, bytesKey(tag));
+        const key = from === undefined ? "" : bytesKey(from);
+        const group = groups.get(key);
+        if (group === undefined) groups.set(key, { from, tags: [tag] });
+        else group.tags.push(tag);
+      }
+
+      for (const group of groups.values()) {
+        for (let offset = 0; offset < group.tags.length; offset += chunkSize) {
+          const chunk = group.tags.slice(offset, offset + chunkSize);
+          const collect =
+            stream === "transactions" ? collectShieldedTransactions : collectProoflessDeposits;
+          const furthest = await collect(
+            {
+              indexer: input.client,
+              chunk,
+              pageLimit,
+              nextRpcConfig,
+              out: stream === "transactions" ? transactions : deposits,
+              from: group.from,
+            },
+            context,
+          );
+          if (furthest !== undefined) {
+            for (const tag of chunk) input.wallet._setSyncCursor(stream, bytesKey(tag), furthest);
+          }
+        }
+      }
     }
 
     const queriedNullifiers = new Set<string>();

--- a/sdk-libs/ts/test/client.test.ts
+++ b/sdk-libs/ts/test/client.test.ts
@@ -301,6 +301,39 @@ describe("ZolanaClient", () => {
     }
   });
 
+  it("allows plaintext non-loopback URLs only when asked explicitly", () => {
+    // The escape hatch for a transport that is already private -- an indexer
+    // inside a VPC, TLS terminated elsewhere. It has to be opt-in, so running a
+    // shielded client over plaintext stays a visible decision.
+    expect(
+      () =>
+        new ZolanaClient({
+          solanaRpcUrl: RPC_URL,
+          indexerUrl: "http://indexer.internal:8784",
+          proverUrl: "http://prover.internal:3001",
+          allowInsecureHttp: true,
+        }),
+    ).not.toThrow();
+  });
+
+  it("still rejects credentials and fragments when insecure http is allowed", () => {
+    // The opt-in relaxes the scheme and nothing else: a service URL carrying
+    // credentials or a fragment is malformed either way.
+    for (const indexerUrl of [
+      "http://user:pass@indexer.internal:8784",
+      "http://indexer.internal:8784#fragment",
+    ]) {
+      expect(
+        () =>
+          new ZolanaClient({
+            solanaRpcUrl: RPC_URL,
+            indexerUrl,
+            allowInsecureHttp: true,
+          }),
+      ).toThrow();
+    }
+  });
+
   it("validates an RPC fallback against each service's HTTPS requirement", () => {
     for (const { config, field } of [
       {

--- a/sdk-libs/ts/test/prover-client.test.ts
+++ b/sdk-libs/ts/test/prover-client.test.ts
@@ -90,7 +90,7 @@ describe("queued prover polling", () => {
     const prover = new ProverClient({
       url: "http://127.0.0.1:3001",
       fetch,
-      asyncPoll: { pollIntervalMs: 1_000, maxWaitMs: 2_000 },
+      asyncPoll: { pollIntervalCapMs: 1_000, maxWaitMs: 2_000 },
     });
 
     const settled = prover.prove(INPUTS);

--- a/sdk-libs/ts/test/wallet-sync.test.ts
+++ b/sdk-libs/ts/test/wallet-sync.test.ts
@@ -61,6 +61,81 @@ describe("wallet sync", () => {
     expect(report).toMatchObject({ storedUtxos: 0, unparsedTransactions: 0 });
   });
 
+  it("resumes each tag stream from where it was read to", async () => {
+    // Without this every sync re-reads the wallet's whole history: 569 ECDH
+    // operations for a wallet holding a handful of notes, growing forever.
+    const keypair = ShieldedKeypair.generate();
+    const wallet = new Wallet({ identity: keypair.shieldedAddress() });
+    const cursor = Uint8Array.of(1, 2, 3);
+    // One page carrying a cursor, then the end. Repeating a cursor would trip
+    // the SDK's loop guard, which is a different behaviour under test.
+    let served = 0;
+    const getShieldedTransactionsByTags = vi.fn(async () => {
+      served += 1;
+      return {
+        context: { blockTime: 1_700_000_000n },
+        transactions: [],
+        ...(served === 1 ? { nextCursor: cursor } : {}),
+      };
+    });
+    const client = {
+      getShieldedTransactionsByTags,
+      getEncryptedUtxosByTags: vi.fn(async () => ({
+        context: { blockTime: 1_700_000_000n },
+        matches: [],
+      })),
+      getShieldedTransactionsByNullifiers: vi.fn(),
+    } as unknown as ZolanaClient;
+    const authority = new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair });
+
+    await syncWallet({ wallet, authority, client });
+    const calls = () =>
+      getShieldedTransactionsByTags.mock.calls as unknown as [{ cursor?: Uint8Array }][];
+    const firstCall = calls()[0]?.[0];
+    expect(firstCall?.cursor).toBeUndefined();
+
+    getShieldedTransactionsByTags.mockClear();
+    await syncWallet({ wallet, authority, client });
+    const secondCall = calls()[0]?.[0];
+    expect(secondCall?.cursor).toEqual(cursor);
+  });
+
+  it("does not resume a newly learned tag from another tag's position", async () => {
+    // The trap the per-tag watermarks exist for. Tags come from a counter plus a
+    // window, so one can be learned after others have advanced far past the
+    // slots it needs. Sharing a cursor would skip its history permanently.
+    const keypair = ShieldedKeypair.generate();
+    const wallet = new Wallet({ identity: keypair.shieldedAddress() });
+    wallet._setSyncCursor("transactions", "deadbeef", Uint8Array.of(9, 9, 9));
+
+    const getShieldedTransactionsByTags = vi.fn(async () => ({
+      context: { blockTime: 1_700_000_000n },
+      transactions: [],
+    }));
+    const client = {
+      getShieldedTransactionsByTags,
+      getEncryptedUtxosByTags: vi.fn(async () => ({
+        context: { blockTime: 1_700_000_000n },
+        matches: [],
+      })),
+      getShieldedTransactionsByNullifiers: vi.fn(),
+    } as unknown as ZolanaClient;
+
+    await syncWallet({
+      wallet,
+      authority: new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+      client,
+    });
+
+    // The wallet's real tags have no watermark, so every query starts at the
+    // beginning -- the unrelated tag's cursor must not leak into them.
+    for (const call of getShieldedTransactionsByTags.mock.calls as unknown as [
+      { cursor?: Uint8Array },
+    ][]) {
+      expect(call[0]?.cursor).toBeUndefined();
+    }
+  });
+
   it("filters registry backfill before downloading program accounts", async () => {
     const keypair = ShieldedKeypair.generate();
     const send = vi.fn(async () => []);

--- a/sdk-tests/client/rust/deposit_transfer_withdraw.rs
+++ b/sdk-tests/client/rust/deposit_transfer_withdraw.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
     } = setup()?;
 
     // Load the funded fee payer and localnet settings, then connect.
-    let client = ZolanaClient::from_urls(SolanaRpc::new(rpc_url), &indexer_url, prover_url, tree);
+    let client = ZolanaClient::from_urls(SolanaRpc::new(rpc_url), &indexer_url, prover_url, tree)?;
 
     // Mints that are registered with Solana Rings for privacy.
     let assets = AssetRegistry::default();

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -431,7 +431,12 @@ fn worker(
     let shielded = ShieldedKeypair::from_solana_keypair(funding)?;
     let mut wallet = Wallet::new(shielded.shielded_address()?, AssetRegistry::default())?;
 
-    let client = ZolanaClient::from_urls(
+    // Explicitly insecure: devnet's ALB has no certificate yet, so the indexer
+    // and prover are plain http. That is a real exposure -- the wallet's UTXO
+    // set and every proof witness cross the network in the clear -- and it is
+    // spelled out here rather than defaulted, so it disappears the moment the
+    // certificate is issued.
+    let client = ZolanaClient::from_urls_allowing_insecure_http(
         SolanaRpc::new(options.rpc_url.clone()),
         options.indexer_url.clone(),
         options.prover_url.clone(),


### PR DESCRIPTION
Two commits, found by building the TypeScript loadtest and discovering it could not talk to devnet at all.

Based on `sdk/proofless-cursor` (#207), where `xtask loadtest` lives.

The SDKs disagreed on a security property. The TypeScript SDK refuses plain `http://` to non-loopback hosts; the Rust client accepted anything. So the Rust loadtest has been talking to devnet in the clear, and no TypeScript integrator can reach devnet at all.

What these endpoints carry is the reason it matters:

- the indexer response is which UTXOs an identity owns
- the prover request carries the witness

In plaintext both are readable by anyone on the path — the privacy property the protocol exists to provide, not a hardening detail. A tamperer can also serve altered merkle proofs or root indices and steer a client into proving against state it did not choose.

`ZolanaClient::from_urls` now validates and returns a `Result`, with `from_urls_allowing_insecure_http` as the escape hatch for a transport that is already private: indexer inside a VPC, TLS terminated elsewhere. It is a named function rather than a boolean so the insecure choice is greppable. TypeScript gains the matching `allowInsecureHttp`, threaded through `ProverClient`, which re-validates independently.

Both loadtests set the opt-in explicitly, because devnet's ALB has no certificate (`acm_certificate_arn = ""`). That exposure now appears in the code that depends on it rather than being the silent default, and it goes away when the certificate is issued.

Tests cover the rule in both SDKs, including the lookalike hosts a `127.` prefix check must reject — `127.0.0.1.evil.com`, `localhost.evil.com` — and that the opt-in relaxes the scheme only, still rejecting credentials and fragments.

The second commit adds `npm run loadtest`, mirroring `xtask/src/loadtest.rs` closely enough that the numbers compare: same wallet-file format, same ring of transfers, same four phases, same 30s windows, same typed error grouping. The shielded derivation matches `ShieldedKeypair::from_solana_keypair`, so wallet directories funded by `xtask fund` work unchanged. It runs against `dist/`, measuring the package as published, and adds no dependency since Node strips the types natively.

First comparison, 8 workers, same fresh wallets, same devnet:

| phase p50 | Rust | TypeScript |
|---|---|---|
| sync | 517ms | 2,683ms |
| prove | 1,349ms | 4,811ms |
| send | 1,079ms | 566ms |
| confirm | 226ms | 1,090ms |
| total | 3,126ms | 9,258ms |
| tps | 2.56 | 0.82 |

Proving is the gap worth chasing: the same prover service serves both, so 3.5x is client-side assembly rather than the backend. Sync is inflated partly by wallet history, which grows every run, so the harness reports first-sync cost — runs are only comparable at similar depth. The prove gap is not investigated here; this PR is the instrument, not the fix.

`cargo test -p zolana-client --features client` 53 pass; TypeScript 230 pass across 15 files; typecheck, oxlint and oxfmt clean. The client crate's tests need `--features client` — without it the module is cfg'd out and `cargo test -p zolana-client` silently runs a different 25.
