### PR TITLE
ci: publish photon, the prover and the forester from one workflow

### DIFF
--- a/.github/workflows/photon-image.yml
+++ b/.github/workflows/photon-image.yml
@@ -105,6 +105,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      # Signing a provenance statement for the published image.
+      attestations: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -189,6 +191,7 @@ jobs:
           docker run --rm --entrypoint photon-snapshotter "$image" --version
           docker run --rm --entrypoint photon-snapshot-loader "$image" --version
       - name: Publish immutable tags
+        id: publish
         env:
           IMAGE_TAGS: ${{ steps.metadata.outputs.tags }}
         run: |
@@ -274,3 +277,22 @@ jobs:
             echo "Photon release tag digest $release_digest does not match commit tag $sha_digest" >&2
             exit 1
           fi
+
+          echo "digest=$release_digest" >> "$GITHUB_OUTPUT"
+          echo "image=$release_image" >> "$GITHUB_OUTPUT"
+
+      # Binds the published digest to the commit, workflow and runner that
+      # produced it, so "this image is what CI built from that source" becomes
+      # checkable rather than assumed:
+      #
+      #   gh attestation verify oci://<image> --owner helius-labs
+      #
+      # Recorded in GitHub's attestation store rather than pushed to the
+      # registry: ECR's support for OCI referrers is uneven, and a failed
+      # attestation push after a successful image push would leave a published
+      # image behind a red job.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.publish.outputs.digest }}

--- a/.github/workflows/photon-image.yml
+++ b/.github/workflows/photon-image.yml
@@ -43,7 +43,13 @@ permissions:
   contents: read
 
 env:
-  IMAGE_NAME: public.ecr.aws/f7o9l7p1/photon
+  # OUR registry. public.ecr.aws/f7o9l7p1/photon is the UPSTREAM Helius photon --
+  # different code, binaries in /app, running as root -- so publishing the fork's
+  # image there would have put two unrelated things behind one name. This
+  # workflow never actually published, so nothing was ever pushed there.
+  IMAGE_NAME: 558215002830.dkr.ecr.eu-north-1.amazonaws.com/zolana-photon
+  AWS_REGION: eu-north-1
+  ECR_REPOSITORY: zolana-photon
 
 jobs:
   validate:
@@ -116,12 +122,14 @@ jobs:
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
-          role-to-assume: ${{ vars.ECR_HELIUS_PROD_AWS_ROLE_ARN }}
+          role-to-assume: ${{ vars.AWS_IMAGE_PUBLISHER_ROLE_ARN }}
           role-session-name: zolana-photon-publish
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
+      # Private ECR, so no registry-type override. The role is trusted for this
+      # job's OIDC subject specifically -- `repo:helius-labs/zolana:environment:
+      # photon-production`, which is what declaring `environment:` above makes
+      # GitHub present instead of the ref.
       - uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
-        with:
-          registry-type: public
       - id: metadata
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
@@ -144,9 +152,9 @@ jobs:
             tag="${image##*:}"
             [[ "$tag" != sha-* ]] || continue
             set +e
-            error="$(aws ecr-public describe-images \
-              --region us-east-1 \
-              --repository-name photon \
+            error="$(aws ecr describe-images \
+              --region "$AWS_REGION" \
+              --repository-name "$ECR_REPOSITORY" \
               --image-ids "imageTag=$tag" 2>&1)"
             status=$?
             set -e
@@ -198,14 +206,16 @@ jobs:
           test -n "$sha_image"
           test -n "$release_image"
 
-          # ECR Public has no server-side tag immutability. Serialize publishers,
-          # publish the commit alias first, and use that exact remote image for
-          # the requested tag so both can be compared after publication.
+          # Our ECR repositories are created with IMMUTABLE tags, so the registry
+          # itself refuses to move a published tag -- the checks here are kept as
+          # a clearer error than a push rejection, not as the only guard.
+          # Publish the commit alias first and reuse that exact remote image for
+          # the requested tag, so both can be compared after publication.
           sha_tag="${sha_image##*:}"
           set +e
-          error="$(aws ecr-public describe-images \
-            --region us-east-1 \
-            --repository-name photon \
+          error="$(aws ecr describe-images \
+            --region "$AWS_REGION" \
+            --repository-name "$ECR_REPOSITORY" \
             --image-ids "imageTag=$sha_tag" 2>&1)"
           status=$?
           set -e
@@ -223,9 +233,9 @@ jobs:
             local tag="$1"
             local digest
             for _ in {1..10}; do
-              if digest="$(aws ecr-public describe-images \
-                --region us-east-1 \
-                --repository-name photon \
+              if digest="$(aws ecr describe-images \
+                --region "$AWS_REGION" \
+                --repository-name "$ECR_REPOSITORY" \
                 --image-ids "imageTag=$tag" \
                 --query 'imageDetails[0].imageDigest' \
                 --output text 2>/dev/null)" && [[ "$digest" != None ]]; then
@@ -242,9 +252,9 @@ jobs:
 
           release_tag="${release_image##*:}"
           set +e
-          error="$(aws ecr-public describe-images \
-            --region us-east-1 \
-            --repository-name photon \
+          error="$(aws ecr describe-images \
+            --region "$AWS_REGION" \
+            --repository-name "$ECR_REPOSITORY" \
             --image-ids "imageTag=$release_tag" 2>&1)"
           status=$?
           set -e

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,4 +1,31 @@
-name: photon-image
+# Publishes the service images to our own ECR: photon, the prover, the forester.
+#
+# These live here, not in the infra repository, because this is the repo that
+# owns the code. Building them from infra meant infra CI checked out this
+# source, so a change here could break a build there, and a protocol change
+# could not publish an image without driving the other repository.
+#
+# Two channels, because one rule could not fit both jobs:
+#
+#   release  the tag must name the commit (<service>-zolana-<sha12>) and the
+#            commit must be on main. This is photon's original rule, now
+#            available to every service.
+#   preview  any branch, any tag. Still immutable, still attested; it just does
+#            not claim to be a release.
+#
+# Preview exists because the release rule would ban what we actually do -- every
+# image running on devnet today was built from a feature branch -- and a rule
+# that bans normal work gets bypassed rather than followed. That is what
+# happened before: photon had this gate, and every photon image ever deployed
+# was built by a different pipeline that had none.
+#
+# The aggregator is NOT here. It is built from the infra repository's dashboard/
+# directory and is not a protocol service.
+#
+# Requires:
+#   vars.AWS_IMAGE_PUBLISHER_ROLE_ARN  image_publisher_role_arn from infra/bootstrap
+
+name: publish-image
 
 on:
   push:
@@ -14,7 +41,7 @@ on:
       - "rust-toolchain.toml"
       - "LICENSE"
       - "THIRD_PARTY_NOTICES"
-      - ".github/workflows/photon-image.yml"
+      - ".github/workflows/publish-image.yml"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -27,11 +54,25 @@ on:
       - "rust-toolchain.toml"
       - "LICENSE"
       - "THIRD_PARTY_NOTICES"
-      - ".github/workflows/photon-image.yml"
+      - ".github/workflows/publish-image.yml"
   workflow_dispatch:
     inputs:
+      service:
+        description: Which image to publish
+        required: true
+        default: photon
+        type: choice
+        options: [photon, prover, forester]
+      channel:
+        description: >-
+          release enforces the commit-naming tag and requires the commit to be
+          on main; preview allows a branch build under any tag
+        required: true
+        default: preview
+        type: choice
+        options: [preview, release]
       image_tag:
-        description: Immutable fork tag, photon-zolana-<12-character Zolana commit>
+        description: Tag to publish. For release, <service>-zolana-<12-char commit>
         required: true
         type: string
 
@@ -47,21 +88,24 @@ env:
   # different code, binaries in /app, running as root -- so publishing the fork's
   # image there would have put two unrelated things behind one name. This
   # workflow never actually published, so nothing was ever pushed there.
-  IMAGE_NAME: 558215002830.dkr.ecr.eu-north-1.amazonaws.com/zolana-photon
+  REGISTRY: 558215002830.dkr.ecr.eu-north-1.amazonaws.com
   AWS_REGION: eu-north-1
-  ECR_REPOSITORY: zolana-photon
 
 jobs:
   validate:
     name: container / photon
     runs-on: ubuntu-24.04
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # Photon's own image check. The prover and forester are built and tested by
+    # prover-server.yml and forester.yml, so this does not gate them.
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'workflow_dispatch' || inputs.service == 'photon')
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: Validate release source
-        if: startsWith(github.ref, 'refs/tags/photon-zolana-') || github.event_name == 'workflow_dispatch'
+        if: startsWith(github.ref, 'refs/tags/photon-zolana-')
         run: |
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
@@ -95,13 +139,15 @@ jobs:
           test "$(docker run --rm --entrypoint id zolana-photon:ci -u)" = 10001
 
   publish:
-    name: publish / photon
+    name: publish / ${{ inputs.service || 'photon' }}
     runs-on: ubuntu-24.04
     needs: validate
     if: >-
-      startsWith(github.ref, 'refs/tags/photon-zolana-') ||
-      github.event_name == 'workflow_dispatch'
-    environment: photon-production
+      always() && needs.validate.result != 'failure' && (
+        startsWith(github.ref, 'refs/tags/photon-zolana-') ||
+        github.event_name == 'workflow_dispatch'
+      )
+    environment: image-publish
     permissions:
       contents: read
       id-token: write
@@ -111,14 +157,62 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - name: Validate manual image tag
-        if: github.event_name == 'workflow_dispatch'
+      # Which service, which registry repository, and what to build. A tag push
+      # is always photon on the release channel -- that is the existing
+      # photon-zolana-* release path, unchanged.
+      - name: Resolve the build
+        id: plan
+        env:
+          SERVICE: ${{ inputs.service || 'photon' }}
+          CHANNEL: ${{ (github.event_name == 'push' && 'release') || inputs.channel }}
+        run: |
+          case "$SERVICE" in
+            photon)
+              echo "repository=zolana-photon" >> "$GITHUB_OUTPUT"
+              echo "context=." >> "$GITHUB_OUTPUT"
+              echo "file=services/photon/Dockerfile" >> "$GITHUB_OUTPUT"
+              ;;
+            prover)
+              # The keyless image. prover/server/Dockerfile bakes 1.4-3.9 GB of
+              # proving keys that are fetched and verified at runtime anyway.
+              echo "repository=zolana-prover" >> "$GITHUB_OUTPUT"
+              echo "context=prover/server" >> "$GITHUB_OUTPUT"
+              echo "file=prover/server/Dockerfile.light" >> "$GITHUB_OUTPUT"
+              ;;
+            forester)
+              # Repository root as context: the crate depends on workspace
+              # crates, so building from forester/ cannot work.
+              echo "repository=zolana-forester" >> "$GITHUB_OUTPUT"
+              echo "context=." >> "$GITHUB_OUTPUT"
+              echo "file=forester/Dockerfile" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::unknown service $SERVICE"; exit 1 ;;
+          esac
+          echo "service=$SERVICE" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+
+      # Release is the strict channel: the tag must name the commit, and the
+      # commit must be on main. Preview exists because that rule would ban what
+      # we actually do -- every image running on devnet today was built from a
+      # feature branch -- and an unenforceable rule gets bypassed rather than
+      # followed. A preview build is still attested and still immutable; it just
+      # does not claim to be a release.
+      - name: Validate the release
+        if: steps.plan.outputs.channel == 'release' && github.event_name == 'workflow_dispatch'
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
+          SERVICE: ${{ steps.plan.outputs.service }}
         run: |
-          expected_tag="photon-zolana-${GITHUB_SHA:0:12}"
+          expected_tag="${SERVICE}-zolana-${GITHUB_SHA:0:12}"
           if [[ "$IMAGE_TAG" != "$expected_tag" ]]; then
-            echo "Fork image tag $IMAGE_TAG must identify Zolana commit ${GITHUB_SHA:0:12}" >&2
+            echo "::error::release tag $IMAGE_TAG must be $expected_tag" >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::a release must be built from a commit on main" >&2
             exit 1
           fi
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -135,7 +229,7 @@ jobs:
       - id: metadata
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.plan.outputs.repository }}
           flavor: latest=false
           tags: |
             type=match,pattern=(photon-zolana-.*),group=1,enable=${{ startsWith(github.ref, 'refs/tags/photon-zolana-') }}
@@ -148,6 +242,7 @@ jobs:
       - name: Refuse to overwrite published tags
         env:
           IMAGE_TAGS: ${{ steps.metadata.outputs.tags }}
+          ECR_REPOSITORY: ${{ steps.plan.outputs.repository }}
         run: |
           while IFS= read -r image; do
             [[ -n "$image" ]] || continue
@@ -171,8 +266,8 @@ jobs:
           done <<< "$IMAGE_TAGS"
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          context: .
-          file: services/photon/Dockerfile
+          context: ${{ steps.plan.outputs.context }}
+          file: ${{ steps.plan.outputs.file }}
           platforms: linux/amd64
           load: true
           push: false
@@ -180,20 +275,37 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           cache-from: type=gha,scope=photon-image-production
           cache-to: type=gha,mode=max,scope=photon-image-production
+      # Proves the image runs before anything is pushed. The binaries differ per
+      # service, so the check does too -- a shared "it built" would assert
+      # nothing about whether the thing inside starts.
       - name: Smoke-test release image
         env:
           IMAGE_TAGS: ${{ steps.metadata.outputs.tags }}
+          SERVICE: ${{ steps.plan.outputs.service }}
         run: |
           image="$(printf '%s\n' "$IMAGE_TAGS" | awk -F: '$NF !~ /^sha-/ { print; exit }')"
           test -n "$image"
-          docker run --rm --entrypoint photon "$image" --version
-          docker run --rm --entrypoint photon-migration "$image" --version
-          docker run --rm --entrypoint photon-snapshotter "$image" --version
-          docker run --rm --entrypoint photon-snapshot-loader "$image" --version
+          case "$SERVICE" in
+            photon)
+              docker run --rm --entrypoint photon "$image" --version
+              docker run --rm --entrypoint photon-migration "$image" --version
+              docker run --rm --entrypoint photon-snapshotter "$image" --version
+              docker run --rm --entrypoint photon-snapshot-loader "$image" --version
+              ;;
+            prover)
+              # Distroless and no shell, so the entrypoint is the only thing to
+              # ask. --help exits 0 without needing keys or a network.
+              docker run --rm "$image" --help >/dev/null
+              ;;
+            forester)
+              docker run --rm "$image" --version
+              ;;
+          esac
       - name: Publish immutable tags
         id: publish
         env:
           IMAGE_TAGS: ${{ steps.metadata.outputs.tags }}
+          ECR_REPOSITORY: ${{ steps.plan.outputs.repository }}
         run: |
           sha_image=""
           release_image=""
@@ -294,5 +406,5 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
-          subject-name: ${{ env.IMAGE_NAME }}
+          subject-name: ${{ env.REGISTRY }}/${{ steps.plan.outputs.repository }}
           subject-digest: ${{ steps.publish.outputs.digest }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -76,8 +76,13 @@ on:
         required: true
         type: string
 
+# Publishing is serialized per service, not globally: GitHub holds at most one
+# pending run per group, so a single 'production' group meant dispatching the
+# prover and then the forester during a photon publish quietly cancelled one of
+# them. Three services can publish at once because ECR tags are immutable -- the
+# registry, not this group, is what prevents two runs claiming one tag.
 concurrency:
-  group: ${{ github.workflow }}-${{ (startsWith(github.ref, 'refs/tags/photon-zolana-') || github.event_name == 'workflow_dispatch') && 'production' || github.ref }}
+  group: ${{ github.workflow }}-${{ (startsWith(github.ref, 'refs/tags/photon-zolana-') || github.event_name == 'workflow_dispatch') && format('production-{0}', inputs.service || 'photon') || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
@@ -142,8 +147,13 @@ jobs:
     name: publish / ${{ inputs.service || 'photon' }}
     runs-on: ubuntu-24.04
     needs: validate
+    # The positive form matters: `!= 'failure'` is also true when validate was
+    # cancelled, which would let a tag push publish an image whose smoke test
+    # never finished. 'skipped' is the prover/forester dispatch path, where
+    # validate does not apply.
     if: >-
-      always() && needs.validate.result != 'failure' && (
+      always() &&
+      (needs.validate.result == 'success' || needs.validate.result == 'skipped') && (
         startsWith(github.ref, 'refs/tags/photon-zolana-') ||
         github.event_name == 'workflow_dispatch'
       )
@@ -171,6 +181,8 @@ jobs:
               echo "repository=zolana-photon" >> "$GITHUB_OUTPUT"
               echo "context=." >> "$GITHUB_OUTPUT"
               echo "file=services/photon/Dockerfile" >> "$GITHUB_OUTPUT"
+              echo "title=Zolana Photon" >> "$GITHUB_OUTPUT"
+              echo "description=Zolana shielded-pool indexer" >> "$GITHUB_OUTPUT"
               ;;
             prover)
               # The keyless image. prover/server/Dockerfile bakes 1.4-3.9 GB of
@@ -178,6 +190,8 @@ jobs:
               echo "repository=zolana-prover" >> "$GITHUB_OUTPUT"
               echo "context=prover/server" >> "$GITHUB_OUTPUT"
               echo "file=prover/server/Dockerfile.light" >> "$GITHUB_OUTPUT"
+              echo "title=Zolana Prover" >> "$GITHUB_OUTPUT"
+              echo "description=Zolana Groth16 proving server" >> "$GITHUB_OUTPUT"
               ;;
             forester)
               # Repository root as context: the crate depends on workspace
@@ -185,6 +199,8 @@ jobs:
               echo "repository=zolana-forester" >> "$GITHUB_OUTPUT"
               echo "context=." >> "$GITHUB_OUTPUT"
               echo "file=forester/Dockerfile" >> "$GITHUB_OUTPUT"
+              echo "title=Zolana Forester" >> "$GITHUB_OUTPUT"
+              echo "description=Zolana queue and tree maintenance service" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "::error::unknown service $SERVICE"; exit 1 ;;
@@ -198,12 +214,26 @@ jobs:
       # feature branch -- and an unenforceable rule gets bypassed rather than
       # followed. A preview build is still attested and still immutable; it just
       # does not claim to be a release.
-      - name: Validate the release
-        if: steps.plan.outputs.channel == 'release' && github.event_name == 'workflow_dispatch'
+      #
+      # Both channels are checked here, because the `-zolana-` shape is what
+      # tells a reader (and infra's image pins) that a tag carries the release
+      # guarantees. Enforcing it on release alone would leave preview free to
+      # mint a name it has not earned.
+      - name: Validate the tag
+        if: github.event_name == 'workflow_dispatch'
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
           SERVICE: ${{ steps.plan.outputs.service }}
+          CHANNEL: ${{ steps.plan.outputs.channel }}
         run: |
+          if [[ "$CHANNEL" != release ]]; then
+            if [[ "$IMAGE_TAG" == *-zolana-* ]]; then
+              echo "::error::preview tag $IMAGE_TAG must not use the release naming scheme" >&2
+              exit 1
+            fi
+            exit 0
+          fi
+
           expected_tag="${SERVICE}-zolana-${GITHUB_SHA:0:12}"
           if [[ "$IMAGE_TAG" != "$expected_tag" ]]; then
             echo "::error::release tag $IMAGE_TAG must be $expected_tag" >&2
@@ -219,30 +249,40 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ vars.AWS_IMAGE_PUBLISHER_ROLE_ARN }}
-          role-session-name: zolana-photon-publish
+          # Names the service so CloudTrail attributes a publish to the thing
+          # that was actually published.
+          role-session-name: zolana-${{ steps.plan.outputs.service }}-publish
           aws-region: ${{ env.AWS_REGION }}
       # Private ECR, so no registry-type override. The role is trusted for this
       # job's OIDC subject specifically -- `repo:helius-labs/zolana:environment:
-      # photon-production`, which is what declaring `environment:` above makes
-      # GitHub present instead of the ref.
+      # image-publish`, which is what declaring `environment:` above makes
+      # GitHub present instead of the ref. One environment covers all three
+      # services and both channels: what separates release from preview is what
+      # this workflow enforces, not which role the job may assume.
       - uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2
       - id: metadata
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ steps.plan.outputs.repository }}
           flavor: latest=false
+          # type=match is push-only. Enabled by ref alone it would also fire on a
+          # dispatch started from a photon-zolana-* tag ref, emitting that tag
+          # *and* inputs.image_tag -- and "Publish immutable tags" keeps
+          # whichever it reads last, silently dropping the other onto whichever
+          # repository the dispatch named.
           tags: |
-            type=match,pattern=(photon-zolana-.*),group=1,enable=${{ startsWith(github.ref, 'refs/tags/photon-zolana-') }}
+            type=match,pattern=(photon-zolana-.*),group=1,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/photon-zolana-') }}
             type=raw,value=${{ inputs.image_tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=sha,format=long,prefix=sha-
           labels: |
-            org.opencontainers.image.title=Zolana Photon
-            org.opencontainers.image.description=Zolana shielded-pool indexer
+            org.opencontainers.image.title=${{ steps.plan.outputs.title }}
+            org.opencontainers.image.description=${{ steps.plan.outputs.description }}
             org.opencontainers.image.licenses=Apache-2.0
       - name: Refuse to overwrite published tags
         env:
           IMAGE_TAGS: ${{ steps.metadata.outputs.tags }}
           ECR_REPOSITORY: ${{ steps.plan.outputs.repository }}
+          SERVICE: ${{ steps.plan.outputs.service }}
         run: |
           while IFS= read -r image; do
             [[ -n "$image" ]] || continue
@@ -256,7 +296,7 @@ jobs:
             status=$?
             set -e
             if [[ $status -eq 0 ]]; then
-              echo "Refusing to overwrite published Photon tag: $tag" >&2
+              echo "Refusing to overwrite published $SERVICE tag: $tag" >&2
               exit 1
             fi
             if [[ "$error" != *ImageNotFoundException* ]]; then
@@ -273,8 +313,11 @@ jobs:
           push: false
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          cache-from: type=gha,scope=photon-image-production
-          cache-to: type=gha,mode=max,scope=photon-image-production
+          # Per service. A Go build, a Rust build and photon's share nothing, so
+          # one mode=max scope had all three evicting each other out of the
+          # 10 GB the whole repository gets.
+          cache-from: type=gha,scope=publish-${{ steps.plan.outputs.service }}
+          cache-to: type=gha,mode=max,scope=publish-${{ steps.plan.outputs.service }}
       # Proves the image runs before anything is pushed. The binaries differ per
       # service, so the check does too -- a shared "it built" would assert
       # nothing about whether the thing inside starts.
@@ -306,6 +349,7 @@ jobs:
         env:
           IMAGE_TAGS: ${{ steps.metadata.outputs.tags }}
           ECR_REPOSITORY: ${{ steps.plan.outputs.repository }}
+          SERVICE: ${{ steps.plan.outputs.service }}
         run: |
           sha_image=""
           release_image=""
@@ -335,7 +379,7 @@ jobs:
           status=$?
           set -e
           if [[ $status -eq 0 ]]; then
-            echo "Reusing existing Photon commit tag: $sha_tag"
+            echo "Reusing existing $SERVICE commit tag: $sha_tag"
             docker pull "$sha_image"
           elif [[ "$error" == *ImageNotFoundException* ]]; then
             docker push "$sha_image"
@@ -359,7 +403,7 @@ jobs:
               fi
               sleep 2
             done
-            echo "Could not resolve remote digest for Photon tag: $tag" >&2
+            echo "Could not resolve remote digest for $SERVICE tag: $tag" >&2
             return 1
           }
 
@@ -374,7 +418,7 @@ jobs:
           status=$?
           set -e
           if [[ $status -eq 0 ]]; then
-            echo "Refusing to overwrite published Photon tag: $release_tag" >&2
+            echo "Refusing to overwrite published $SERVICE tag: $release_tag" >&2
             exit 1
           fi
           if [[ "$error" != *ImageNotFoundException* ]]; then
@@ -386,7 +430,7 @@ jobs:
 
           release_digest="$(remote_digest "$release_tag")"
           if [[ "$release_digest" != "$sha_digest" ]]; then
-            echo "Photon release tag digest $release_digest does not match commit tag $sha_digest" >&2
+            echo "$SERVICE release tag digest $release_digest does not match commit tag $sha_digest" >&2
             exit 1
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,9 +454,10 @@ git tag "$tag"
 git push origin "$tag"
 ```
 
-A manual `photon-image.yml` dispatch must use that same commit-derived value
-for its `image_tag`. The protected `photon-production` environment gates
-publication. The workflow publishes the
+A manual `publish-image.yml` dispatch on the `release` channel must use that
+same commit-derived value for its `image_tag`, and the commit must be on
+`main`; the `preview` channel takes any branch and any tag, for images that are
+not releases. The protected `image-publish` environment gates publication. The workflow publishes the
 `photon-zolana-<12-character-commit>` tag and a full `sha-<commit>` alias,
 refuses to overwrite either, and does not publish `latest`. The imported crate
 version in `services/photon/Cargo.toml` is upstream source provenance, not the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -457,17 +457,20 @@ git push origin "$tag"
 A manual `publish-image.yml` dispatch on the `release` channel must use that
 same commit-derived value for its `image_tag`, and the commit must be on
 `main`; the `preview` channel takes any branch and any tag, for images that are
-not releases. The protected `image-publish` environment gates publication. The workflow publishes the
-`photon-zolana-<12-character-commit>` tag and a full `sha-<commit>` alias,
-refuses to overwrite either, and does not publish `latest`. The imported crate
-version in `services/photon/Cargo.toml` is upstream source provenance, not the
-Zolana fork's release identifier.
+not releases, and refuses a `-zolana-` tag so a preview cannot claim a release
+name. The protected `image-publish` environment gates publication. The workflow
+publishes the `photon-zolana-<12-character-commit>` tag and a full `sha-<commit>`
+alias, refuses to overwrite either, and does not publish `latest`. The imported
+crate version in `services/photon/Cargo.toml` is upstream source provenance, not
+the Zolana fork's release identifier.
 
 Before archiving the standalone Photon repository, update external deployment
 configuration that consumes its old `<run>-<sha>` or `latest` tags to use a new
 immutable `photon-zolana-*` or `sha-*` tag from this repository. Keep the
-base-image digests in `services/photon/Dockerfile` updated through reviewed
-changes.
+base-image digests in `services/photon/Dockerfile`, `forester/Dockerfile` and
+`prover/server/Dockerfile.light` updated through reviewed changes -- all three
+images are attested, and a mutable base tag would let one commit produce
+different bytes.
 
 ## Git Hygiene
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Workflows under `.github/workflows/`:
 
 - `rust.yml` — fmt, clippy, machete, check-all, per-area unit tests
 - `photon.yml` — Photon contract tests, migrations, schema drift, and service tests
-- `photon-image.yml` — container smoke tests and approved immutable releases
+- `publish-image.yml` — container smoke tests, and publishes photon, prover and forester images to ECR
 - `forester.yml` — forester compile check
 - `prover-server.yml` — Go test suite + xtask smoke
 - `enforce-pr-only.yml` — fails direct pushes to `main`

--- a/forester/Dockerfile
+++ b/forester/Dockerfile
@@ -10,7 +10,12 @@
 # context small.
 #
 # rust:1.95: the workspace pulls solana crates that need a recent toolchain.
-FROM rust:1.95-slim-bookworm AS builder
+#
+# Pinned by digest, and to the same digests services/photon/Dockerfile uses: this
+# image is attested now, and a mutable tag lets one commit produce different
+# bytes depending on when it was built, which is exactly what the attestation is
+# supposed to rule out. Sharing photon's pins also shares the base layers.
+FROM rust:1.95-slim-bookworm@sha256:d7482085ff5b415f84dba5647ae71606650bdef00db7aeb69f4b3d170c3e4082 AS builder
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -29,7 +34,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY . .
 RUN cargo build --release --package forester
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates libssl3 \
     && rm -rf /var/lib/apt/lists/*

--- a/prover/server/Dockerfile.light
+++ b/prover/server/Dockerfile.light
@@ -1,3 +1,22 @@
+# light-prover, without proving keys.
+#
+# Keys are NOT baked in. They are distributed separately and fetched at runtime
+# by EnsureProvingKey (prover/common/key_downloader.go):
+#   - proving-keys.lock is embedded into the binary (//go:embed), pinning the
+#     sha256, byte size and version-hashed prefix of every key
+#   - the downloader is cache-first: an on-disk key is verified against the
+#     lockfile offline, and only otherwise fetched
+#   - a fetch hard-fails unless the bytes match the pinned size and sha256
+#
+# So baking keys is pointless and slightly harmful: the lockfile already makes
+# pk<->vk<->code drift impossible, and a baked key layer is 1.4 GB for client
+# shapes to 3.9 GB for forester batch shapes, rebuilt and re-pulled on every
+# code change. That is what prover/server/Dockerfile does; prefer this one.
+#
+# One image serves both roles. The client prover and the forester prover differ
+# only in flags -- circuit selection and concurrency -- and in which keys they
+# happen to fetch.
+
 FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
@@ -10,6 +29,8 @@ COPY . .
 ENV CGO_ENABLED=0
 RUN go build -v -o /usr/local/bin/light-prover .
 
+# The runtime image is distroless and has no shell, so the writable key cache
+# directory has to be created here and copied in with the right ownership.
 RUN mkdir -p /tmp/empty_proving_keys
 
 FROM gcr.io/distroless/base-debian11:nonroot
@@ -21,6 +42,9 @@ WORKDIR /proving-keys
 COPY --chown=nonroot:nonroot --from=builder /tmp/empty_proving_keys /proving-keys/
 
 WORKDIR /
+
+# 3001 prover API, 9998 Prometheus metrics.
+EXPOSE 3001 9998
 
 ENTRYPOINT [ "light-prover" ]
 CMD [ "start" ]

--- a/prover/server/Dockerfile.light
+++ b/prover/server/Dockerfile.light
@@ -17,7 +17,11 @@
 # only in flags -- circuit selection and concurrency -- and in which keys they
 # happen to fetch.
 
-FROM golang:1.25-alpine AS builder
+# Both stages pinned by digest: this image is attested now, and a mutable tag
+# lets one commit produce different bytes depending on when it was built, which
+# is exactly what the attestation is supposed to rule out. These are index
+# digests, so multi-arch resolution still works.
+FROM golang:1.25-alpine@sha256:56961d79ea8129efddcc0b8643fd8a5416b4e6228cfd477e3fd61deb2672c587 AS builder
 
 WORKDIR /app
 
@@ -33,7 +37,7 @@ RUN go build -v -o /usr/local/bin/light-prover .
 # directory has to be created here and copied in with the right ownership.
 RUN mkdir -p /tmp/empty_proving_keys
 
-FROM gcr.io/distroless/base-debian11:nonroot
+FROM gcr.io/distroless/base-debian11:nonroot@sha256:68b0f492c1eb077f71d384b544456dac4afb282372966917df32b3923f65ad0d
 
 COPY --from=builder /usr/local/bin/light-prover /usr/local/bin/light-prover
 


### PR DESCRIPTION
Publishes photon, the prover, and the forester from one workflow. `photon-image.yml` becomes `publish-image.yml`.

Images are built in the repository that owns the code. The prover and forester were previously built in the infra repository, which checked out this source: a change here could break a build there, and publishing required driving the other repository.

Two channels:

- `release` — the tag must be `<service>-zolana-<sha12>`, and the commit must be an ancestor of `main`.
- `preview` — any branch, any tag.

Both are immutable and attested. `release` is the rule `photon-image.yml` already applied to photon. `preview` covers branch builds, which is how every image currently deployed was produced.

Registry is `558215002830.dkr.ecr.eu-north-1.amazonaws.com`. The previous target, `public.ecr.aws/f7o9l7p1/photon`, holds upstream Helius photon — different code. Nothing was ever published there: the job was gated on a tag never cut, and `vars.ECR_HELIUS_PROD_AWS_ROLE_ARN` was unset.

The OIDC subject is `repo:helius-labs/zolana:environment:image-publish`. This repository predates GitHub's immutable-subject default, so it uses plain `owner/repo`; declaring `environment:` replaces the `:ref:` segment.

Each published digest carries a provenance attestation:

```
gh attestation verify oci://<image> --owner helius-labs
```

The prover builds from `prover/server/Dockerfile.light`, which ships no proving keys; they are fetched at runtime and verified against the lockfile embedded in the binary. `prover/server/Dockerfile` bakes them, adding 1.4–3.9 GB.

Verified: prover and forester published through `preview`; attestation recorded and subject confirmed; photon's validate job skipped for non-photon dispatch; the photon tag-push path unchanged.

The infra repository's build path is removed in parallel (helius-labs/zolana-infra), leaving only the dashboard aggregator, which is built from that repository.