### PR TITLE
Start Photon by default in zolana dev start

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -87,6 +87,13 @@ Every artifact is verified against the sha256 lockfile embedded in the CLI
 so repeat starts are offline. This means a fresh `cargo install --path cli` can
 boot a fully-initialized localnet with no repo checkout and nothing prebuilt.
 
+Skip the indexer or prover:
+
+```bash
+zolana dev start --skip-indexer
+zolana dev start --skip-prover
+```
+
 Use `--local` to run against locally built artifacts instead (what dev and CI
 use after `just build-programs` / `just build-prover-server` / `just
 build-photon`):

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -220,7 +220,18 @@ pub(crate) struct TestValidatorOptions {
     #[arg(long, help = "Do not start the prover server")]
     pub(crate) skip_prover: bool,
 
-    #[arg(long, help = "Start a local Photon indexer")]
+    #[arg(
+        long,
+        help = "Do not start the Photon indexer",
+        conflicts_with = "with_photon"
+    )]
+    pub(crate) skip_indexer: bool,
+
+    #[arg(
+        long,
+        hide = true,
+        help = "Deprecated alias: Photon starts by default"
+    )]
     pub(crate) with_photon: bool,
 
     #[arg(
@@ -699,6 +710,10 @@ impl TestValidatorOptions {
         self.use_surfpool || !self.no_use_surfpool
     }
 
+    pub(crate) fn start_indexer(&self) -> bool {
+        !self.skip_indexer
+    }
+
     /// Fetch programs, account snapshots, and helper binaries from the pinned
     /// release unless the user opted into local builds or passed explicit
     /// programs (in which case those local artifacts take precedence).
@@ -822,6 +837,7 @@ mod tests {
             "--ledger <PATH>",
             "--log-dir <LOG_DIR>",
             "--photon-port <PHOTON_PORT>",
+            "--skip-indexer",
             "--sbf-program <ADDRESS> <PATH>",
         ] {
             assert!(help.contains(flag), "missing help entry for {flag}");
@@ -894,6 +910,8 @@ mod tests {
 
         assert!(!opts.use_surfpool_backend());
         assert!(opts.skip_prover);
+        assert!(!opts.skip_indexer);
+        assert!(opts.start_indexer());
         assert!(opts.with_photon);
         assert_eq!(opts.rpc_port, 8901);
         assert_eq!(opts.faucet_port, Some(9901));
@@ -943,6 +961,21 @@ mod tests {
             "target/deploy/pool.so",
         ]);
         assert!(!explicit_program.use_release());
+    }
+
+    #[test]
+    fn indexer_defaults_on_and_skip_indexer_opts_out() {
+        let default = parse_validator(&[]);
+        assert!(!default.skip_indexer);
+        assert!(default.start_indexer());
+
+        let skipped = parse_validator(&["--skip-indexer"]);
+        assert!(skipped.skip_indexer);
+        assert!(!skipped.start_indexer());
+
+        let alias = parse_validator(&["--with-photon"]);
+        assert!(alias.with_photon);
+        assert!(alias.start_indexer());
     }
 
     #[test]

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -227,11 +227,7 @@ pub(crate) struct TestValidatorOptions {
     )]
     pub(crate) skip_indexer: bool,
 
-    #[arg(
-        long,
-        hide = true,
-        help = "Deprecated alias: Photon starts by default"
-    )]
+    #[arg(long, hide = true, help = "Deprecated alias: Photon starts by default")]
     pub(crate) with_photon: bool,
 
     #[arg(

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -220,15 +220,8 @@ pub(crate) struct TestValidatorOptions {
     #[arg(long, help = "Do not start the prover server")]
     pub(crate) skip_prover: bool,
 
-    #[arg(
-        long,
-        help = "Do not start the Photon indexer",
-        conflicts_with = "with_photon"
-    )]
+    #[arg(long, help = "Do not start the Photon indexer")]
     pub(crate) skip_indexer: bool,
-
-    #[arg(long, hide = true, help = "Deprecated alias: Photon starts by default")]
-    pub(crate) with_photon: bool,
 
     #[arg(
         long,
@@ -885,7 +878,6 @@ mod tests {
             "8901",
             "--faucet-port",
             "9901",
-            "--with-photon",
             "--photon-port",
             "8785",
             "--photon-db-url",
@@ -908,7 +900,6 @@ mod tests {
         assert!(opts.skip_prover);
         assert!(!opts.skip_indexer);
         assert!(opts.start_indexer());
-        assert!(opts.with_photon);
         assert_eq!(opts.rpc_port, 8901);
         assert_eq!(opts.faucet_port, Some(9901));
         assert_eq!(opts.photon_port, 8785);
@@ -968,10 +959,6 @@ mod tests {
         let skipped = parse_validator(&["--skip-indexer"]);
         assert!(skipped.skip_indexer);
         assert!(!skipped.start_indexer());
-
-        let alias = parse_validator(&["--with-photon"]);
-        assert!(alias.with_photon);
-        assert!(alias.start_indexer());
     }
 
     #[test]

--- a/cli/src/localnet.rs
+++ b/cli/src/localnet.rs
@@ -318,7 +318,7 @@ mod tests {
 
     #[test]
     fn parses_photon_options() {
-        let opts = parse_validator(&["--with-photon", "--photon-port", "8785"]);
+        let opts = parse_validator(&["--photon-port", "8785"]);
         assert!(opts.start_indexer());
         assert_eq!(opts.photon_port, 8785);
         assert_eq!(opts.photon_start_slot, "latest");

--- a/cli/src/localnet.rs
+++ b/cli/src/localnet.rs
@@ -95,7 +95,7 @@ pub(crate) fn run_test_validator(mut opts: TestValidatorOptions) -> Result<()> {
         )?;
     }
 
-    if opts.with_photon {
+    if opts.start_indexer() {
         let photon_binary = match &release {
             Some(release) => Some(release.photon_binary()?),
             None => None,
@@ -188,7 +188,7 @@ fn stop_test_env(opts: &TestValidatorOptions) {
         stop_name("prover-server");
         stop_port(opts.prover_port);
     }
-    if opts.with_photon {
+    if opts.start_indexer() {
         stop_name("photon");
         stop_port(opts.photon_port);
     }
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     fn parses_photon_options() {
         let opts = parse_validator(&["--with-photon", "--photon-port", "8785"]);
-        assert!(opts.with_photon);
+        assert!(opts.start_indexer());
         assert_eq!(opts.photon_port, 8785);
         assert_eq!(opts.photon_start_slot, "latest");
     }

--- a/justfile
+++ b/justfile
@@ -162,7 +162,7 @@ test-ts-e2e: build-programs build-prover-server build-cli ensure-photon
     cleanup
     sleep 2
 
-    "$bin" dev start --with-photon --no-use-surfpool \
+    "$bin" dev start --no-use-surfpool \
       --rpc-port {{localnet-rpc-port}} --prover-port {{localnet-prover-port}} \
       --photon-port {{localnet-photon-port}} \
       --sbf-program "$SHIELDED_POOL_PROGRAM_ID" target/deploy/shielded_pool_program.so \
@@ -645,7 +645,7 @@ test-cli-smoke: build-programs build-prover-server build-cli ensure-photon
 
     # 1. Spawn services (dev start daemonizes the validator/prover/photon and
     #    returns once each is ready).
-    "$bin" dev start --with-photon --no-use-surfpool \
+    "$bin" dev start --no-use-surfpool \
       --rpc-port {{localnet-rpc-port}} --prover-port {{localnet-prover-port}} \
       --photon-port {{localnet-photon-port}} \
       --sbf-program "$SHIELDED_POOL_PROGRAM_ID" target/deploy/shielded_pool_program.so \

--- a/program-tests/test-utils/src/localnet.rs
+++ b/program-tests/test-utils/src/localnet.rs
@@ -149,7 +149,6 @@ impl LocalnetValidator {
             "test-env".into(),
             "--local".into(),
             "--no-use-surfpool".into(),
-            "--with-photon".into(),
             "--skip-prover".into(),
             "--rpc-port".into(),
             self.rpc_port.clone(),


### PR DESCRIPTION
## Goal

`zolana dev start` starts the full localnet (validator, prover, Photon) so installing the CLI is enough to run client examples — no zolana checkout or locally built programs.

## Changes

- Photon starts by default. `--skip-indexer` turns it off, matching `--skip-prover`.
- `cli/README.md` documents the skip flags.