### PR TITLE
sdk, photon: resume every stream the wallet reads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,7 +407,7 @@ regenerated. The codegen lives in the `xtask` crate, which depends on the
 
 - **transfer_p256 (P256):** the emulated-P256 gadget adds one BSB22 commitment over
   private wires. Its vk has `vk_commitment_g2: Some(..)` and `vk_ic.len() ==
-  public_inputs + 2`. Proofs include `proof_commitment` + `proof_commitment_pok`.
+  public_inputs + 2`. Proofs include `proofCommitment` + `proofCommitmentPok`.
   Verify with `Groth16Verifier::new_with_commitment`.
 - **transfer (eddsa, Solana-only):** standard Groth16, zero commitments. Its vk
   has `vk_commitment_g2: None` and `vk_ic.len() == public_inputs + 1`. Verify
@@ -416,7 +416,7 @@ regenerated. The codegen lives in the `xtask` crate, which depends on the
 Both verify in one binary built with the `bsb22` feature: `verify_common` runs
 the standard Groth16 pairing for every proof and only adds the Pedersen PoK
 pairing when a commitment is present. Dispatch on `vk.vk_commitment_g2.is_some()`
-(or the rail). The Go prover marshals `proof_commitment` as `omitempty`, so it is
+(or the rail). The Go prover marshals `proofCommitment` as `omitempty`, so it is
 absent for the eddsa rail and present for the P256 rail.
 
 NOTE: the parser/verifier support a single commitment over **private** wires

--- a/prover/server/server/queue.go
+++ b/prover/server/server/queue.go
@@ -928,9 +928,8 @@ func (rq *RedisQueue) failStuckJobsFromQueue(queueName string, timeoutCutoff tim
 						}
 					}
 
-					// Keys must match what the status endpoint reads off
-					// `failure`; see failureDetails, which every other
-					// MarkJobFailed caller goes through.
+					// Keys must match failureDetails, which the status
+					// endpoint reads and every other caller uses.
 					details := map[string]interface{}{
 						"originalJob": map[string]interface{}{
 							"id":          originalJobID,

--- a/prover/server/server/queue.go
+++ b/prover/server/server/queue.go
@@ -928,17 +928,20 @@ func (rq *RedisQueue) failStuckJobsFromQueue(queueName string, timeoutCutoff tim
 						}
 					}
 
+					// Keys must match what the status endpoint reads off
+					// `failure`; see failureDetails, which every other
+					// MarkJobFailed caller goes through.
 					details := map[string]interface{}{
-						"original_job": map[string]interface{}{
-							"id":           originalJobID,
-							"type":         "zk_proof",
-							"circuit_type": circuitType,
-							"payload_size": len(job.Payload),
-							"created_at":   job.CreatedAt,
+						"originalJob": map[string]interface{}{
+							"id":          originalJobID,
+							"type":        "zk_proof",
+							"circuitType": circuitType,
+							"payloadSize": len(job.Payload),
+							"createdAt":   job.CreatedAt,
 						},
-						"error":     fmt.Sprintf("Job timed out in processing queue (stuck since %s)", job.CreatedAt.Format(time.RFC3339)),
-						"failed_at": time.Now(),
-						"timeout":   true,
+						"error":    fmt.Sprintf("Job timed out in processing queue (stuck since %s)", job.CreatedAt.Format(time.RFC3339)),
+						"failedAt": time.Now(),
+						"timeout":  true,
 					}
 
 					// A reaped job is terminal, and the client polling it has no

--- a/prover/server/status_lookup_test.go
+++ b/prover/server/status_lookup_test.go
@@ -186,11 +186,9 @@ func TestMarkJobFailedRecreatesExpiredMetadata(t *testing.T) {
 	}
 }
 
-// The stuck-job reaper builds its failure details inline instead of going
-// through failureDetails, so nothing but this test keeps the two spellings
-// together. Drift is quiet: a reaped job still reports "failed" and its error,
-// so the client stops waiting, but the status response loses failedAt and
-// circuitType with nothing failing anywhere.
+// The reaper builds its details inline, so only this test keeps them in step with
+// failureDetails. Drift is quiet: status stays "failed", but loses failedAt and
+// circuitType.
 func TestStuckJobReaperUsesTheKeysTheStatusEndpointReads(t *testing.T) {
 	queue := setupRedisQueue(t)
 	defer teardownRedisQueue(t, queue)

--- a/prover/server/status_lookup_test.go
+++ b/prover/server/status_lookup_test.go
@@ -1,8 +1,10 @@
 package main_test
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
+	"zolana/prover/server"
 
 	"github.com/google/uuid"
 )
@@ -181,5 +183,52 @@ func TestMarkJobFailedRecreatesExpiredMetadata(t *testing.T) {
 	// Recreated records must still expire, or a reaped job leaks a key forever.
 	if ttl := queue.Client.TTL(queue.Ctx, "zk_job_meta_"+jobID).Val(); ttl <= 0 {
 		t.Fatalf("TTL = %v, want a bounded lifetime", ttl)
+	}
+}
+
+// The stuck-job reaper builds its failure details inline instead of going
+// through failureDetails, so nothing but this test keeps the two spellings
+// together. Drift is quiet: a reaped job still reports "failed" and its error,
+// so the client stops waiting, but the status response loses failedAt and
+// circuitType with nothing failing anywhere.
+func TestStuckJobReaperUsesTheKeysTheStatusEndpointReads(t *testing.T) {
+	queue := setupRedisQueue(t)
+	defer teardownRedisQueue(t, queue)
+	jobID := uuid.NewString()
+
+	stuck := &server.ProofJob{
+		ID:        jobID + "_processing",
+		Type:      "zk_proof",
+		Payload:   json.RawMessage(`{"circuitType":"transfer"}`),
+		CreatedAt: time.Now().Add(-30 * time.Minute),
+	}
+	if err := queue.EnqueueProof("zk_transfer_processing_queue", stuck); err != nil {
+		t.Fatalf("enqueue stuck job: %v", err)
+	}
+
+	if err := queue.CleanupStuckProcessingJobs(); err != nil {
+		t.Fatalf("cleanup stuck jobs: %v", err)
+	}
+
+	meta, err := queue.GetJobMeta(jobID)
+	if err != nil {
+		t.Fatalf("get job meta: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("a reaped job left no record; the client cannot learn it failed")
+	}
+	failure, ok := meta["failure"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("failure = %v, want the details map", meta["failure"])
+	}
+	if _, ok := failure["failedAt"]; !ok {
+		t.Errorf("failure carries no failedAt, so the status response drops it")
+	}
+	originalJob, ok := failure["originalJob"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("originalJob = %v, want the nested map", failure["originalJob"])
+	}
+	if got := originalJob["circuitType"]; got != "transfer" {
+		t.Errorf("circuitType = %v, want transfer", got)
 	}
 }

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -315,6 +315,7 @@ impl Rpc for ZolanaIndexer {
                         })
                         .collect::<Result<Vec<_>, _>>()?,
                     next_cursor: response.next_cursor.map(Into::into),
+                    scanned_through: response.scanned_through.map(Into::into),
                 })
             },
         )
@@ -526,6 +527,7 @@ impl AsyncRpc for AsyncZolanaIndexer {
                         })
                         .collect::<Result<Vec<_>, _>>()?,
                     next_cursor: response.next_cursor.map(Into::into),
+                    scanned_through: response.scanned_through.map(Into::into),
                 })
             },
         )
@@ -1075,6 +1077,7 @@ mod tests {
                 },
                 transactions: vec![],
                 next_cursor: None,
+                scanned_through: None,
             }
         );
     }

--- a/sdk-libs/client/src/rpc.rs
+++ b/sdk-libs/client/src/rpc.rs
@@ -85,6 +85,12 @@ pub struct GetShieldedTransactionsByNullifiersResponse {
     pub context: Context,
     pub transactions: Vec<ShieldedTransaction>,
     pub next_cursor: Option<Vec<u8>>,
+    /// How far the indexer scanned, when it reached the end of the stream.
+    ///
+    /// Set only on a page the limit did not truncate. Unspent nullifiers match
+    /// nothing, so `next_cursor` is `None` for them and this is the only thing
+    /// that tells the caller its scan can resume rather than restart.
+    pub scanned_through: Option<Vec<u8>>,
 }
 
 /// Stream of shielded transactions pushed as they land, one per matching transaction.

--- a/sdk-libs/client/src/rpc.rs
+++ b/sdk-libs/client/src/rpc.rs
@@ -85,11 +85,9 @@ pub struct GetShieldedTransactionsByNullifiersResponse {
     pub context: Context,
     pub transactions: Vec<ShieldedTransaction>,
     pub next_cursor: Option<Vec<u8>>,
-    /// How far the indexer scanned, when it reached the end of the stream.
-    ///
-    /// Set only on a page the limit did not truncate. Unspent nullifiers match
-    /// nothing, so `next_cursor` is `None` for them and this is the only thing
-    /// that tells the caller its scan can resume rather than restart.
+    /// Where the indexer's scan reached. Set only on a page the limit did not
+    /// truncate. Unspent nullifiers match nothing, so `next_cursor` is `None`
+    /// for them and this is the only resume point.
     pub scanned_through: Option<Vec<u8>>,
 }
 

--- a/sdk-libs/indexer-api/src/lib.rs
+++ b/sdk-libs/indexer-api/src/lib.rs
@@ -626,19 +626,13 @@ pub struct GetShieldedTransactionsByNullifiersResponse {
     /// requested nullifier and includes all of its output and input slots.
     pub transactions: Vec<ShieldedTransaction>,
     pub next_cursor: Option<Base64String>,
-    /// How far the scan got, when it reached the end rather than filling a page.
+    /// Where the scan reached, when it ran out of rows rather than filling a
+    /// page.
     ///
-    /// `next_cursor` cannot answer this: it is the position of the last returned
-    /// row, and the useful case here returns no rows at all. A wallet asks about
-    /// unspent nullifiers, which by definition have no spending transaction, so
-    /// every page comes back empty and the caller learns nothing about how much
-    /// of the stream it just paid to scan -- and starts from zero again next
-    /// time.
-    ///
-    /// Present only on a page the limit did not truncate, which is exactly when
-    /// "no more matches exist at or before this position" is true. Resuming a
-    /// later query for the same nullifiers here skips only ground already
-    /// covered.
+    /// `next_cursor` is the last returned row's position, and a query for
+    /// unspent nullifiers returns none. Present only on a page the limit did not
+    /// truncate, which is when "no match exists at or before this position"
+    /// holds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scanned_through: Option<Base64String>,
 }

--- a/sdk-libs/indexer-api/src/lib.rs
+++ b/sdk-libs/indexer-api/src/lib.rs
@@ -626,6 +626,21 @@ pub struct GetShieldedTransactionsByNullifiersResponse {
     /// requested nullifier and includes all of its output and input slots.
     pub transactions: Vec<ShieldedTransaction>,
     pub next_cursor: Option<Base64String>,
+    /// How far the scan got, when it reached the end rather than filling a page.
+    ///
+    /// `next_cursor` cannot answer this: it is the position of the last returned
+    /// row, and the useful case here returns no rows at all. A wallet asks about
+    /// unspent nullifiers, which by definition have no spending transaction, so
+    /// every page comes back empty and the caller learns nothing about how much
+    /// of the stream it just paid to scan -- and starts from zero again next
+    /// time.
+    ///
+    /// Present only on a page the limit did not truncate, which is exactly when
+    /// "no more matches exist at or before this position" is true. Resuming a
+    /// later query for the same nullifiers here skips only ground already
+    /// covered.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scanned_through: Option<Base64String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/sdk-libs/transaction/src/lib.rs
+++ b/sdk-libs/transaction/src/lib.rs
@@ -31,11 +31,11 @@ pub use solana_address::Address;
 pub use utxo::{derive_blinding, owner_utxo_hash, Blinding, ProofInputUtxo, Utxo};
 pub use wallet::{
     asset::{AssetRegistry, SOL_ASSET_ID, SOL_MINT},
-    AnonymousRecipientSlot, ApprovalRequest, AssetBalance, Balances, EncryptedEnvelope,
-    EncryptedSplit, EncryptedTransfer, Filter, LocalWalletAuthority, P256Signature,
-    PrivateTransaction, PrivateTransactionDirection, PrivateTransactionId, PrivateTransactionKind,
-    PrivateTransactionStatus, SyncReport, SyncWalletAuthority, ViewingKeyEntry, Wallet,
-    WalletAuthority, WalletSyncMaterial, WalletUtxo, DEFAULT_TAG_WINDOW,
+    AnonymousRecipientSlot, ApprovalRequest, AssetBalance, Balances, CursorStream,
+    EncryptedEnvelope, EncryptedSplit, EncryptedTransfer, Filter, LocalWalletAuthority,
+    P256Signature, PrivateTransaction, PrivateTransactionDirection, PrivateTransactionId,
+    PrivateTransactionKind, PrivateTransactionStatus, SyncReport, SyncWalletAuthority,
+    ViewingKeyEntry, Wallet, WalletAuthority, WalletSyncMaterial, WalletUtxo, DEFAULT_TAG_WINDOW,
 };
 pub use wallet::{decrypt_transactions, decrypt_transactions_with_config, SyncConfig};
 pub use zolana_keypair::constants::VIEW_TAG_LEN;

--- a/sdk-libs/transaction/src/wallet/mod.rs
+++ b/sdk-libs/transaction/src/wallet/mod.rs
@@ -10,7 +10,7 @@ pub use authority::{
     LocalWalletAuthority, P256Signature, SyncWalletAuthority, WalletAuthority, WalletSyncMaterial,
 };
 pub use state::{
-    AssetBalance, Balances, Filter, PrivateTransaction, PrivateTransactionDirection,
+    AssetBalance, Balances, CursorStream, Filter, PrivateTransaction, PrivateTransactionDirection,
     PrivateTransactionId, PrivateTransactionKind, PrivateTransactionStatus, SyncReport,
     ViewingKeyEntry, Wallet, WalletUtxo, DEFAULT_TAG_WINDOW,
 };

--- a/sdk-libs/transaction/src/wallet/state.rs
+++ b/sdk-libs/transaction/src/wallet/state.rs
@@ -1,7 +1,7 @@
 use std::collections::{hash_map::Entry, BTreeSet, HashMap, HashSet};
 
 use solana_address::Address;
-use zolana_keypair::{shielded::ShieldedAddress, P256Pubkey};
+use zolana_keypair::{shielded::ShieldedAddress, viewing_key::ViewTag, P256Pubkey};
 
 use crate::{
     error::TransactionError, instructions::transact::OutputContext, utxo::Utxo, AssetRegistry,
@@ -128,19 +128,29 @@ pub struct SyncReport {
     pub unknown_asset_ids: BTreeSet<u64>,
 }
 
-/// One of the indexer streams the wallet resumes.
+/// One key on one of the indexer streams the wallet resumes.
 ///
-/// A selector rather than a key wrapper: the inner maps stay
-/// `HashMap<[u8; 32], Vec<u8>>`, which is what the generic resume-point helpers
-/// already take, so nothing downstream needs to know a stream exists.
+/// The variant carries what its stream indexes by, so the map is flat and a tag
+/// cannot be mistaken for a nullifier -- `ViewTag` is itself `[u8; 32]`, so
+/// keying by the bare value would make the two interchangeable.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum CursorStream {
     /// Shielded transactions matched by output view tag.
-    Tags,
+    Tags(ViewTag),
     /// Shielded transactions matched by spent nullifier.
-    Nullifiers,
+    Nullifiers([u8; 32]),
     /// Encrypted UTXOs, which proofless deposits are read from.
-    Proofless,
+    Proofless(ViewTag),
+}
+
+impl CursorStream {
+    /// The tag or nullifier itself, for building the query its stream is read
+    /// with.
+    pub fn value(self) -> [u8; 32] {
+        match self {
+            Self::Tags(value) | Self::Nullifiers(value) | Self::Proofless(value) => value,
+        }
+    }
 }
 
 pub struct Wallet {
@@ -159,16 +169,13 @@ pub struct Wallet {
     /// spent.
     pub nullifiers: HashSet<[u8; 32]>,
     pub last_synced: i64,
-    /// Sync watermarks, one map per stream.
+    /// Sync watermarks: for each key on each stream, the indexer position
+    /// through which everything matching it has already been seen.
     ///
-    /// For each key the stream indexes by -- a view tag, or a nullifier for
-    /// [`CursorStream::Nullifiers`] -- the indexer position through which
-    /// everything matching has already been seen.
-    ///
-    /// The streams are independent: reaching the tip of one says nothing about
-    /// the others, so a shared map would conflate watermarks that advance
-    /// separately. Nullifier entries are dropped once the nullifier is spent.
-    pub cursors: HashMap<CursorStream, HashMap<[u8; 32], Vec<u8>>>,
+    /// Keyed by [`CursorStream`], so the streams stay independent -- reaching the
+    /// tip of one says nothing about the others -- without a map per stream.
+    /// Nullifier entries are dropped once the nullifier is spent.
+    pub cursors: HashMap<CursorStream, Vec<u8>>,
 }
 
 impl Wallet {

--- a/sdk-libs/transaction/src/wallet/state.rs
+++ b/sdk-libs/transaction/src/wallet/state.rs
@@ -128,11 +128,8 @@ pub struct SyncReport {
     pub unknown_asset_ids: BTreeSet<u64>,
 }
 
-/// One key on one of the indexer streams the wallet resumes.
-///
-/// The variant carries what its stream indexes by, so the map is flat and a tag
-/// cannot be mistaken for a nullifier -- `ViewTag` is itself `[u8; 32]`, so
-/// keying by the bare value would make the two interchangeable.
+/// One key on one indexer stream. `ViewTag` is `[u8; 32]`, so the variant is
+/// what stops a tag being read as a nullifier.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum CursorStream {
     /// Shielded transactions matched by output view tag.
@@ -144,8 +141,7 @@ pub enum CursorStream {
 }
 
 impl CursorStream {
-    /// The tag or nullifier itself, for building the query its stream is read
-    /// with.
+    /// The tag or nullifier, for building the query.
     pub fn value(self) -> [u8; 32] {
         match self {
             Self::Tags(value) | Self::Nullifiers(value) | Self::Proofless(value) => value,
@@ -169,12 +165,8 @@ pub struct Wallet {
     /// spent.
     pub nullifiers: HashSet<[u8; 32]>,
     pub last_synced: i64,
-    /// Sync watermarks: for each key on each stream, the indexer position
-    /// through which everything matching it has already been seen.
-    ///
-    /// Keyed by [`CursorStream`], so the streams stay independent -- reaching the
-    /// tip of one says nothing about the others -- without a map per stream.
-    /// Nullifier entries are dropped once the nullifier is spent.
+    /// Per key, the position everything matching it has been seen through.
+    /// Streams advance independently. Nullifier entries die with their spend.
     pub cursors: HashMap<CursorStream, Vec<u8>>,
 }
 

--- a/sdk-libs/transaction/src/wallet/state.rs
+++ b/sdk-libs/transaction/src/wallet/state.rs
@@ -157,6 +157,18 @@ pub struct Wallet {
     /// Entries are dropped once the nullifier is spent, since the question is
     /// then answered for good.
     pub nullifier_cursors: HashMap<[u8; 32], Vec<u8>>,
+    /// The same watermarks for the encrypted-utxo stream, which proofless
+    /// deposits are read from.
+    ///
+    /// Separate again for the same reason: reaching the tip of the transaction
+    /// stream says nothing about where the encrypted-utxo stream has been read
+    /// to, and sharing one cursor would skip rows in whichever is behind.
+    ///
+    /// This existed only for the duration of a single sync before, so every sync
+    /// re-read the whole encrypted-utxo history for every tag and discarded all
+    /// but the deposits. Measured on devnet: 909ms per sync to keep 2.5 rows,
+    /// about a third of the sync phase, and growing with history.
+    pub proofless_cursors: HashMap<ViewTag, Vec<u8>>,
 }
 
 impl Wallet {
@@ -175,6 +187,7 @@ impl Wallet {
             last_synced: 0,
             sync_cursors: HashMap::new(),
             nullifier_cursors: HashMap::new(),
+            proofless_cursors: HashMap::new(),
         })
     }
 

--- a/sdk-libs/transaction/src/wallet/state.rs
+++ b/sdk-libs/transaction/src/wallet/state.rs
@@ -145,8 +145,18 @@ pub struct Wallet {
     pub nullifiers: HashSet<[u8; 32]>,
     pub last_synced: i64,
     /// Per-view-tag sync watermarks: for each tag, the indexer cursor up to which
-    /// every matching transaction has already been seen.    
+    /// every matching transaction has already been seen.
     pub sync_cursors: HashMap<ViewTag, Vec<u8>>,
+    /// The same watermark for the nullifier stream: for each unspent nullifier,
+    /// the position through which no spend of it exists.
+    ///
+    /// Separate from [`Self::sync_cursors`] because the two are separate streams
+    /// -- reaching the tip of one says nothing about the other -- and because an
+    /// entry here means the opposite thing: a tag cursor records what has been
+    /// found, a nullifier cursor records how far it has been confirmed absent.
+    /// Entries are dropped once the nullifier is spent, since the question is
+    /// then answered for good.
+    pub nullifier_cursors: HashMap<[u8; 32], Vec<u8>>,
 }
 
 impl Wallet {
@@ -164,6 +174,7 @@ impl Wallet {
             nullifiers: HashSet::new(),
             last_synced: 0,
             sync_cursors: HashMap::new(),
+            nullifier_cursors: HashMap::new(),
         })
     }
 

--- a/sdk-libs/transaction/src/wallet/state.rs
+++ b/sdk-libs/transaction/src/wallet/state.rs
@@ -147,27 +147,15 @@ pub struct Wallet {
     /// Per-view-tag sync watermarks: for each tag, the indexer cursor up to which
     /// every matching transaction has already been seen.
     pub sync_cursors: HashMap<ViewTag, Vec<u8>>,
-    /// The same watermark for the nullifier stream: for each unspent nullifier,
-    /// the position through which no spend of it exists.
+    /// For each unspent nullifier, the position through which no spend of it
+    /// exists.
     ///
-    /// Separate from [`Self::sync_cursors`] because the two are separate streams
-    /// -- reaching the tip of one says nothing about the other -- and because an
-    /// entry here means the opposite thing: a tag cursor records what has been
-    /// found, a nullifier cursor records how far it has been confirmed absent.
-    /// Entries are dropped once the nullifier is spent, since the question is
-    /// then answered for good.
+    /// A separate stream from [`Self::sync_cursors`]: reaching the tip of one
+    /// says nothing about the other. Entries are dropped once the nullifier is
+    /// spent.
     pub nullifier_cursors: HashMap<[u8; 32], Vec<u8>>,
-    /// The same watermarks for the encrypted-utxo stream, which proofless
-    /// deposits are read from.
-    ///
-    /// Separate again for the same reason: reaching the tip of the transaction
-    /// stream says nothing about where the encrypted-utxo stream has been read
-    /// to, and sharing one cursor would skip rows in whichever is behind.
-    ///
-    /// This existed only for the duration of a single sync before, so every sync
-    /// re-read the whole encrypted-utxo history for every tag and discarded all
-    /// but the deposits. Measured on devnet: 909ms per sync to keep 2.5 rows,
-    /// about a third of the sync phase, and growing with history.
+    /// The same for the encrypted-utxo stream, which proofless deposits are read
+    /// from. Separate for the same reason.
     pub proofless_cursors: HashMap<ViewTag, Vec<u8>>,
 }
 

--- a/sdk-libs/transaction/src/wallet/state.rs
+++ b/sdk-libs/transaction/src/wallet/state.rs
@@ -1,7 +1,7 @@
 use std::collections::{hash_map::Entry, BTreeSet, HashMap, HashSet};
 
 use solana_address::Address;
-use zolana_keypair::{shielded::ShieldedAddress, viewing_key::ViewTag, P256Pubkey};
+use zolana_keypair::{shielded::ShieldedAddress, P256Pubkey};
 
 use crate::{
     error::TransactionError, instructions::transact::OutputContext, utxo::Utxo, AssetRegistry,
@@ -128,6 +128,21 @@ pub struct SyncReport {
     pub unknown_asset_ids: BTreeSet<u64>,
 }
 
+/// One of the indexer streams the wallet resumes.
+///
+/// A selector rather than a key wrapper: the inner maps stay
+/// `HashMap<[u8; 32], Vec<u8>>`, which is what the generic resume-point helpers
+/// already take, so nothing downstream needs to know a stream exists.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum CursorStream {
+    /// Shielded transactions matched by output view tag.
+    Tags,
+    /// Shielded transactions matched by spent nullifier.
+    Nullifiers,
+    /// Encrypted UTXOs, which proofless deposits are read from.
+    Proofless,
+}
+
 pub struct Wallet {
     /// Public wallet identity. All secret key material is supplied by a
     /// `WalletAuthority` when cryptographic work is required.
@@ -144,19 +159,16 @@ pub struct Wallet {
     /// spent.
     pub nullifiers: HashSet<[u8; 32]>,
     pub last_synced: i64,
-    /// Per-view-tag sync watermarks: for each tag, the indexer cursor up to which
-    /// every matching transaction has already been seen.
-    pub sync_cursors: HashMap<ViewTag, Vec<u8>>,
-    /// For each unspent nullifier, the position through which no spend of it
-    /// exists.
+    /// Sync watermarks, one map per stream.
     ///
-    /// A separate stream from [`Self::sync_cursors`]: reaching the tip of one
-    /// says nothing about the other. Entries are dropped once the nullifier is
-    /// spent.
-    pub nullifier_cursors: HashMap<[u8; 32], Vec<u8>>,
-    /// The same for the encrypted-utxo stream, which proofless deposits are read
-    /// from. Separate for the same reason.
-    pub proofless_cursors: HashMap<ViewTag, Vec<u8>>,
+    /// For each key the stream indexes by -- a view tag, or a nullifier for
+    /// [`CursorStream::Nullifiers`] -- the indexer position through which
+    /// everything matching has already been seen.
+    ///
+    /// The streams are independent: reaching the tip of one says nothing about
+    /// the others, so a shared map would conflate watermarks that advance
+    /// separately. Nullifier entries are dropped once the nullifier is spent.
+    pub cursors: HashMap<CursorStream, HashMap<[u8; 32], Vec<u8>>>,
 }
 
 impl Wallet {
@@ -173,9 +185,7 @@ impl Wallet {
             transactions: Vec::new(),
             nullifiers: HashSet::new(),
             last_synced: 0,
-            sync_cursors: HashMap::new(),
-            nullifier_cursors: HashMap::new(),
-            proofless_cursors: HashMap::new(),
+            cursors: HashMap::new(),
         })
     }
 

--- a/sdk-libs/transaction/src/wallet/sync.rs
+++ b/sdk-libs/transaction/src/wallet/sync.rs
@@ -1016,6 +1016,11 @@ impl Wallet {
                 utxo.spent = true;
             }
         }
+        // A spent nullifier is never queried again, so its watermark is dead
+        // weight. Without this the map grows with history even though the query
+        // set shrinks.
+        self.nullifier_cursors
+            .retain(|nullifier, _| !self.nullifiers.contains(nullifier));
         self.transactions.sort_by(|a, b| {
             (a.id.slot, &a.id.signature, a.id.index).cmp(&(b.id.slot, &b.id.signature, b.id.index))
         });

--- a/sdk-libs/transaction/src/wallet/sync.rs
+++ b/sdk-libs/transaction/src/wallet/sync.rs
@@ -1017,8 +1017,7 @@ impl Wallet {
             }
         }
         // A spent nullifier is never queried again, so its watermark is dead
-        // weight. Without this the map grows with history even though the query
-        // set shrinks.
+        // weight.
         self.nullifier_cursors
             .retain(|nullifier, _| !self.nullifiers.contains(nullifier));
         self.transactions.sort_by(|a, b| {

--- a/sdk-libs/transaction/src/wallet/sync.rs
+++ b/sdk-libs/transaction/src/wallet/sync.rs
@@ -9,7 +9,7 @@ use zolana_keypair::{
 };
 
 use super::state::{
-    Balances, PrivateTransaction, PrivateTransactionDirection, PrivateTransactionId,
+    Balances, CursorStream, PrivateTransaction, PrivateTransactionDirection, PrivateTransactionId,
     PrivateTransactionKind, PrivateTransactionStatus, SyncReport, ViewingKeyEntry, Wallet,
     WalletUtxo, DEFAULT_TAG_WINDOW, SENDER_HISTORY_ROW_BASE,
 };
@@ -1018,8 +1018,9 @@ impl Wallet {
         }
         // A spent nullifier is never queried again, so its watermark is dead
         // weight.
-        self.nullifier_cursors
-            .retain(|nullifier, _| !self.nullifiers.contains(nullifier));
+        if let Some(cursors) = self.cursors.get_mut(&CursorStream::Nullifiers) {
+            cursors.retain(|nullifier, _| !self.nullifiers.contains(nullifier));
+        }
         self.transactions.sort_by(|a, b| {
             (a.id.slot, &a.id.signature, a.id.index).cmp(&(b.id.slot, &b.id.signature, b.id.index))
         });

--- a/sdk-libs/transaction/src/wallet/sync.rs
+++ b/sdk-libs/transaction/src/wallet/sync.rs
@@ -1018,9 +1018,10 @@ impl Wallet {
         }
         // A spent nullifier is never queried again, so its watermark is dead
         // weight.
-        if let Some(cursors) = self.cursors.get_mut(&CursorStream::Nullifiers) {
-            cursors.retain(|nullifier, _| !self.nullifiers.contains(nullifier));
-        }
+        self.cursors.retain(|stream, _| match stream {
+            CursorStream::Nullifiers(nullifier) => !self.nullifiers.contains(nullifier),
+            _ => true,
+        });
         self.transactions.sort_by(|a, b| {
             (a.id.slot, &a.id.signature, a.id.index).cmp(&(b.id.slot, &b.id.signature, b.id.index))
         });

--- a/sdk-libs/ts/src/api/index.ts
+++ b/sdk-libs/ts/src/api/index.ts
@@ -605,7 +605,7 @@ function hasControlCharacter(value: string): boolean {
 
 function safeSchemaPath(path: string): string | undefined {
   const knownField =
-    "(?:blockTime|context|hash|highElement|highElementIndex|leaf|leafIndex|leaves|limit|lowElement|lowElementIndex|matches|merkleContext|nextCursor|nullifiers|outputContext|outputSlot|outputSlots|path|payload|proofless|proofs|root|rootIndex|rootSeq|salt|slot|tags|transactions|tree|treeAccount|treeType|txSignature|txViewingPk|viewTag)";
+    "(?:blockTime|context|hash|highElement|highElementIndex|leaf|leafIndex|leaves|limit|lowElement|lowElementIndex|matches|merkleContext|nextCursor|nullifiers|outputContext|outputSlot|outputSlots|path|payload|proofless|proofs|root|rootIndex|rootSeq|salt|scannedThrough|slot|tags|transactions|tree|treeAccount|treeType|txSignature|txViewingPk|viewTag)";
   const pattern = new RegExp(`^\\$(?:(?:\\.${knownField})|(?:\\[\\d+\\]))*$`, "u");
   return path.length <= 256 && pattern.test(path) ? path : undefined;
 }

--- a/sdk-libs/ts/src/client/indexer.ts
+++ b/sdk-libs/ts/src/client/indexer.ts
@@ -343,7 +343,15 @@ function convertShieldedTransactionsByNullifiersResponse(
   response: WireGetShieldedTransactionsByNullifiersResponse,
   method: string,
 ): GetShieldedTransactionsByNullifiersResponse {
-  return convertShieldedTransactionsResponse(response, method);
+  // Delegating alone would silently drop the scan frontier, leaving the sync to
+  // restart from zero every time with nothing to show it had been told
+  // otherwise.
+  return Object.freeze({
+    ...convertShieldedTransactionsResponse(response, method),
+    ...(response.scannedThrough === undefined
+      ? {}
+      : { scannedThrough: decodeBase64(response.scannedThrough, "scanned_through") }),
+  });
 }
 
 function convertShieldedTransactionsBySignatureResponse(

--- a/sdk-libs/ts/src/client/indexer.ts
+++ b/sdk-libs/ts/src/client/indexer.ts
@@ -343,9 +343,8 @@ function convertShieldedTransactionsByNullifiersResponse(
   response: WireGetShieldedTransactionsByNullifiersResponse,
   method: string,
 ): GetShieldedTransactionsByNullifiersResponse {
-  // Delegating alone would silently drop how far the scan reached, leaving sync to
-  // restart from zero every time with nothing to show it had been told
-  // otherwise.
+  // Delegating alone would drop the scan position, leaving sync restarting from
+  // zero while appearing to resume.
   return Object.freeze({
     ...convertShieldedTransactionsResponse(response, method),
     ...(response.scannedThrough === undefined

--- a/sdk-libs/ts/src/client/indexer.ts
+++ b/sdk-libs/ts/src/client/indexer.ts
@@ -343,7 +343,7 @@ function convertShieldedTransactionsByNullifiersResponse(
   response: WireGetShieldedTransactionsByNullifiersResponse,
   method: string,
 ): GetShieldedTransactionsByNullifiersResponse {
-  // Delegating alone would silently drop the scan frontier, leaving the sync to
+  // Delegating alone would silently drop how far the scan reached, leaving sync to
   // restart from zero every time with nothing to show it had been told
   // otherwise.
   return Object.freeze({

--- a/sdk-libs/ts/src/client/indexer.ts
+++ b/sdk-libs/ts/src/client/indexer.ts
@@ -349,7 +349,7 @@ function convertShieldedTransactionsByNullifiersResponse(
     ...convertShieldedTransactionsResponse(response, method),
     ...(response.scannedThrough === undefined
       ? {}
-      : { scannedThrough: decodeBase64(response.scannedThrough, "scanned_through") }),
+      : { scannedThrough: decodeBase64(response.scannedThrough, "scannedThrough") }),
   });
 }
 

--- a/sdk-libs/ts/src/client/rpc.ts
+++ b/sdk-libs/ts/src/client/rpc.ts
@@ -52,6 +52,14 @@ export interface GetShieldedTransactionsByNullifiersResponse {
   readonly context: RpcContext;
   readonly transactions: readonly IndexedShieldedTransaction[];
   readonly nextCursor?: Uint8Array;
+  /**
+   * How far the indexer scanned, when it reached the end of the stream.
+   *
+   * Present only on a page the limit did not truncate. Unspent nullifiers match
+   * nothing, so `nextCursor` is absent for them and this is the only thing that
+   * lets a later sync resume rather than restart.
+   */
+  readonly scannedThrough?: Uint8Array;
 }
 
 export interface GetShieldedTransactionsBySignatureResponse {

--- a/sdk-libs/ts/src/client/rpc.ts
+++ b/sdk-libs/ts/src/client/rpc.ts
@@ -53,11 +53,9 @@ export interface GetShieldedTransactionsByNullifiersResponse {
   readonly transactions: readonly IndexedShieldedTransaction[];
   readonly nextCursor?: Uint8Array;
   /**
-   * How far the indexer scanned, when it reached the end of the stream.
-   *
-   * Present only on a page the limit did not truncate. Unspent nullifiers match
-   * nothing, so `nextCursor` is absent for them and this is the only thing that
-   * lets a later sync resume rather than restart.
+   * Where the indexer's scan reached. Present only on a page the limit did not
+   * truncate. Unspent nullifiers match nothing, so `nextCursor` is absent for
+   * them and this is the only resume point.
    */
   readonly scannedThrough?: Uint8Array;
 }

--- a/sdk-libs/ts/src/indexer/codec.ts
+++ b/sdk-libs/ts/src/indexer/codec.ts
@@ -430,7 +430,19 @@ export function decodeShieldedTransactionsResponse(
 export function decodeShieldedTransactionsByNullifiersResponse(
   value: unknown,
 ): GetShieldedTransactionsByNullifiersResponse {
-  return decodeShieldedTransactionsResponse(value);
+  // Not `decodeShieldedTransactionsResponse`: this response carries one extra
+  // field, and `object` rejects any key it was not told about. Delegating would
+  // make every nullifier query fail against an indexer that reports how far it
+  // scanned.
+  const record = object(value, "$", ["context", "transactions", "next_cursor", "scanned_through"]);
+  const nextCursor = optional(record["next_cursor"], "$.next_cursor", checkedBase64);
+  const scannedThrough = optional(record["scanned_through"], "$.scanned_through", checkedBase64);
+  return {
+    context: context(record["context"], "$.context"),
+    transactions: array(record["transactions"], "$.transactions", indexedTransaction),
+    ...(nextCursor === undefined ? {} : { nextCursor }),
+    ...(scannedThrough === undefined ? {} : { scannedThrough }),
+  };
 }
 
 export function decodeShieldedTransactionsBySignatureResponse(

--- a/sdk-libs/ts/src/indexer/codec.ts
+++ b/sdk-libs/ts/src/indexer/codec.ts
@@ -430,10 +430,8 @@ export function decodeShieldedTransactionsResponse(
 export function decodeShieldedTransactionsByNullifiersResponse(
   value: unknown,
 ): GetShieldedTransactionsByNullifiersResponse {
-  // Not `decodeShieldedTransactionsResponse`: this response carries one extra
-  // field, and `object` rejects any key it was not told about. Delegating would
-  // make every nullifier query fail against an indexer that reports how far it
-  // scanned.
+  // Not `decodeShieldedTransactionsResponse`: `object` rejects any key it was
+  // not told about, and this response carries one more.
   const record = object(value, "$", ["context", "transactions", "next_cursor", "scanned_through"]);
   const nextCursor = optional(record["next_cursor"], "$.next_cursor", checkedBase64);
   const scannedThrough = optional(record["scanned_through"], "$.scanned_through", checkedBase64);

--- a/sdk-libs/ts/src/indexer/codec.ts
+++ b/sdk-libs/ts/src/indexer/codec.ts
@@ -432,9 +432,9 @@ export function decodeShieldedTransactionsByNullifiersResponse(
 ): GetShieldedTransactionsByNullifiersResponse {
   // Not `decodeShieldedTransactionsResponse`: `object` rejects any key it was
   // not told about, and this response carries one more.
-  const record = object(value, "$", ["context", "transactions", "next_cursor", "scanned_through"]);
-  const nextCursor = optional(record["next_cursor"], "$.next_cursor", checkedBase64);
-  const scannedThrough = optional(record["scanned_through"], "$.scanned_through", checkedBase64);
+  const record = object(value, "$", ["context", "transactions", "nextCursor", "scannedThrough"]);
+  const nextCursor = optional(record["nextCursor"], "$.nextCursor", checkedBase64);
+  const scannedThrough = optional(record["scannedThrough"], "$.scannedThrough", checkedBase64);
   return {
     context: context(record["context"], "$.context"),
     transactions: array(record["transactions"], "$.transactions", indexedTransaction),

--- a/sdk-libs/ts/src/indexer/types.ts
+++ b/sdk-libs/ts/src/indexer/types.ts
@@ -74,6 +74,14 @@ export interface GetShieldedTransactionsByNullifiersResponse {
   readonly context: IndexerContext;
   readonly transactions: readonly IndexedShieldedTransaction[];
   readonly nextCursor?: Base64String;
+  /**
+   * How far the indexer scanned, when it reached the end of the stream.
+   *
+   * Present only on a page the limit did not truncate. Unspent nullifiers match
+   * nothing, so `nextCursor` is absent for them and this is the only thing that
+   * lets a later sync resume rather than restart.
+   */
+  readonly scannedThrough?: Base64String;
 }
 
 export interface GetShieldedTransactionsBySignatureRequest {

--- a/sdk-libs/ts/src/indexer/types.ts
+++ b/sdk-libs/ts/src/indexer/types.ts
@@ -75,11 +75,9 @@ export interface GetShieldedTransactionsByNullifiersResponse {
   readonly transactions: readonly IndexedShieldedTransaction[];
   readonly nextCursor?: Base64String;
   /**
-   * How far the indexer scanned, when it reached the end of the stream.
-   *
-   * Present only on a page the limit did not truncate. Unspent nullifiers match
-   * nothing, so `nextCursor` is absent for them and this is the only thing that
-   * lets a later sync resume rather than restart.
+   * Where the indexer's scan reached. Present only on a page the limit did not
+   * truncate. Unspent nullifiers match nothing, so `nextCursor` is absent for
+   * them and this is the only resume point.
    */
   readonly scannedThrough?: Base64String;
 }

--- a/sdk-libs/ts/src/transaction/wallet/state.ts
+++ b/sdk-libs/ts/src/transaction/wallet/state.ts
@@ -48,6 +48,16 @@ export type PrivateTransactionKind =
 export type PrivateTransactionDirection = "inbound" | "outbound" | "selfTransfer";
 
 /**
+ * Streams the wallet keeps read positions in.
+ *
+ * They are separate because reaching the tip of one says nothing about the
+ * others, and sharing a cursor would skip rows in whichever stream is behind.
+ * `transactions` and `proofless` are keyed by view tag; `nullifiers` by
+ * nullifier.
+ */
+export type CursorStream = "transactions" | "proofless" | "nullifiers";
+
+/**
  * A history row is reconstructed from an indexed transaction, so it exists only
  * once that transaction has landed. Nothing stages a locally submitted transfer
  * into the history ahead of a sync, in either language, so `confirmed` is the
@@ -183,6 +193,16 @@ export class Wallet {
    * would skip rows in whichever stream is behind.
    */
   #prooflessCursors = new Map<string, Uint8Array>();
+  /**
+   * The same watermarks for the nullifier stream, keyed by nullifier rather than
+   * by tag. Mirrors Rust's `Wallet::nullifier_cursors`.
+   *
+   * An entry here means the opposite of a tag cursor: a tag cursor records what
+   * has been found, this records how far a spend has been confirmed *absent*.
+   * Entries are dropped once the nullifier is spent, since the question is then
+   * answered for good.
+   */
+  #nullifierCursors = new Map<string, Uint8Array>();
 
   constructor(input: Readonly<{ identity: ShieldedAddress; registry?: AssetRegistry }>) {
     this.identity = input.identity;
@@ -210,17 +230,30 @@ export class Wallet {
    *
    * @internal
    */
-  _syncCursor(stream: "transactions" | "proofless", tag: string): Uint8Array | undefined {
+  _syncCursor(stream: CursorStream, tag: string): Uint8Array | undefined {
     return this.#cursorsFor(stream).get(tag);
   }
 
   /** @internal */
-  _setSyncCursor(stream: "transactions" | "proofless", tag: string, cursor: Uint8Array): void {
+  _setSyncCursor(stream: CursorStream, tag: string, cursor: Uint8Array): void {
     this.#cursorsFor(stream).set(tag, Uint8Array.from(cursor));
   }
 
-  #cursorsFor(stream: "transactions" | "proofless"): Map<string, Uint8Array> {
-    return stream === "transactions" ? this.#syncCursors : this.#prooflessCursors;
+  /**
+   * Forget the watermarks for nullifiers now known spent.
+   *
+   * A spent nullifier is never queried again, so its watermark is dead weight.
+   * Without this the map grows with history even though the query set shrinks.
+   *
+   * @internal
+   */
+  _forgetNullifierCursors(spent: ReadonlySet<string>): void {
+    for (const nullifier of spent) this.#nullifierCursors.delete(nullifier);
+  }
+
+  #cursorsFor(stream: CursorStream): Map<string, Uint8Array> {
+    if (stream === "transactions") return this.#syncCursors;
+    return stream === "proofless" ? this.#prooflessCursors : this.#nullifierCursors;
   }
 
   registerAsset(assetId: bigint, mint: Address): void {
@@ -313,6 +346,9 @@ export class Wallet {
       Object.freeze({ ...transaction, id: Object.freeze({ ...transaction.id }) }),
     );
     this.#nullifiers = new Set(input.nullifiers);
+    // A spent nullifier is never queried again, so its watermark is dead weight.
+    // Both key spaces are lowercase hex of the same bytes, so the sets line up.
+    this._forgetNullifierCursors(this.#nullifiers);
     if (input.viewingKeyHistory !== undefined) {
       this.#viewingKeyHistory = input.viewingKeyHistory.map(snapshotViewingKeyEntry);
     }

--- a/sdk-libs/ts/src/transaction/wallet/state.ts
+++ b/sdk-libs/ts/src/transaction/wallet/state.ts
@@ -194,13 +194,8 @@ export class Wallet {
    */
   #prooflessCursors = new Map<string, Uint8Array>();
   /**
-   * The same watermarks for the nullifier stream, keyed by nullifier rather than
-   * by tag. Mirrors Rust's `Wallet::nullifier_cursors`.
-   *
-   * An entry here means the opposite of a tag cursor: a tag cursor records what
-   * has been found, this records how far a spend has been confirmed *absent*.
-   * Entries are dropped once the nullifier is spent, since the question is then
-   * answered for good.
+   * The same for the nullifier stream, keyed by nullifier rather than tag.
+   * Entries are dropped once the nullifier is spent.
    */
   #nullifierCursors = new Map<string, Uint8Array>();
 

--- a/sdk-libs/ts/src/wallet/sync.ts
+++ b/sdk-libs/ts/src/wallet/sync.ts
@@ -386,7 +386,9 @@ async function collectShieldedTransactionsByNullifiers(
 ): Promise<Uint8Array | undefined> {
   let cursor = input.start;
   let resume: Uint8Array | undefined;
-  const seenCursors = new Set<string>();
+  // Seeded with the resume point, so an indexer that hands back the cursor it
+  // was given trips the guard on the spot rather than after a wasted round trip.
+  const seenCursors = new Set<string>(input.start === undefined ? [] : [bytesKey(input.start)]);
   do {
     const response = await input.indexer.getShieldedTransactionsByNullifiers(
       {

--- a/sdk-libs/ts/src/wallet/sync.ts
+++ b/sdk-libs/ts/src/wallet/sync.ts
@@ -362,6 +362,29 @@ async function collectProoflessDeposits(
   return furthest;
 }
 
+/**
+ * Bucket keys by the position their stream was last read to.
+ *
+ * A chunk carries one cursor, so keys at different positions cannot share a
+ * request: a key learned this sync would resume from a position it was never
+ * scanned to and skip its history permanently. `undefined` (never queried) is
+ * its own group.
+ */
+function groupByResumePoint(
+  keys: readonly Bytes32[],
+  cursorFor: (key: Bytes32) => Uint8Array | undefined,
+): readonly { readonly from: Uint8Array | undefined; readonly keys: Bytes32[] }[] {
+  const groups = new Map<string, { from: Uint8Array | undefined; keys: Bytes32[] }>();
+  for (const key of keys) {
+    const from = cursorFor(key);
+    const groupKey = from === undefined ? "" : bytesKey(from);
+    const group = groups.get(groupKey);
+    if (group === undefined) groups.set(groupKey, { from, keys: [key] });
+    else group.keys.push(key);
+  }
+  return [...groups.values()];
+}
+
 interface CollectByNullifiersInput {
   readonly indexer: Pick<ZolanaClient, "getShieldedTransactionsByNullifiers">;
   readonly chunk: readonly Bytes32[];
@@ -452,18 +475,13 @@ export async function syncWallet(
     // permanently -- which is why the watermarks are per tag, not per wallet.
     // `undefined` (never queried) is its own group.
     for (const stream of ["transactions", "proofless"] as const) {
-      const groups = new Map<string, { from: Uint8Array | undefined; tags: Bytes32[] }>();
-      for (const tag of tags) {
-        const from = input.wallet._syncCursor(stream, bytesKey(tag));
-        const key = from === undefined ? "" : bytesKey(from);
-        const group = groups.get(key);
-        if (group === undefined) groups.set(key, { from, tags: [tag] });
-        else group.tags.push(tag);
-      }
+      const groups = groupByResumePoint(tags, (tag) =>
+        input.wallet._syncCursor(stream, bytesKey(tag)),
+      );
 
-      for (const group of groups.values()) {
-        for (let offset = 0; offset < group.tags.length; offset += chunkSize) {
-          const chunk = group.tags.slice(offset, offset + chunkSize);
+      for (const group of groups) {
+        for (let offset = 0; offset < group.keys.length; offset += chunkSize) {
+          const chunk = group.keys.slice(offset, offset + chunkSize);
           const collect =
             stream === "transactions" ? collectShieldedTransactions : collectProoflessDeposits;
           const furthest = await collect(
@@ -485,21 +503,13 @@ export async function syncWallet(
     }
 
     const scanNullifiers = async (nullifiers: readonly Bytes32[]): Promise<void> => {
-      // Grouped by resume point for the same reason tags are: a chunk carries
-      // one cursor, and a nullifier learned this sync must not inherit the
-      // position of one already at the tip.
-      const groups = new Map<string, { from: Uint8Array | undefined; nullifiers: Bytes32[] }>();
-      for (const nullifier of nullifiers) {
-        const from = input.wallet._syncCursor("nullifiers", bytesKey(nullifier));
-        const key = from === undefined ? "" : bytesKey(from);
-        const group = groups.get(key);
-        if (group === undefined) groups.set(key, { from, nullifiers: [nullifier] });
-        else group.nullifiers.push(nullifier);
-      }
+      const groups = groupByResumePoint(nullifiers, (nullifier) =>
+        input.wallet._syncCursor("nullifiers", bytesKey(nullifier)),
+      );
 
-      for (const group of groups.values()) {
-        for (let offset = 0; offset < group.nullifiers.length; offset += chunkSize) {
-          const chunk = group.nullifiers.slice(offset, offset + chunkSize);
+      for (const group of groups) {
+        for (let offset = 0; offset < group.keys.length; offset += chunkSize) {
+          const chunk = group.keys.slice(offset, offset + chunkSize);
           const furthest = await collectShieldedTransactionsByNullifiers(
             {
               indexer: input.client,

--- a/sdk-libs/ts/src/wallet/sync.ts
+++ b/sdk-libs/ts/src/wallet/sync.ts
@@ -292,14 +292,46 @@ interface CollectByTagsInput {
   readonly from: Uint8Array | undefined;
 }
 
+/** One page of a cursor-ordered stream, reduced to what paging needs. */
+interface Page {
+  readonly nextCursor?: Uint8Array | undefined;
+  /** Where the server says its scan reached; only the nullifier stream reports it. */
+  readonly scannedThrough?: Uint8Array | undefined;
+}
+
+/**
+ * Read one chunk to the end of its stream, returning the position reached.
+ *
+ * Only a missing cursor ends the read. Stopping on a page short of the limit
+ * would save a request per chunk, but it makes the non-advancing-cursor guard
+ * unreachable and stakes correctness on every endpoint returning a short page
+ * only when genuinely out of rows. Mirrors the Rust SDK, which has to agree
+ * with this or the two clients read different amounts.
+ */
+async function readChunk(
+  method: string,
+  start: Uint8Array | undefined,
+  request: (cursor: Uint8Array | undefined) => Promise<Page>,
+): Promise<Uint8Array | undefined> {
+  let cursor = start;
+  let furthest = start;
+  // Seeded with the resume point, so an indexer handing back the cursor it was
+  // given trips the guard immediately rather than after a wasted round trip.
+  const seenCursors = new Set<string>(start === undefined ? [] : [bytesKey(start)]);
+  for (;;) {
+    const page = await request(cursor);
+    furthest = page.scannedThrough ?? page.nextCursor ?? furthest;
+    const next = checkedNextCursor(method, page.nextCursor, seenCursors);
+    if (next === undefined) return furthest;
+    cursor = next;
+  }
+}
+
 async function collectShieldedTransactions(
   input: CollectByTagsInput,
   context?: RequestContext,
 ): Promise<Uint8Array | undefined> {
-  let cursor: Uint8Array | undefined = input.from;
-  let furthest: Uint8Array | undefined = input.from;
-  const seenCursors = new Set<string>();
-  do {
+  return readChunk("getShieldedTransactionsByTags", input.from, async (cursor) => {
     const response = await input.indexer.getShieldedTransactionsByTags(
       { tags: input.chunk, limit: input.pageLimit, ...(cursor === undefined ? {} : { cursor }) },
       input.nextRpcConfig(),
@@ -313,22 +345,15 @@ async function collectShieldedTransactions(
       const key = shieldedTransactionKey(transaction);
       if (!input.out.has(key)) input.out.set(key, transaction);
     }
-    cursor = checkedNextCursor("getShieldedTransactionsByTags", response.nextCursor, seenCursors);
-    // Kept even on the last page: the resume point for the next sync is a
-    // different question from whether another page exists now.
-    if (cursor !== undefined) furthest = cursor;
-  } while (cursor !== undefined);
-  return furthest;
+    return { nextCursor: response.nextCursor };
+  });
 }
 
 async function collectProoflessDeposits(
   input: CollectByTagsInput,
   context?: RequestContext,
 ): Promise<Uint8Array | undefined> {
-  let cursor: Uint8Array | undefined = input.from;
-  let furthest: Uint8Array | undefined = input.from;
-  const seenCursors = new Set<string>();
-  do {
+  return readChunk("getEncryptedUtxosByTags", input.from, async (cursor) => {
     const response = await input.indexer.getEncryptedUtxosByTags(
       { tags: input.chunk, limit: input.pageLimit, ...(cursor === undefined ? {} : { cursor }) },
       input.nextRpcConfig(),
@@ -356,10 +381,8 @@ async function collectProoflessDeposits(
         }),
       );
     }
-    cursor = checkedNextCursor("getEncryptedUtxosByTags", response.nextCursor, seenCursors);
-    if (cursor !== undefined) furthest = cursor;
-  } while (cursor !== undefined);
-  return furthest;
+    return { nextCursor: response.nextCursor };
+  });
 }
 
 /**
@@ -407,12 +430,7 @@ async function collectShieldedTransactionsByNullifiers(
   input: CollectByNullifiersInput,
   context?: RequestContext,
 ): Promise<Uint8Array | undefined> {
-  let cursor = input.start;
-  let resume: Uint8Array | undefined;
-  // Seeded with the resume point, so an indexer that hands back the cursor it
-  // was given trips the guard on the spot rather than after a wasted round trip.
-  const seenCursors = new Set<string>(input.start === undefined ? [] : [bytesKey(input.start)]);
-  do {
+  return readChunk("getShieldedTransactionsByNullifiers", input.start, async (cursor) => {
     const response = await input.indexer.getShieldedTransactionsByNullifiers(
       {
         nullifiers: input.chunk,
@@ -427,14 +445,11 @@ async function collectShieldedTransactionsByNullifiers(
       const key = shieldedTransactionKey(transaction);
       if (!input.out.has(key)) input.out.set(key, transaction);
     }
-    if (response.scannedThrough !== undefined) resume = response.scannedThrough;
-    cursor = checkedNextCursor(
-      "getShieldedTransactionsByNullifiers",
-      response.nextCursor,
-      seenCursors,
-    );
-  } while (cursor !== undefined);
-  return resume;
+    return {
+      nextCursor: response.nextCursor,
+      scannedThrough: response.scannedThrough,
+    };
+  });
 }
 
 export async function syncWallet(

--- a/sdk-libs/ts/src/wallet/sync.ts
+++ b/sdk-libs/ts/src/wallet/sync.ts
@@ -151,13 +151,10 @@ function walletQueryTags(wallet: Wallet, material: WalletSyncMaterial): readonly
 }
 
 /**
- * Nullifiers still worth asking about: the unspent ones.
+ * Nullifiers of unspent notes.
  *
- * This query asks "was this note spent, and in which transaction". A nullifier
- * appears at most once on chain -- that is what it is for -- so once the
- * spending transaction is in hand the answer is final and re-asking returns the
- * same row forever. The set therefore shrinks as a wallet ages rather than
- * growing with it: cost tracks the unspent note count, not history.
+ * A nullifier appears at most once on chain, so once its spend is known the
+ * answer is final. Cost tracks the unspent count, not history.
  */
 function walletQueryNullifiers(wallet: Wallet): readonly Bytes32[] {
   const nullifiers = new Map<string, Bytes32>();
@@ -300,13 +297,11 @@ interface Page {
 }
 
 /**
- * Read one chunk to the end of its stream, returning the position reached.
+ * Reads one chunk until the stream offers no further cursor.
  *
- * Only a missing cursor ends the read. Stopping on a page short of the limit
- * would save a request per chunk, but it makes the non-advancing-cursor guard
- * unreachable and stakes correctness on every endpoint returning a short page
- * only when genuinely out of rows. Mirrors the Rust SDK, which has to agree
- * with this or the two clients read different amounts.
+ * A cursor means there may be more, whatever the page size. Stopping on a short
+ * page would make the non-advancing-cursor guard unreachable. Mirrors the Rust
+ * SDK, which must agree or the two clients read different amounts.
  */
 async function readChunk(
   method: string,
@@ -386,12 +381,10 @@ async function collectProoflessDeposits(
 }
 
 /**
- * Bucket keys by the position their stream was last read to.
+ * Buckets keys by the position their stream was last read to.
  *
  * A chunk carries one cursor, so keys at different positions cannot share a
- * request: a key learned this sync would resume from a position it was never
- * scanned to and skip its history permanently. `undefined` (never queried) is
- * its own group.
+ * request. `undefined` (never queried) is its own group.
  */
 function groupByResumePoint(
   keys: readonly Bytes32[],

--- a/sdk-libs/ts/src/wallet/sync.ts
+++ b/sdk-libs/ts/src/wallet/sync.ts
@@ -150,10 +150,19 @@ function walletQueryTags(wallet: Wallet, material: WalletSyncMaterial): readonly
   return [...tags.values()];
 }
 
-/** Every note nullifier is queried, including notes already marked spent. */
+/**
+ * Nullifiers still worth asking about: the unspent ones.
+ *
+ * This query asks "was this note spent, and in which transaction". A nullifier
+ * appears at most once on chain -- that is what it is for -- so once the
+ * spending transaction is in hand the answer is final and re-asking returns the
+ * same row forever. The set therefore shrinks as a wallet ages rather than
+ * growing with it: cost tracks the unspent note count, not history.
+ */
 function walletQueryNullifiers(wallet: Wallet): readonly Bytes32[] {
   const nullifiers = new Map<string, Bytes32>();
   for (const entry of wallet.utxos()) {
+    if (entry.spent) continue;
     nullifiers.set(bytesKey(entry.nullifier), entry.nullifier);
   }
   return [...nullifiers.values()];

--- a/sdk-libs/ts/src/wallet/sync.ts
+++ b/sdk-libs/ts/src/wallet/sync.ts
@@ -368,13 +368,24 @@ interface CollectByNullifiersInput {
   readonly pageLimit: number;
   readonly nextRpcConfig: () => IndexerRpcConfig;
   readonly out: Map<string, IndexedShieldedTransaction>;
+  /** Where this chunk was read to last time, if it has been read before. */
+  readonly start?: Uint8Array;
 }
 
+/**
+ * Returns how far the scan reached, or `undefined` if the indexer did not say.
+ *
+ * The position comes from `scannedThrough`, not from the rows: an unspent
+ * nullifier matches nothing, so there is no last row to take a position from.
+ * An indexer that does not report it leaves the caller starting from zero next
+ * time, which is exactly the old behaviour.
+ */
 async function collectShieldedTransactionsByNullifiers(
   input: CollectByNullifiersInput,
   context?: RequestContext,
-): Promise<void> {
-  let cursor: Uint8Array | undefined;
+): Promise<Uint8Array | undefined> {
+  let cursor = input.start;
+  let resume: Uint8Array | undefined;
   const seenCursors = new Set<string>();
   do {
     const response = await input.indexer.getShieldedTransactionsByNullifiers(
@@ -391,12 +402,14 @@ async function collectShieldedTransactionsByNullifiers(
       const key = shieldedTransactionKey(transaction);
       if (!input.out.has(key)) input.out.set(key, transaction);
     }
+    if (response.scannedThrough !== undefined) resume = response.scannedThrough;
     cursor = checkedNextCursor(
       "getShieldedTransactionsByNullifiers",
       response.nextCursor,
       seenCursors,
     );
   } while (cursor !== undefined);
+  return resume;
 }
 
 export async function syncWallet(
@@ -469,21 +482,46 @@ export async function syncWallet(
       }
     }
 
+    const scanNullifiers = async (nullifiers: readonly Bytes32[]): Promise<void> => {
+      // Grouped by resume point for the same reason tags are: a chunk carries
+      // one cursor, and a nullifier learned this sync must not inherit the
+      // position of one already at the tip.
+      const groups = new Map<string, { from: Uint8Array | undefined; nullifiers: Bytes32[] }>();
+      for (const nullifier of nullifiers) {
+        const from = input.wallet._syncCursor("nullifiers", bytesKey(nullifier));
+        const key = from === undefined ? "" : bytesKey(from);
+        const group = groups.get(key);
+        if (group === undefined) groups.set(key, { from, nullifiers: [nullifier] });
+        else group.nullifiers.push(nullifier);
+      }
+
+      for (const group of groups.values()) {
+        for (let offset = 0; offset < group.nullifiers.length; offset += chunkSize) {
+          const chunk = group.nullifiers.slice(offset, offset + chunkSize);
+          const furthest = await collectShieldedTransactionsByNullifiers(
+            {
+              indexer: input.client,
+              chunk,
+              pageLimit,
+              nextRpcConfig,
+              out: transactions,
+              ...(group.from === undefined ? {} : { start: group.from }),
+            },
+            context,
+          );
+          if (furthest !== undefined) {
+            for (const nullifier of chunk) {
+              input.wallet._setSyncCursor("nullifiers", bytesKey(nullifier), furthest);
+            }
+          }
+        }
+      }
+    };
+
     const queriedNullifiers = new Set<string>();
     const initialNullifiers = walletQueryNullifiers(input.wallet);
     for (const nullifier of initialNullifiers) queriedNullifiers.add(bytesKey(nullifier));
-    for (let offset = 0; offset < initialNullifiers.length; offset += chunkSize) {
-      await collectShieldedTransactionsByNullifiers(
-        {
-          indexer: input.client,
-          chunk: initialNullifiers.slice(offset, offset + chunkSize),
-          pageLimit,
-          nextRpcConfig,
-          out: transactions,
-        },
-        context,
-      );
-    }
+    await scanNullifiers(initialNullifiers);
 
     const orderedTransactions = (): readonly IndexedShieldedTransaction[] => [
       ...[...transactions.values()].sort(compareBySlotThenSignature),
@@ -521,18 +559,7 @@ export async function syncWallet(
       (nullifier) => !queriedNullifiers.has(bytesKey(nullifier)),
     );
     const beforeFollowUp = transactions.size;
-    for (let offset = 0; offset < followUpNullifiers.length; offset += chunkSize) {
-      await collectShieldedTransactionsByNullifiers(
-        {
-          indexer: input.client,
-          chunk: followUpNullifiers.slice(offset, offset + chunkSize),
-          pageLimit,
-          nextRpcConfig,
-          out: transactions,
-        },
-        context,
-      );
-    }
+    await scanNullifiers(followUpNullifiers);
     if (transactions.size !== beforeFollowUp) {
       ordered = orderedTransactions();
       report = await decryptTransactions({

--- a/sdk-libs/ts/test/client.test.ts
+++ b/sdk-libs/ts/test/client.test.ts
@@ -379,7 +379,7 @@ describe("ZolanaClient", () => {
 
   it("accepts a nullifier response that reports how far the scan reached", async () => {
     // The decoder rejects unknown fields, so an indexer that reports its scan
-    // frontier would otherwise fail every nullifier query outright -- which is
+    // scanned to would otherwise fail every nullifier query outright -- which is
     // exactly what the live e2e suite hit.
     const fetch = vi.fn<typeof globalThis.fetch>(() =>
       Promise.resolve(

--- a/sdk-libs/ts/test/client.test.ts
+++ b/sdk-libs/ts/test/client.test.ts
@@ -377,6 +377,36 @@ describe("ZolanaClient", () => {
     });
   });
 
+  it("accepts a nullifier response that reports how far the scan reached", async () => {
+    // The decoder rejects unknown fields, so an indexer that reports its scan
+    // frontier would otherwise fail every nullifier query outright -- which is
+    // exactly what the live e2e suite hit.
+    const fetch = vi.fn<typeof globalThis.fetch>(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            id: "test-account",
+            jsonrpc: "2.0",
+            result: {
+              context: { block_time: 1, slot: 1 },
+              transactions: [],
+              next_cursor: null,
+              scanned_through: "Aw==",
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+
+    const response = await client(fetch).getShieldedTransactionsByNullifiers({
+      nullifiers: [bytes(7)],
+    });
+
+    expect(response.nextCursor).toBeUndefined();
+    expect(response.scannedThrough).toEqual(Uint8Array.of(3));
+  });
+
   it("forwards paginated nullifier lookups through the client facade", async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(() =>
       Promise.resolve(

--- a/sdk-libs/ts/test/client.test.ts
+++ b/sdk-libs/ts/test/client.test.ts
@@ -388,10 +388,10 @@ describe("ZolanaClient", () => {
             id: "test-account",
             jsonrpc: "2.0",
             result: {
-              context: { block_time: 1, slot: 1 },
+              context: { blockTime: 1, slot: 1 },
               transactions: [],
-              next_cursor: null,
-              scanned_through: "Aw==",
+              nextCursor: null,
+              scannedThrough: "Aw==",
             },
           }),
           { headers: { "content-type": "application/json" } },

--- a/sdk-libs/ts/test/wallet-sync.test.ts
+++ b/sdk-libs/ts/test/wallet-sync.test.ts
@@ -434,14 +434,72 @@ describe("wallet sync", () => {
     expect(getShieldedTransactionsByTags).toHaveBeenCalledOnce();
     expect(getEncryptedUtxosByTags).toHaveBeenCalledOnce();
     expect(getShieldedTransactionsByNullifiers).toHaveBeenCalledTimes(2);
+    // entries[1] was already known spent, so it is not asked about again: a
+    // nullifier appears at most once on chain, and that answer is already in
+    // hand. Only the unspent entries[0] is still an open question.
+    const unspent = [entries[0]!.nullifier];
     expect(getShieldedTransactionsByNullifiers.mock.calls[0]?.[0]).toMatchObject({
-      nullifiers: entries.map((entry) => entry.nullifier),
+      nullifiers: unspent,
       limit: 1000,
     });
     expect(getShieldedTransactionsByNullifiers.mock.calls[1]?.[0]).toMatchObject({
-      nullifiers: entries.map((entry) => entry.nullifier),
+      nullifiers: unspent,
       cursor,
       limit: 1000,
+    });
+  });
+
+  it("does not ask about notes already known spent", async () => {
+    const keypair = ShieldedKeypair.generate();
+    const wallet = new Wallet({ identity: keypair.shieldedAddress() });
+    const entries = [31n, 11n, 17n].map((amount, index) => {
+      const blinding = bytes(index + 40);
+      const utxo = new Utxo({
+        owner: keypair.signingPublicKey(),
+        asset: SOL_MINT,
+        amount,
+        blinding,
+      });
+      const hash = utxo.hash(keypair.nullifierPublicKey());
+      return {
+        utxo,
+        outputContext: { hash, tree: TREE, leafIndex: BigInt(index) },
+        nullifier: keypair.nullifier(hash, blinding),
+        // Only the last note is still unspent.
+        spent: index < 2,
+      };
+    });
+    wallet._replace({ ...wallet._state(), utxos: entries });
+
+    const getShieldedTransactionsByNullifiers = vi.fn(
+      async (_request: Readonly<{ nullifiers: readonly Bytes32[] }>) => ({
+        context: { blockTime: 1n },
+        transactions: [],
+      }),
+    );
+    const client = {
+      getShieldedTransactionsByTags: vi.fn(async () => ({
+        context: { blockTime: 1n },
+        transactions: [],
+      })),
+      getEncryptedUtxosByTags: vi.fn(async () => ({
+        context: { blockTime: 1n },
+        matches: [],
+      })),
+      getShieldedTransactionsByNullifiers,
+    } as unknown as ZolanaClient;
+
+    await syncWallet({
+      wallet,
+      authority: new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+      client,
+    });
+
+    // One request carrying one nullifier -- not three, and not one request per
+    // note the wallet has ever held.
+    expect(getShieldedTransactionsByNullifiers).toHaveBeenCalledOnce();
+    expect(getShieldedTransactionsByNullifiers.mock.calls[0]?.[0]).toMatchObject({
+      nullifiers: [entries[2]!.nullifier],
     });
   });
 

--- a/sdk-libs/ts/test/wallet-sync.test.ts
+++ b/sdk-libs/ts/test/wallet-sync.test.ts
@@ -503,6 +503,59 @@ describe("wallet sync", () => {
     });
   });
 
+  it("resumes the nullifier stream from where the indexer said it scanned to", async () => {
+    // The rows cannot supply this: an unspent note matches nothing, so there is
+    // no last row whose position could be remembered, and every sync would walk
+    // the whole stream again.
+    const keypair = ShieldedKeypair.generate();
+    const wallet = new Wallet({ identity: keypair.shieldedAddress() });
+    // Blinding is a field element, so the leading byte has to stay below the
+    // BN254 modulus -- 51 (0x33) does not.
+    const blinding = bytes(23);
+    const utxo = new Utxo({
+      owner: keypair.signingPublicKey(),
+      asset: SOL_MINT,
+      amount: 5n,
+      blinding,
+    });
+    const hash = utxo.hash(keypair.nullifierPublicKey());
+    const nullifier = keypair.nullifier(hash, blinding);
+    wallet._replace({
+      ...wallet._state(),
+      utxos: [
+        { utxo, outputContext: { hash, tree: TREE, leafIndex: 0n }, nullifier, spent: false },
+      ],
+    });
+
+    const scannedThrough = Uint8Array.of(4, 2);
+    const getShieldedTransactionsByNullifiers = vi.fn(
+      async (_request: Readonly<{ nullifiers: readonly Bytes32[]; cursor?: Uint8Array }>) => ({
+        context: { blockTime: 1n },
+        transactions: [],
+        scannedThrough,
+      }),
+    );
+    const client = {
+      getShieldedTransactionsByTags: vi.fn(async () => ({
+        context: { blockTime: 1n },
+        transactions: [],
+      })),
+      getEncryptedUtxosByTags: vi.fn(async () => ({
+        context: { blockTime: 1n },
+        matches: [],
+      })),
+      getShieldedTransactionsByNullifiers,
+    } as unknown as ZolanaClient;
+    const authority = new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair });
+
+    await syncWallet({ wallet, authority, client });
+    expect(getShieldedTransactionsByNullifiers.mock.calls[0]?.[0]?.cursor).toBeUndefined();
+
+    getShieldedTransactionsByNullifiers.mockClear();
+    await syncWallet({ wallet, authority, client });
+    expect(getShieldedTransactionsByNullifiers.mock.calls[0]?.[0]?.cursor).toEqual(scannedThrough);
+  });
+
   it("rejects a non-advancing nullifier cursor", async () => {
     const keypair = ShieldedKeypair.generate();
     const wallet = new Wallet({ identity: keypair.shieldedAddress() });

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -15,8 +15,8 @@ use zolana_interface::{
 };
 use zolana_keypair::viewing_key::ViewTag;
 use zolana_transaction::{
-    AssetBalance, OutputContext, OutputSlot, PrivateTransaction, ShieldedTransaction, SyncReport,
-    SyncWalletAuthority, TransactionError, Wallet, WalletAuthority, WalletSyncMaterial,
+    AssetBalance, CursorStream, OutputContext, OutputSlot, PrivateTransaction, ShieldedTransaction,
+    SyncReport, SyncWalletAuthority, TransactionError, Wallet, WalletAuthority, WalletSyncMaterial,
     DEFAULT_TAG_WINDOW,
 };
 
@@ -123,9 +123,18 @@ where
             //
             // Cursors come out of the wallet and go back rather than staying
             // borrowed, because `wallet` is needed mutably further down.
-            let mut cursors = std::mem::take(&mut wallet.sync_cursors);
-            let mut nullifier_cursors = std::mem::take(&mut wallet.nullifier_cursors);
-            let mut proofless_cursors = std::mem::take(&mut wallet.proofless_cursors);
+            let mut cursors = wallet
+                .cursors
+                .remove(&CursorStream::Tags)
+                .unwrap_or_default();
+            let mut nullifier_cursors = wallet
+                .cursors
+                .remove(&CursorStream::Nullifiers)
+                .unwrap_or_default();
+            let mut proofless_cursors = wallet
+                .cursors
+                .remove(&CursorStream::Proofless)
+                .unwrap_or_default();
             let mut by_nullifier: HashMap<String, ShieldedTransaction> = HashMap::new();
             // One gate for the whole round, not one per call: every query in a
             // round should read the chain at the same freshness bound, and
@@ -177,9 +186,13 @@ where
                 )
             });
 
-            wallet.sync_cursors = cursors;
-            wallet.nullifier_cursors = nullifier_cursors;
-            wallet.proofless_cursors = proofless_cursors;
+            wallet.cursors.insert(CursorStream::Tags, cursors);
+            wallet
+                .cursors
+                .insert(CursorStream::Nullifiers, nullifier_cursors);
+            wallet
+                .cursors
+                .insert(CursorStream::Proofless, proofless_cursors);
             // Propagate a panic rather than swallowing it into a sync error: a
             // panicked fetch means a bug here, not an unreachable indexer.
             let tag_result = tag_result.unwrap_or_else(|payload| resume_unwind(payload));
@@ -196,8 +209,12 @@ where
             for (key, tx) in by_nullifier {
                 transactions.entry(key).or_insert(tx);
             }
-            timing::note(round, "tag_cursors", wallet.sync_cursors.len());
-            timing::note(round, "nullifier_cursors", wallet.nullifier_cursors.len());
+            timing::note(round, "tag_cursors", stream_len(wallet, CursorStream::Tags));
+            timing::note(
+                round,
+                "nullifier_cursors",
+                stream_len(wallet, CursorStream::Nullifiers),
+            );
         }
         timing::note(round, "transactions", transactions.len());
         timing::note(round, "proofless_deposits", proofless_deposits.len());
@@ -289,7 +306,10 @@ where
         let before = (transactions.len(), proofless_deposits.len());
         let tags = wallet_query_tags(wallet, &material, config.tag_window)?;
         let nullifiers = wallet_query_nullifiers(wallet);
-        let mut cursors = std::mem::take(&mut wallet.sync_cursors);
+        let mut cursors = wallet
+            .cursors
+            .remove(&CursorStream::Tags)
+            .unwrap_or_default();
         let fetched = fetch_shielded_transactions_incremental_async(
             indexer,
             &tags,
@@ -300,9 +320,12 @@ where
             &mut scanned_to_tip,
         )
         .await;
-        wallet.sync_cursors = cursors;
+        wallet.cursors.insert(CursorStream::Tags, cursors);
         fetched?;
-        let mut nullifier_cursors = std::mem::take(&mut wallet.nullifier_cursors);
+        let mut nullifier_cursors = wallet
+            .cursors
+            .remove(&CursorStream::Nullifiers)
+            .unwrap_or_default();
         let nullifiers_fetched = fetch_shielded_transactions_by_nullifiers_async(
             indexer,
             &nullifiers,
@@ -313,9 +336,14 @@ where
             &mut nullifier_scanned_to_tip,
         )
         .await;
-        wallet.nullifier_cursors = nullifier_cursors;
+        wallet
+            .cursors
+            .insert(CursorStream::Nullifiers, nullifier_cursors);
         nullifiers_fetched?;
-        let mut proofless_cursors = std::mem::take(&mut wallet.proofless_cursors);
+        let mut proofless_cursors = wallet
+            .cursors
+            .remove(&CursorStream::Proofless)
+            .unwrap_or_default();
         let fetched_proofless = fetch_proofless_deposits_async(
             indexer,
             &tags,
@@ -326,7 +354,9 @@ where
             &mut proofless_scanned_to_tip,
         )
         .await;
-        wallet.proofless_cursors = proofless_cursors;
+        wallet
+            .cursors
+            .insert(CursorStream::Proofless, proofless_cursors);
         fetched_proofless?;
 
         txs = transactions.values().cloned().collect::<Vec<_>>();
@@ -567,6 +597,11 @@ where
         };
         cursor = Some(next);
     }
+}
+
+/// How many keys the wallet has a watermark for on one stream.
+fn stream_len(wallet: &Wallet, stream: CursorStream) -> usize {
+    wallet.cursors.get(&stream).map_or(0, HashMap::len)
 }
 
 /// Records one position for every key in the chunk.

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -94,11 +94,11 @@ where
     let mut proofless_deposits: HashMap<String, ShieldedTransaction> = HashMap::new();
     // Tags read to the tip during THIS sync. Unlike `wallet.sync_cursors` this
     // is deliberately not persisted: "the tip" means the tip as of now.
-    let mut scanned_to_tip: HashSet<ViewTag> = HashSet::new();
+    let mut scanned_to_tip: HashSet<CursorStream> = HashSet::new();
     // Separate stream, separate watermark: reaching the tip of the transaction
     // stream says nothing about the encrypted-utxo stream.
-    let mut proofless_scanned_to_tip: HashSet<ViewTag> = HashSet::new();
-    let mut nullifier_scanned_to_tip: HashSet<[u8; 32]> = HashSet::new();
+    let mut proofless_scanned_to_tip: HashSet<CursorStream> = HashSet::new();
+    let mut nullifier_scanned_to_tip: HashSet<CursorStream> = HashSet::new();
     let mut report = SyncReport::default();
     let mut txs: Vec<ShieldedTransaction> = Vec::new();
 
@@ -123,18 +123,15 @@ where
             //
             // Cursors come out of the wallet and go back rather than staying
             // borrowed, because `wallet` is needed mutably further down.
-            let mut cursors = wallet
-                .cursors
-                .remove(&CursorStream::Tags)
-                .unwrap_or_default();
-            let mut nullifier_cursors = wallet
-                .cursors
-                .remove(&CursorStream::Nullifiers)
-                .unwrap_or_default();
-            let mut proofless_cursors = wallet
-                .cursors
-                .remove(&CursorStream::Proofless)
-                .unwrap_or_default();
+            // Split per stream for the round: the three threads below each need
+            // their own `&mut`, and one map cannot be borrowed mutably three
+            // times. The variants keep the keys apart, so merging after the join
+            // is lossless.
+            let (mut cursors, mut nullifier_cursors, mut proofless_cursors) =
+                split_by_stream(std::mem::take(&mut wallet.cursors));
+            let tag_keys = stream_keys(&tags, CursorStream::Tags);
+            let nullifier_keys = stream_keys(&nullifiers, CursorStream::Nullifiers);
+            let proofless_keys = stream_keys(&tags, CursorStream::Proofless);
             let mut by_nullifier: HashMap<String, ShieldedTransaction> = HashMap::new();
             // One gate for the whole round, not one per call: every query in a
             // round should read the chain at the same freshness bound, and
@@ -142,12 +139,13 @@ where
             let gate = freshness_gate.take();
 
             let (tag_result, nullifier_result, proofless_result) = thread::scope(|scope| {
-                let tags_ref = &tags;
+                let tag_keys_ref = &tag_keys;
+                let proofless_keys_ref = &proofless_keys;
                 let tag_handle = scope.spawn(|| {
                     let _t = timing::Phase::start("fetch_shielded_by_tags", round);
                     fetch_shielded_transactions_incremental(
                         indexer,
-                        tags_ref,
+                        tag_keys_ref,
                         &mut transactions,
                         config,
                         gate,
@@ -159,7 +157,7 @@ where
                     let _t = timing::Phase::start("fetch_shielded_by_nullifiers", round);
                     fetch_shielded_transactions_by_nullifiers(
                         indexer,
-                        &nullifiers,
+                        &nullifier_keys,
                         &mut by_nullifier,
                         config,
                         gate,
@@ -171,7 +169,7 @@ where
                     let _t = timing::Phase::start("fetch_proofless_deposits", round);
                     fetch_proofless_deposits(
                         indexer,
-                        tags_ref,
+                        proofless_keys_ref,
                         &mut proofless_deposits,
                         config,
                         gate,
@@ -186,13 +184,9 @@ where
                 )
             });
 
-            wallet.cursors.insert(CursorStream::Tags, cursors);
-            wallet
-                .cursors
-                .insert(CursorStream::Nullifiers, nullifier_cursors);
-            wallet
-                .cursors
-                .insert(CursorStream::Proofless, proofless_cursors);
+            wallet.cursors = cursors;
+            wallet.cursors.extend(nullifier_cursors);
+            wallet.cursors.extend(proofless_cursors);
             // Propagate a panic rather than swallowing it into a sync error: a
             // panicked fetch means a bug here, not an unreachable indexer.
             let tag_result = tag_result.unwrap_or_else(|payload| resume_unwind(payload));
@@ -209,11 +203,15 @@ where
             for (key, tx) in by_nullifier {
                 transactions.entry(key).or_insert(tx);
             }
-            timing::note(round, "tag_cursors", stream_len(wallet, CursorStream::Tags));
+            timing::note(
+                round,
+                "tag_cursors",
+                stream_len(wallet, |key| matches!(key, CursorStream::Tags(_))),
+            );
             timing::note(
                 round,
                 "nullifier_cursors",
-                stream_len(wallet, CursorStream::Nullifiers),
+                stream_len(wallet, |key| matches!(key, CursorStream::Nullifiers(_))),
             );
         }
         timing::note(round, "transactions", transactions.len());
@@ -294,11 +292,11 @@ where
     let mut proofless_deposits: HashMap<String, ShieldedTransaction> = HashMap::new();
     // Tags read to the tip during THIS sync. Unlike `wallet.sync_cursors` this
     // is deliberately not persisted: "the tip" means the tip as of now.
-    let mut scanned_to_tip: HashSet<ViewTag> = HashSet::new();
+    let mut scanned_to_tip: HashSet<CursorStream> = HashSet::new();
     // Separate stream, separate watermark: reaching the tip of the transaction
     // stream says nothing about the encrypted-utxo stream.
-    let mut proofless_scanned_to_tip: HashSet<ViewTag> = HashSet::new();
-    let mut nullifier_scanned_to_tip: HashSet<[u8; 32]> = HashSet::new();
+    let mut proofless_scanned_to_tip: HashSet<CursorStream> = HashSet::new();
+    let mut nullifier_scanned_to_tip: HashSet<CursorStream> = HashSet::new();
     let mut report = SyncReport::default();
     let mut txs = Vec::new();
 
@@ -306,13 +304,16 @@ where
         let before = (transactions.len(), proofless_deposits.len());
         let tags = wallet_query_tags(wallet, &material, config.tag_window)?;
         let nullifiers = wallet_query_nullifiers(wallet);
-        let mut cursors = wallet
-            .cursors
-            .remove(&CursorStream::Tags)
-            .unwrap_or_default();
+        // One map for every stream now, so it comes out of the wallet once and
+        // goes back once.
+        let mut cursors = std::mem::take(&mut wallet.cursors);
+        let tag_keys = stream_keys(&tags, CursorStream::Tags);
+        let nullifier_keys = stream_keys(&nullifiers, CursorStream::Nullifiers);
+        let proofless_keys = stream_keys(&tags, CursorStream::Proofless);
+
         let fetched = fetch_shielded_transactions_incremental_async(
             indexer,
-            &tags,
+            &tag_keys,
             &mut transactions,
             config,
             freshness_gate.take(),
@@ -320,43 +321,37 @@ where
             &mut scanned_to_tip,
         )
         .await;
-        wallet.cursors.insert(CursorStream::Tags, cursors);
+        let nullifiers_fetched = if fetched.is_ok() {
+            fetch_shielded_transactions_by_nullifiers_async(
+                indexer,
+                &nullifier_keys,
+                &mut transactions,
+                config,
+                freshness_gate.take(),
+                &mut cursors,
+                &mut nullifier_scanned_to_tip,
+            )
+            .await
+        } else {
+            Ok(())
+        };
+        let fetched_proofless = if fetched.is_ok() && nullifiers_fetched.is_ok() {
+            fetch_proofless_deposits_async(
+                indexer,
+                &proofless_keys,
+                &mut proofless_deposits,
+                config,
+                freshness_gate.take(),
+                &mut cursors,
+                &mut proofless_scanned_to_tip,
+            )
+            .await
+        } else {
+            Ok(())
+        };
+        wallet.cursors = cursors;
         fetched?;
-        let mut nullifier_cursors = wallet
-            .cursors
-            .remove(&CursorStream::Nullifiers)
-            .unwrap_or_default();
-        let nullifiers_fetched = fetch_shielded_transactions_by_nullifiers_async(
-            indexer,
-            &nullifiers,
-            &mut transactions,
-            config,
-            freshness_gate.take(),
-            &mut nullifier_cursors,
-            &mut nullifier_scanned_to_tip,
-        )
-        .await;
-        wallet
-            .cursors
-            .insert(CursorStream::Nullifiers, nullifier_cursors);
         nullifiers_fetched?;
-        let mut proofless_cursors = wallet
-            .cursors
-            .remove(&CursorStream::Proofless)
-            .unwrap_or_default();
-        let fetched_proofless = fetch_proofless_deposits_async(
-            indexer,
-            &tags,
-            &mut proofless_deposits,
-            config,
-            freshness_gate.take(),
-            &mut proofless_cursors,
-            &mut proofless_scanned_to_tip,
-        )
-        .await;
-        wallet
-            .cursors
-            .insert(CursorStream::Proofless, proofless_cursors);
         fetched_proofless?;
 
         txs = transactions.values().cloned().collect::<Vec<_>>();
@@ -599,9 +594,34 @@ where
     }
 }
 
+/// Watermarks keyed by stream: for each key, the position read through.
+type StreamCursors = HashMap<CursorStream, Vec<u8>>;
+
+/// Splits watermarks into one map per stream, so concurrent fetches hold
+/// disjoint `&mut` instead of contending on one map. The caller merges them
+/// back; the variants keep the keys from colliding.
+fn split_by_stream(cursors: StreamCursors) -> (StreamCursors, StreamCursors, StreamCursors) {
+    let mut tags = HashMap::new();
+    let mut nullifiers = HashMap::new();
+    let mut proofless = HashMap::new();
+    for (key, position) in cursors {
+        match key {
+            CursorStream::Tags(_) => tags.insert(key, position),
+            CursorStream::Nullifiers(_) => nullifiers.insert(key, position),
+            CursorStream::Proofless(_) => proofless.insert(key, position),
+        };
+    }
+    (tags, nullifiers, proofless)
+}
+
+/// Labels each of a stream's keys with the stream it belongs to.
+fn stream_keys(values: &[[u8; 32]], stream: fn([u8; 32]) -> CursorStream) -> Vec<CursorStream> {
+    values.iter().copied().map(stream).collect()
+}
+
 /// How many keys the wallet has a watermark for on one stream.
-fn stream_len(wallet: &Wallet, stream: CursorStream) -> usize {
-    wallet.cursors.get(&stream).map_or(0, HashMap::len)
+fn stream_len(wallet: &Wallet, matches: fn(&CursorStream) -> bool) -> usize {
+    wallet.cursors.keys().filter(|key| matches(key)).count()
 }
 
 /// Records one position for every key in the chunk.
@@ -660,18 +680,18 @@ fn advance(furthest: &mut Option<Vec<u8>>, page: Page) -> Option<Vec<u8>> {
 /// more than the window can absorb.
 fn fetch_shielded_transactions_incremental<I: Rpc>(
     indexer: &I,
-    tags: &[ViewTag],
+    keys: &[CursorStream],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
-    cursors: &mut HashMap<ViewTag, Vec<u8>>,
-    scanned_to_tip: &mut HashSet<ViewTag>,
+    cursors: &mut HashMap<CursorStream, Vec<u8>>,
+    scanned_to_tip: &mut HashSet<CursorStream>,
 ) -> Result<(), ClientError> {
-    for (start, group) in group_by_resume_point(tags, cursors, scanned_to_tip) {
+    for (start, group) in group_by_resume_point(keys, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
             let furthest = read_chunk(start.clone(), |cursor| {
                 let response = indexer.get_shielded_transactions_by_tags(
-                    chunk.to_vec(),
+                    chunk.iter().copied().map(CursorStream::value).collect(),
                     cursor,
                     Some(config.page_limit),
                     rpc_config,
@@ -699,21 +719,21 @@ fn fetch_shielded_transactions_incremental<I: Rpc>(
 /// loop rather than calling [`read_chunk`]; see [`advance`].
 async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
     indexer: &I,
-    tags: &[ViewTag],
+    keys: &[CursorStream],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
-    cursors: &mut HashMap<ViewTag, Vec<u8>>,
-    scanned_to_tip: &mut HashSet<ViewTag>,
+    cursors: &mut HashMap<CursorStream, Vec<u8>>,
+    scanned_to_tip: &mut HashSet<CursorStream>,
 ) -> Result<(), ClientError> {
-    for (start, group) in group_by_resume_point(tags, cursors, scanned_to_tip) {
+    for (start, group) in group_by_resume_point(keys, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
             let mut cursor = start.clone();
             let mut furthest = start.clone();
             loop {
                 let response = indexer
                     .get_shielded_transactions_by_tags(
-                        chunk.to_vec(),
+                        chunk.iter().copied().map(CursorStream::value).collect(),
                         cursor,
                         Some(config.page_limit),
                         rpc_config,
@@ -750,18 +770,18 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
 /// zero.
 fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
     indexer: &I,
-    nullifiers: &[[u8; 32]],
+    keys: &[CursorStream],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
-    cursors: &mut HashMap<[u8; 32], Vec<u8>>,
-    scanned_to_tip: &mut HashSet<[u8; 32]>,
+    cursors: &mut HashMap<CursorStream, Vec<u8>>,
+    scanned_to_tip: &mut HashSet<CursorStream>,
 ) -> Result<(), ClientError> {
-    for (start, group) in group_by_resume_point(nullifiers, cursors, scanned_to_tip) {
+    for (start, group) in group_by_resume_point(keys, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
             let furthest = read_chunk(start.clone(), |cursor| {
                 let response = indexer.get_shielded_transactions_by_nullifiers(
-                    chunk.to_vec(),
+                    chunk.iter().copied().map(CursorStream::value).collect(),
                     cursor,
                     Some(config.page_limit),
                     rpc_config,
@@ -786,21 +806,21 @@ fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
 /// loop rather than calling [`read_chunk`]; see [`advance`].
 async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
     indexer: &I,
-    nullifiers: &[[u8; 32]],
+    keys: &[CursorStream],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
-    cursors: &mut HashMap<[u8; 32], Vec<u8>>,
-    scanned_to_tip: &mut HashSet<[u8; 32]>,
+    cursors: &mut HashMap<CursorStream, Vec<u8>>,
+    scanned_to_tip: &mut HashSet<CursorStream>,
 ) -> Result<(), ClientError> {
-    for (start, group) in group_by_resume_point(nullifiers, cursors, scanned_to_tip) {
+    for (start, group) in group_by_resume_point(keys, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
             let mut cursor = start.clone();
             let mut furthest = start.clone();
             loop {
                 let response = indexer
                     .get_shielded_transactions_by_nullifiers(
-                        chunk.to_vec(),
+                        chunk.iter().copied().map(CursorStream::value).collect(),
                         cursor,
                         Some(config.page_limit),
                         rpc_config,
@@ -833,21 +853,21 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
 /// learned late must be read from the beginning while others are far ahead.
 fn fetch_proofless_deposits<I>(
     indexer: &I,
-    tags: &[ViewTag],
+    keys: &[CursorStream],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
-    cursors: &mut HashMap<ViewTag, Vec<u8>>,
-    scanned_to_tip: &mut HashSet<ViewTag>,
+    cursors: &mut HashMap<CursorStream, Vec<u8>>,
+    scanned_to_tip: &mut HashSet<CursorStream>,
 ) -> Result<(), ClientError>
 where
     I: Rpc,
 {
-    for (start, group) in group_by_resume_point(tags, cursors, scanned_to_tip) {
+    for (start, group) in group_by_resume_point(keys, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
             let furthest = read_chunk(start.clone(), |cursor| {
                 let response = indexer.get_encrypted_utxos_by_tags(
-                    chunk.to_vec(),
+                    chunk.iter().copied().map(CursorStream::value).collect(),
                     cursor,
                     Some(config.page_limit),
                     rpc_config,
@@ -883,21 +903,21 @@ where
 /// calling [`read_chunk`]; see [`advance`].
 async fn fetch_proofless_deposits_async<I: AsyncRpc>(
     indexer: &I,
-    tags: &[ViewTag],
+    keys: &[CursorStream],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
-    cursors: &mut HashMap<ViewTag, Vec<u8>>,
-    scanned_to_tip: &mut HashSet<ViewTag>,
+    cursors: &mut HashMap<CursorStream, Vec<u8>>,
+    scanned_to_tip: &mut HashSet<CursorStream>,
 ) -> Result<(), ClientError> {
-    for (start, group) in group_by_resume_point(tags, cursors, scanned_to_tip) {
+    for (start, group) in group_by_resume_point(keys, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
             let mut cursor = start.clone();
             let mut furthest = start.clone();
             loop {
                 let response = indexer
                     .get_encrypted_utxos_by_tags(
-                        chunk.to_vec(),
+                        chunk.iter().copied().map(CursorStream::value).collect(),
                         cursor,
                         Some(config.page_limit),
                         rpc_config,
@@ -1385,13 +1405,13 @@ mod tests {
 
         let config = SyncWalletConfig::default();
         let mut out = HashMap::new();
-        let mut cursors: HashMap<ViewTag, Vec<u8>> = HashMap::new();
+        let mut cursors: HashMap<CursorStream, Vec<u8>> = HashMap::new();
         let mut scanned = HashSet::new();
 
         // Round 0: only the early tag is known.
         fetch_shielded_transactions_incremental(
             &indexer,
-            &[early],
+            &[CursorStream::Tags(early)],
             &mut out,
             config,
             None,
@@ -1404,7 +1424,7 @@ mod tests {
         // scanned to the tip, so only the late one is worth a request.
         fetch_shielded_transactions_incremental(
             &indexer,
-            &[early, late],
+            &[CursorStream::Tags(early), CursorStream::Tags(late)],
             &mut out,
             config,
             None,
@@ -1442,10 +1462,10 @@ mod tests {
         };
 
         let mut out = HashMap::new();
-        let mut cursors: HashMap<ViewTag, Vec<u8>> = HashMap::new();
+        let mut cursors: HashMap<CursorStream, Vec<u8>> = HashMap::new();
         fetch_shielded_transactions_incremental(
             &indexer,
-            &[tag],
+            &[CursorStream::Tags(tag)],
             &mut out,
             SyncWalletConfig::default(),
             None,
@@ -1456,7 +1476,7 @@ mod tests {
 
         assert_eq!(
             cursors
-                .get(&tag)
+                .get(&CursorStream::Tags(tag))
                 .map(|c| u64::from_be_bytes(c.as_slice().try_into().expect("8-byte cursor"))),
             Some(50),
             "a short page still records the tip, so the next sync resumes there"
@@ -1505,7 +1525,7 @@ mod tests {
         };
         fetch_shielded_transactions_by_nullifiers(
             &indexer,
-            &queried,
+            &stream_keys(&queried, CursorStream::Nullifiers),
             &mut HashMap::new(),
             SyncWalletConfig::default(),
             None,
@@ -1593,7 +1613,7 @@ mod tests {
         let mut tag_cursors = HashMap::new();
         fetch_shielded_transactions_incremental_async(
             &indexer,
-            &[tag],
+            &[CursorStream::Tags(tag)],
             &mut HashMap::new(),
             config,
             None,
@@ -1602,12 +1622,15 @@ mod tests {
         )
         .await
         .expect("tags");
-        assert_eq!(tag_cursors.get(&tag).map(slot_of), Some(50));
+        assert_eq!(
+            tag_cursors.get(&CursorStream::Tags(tag)).map(slot_of),
+            Some(50)
+        );
 
         let mut nullifier_cursors = HashMap::new();
         fetch_shielded_transactions_by_nullifiers_async(
             &indexer,
-            &[unspent],
+            &[CursorStream::Nullifiers(unspent)],
             &mut HashMap::new(),
             config,
             None,
@@ -1617,7 +1640,9 @@ mod tests {
         .await
         .expect("nullifiers");
         assert_eq!(
-            nullifier_cursors.get(&unspent).map(slot_of),
+            nullifier_cursors
+                .get(&CursorStream::Nullifiers(unspent))
+                .map(slot_of),
             Some(50),
             "no spend matched, so the position comes from the reported scan"
         );
@@ -1625,7 +1650,7 @@ mod tests {
         let mut proofless_cursors = HashMap::new();
         fetch_proofless_deposits_async(
             &indexer,
-            &[tag],
+            &[CursorStream::Proofless(tag)],
             &mut HashMap::new(),
             config,
             None,
@@ -1634,7 +1659,12 @@ mod tests {
         )
         .await
         .expect("proofless");
-        assert_eq!(proofless_cursors.get(&tag).map(slot_of), Some(30));
+        assert_eq!(
+            proofless_cursors
+                .get(&CursorStream::Proofless(tag))
+                .map(slot_of),
+            Some(30)
+        );
 
         // The streams that return rows take a second request to reach the empty
         // page that ends them. The nullifier stream matches nothing, so its
@@ -1671,11 +1701,11 @@ mod tests {
 
         let config = SyncWalletConfig::default();
         let mut out = HashMap::new();
-        let mut cursors: HashMap<[u8; 32], Vec<u8>> = HashMap::new();
+        let mut cursors: HashMap<CursorStream, Vec<u8>> = HashMap::new();
 
         fetch_shielded_transactions_by_nullifiers(
             &indexer,
-            &[unspent],
+            &[CursorStream::Nullifiers(unspent)],
             &mut out,
             config,
             None,
@@ -1686,7 +1716,7 @@ mod tests {
 
         assert_eq!(
             cursors
-                .get(&unspent)
+                .get(&CursorStream::Nullifiers(unspent))
                 .map(|c| u64::from_be_bytes(c.as_slice().try_into().expect("8-byte cursor"))),
             Some(50),
             "nothing matched, but the scan still reached the tip of the stream"
@@ -1700,7 +1730,7 @@ mod tests {
             .clear();
         fetch_shielded_transactions_by_nullifiers(
             &indexer,
-            &[unspent],
+            &[CursorStream::Nullifiers(unspent)],
             &mut out,
             config,
             None,
@@ -1734,11 +1764,11 @@ mod tests {
 
         let config = SyncWalletConfig::default();
         let mut out = HashMap::new();
-        let mut cursors: HashMap<ViewTag, Vec<u8>> = HashMap::new();
+        let mut cursors: HashMap<CursorStream, Vec<u8>> = HashMap::new();
 
         fetch_proofless_deposits(
             &indexer,
-            &[tag],
+            &[CursorStream::Proofless(tag)],
             &mut out,
             config,
             None,
@@ -1749,7 +1779,7 @@ mod tests {
 
         assert_eq!(
             cursors
-                .get(&tag)
+                .get(&CursorStream::Proofless(tag))
                 .map(|c| u64::from_be_bytes(c.as_slice().try_into().expect("8-byte cursor"))),
             Some(50),
             "the scan read to the last row, so that is where it resumes"
@@ -1759,7 +1789,7 @@ mod tests {
         indexer.utxo_calls.lock().expect("calls poisoned").clear();
         fetch_proofless_deposits(
             &indexer,
-            &[tag],
+            &[CursorStream::Proofless(tag)],
             &mut out,
             config,
             None,
@@ -1803,13 +1833,13 @@ mod tests {
             page_limit: 1,
             ..SyncWalletConfig::default()
         };
-        let mut cursors: HashMap<ViewTag, Vec<u8>> = HashMap::new();
+        let mut cursors: HashMap<CursorStream, Vec<u8>> = HashMap::new();
 
         // First sync knows only the early tag, and advances past slot 50.
         let mut first = HashMap::new();
         fetch_shielded_transactions_incremental(
             &indexer,
-            &[early],
+            &[CursorStream::Tags(early)],
             &mut first,
             config,
             None,
@@ -1821,13 +1851,13 @@ mod tests {
         .expect("first sync");
         assert_eq!(
             cursors
-                .get(&early)
+                .get(&CursorStream::Tags(early))
                 .map(|c| u64::from_be_bytes(c.as_slice().try_into().unwrap())),
             Some(50),
             "the early tag should have advanced to the last row it saw"
         );
         assert!(
-            !cursors.contains_key(&late),
+            !cursors.contains_key(&CursorStream::Tags(late)),
             "a tag that was never queried must not carry a cursor"
         );
 
@@ -1836,7 +1866,7 @@ mod tests {
         let mut second = HashMap::new();
         fetch_shielded_transactions_incremental(
             &indexer,
-            &[early, late],
+            &[CursorStream::Tags(early), CursorStream::Tags(late)],
             &mut second,
             config,
             None,
@@ -2229,7 +2259,7 @@ mod tests {
 
         fetch_shielded_transactions_incremental(
             &indexer,
-            &[[1u8; 32]],
+            &[CursorStream::Tags([1u8; 32])],
             &mut out,
             SyncWalletConfig::default(),
             None,
@@ -2255,7 +2285,9 @@ mod tests {
 
         fetch_proofless_deposits(
             &indexer,
-            &[keypair.recipient_bootstrap_view_tag()],
+            &[CursorStream::Proofless(
+                keypair.recipient_bootstrap_view_tag(),
+            )],
             &mut out,
             SyncWalletConfig::default(),
             None,
@@ -2375,7 +2407,9 @@ mod tests {
 
         fetch_proofless_deposits(
             &indexer,
-            &[keypair.recipient_bootstrap_view_tag()],
+            &[CursorStream::Proofless(
+                keypair.recipient_bootstrap_view_tag(),
+            )],
             &mut out,
             SyncWalletConfig::default(),
             None,

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -684,8 +684,9 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
 /// about D. A nullifier with no entry is queried from zero, which is wasteful
 /// rather than wrong.
 ///
-/// An indexer that does not report `scanned_through` simply never populates
-/// `cursors`, which is exactly the old behaviour.
+/// `scanned_through` is absent on a page the limit truncated, because nothing
+/// can then be claimed beyond it; the loop keeps paging and takes the position
+/// from the short page that ends it.
 fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
     indexer: &I,
     nullifiers: &[[u8; 32]],
@@ -724,8 +725,8 @@ fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
                     let key = tx.tx_signature.to_string();
                     out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
-                if response.scanned_through.is_some() {
-                    resume = response.scanned_through;
+                if let Some(position) = response.scanned_through {
+                    resume = Some(position);
                 }
                 cursor = response.next_cursor;
                 if cursor.is_none() {
@@ -785,8 +786,8 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
                     let key = tx.tx_signature.to_string();
                     out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
-                if response.scanned_through.is_some() {
-                    resume = response.scanned_through;
+                if let Some(position) = response.scanned_through {
+                    resume = Some(position);
                 }
                 cursor = response.next_cursor;
                 if cursor.is_none() {

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -124,6 +124,7 @@ where
             // Cursors come out of the wallet and go back rather than staying
             // borrowed, because `wallet` is needed mutably further down.
             let mut cursors = std::mem::take(&mut wallet.sync_cursors);
+            let mut nullifier_cursors = std::mem::take(&mut wallet.nullifier_cursors);
             let mut by_nullifier: HashMap<String, ShieldedTransaction> = HashMap::new();
             // One gate for the whole round, not one per call: every query in a
             // round should read the chain at the same freshness bound, and
@@ -152,6 +153,7 @@ where
                         &mut by_nullifier,
                         config,
                         gate,
+                        &mut nullifier_cursors,
                         &mut nullifier_scanned_to_tip,
                     )
                 });
@@ -174,6 +176,7 @@ where
             });
 
             wallet.sync_cursors = cursors;
+            wallet.nullifier_cursors = nullifier_cursors;
             // Propagate a panic rather than swallowing it into a sync error: a
             // panicked fetch means a bug here, not an unreachable indexer.
             let tag_result = tag_result.unwrap_or_else(|payload| resume_unwind(payload));
@@ -191,6 +194,7 @@ where
                 transactions.entry(key).or_insert(tx);
             }
             timing::note(round, "tag_cursors", wallet.sync_cursors.len());
+            timing::note(round, "nullifier_cursors", wallet.nullifier_cursors.len());
         }
         timing::note(round, "transactions", transactions.len());
         timing::note(round, "proofless_deposits", proofless_deposits.len());
@@ -295,15 +299,19 @@ where
         .await;
         wallet.sync_cursors = cursors;
         fetched?;
-        fetch_shielded_transactions_by_nullifiers_async(
+        let mut nullifier_cursors = std::mem::take(&mut wallet.nullifier_cursors);
+        let nullifiers_fetched = fetch_shielded_transactions_by_nullifiers_async(
             indexer,
             &nullifiers,
             &mut transactions,
             config,
             freshness_gate.take(),
+            &mut nullifier_cursors,
             &mut nullifier_scanned_to_tip,
         )
-        .await?;
+        .await;
+        wallet.nullifier_cursors = nullifier_cursors;
+        nullifiers_fetched?;
         fetch_proofless_deposits_async(
             indexer,
             &tags,
@@ -664,76 +672,135 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
     Ok(())
 }
 
+/// Fetch spends of `nullifiers`, resuming each from where it was last checked.
+///
+/// The resume point comes from the indexer's `scanned_through`, not from the
+/// rows: an unspent nullifier matches nothing, so there is no last row to take a
+/// position from. That is the whole difficulty here and the reason this cannot
+/// be modelled on the tag path, whose cursor rides on rows it actually returns.
+///
+/// The position is per-nullifier rather than one shared value because it is only
+/// sound for the set that was asked about: a scan over {A, B, C} says nothing
+/// about D. A nullifier with no entry is queried from zero, which is wasteful
+/// rather than wrong.
+///
+/// An indexer that does not report `scanned_through` simply never populates
+/// `cursors`, which is exactly the old behaviour.
 fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
     indexer: &I,
     nullifiers: &[[u8; 32]],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    cursors: &mut HashMap<[u8; 32], Vec<u8>>,
     scanned_to_tip: &mut HashSet<[u8; 32]>,
 ) -> Result<(), ClientError> {
-    let pending: Vec<[u8; 32]> = nullifiers
-        .iter()
-        .copied()
-        .filter(|nullifier| !scanned_to_tip.contains(nullifier))
-        .collect();
-    for chunk in pending.chunks(config.tag_query_chunk) {
-        let mut cursor = None;
-        loop {
-            let response = indexer.get_shielded_transactions_by_nullifiers(
-                chunk.to_vec(),
-                cursor,
-                Some(config.page_limit),
-                rpc_config,
-            )?;
-            for tx in response.transactions.into_iter().filter(|tx| !tx.proofless) {
-                let key = tx.tx_signature.to_string();
-                out.entry(key).or_insert(convert_sync_transaction(tx)?);
-            }
-            cursor = response.next_cursor;
-            if cursor.is_none() {
-                break;
-            }
+    // Group by resume point, exactly as the tag path does. In the steady state
+    // every known nullifier shares one position and newly created ones have
+    // none, so this is two queries however many UTXOs the wallet holds.
+    let mut groups: HashMap<Option<Vec<u8>>, Vec<[u8; 32]>> = HashMap::new();
+    for nullifier in nullifiers {
+        if scanned_to_tip.contains(nullifier) {
+            continue;
         }
-        scanned_to_tip.extend(chunk.iter().copied());
+        groups
+            .entry(cursors.get(nullifier).cloned())
+            .or_default()
+            .push(*nullifier);
+    }
+
+    for (start, group) in groups {
+        for chunk in group.chunks(config.tag_query_chunk) {
+            let mut cursor = start.clone();
+            let mut resume = None;
+            loop {
+                let response = indexer.get_shielded_transactions_by_nullifiers(
+                    chunk.to_vec(),
+                    cursor,
+                    Some(config.page_limit),
+                    rpc_config,
+                )?;
+                for tx in response.transactions.into_iter().filter(|tx| !tx.proofless) {
+                    let key = tx.tx_signature.to_string();
+                    out.entry(key).or_insert(convert_sync_transaction(tx)?);
+                }
+                if response.scanned_through.is_some() {
+                    resume = response.scanned_through;
+                }
+                cursor = response.next_cursor;
+                if cursor.is_none() {
+                    break;
+                }
+            }
+
+            if let Some(position) = resume {
+                for nullifier in chunk {
+                    cursors.insert(*nullifier, position.clone());
+                }
+            }
+            scanned_to_tip.extend(chunk.iter().copied());
+        }
     }
     Ok(())
 }
 
+/// Async twin of [`fetch_shielded_transactions_by_nullifiers`], kept deliberately
+/// parallel rather than shared for the same reason as the tag pair: the two
+/// differ only in `.await`, and an async client that missed the per-nullifier
+/// resume rule would rescan the whole stream on every sync.
 async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
     indexer: &I,
     nullifiers: &[[u8; 32]],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    cursors: &mut HashMap<[u8; 32], Vec<u8>>,
     scanned_to_tip: &mut HashSet<[u8; 32]>,
 ) -> Result<(), ClientError> {
-    let pending: Vec<[u8; 32]> = nullifiers
-        .iter()
-        .copied()
-        .filter(|nullifier| !scanned_to_tip.contains(nullifier))
-        .collect();
-    for chunk in pending.chunks(config.tag_query_chunk) {
-        let mut cursor = None;
-        loop {
-            let response = indexer
-                .get_shielded_transactions_by_nullifiers(
-                    chunk.to_vec(),
-                    cursor,
-                    Some(config.page_limit),
-                    rpc_config,
-                )
-                .await?;
-            for tx in response.transactions.into_iter().filter(|tx| !tx.proofless) {
-                let key = tx.tx_signature.to_string();
-                out.entry(key).or_insert(convert_sync_transaction(tx)?);
-            }
-            cursor = response.next_cursor;
-            if cursor.is_none() {
-                break;
-            }
+    let mut groups: HashMap<Option<Vec<u8>>, Vec<[u8; 32]>> = HashMap::new();
+    for nullifier in nullifiers {
+        if scanned_to_tip.contains(nullifier) {
+            continue;
         }
-        scanned_to_tip.extend(chunk.iter().copied());
+        groups
+            .entry(cursors.get(nullifier).cloned())
+            .or_default()
+            .push(*nullifier);
+    }
+
+    for (start, group) in groups {
+        for chunk in group.chunks(config.tag_query_chunk) {
+            let mut cursor = start.clone();
+            let mut resume = None;
+            loop {
+                let response = indexer
+                    .get_shielded_transactions_by_nullifiers(
+                        chunk.to_vec(),
+                        cursor,
+                        Some(config.page_limit),
+                        rpc_config,
+                    )
+                    .await?;
+                for tx in response.transactions.into_iter().filter(|tx| !tx.proofless) {
+                    let key = tx.tx_signature.to_string();
+                    out.entry(key).or_insert(convert_sync_transaction(tx)?);
+                }
+                if response.scanned_through.is_some() {
+                    resume = response.scanned_through;
+                }
+                cursor = response.next_cursor;
+                if cursor.is_none() {
+                    break;
+                }
+            }
+
+            if let Some(position) = resume {
+                for nullifier in chunk {
+                    cursors.insert(*nullifier, position.clone());
+                }
+            }
+            scanned_to_tip.extend(chunk.iter().copied());
+        }
     }
     Ok(())
 }
@@ -1008,7 +1075,7 @@ mod tests {
             nullifiers: &[[u8; 32]],
             cursor: Option<Vec<u8>>,
             limit: usize,
-        ) -> (Vec<ShieldedTransaction>, Option<Vec<u8>>) {
+        ) -> (Vec<ShieldedTransaction>, Option<Vec<u8>>, Option<Vec<u8>>) {
             let after = cursor.as_ref().map(|bytes| {
                 u64::from_be_bytes(bytes.as_slice().try_into().expect("8-byte cursor"))
             });
@@ -1027,6 +1094,12 @@ mod tests {
             rows.truncate(limit);
 
             let next = rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec());
+            // Photon's rule: the frontier is reported only when the limit did
+            // not cut the scan short, and it is the tip of the whole stream --
+            // not of the matching rows, of which there are usually none.
+            let scanned_through = (rows.len() < limit)
+                .then(|| self.stream_tip().map(|slot| slot.to_be_bytes().to_vec()))
+                .flatten();
             let transactions = rows
                 .into_iter()
                 .map(|(slot, nullifier)| ShieldedTransaction {
@@ -1040,7 +1113,17 @@ mod tests {
                     proofless: false,
                 })
                 .collect();
-            (transactions, next)
+            (transactions, next, scanned_through)
+        }
+
+        /// The greatest position in the stream, matching or not, as photon reads
+        /// it straight off `rings_transactions`.
+        fn stream_tip(&self) -> Option<u64> {
+            self.entries
+                .iter()
+                .map(|(slot, _)| *slot)
+                .chain(self.spends.iter().map(|(slot, _)| *slot))
+                .max()
         }
     }
 
@@ -1114,6 +1197,10 @@ mod tests {
                     .cloned()
                     .collect(),
                 next_cursor: None,
+                // This mock answers everything in one page and never paginates,
+                // so it has no frontier to report; the resume path is covered by
+                // TaggedIndexer instead.
+                scanned_through: None,
             })
         }
     }
@@ -1175,7 +1262,8 @@ mod tests {
             _config: Option<IndexerRpcConfig>,
         ) -> Result<GetShieldedTransactionsByNullifiersResponse, ClientError> {
             let limit = limit.unwrap_or(1_000).max(1) as usize;
-            let (transactions, next_cursor) = self.matching_nullifiers(&nullifiers, cursor, limit);
+            let (transactions, next_cursor, scanned_through) =
+                self.matching_nullifiers(&nullifiers, cursor, limit);
             Ok(GetShieldedTransactionsByNullifiersResponse {
                 context: Context {
                     block_time: 0,
@@ -1183,6 +1271,7 @@ mod tests {
                 },
                 transactions,
                 next_cursor,
+                scanned_through,
             })
         }
     }
@@ -1343,6 +1432,7 @@ mod tests {
             &mut HashMap::new(),
             SyncWalletConfig::default(),
             None,
+            &mut HashMap::new(),
             &mut HashSet::new(),
         )
         .expect("fetch");
@@ -1351,6 +1441,63 @@ mod tests {
             *indexer.nullifier_calls.borrow(),
             vec![(1, None)],
             "one request carrying one nullifier, not the whole utxo history"
+        );
+    }
+
+    /// A second sync resumes the nullifier stream instead of walking it again.
+    ///
+    /// This is what the indexer's `scanned_through` buys. The rows cannot supply
+    /// it: an unspent nullifier matches nothing, so there is no last row whose
+    /// position could be remembered, and every sync would start from zero.
+    #[test]
+    fn a_second_sync_resumes_the_nullifier_stream() {
+        let unspent = [7u8; 32];
+        // A stream with traffic in it, none of which spends `unspent`.
+        let indexer = TaggedIndexer {
+            spends: vec![(10, [9u8; 32]), (50, [9u8; 32])],
+            ..Default::default()
+        };
+
+        let config = SyncWalletConfig::default();
+        let mut out = HashMap::new();
+        let mut cursors: HashMap<[u8; 32], Vec<u8>> = HashMap::new();
+
+        fetch_shielded_transactions_by_nullifiers(
+            &indexer,
+            &[unspent],
+            &mut out,
+            config,
+            None,
+            &mut cursors,
+            &mut HashSet::new(),
+        )
+        .expect("first sync");
+
+        assert_eq!(
+            cursors
+                .get(&unspent)
+                .map(|c| u64::from_be_bytes(c.as_slice().try_into().expect("8-byte cursor"))),
+            Some(50),
+            "nothing matched, but the scan still reached the tip of the stream"
+        );
+
+        // A fresh scanned_to_tip, as a later sync would have.
+        indexer.nullifier_calls.borrow_mut().clear();
+        fetch_shielded_transactions_by_nullifiers(
+            &indexer,
+            &[unspent],
+            &mut out,
+            config,
+            None,
+            &mut cursors,
+            &mut HashSet::new(),
+        )
+        .expect("second sync");
+
+        assert_eq!(
+            *indexer.nullifier_calls.borrow(),
+            vec![(1, Some(50))],
+            "the second sync resumes at 50 rather than rescanning from zero"
         );
     }
 

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -1077,7 +1077,7 @@ mod tests {
             rows.truncate(limit);
 
             let next = rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec());
-            // Photon's rule: the frontier is reported only when the limit did
+            // Photon.s rule: the position is reported only when the limit did
             // not cut the scan short, and it is the tip of the whole stream --
             // not of the matching rows, of which there are usually none.
             let scanned_through = (rows.len() < limit)
@@ -1181,7 +1181,7 @@ mod tests {
                     .collect(),
                 next_cursor: None,
                 // This mock answers everything in one page and never paginates,
-                // so it has no frontier to report; the resume path is covered by
+                // so it has nothing to report; the resume path is covered by
                 // TaggedIndexer instead.
                 scanned_through: None,
             })

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -553,9 +553,6 @@ fn group_by_resume_point<K: Copy + Eq + std::hash::Hash>(
 
 /// One page of a cursor-ordered stream, reduced to what paging needs.
 struct Page {
-    /// Rows the server returned, before any client-side filtering. A page short
-    /// of the limit means the server ran out of rows, not out of room.
-    rows: usize,
     next_cursor: Option<Vec<u8>>,
     /// Where the server says its scan reached. Only the nullifier stream reports
     /// this, and only it needs to: its pages are normally empty, so there is no
@@ -569,11 +566,7 @@ struct Page {
 /// the rule that a short page ends the read lives here rather than in each
 /// caller. Paging until `next_cursor` is `None` instead costs one extra request
 /// per chunk per sync, to be told the stream is empty.
-fn read_chunk<F>(
-    start: Option<Vec<u8>>,
-    page_limit: u32,
-    mut request: F,
-) -> Result<Option<Vec<u8>>, ClientError>
+fn read_chunk<F>(start: Option<Vec<u8>>, mut request: F) -> Result<Option<Vec<u8>>, ClientError>
 where
     F: FnMut(Option<Vec<u8>>) -> Result<Page, ClientError>,
 {
@@ -581,11 +574,31 @@ where
     let mut furthest = start;
     loop {
         let page = request(cursor)?;
-        let Some(next) = advance(&mut furthest, page, page_limit) else {
+        let Some(next) = advance(&mut furthest, page) else {
             return Ok(furthest);
         };
         cursor = Some(next);
     }
+}
+
+/// Record where a chunk was read to, once its read has ended.
+///
+/// Advancing every key in the chunk to one position is sound only because the
+/// ordering is global: a position obtained from a query over {A, B, C} states,
+/// for each of them individually, that everything matching up to there has been
+/// seen.
+fn record_chunk<K: Copy + Eq + std::hash::Hash>(
+    chunk: &[K],
+    furthest: Option<Vec<u8>>,
+    cursors: &mut HashMap<K, Vec<u8>>,
+    scanned_to_tip: &mut HashSet<K>,
+) {
+    if let Some(position) = furthest {
+        for key in chunk {
+            cursors.insert(*key, position.clone());
+        }
+    }
+    scanned_to_tip.extend(chunk.iter().copied());
 }
 
 /// Fold one page into the position read so far, and say where to read next.
@@ -597,7 +610,7 @@ where
 ///
 /// `None` ends the read: either the page was short of the limit, so the server
 /// had no more rows, or it offered no cursor to continue from.
-fn advance(furthest: &mut Option<Vec<u8>>, page: Page, page_limit: u32) -> Option<Vec<u8>> {
+fn advance(furthest: &mut Option<Vec<u8>>, page: Page) -> Option<Vec<u8>> {
     // The server's own scan position when it reports one, else the last row it
     // returned, else stay put.
     *furthest = page
@@ -605,7 +618,6 @@ fn advance(furthest: &mut Option<Vec<u8>>, page: Page, page_limit: u32) -> Optio
         .or_else(|| page.next_cursor.clone())
         .or_else(|| furthest.take());
     page.next_cursor
-        .filter(|_| page.rows >= page_limit as usize)
 }
 
 /// Fetch shielded transactions for `tags`, resuming each tag from where it was
@@ -639,14 +651,13 @@ fn fetch_shielded_transactions_incremental<I: Rpc>(
 ) -> Result<(), ClientError> {
     for (start, group) in group_by_resume_point(tags, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
-            let furthest = read_chunk(start.clone(), config.page_limit, |cursor| {
+            let furthest = read_chunk(start.clone(), |cursor| {
                 let response = indexer.get_shielded_transactions_by_tags(
                     chunk.to_vec(),
                     cursor,
                     Some(config.page_limit),
                     rpc_config,
                 )?;
-                let rows = response.transactions.len();
                 for tx in response.transactions {
                     if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
                         continue;
@@ -655,20 +666,12 @@ fn fetch_shielded_transactions_incremental<I: Rpc>(
                     out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
                 Ok(Page {
-                    rows,
                     next_cursor: response.next_cursor,
                     scanned_through: None,
                 })
             })?;
 
-            // Sound only because the ordering is global: every tag in the chunk
-            // has now been read to that one position.
-            if let Some(position) = furthest {
-                for tag in chunk {
-                    cursors.insert(*tag, position.clone());
-                }
-            }
-            scanned_to_tip.extend(chunk.iter().copied());
+            record_chunk(chunk, furthest, cursors, scanned_to_tip);
         }
     }
     Ok(())
@@ -698,7 +701,6 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
                         rpc_config,
                     )
                     .await?;
-                let rows = response.transactions.len();
                 for tx in response.transactions {
                     if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
                         continue;
@@ -707,22 +709,16 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
                     out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
                 let page = Page {
-                    rows,
                     next_cursor: response.next_cursor,
                     scanned_through: None,
                 };
-                let Some(next) = advance(&mut furthest, page, config.page_limit) else {
+                let Some(next) = advance(&mut furthest, page) else {
                     break;
                 };
                 cursor = Some(next);
             }
 
-            if let Some(position) = furthest {
-                for tag in chunk {
-                    cursors.insert(*tag, position.clone());
-                }
-            }
-            scanned_to_tip.extend(chunk.iter().copied());
+            record_chunk(chunk, furthest, cursors, scanned_to_tip);
         }
     }
     Ok(())
@@ -753,31 +749,24 @@ fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
     // holds.
     for (start, group) in group_by_resume_point(nullifiers, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
-            let furthest = read_chunk(start.clone(), config.page_limit, |cursor| {
+            let furthest = read_chunk(start.clone(), |cursor| {
                 let response = indexer.get_shielded_transactions_by_nullifiers(
                     chunk.to_vec(),
                     cursor,
                     Some(config.page_limit),
                     rpc_config,
                 )?;
-                let rows = response.transactions.len();
                 for tx in response.transactions.into_iter().filter(|tx| !tx.proofless) {
                     let key = tx.tx_signature.to_string();
                     out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
                 Ok(Page {
-                    rows,
                     next_cursor: response.next_cursor,
                     scanned_through: response.scanned_through,
                 })
             })?;
 
-            if let Some(position) = furthest {
-                for nullifier in chunk {
-                    cursors.insert(*nullifier, position.clone());
-                }
-            }
-            scanned_to_tip.extend(chunk.iter().copied());
+            record_chunk(chunk, furthest, cursors, scanned_to_tip);
         }
     }
     Ok(())
@@ -807,28 +796,21 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
                         rpc_config,
                     )
                     .await?;
-                let rows = response.transactions.len();
                 for tx in response.transactions.into_iter().filter(|tx| !tx.proofless) {
                     let key = tx.tx_signature.to_string();
                     out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
                 let page = Page {
-                    rows,
                     next_cursor: response.next_cursor,
                     scanned_through: response.scanned_through,
                 };
-                let Some(next) = advance(&mut furthest, page, config.page_limit) else {
+                let Some(next) = advance(&mut furthest, page) else {
                     break;
                 };
                 cursor = Some(next);
             }
 
-            if let Some(position) = furthest {
-                for nullifier in chunk {
-                    cursors.insert(*nullifier, position.clone());
-                }
-            }
-            scanned_to_tip.extend(chunk.iter().copied());
+            record_chunk(chunk, furthest, cursors, scanned_to_tip);
         }
     }
     Ok(())
@@ -859,14 +841,13 @@ where
 {
     for (start, group) in group_by_resume_point(tags, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
-            let furthest = read_chunk(start.clone(), config.page_limit, |cursor| {
+            let furthest = read_chunk(start.clone(), |cursor| {
                 let response = indexer.get_encrypted_utxos_by_tags(
                     chunk.to_vec(),
                     cursor,
                     Some(config.page_limit),
                     rpc_config,
                 )?;
-                let rows = response.matches.len();
                 for item in response.matches {
                     if item.tx_viewing_pk.is_some() || item.salt.is_some() {
                         continue;
@@ -883,18 +864,12 @@ where
                     }
                 }
                 Ok(Page {
-                    rows,
                     next_cursor: response.next_cursor,
                     scanned_through: None,
                 })
             })?;
 
-            if let Some(position) = furthest {
-                for tag in chunk {
-                    cursors.insert(*tag, position.clone());
-                }
-            }
-            scanned_to_tip.extend(chunk.iter().copied());
+            record_chunk(chunk, furthest, cursors, scanned_to_tip);
         }
     }
     Ok(())
@@ -924,7 +899,6 @@ async fn fetch_proofless_deposits_async<I: AsyncRpc>(
                         rpc_config,
                     )
                     .await?;
-                let rows = response.matches.len();
                 for item in response.matches {
                     if item.tx_viewing_pk.is_some() || item.salt.is_some() {
                         continue;
@@ -941,22 +915,16 @@ async fn fetch_proofless_deposits_async<I: AsyncRpc>(
                     }
                 }
                 let page = Page {
-                    rows,
                     next_cursor: response.next_cursor,
                     scanned_through: None,
                 };
-                let Some(next) = advance(&mut furthest, page, config.page_limit) else {
+                let Some(next) = advance(&mut furthest, page) else {
                     break;
                 };
                 cursor = Some(next);
             }
 
-            if let Some(position) = furthest {
-                for tag in chunk {
-                    cursors.insert(*tag, position.clone());
-                }
-            }
-            scanned_to_tip.extend(chunk.iter().copied());
+            record_chunk(chunk, furthest, cursors, scanned_to_tip);
         }
     }
     Ok(())
@@ -1444,12 +1412,12 @@ mod tests {
         )
         .expect("round 1");
 
-        // One request per round, each carrying one tag: the early tag is already
-        // at the tip and is never re-queried, and neither round pays for a
-        // second request just to learn its page was the last.
+        // Two requests per round: one for the rows, one that comes back empty
+        // and ends the stream. What matters is that no request ever carries two
+        // tags -- the early tag is never re-queried.
         assert_eq!(
             *indexer.calls.lock().expect("calls poisoned"),
-            vec![(1, None), (1, None)],
+            vec![(1, None), (1, Some(10)), (1, None), (1, Some(50))],
             "round 1 must ask for the late tag alone, not both tags again"
         );
     }
@@ -1494,9 +1462,8 @@ mod tests {
         );
         assert_eq!(
             *indexer.calls.lock().expect("calls poisoned"),
-            vec![(1, None)],
-            "a page short of the limit ends the read: asking again only to be \
-             told the stream is empty costs a round trip per chunk per sync"
+            vec![(1, None), (1, Some(50))],
+            "one request for the rows, one more that returns none and ends the loop"
         );
     }
 
@@ -1553,33 +1520,43 @@ mod tests {
         );
     }
 
-    /// A full page keeps reading; a short one stops. Every stream pages through
-    /// [`advance`], so this is the rule for all three.
+    /// A cursor means there may be more; only its absence ends the read. Every
+    /// stream pages through [`advance`], so this is the rule for all three.
+    ///
+    /// Guessing from page size instead would save a request per chunk, and was
+    /// tried: it makes the non-advancing-cursor guard unreachable, and stakes
+    /// correctness on every endpoint returning a short page only when genuinely
+    /// out of rows. Skipping a spend silently is not worth a round trip.
     #[test]
-    fn a_full_page_continues_and_a_short_page_ends_the_read() {
-        let page = |rows, next: Option<u64>| Page {
-            rows,
-            next_cursor: next.map(|slot| slot.to_be_bytes().to_vec()),
-            scanned_through: None,
-        };
+    fn only_a_missing_cursor_ends_the_read() {
+        let cursor = |slot: u64| Some(slot.to_be_bytes().to_vec());
 
         let mut furthest = None;
         assert_eq!(
-            advance(&mut furthest, page(10, Some(50)), 10),
-            Some(50u64.to_be_bytes().to_vec()),
-            "a page at the limit may have been truncated, so keep reading"
+            advance(
+                &mut furthest,
+                Page {
+                    next_cursor: cursor(50),
+                    scanned_through: None,
+                },
+            ),
+            cursor(50),
+            "a cursor is an invitation to read on"
         );
 
-        let mut furthest = None;
+        let mut furthest = cursor(10);
         assert!(
-            advance(&mut furthest, page(3, Some(50)), 10).is_none(),
-            "a short page means the server ran out of rows, not out of room"
+            advance(
+                &mut furthest,
+                Page {
+                    next_cursor: None,
+                    scanned_through: None,
+                },
+            )
+            .is_none(),
+            "no cursor ends it"
         );
-        assert_eq!(
-            furthest,
-            Some(50u64.to_be_bytes().to_vec()),
-            "and it still records where it read to"
-        );
+        assert_eq!(furthest, cursor(10), "and the earlier position is kept");
 
         // The nullifier stream's pages are normally empty, so its position comes
         // from the server rather than from a row.
@@ -1587,14 +1564,12 @@ mod tests {
         assert!(advance(
             &mut furthest,
             Page {
-                rows: 0,
                 next_cursor: None,
-                scanned_through: Some(99u64.to_be_bytes().to_vec()),
+                scanned_through: cursor(99),
             },
-            10,
         )
         .is_none());
-        assert_eq!(furthest, Some(99u64.to_be_bytes().to_vec()));
+        assert_eq!(furthest, cursor(99));
     }
 
     /// The async twins page and resume like the blocking ones.
@@ -1660,8 +1635,11 @@ mod tests {
         .expect("proofless");
         assert_eq!(proofless_cursors.get(&tag).map(slot_of), Some(30));
 
-        // One request per stream: each page was short of the limit.
-        assert_eq!(indexer.calls.lock().expect("calls poisoned").len(), 1);
+        // The streams that return rows take a second request to reach the empty
+        // page that ends them. The nullifier stream matches nothing, so its
+        // first page is already the last.
+        assert_eq!(indexer.calls.lock().expect("calls poisoned").len(), 2);
+        assert_eq!(indexer.utxo_calls.lock().expect("calls poisoned").len(), 2);
         assert_eq!(
             indexer
                 .nullifier_calls
@@ -1670,7 +1648,6 @@ mod tests {
                 .len(),
             1
         );
-        assert_eq!(indexer.utxo_calls.lock().expect("calls poisoned").len(), 1);
     }
 
     fn slot_of(cursor: &Vec<u8>) -> u64 {

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -508,16 +508,10 @@ fn indexer_rpc_config(config: SyncWalletConfig) -> Option<IndexerRpcConfig> {
     })
 }
 
-/// Nullifiers still worth asking about: the unspent ones.
+/// Nullifiers of unspent UTXOs.
 ///
-/// This query asks "was this UTXO spent, and in which transaction". A nullifier
-/// appears at most once on chain -- that is what it is for -- so once the
-/// spending transaction has been seen the answer is final and re-asking returns
-/// the same row forever. `spent` is set precisely when that transaction is in
-/// hand, so it is the exact condition for dropping a nullifier from the query.
-///
-/// The set therefore shrinks as a wallet ages rather than growing with it: cost
-/// tracks the unspent UTXO count, not history.
+/// A nullifier appears at most once on chain, so once its spend is known the
+/// answer is final. Cost tracks the unspent count, not history.
 fn wallet_query_nullifiers(wallet: &Wallet) -> Vec<[u8; 32]> {
     wallet
         .utxos
@@ -527,12 +521,11 @@ fn wallet_query_nullifiers(wallet: &Wallet) -> Vec<[u8; 32]> {
         .collect()
 }
 
-/// Bucket keys by the position their stream was last read to.
+/// Buckets keys by the position their stream was last read to.
 ///
 /// A chunk carries one cursor, so keys at different positions cannot share a
-/// request: a key learned this sync would resume from a position it was never
-/// scanned to and skip its history permanently. `None` (never queried) is its
-/// own group. Keys already read to the tip earlier in this sync are dropped.
+/// request. `None` (never queried) is its own group. Keys already read to the
+/// tip in this sync are dropped.
 fn group_by_resume_point<K: Copy + Eq + std::hash::Hash>(
     keys: &[K],
     cursors: &HashMap<K, Vec<u8>>,
@@ -554,18 +547,13 @@ fn group_by_resume_point<K: Copy + Eq + std::hash::Hash>(
 /// One page of a cursor-ordered stream, reduced to what paging needs.
 struct Page {
     next_cursor: Option<Vec<u8>>,
-    /// Where the server says its scan reached. Only the nullifier stream reports
-    /// this, and only it needs to: its pages are normally empty, so there is no
-    /// last row to take a position from.
+    /// Where the server's scan reached. Reported only by the nullifier stream,
+    /// whose pages are normally empty and so carry no last row.
     scanned_through: Option<Vec<u8>>,
 }
 
-/// Read one chunk to the end of its stream, returning the position reached.
-///
-/// Every stream pages the same way and differs only in the request it makes, so
-/// the rule that a short page ends the read lives here rather than in each
-/// caller. Paging until `next_cursor` is `None` instead costs one extra request
-/// per chunk per sync, to be told the stream is empty.
+/// Reads one chunk until the stream offers no further cursor, returning the
+/// position reached.
 fn read_chunk<F>(start: Option<Vec<u8>>, mut request: F) -> Result<Option<Vec<u8>>, ClientError>
 where
     F: FnMut(Option<Vec<u8>>) -> Result<Page, ClientError>,
@@ -581,12 +569,10 @@ where
     }
 }
 
-/// Record where a chunk was read to, once its read has ended.
+/// Records one position for every key in the chunk.
 ///
-/// Advancing every key in the chunk to one position is sound only because the
-/// ordering is global: a position obtained from a query over {A, B, C} states,
-/// for each of them individually, that everything matching up to there has been
-/// seen.
+/// Sound because the ordering is global: a position from a query over
+/// {A, B, C} holds for each of them individually.
 fn record_chunk<K: Copy + Eq + std::hash::Hash>(
     chunk: &[K],
     furthest: Option<Vec<u8>>,
@@ -601,18 +587,15 @@ fn record_chunk<K: Copy + Eq + std::hash::Hash>(
     scanned_to_tip.extend(chunk.iter().copied());
 }
 
-/// Fold one page into the position read so far, and say where to read next.
+/// Folds one page into the position read so far. `None` ends the read.
 ///
-/// The async paths drive their own loop rather than calling [`read_chunk`]: an
-/// `AsyncFnMut` cannot carry the `Send` bound its callers need, and a test
-/// asserts the sync future is `Send`. They share this instead, so the rule for
-/// when a read ends is written once even though the loop is not.
+/// A cursor means there may be more, whatever the page size. Stopping on a short
+/// page would make the non-advancing-cursor guard unreachable.
 ///
-/// `None` ends the read: either the page was short of the limit, so the server
-/// had no more rows, or it offered no cursor to continue from.
+/// The async paths keep their own loop and share only this: an `AsyncFnMut`
+/// cannot carry the `Send` bound their callers require.
 fn advance(furthest: &mut Option<Vec<u8>>, page: Page) -> Option<Vec<u8>> {
-    // The server's own scan position when it reports one, else the last row it
-    // returned, else stay put.
+    // The server's scan position if reported, else the last row, else unchanged.
     *furthest = page
         .scanned_through
         .or_else(|| page.next_cursor.clone())
@@ -724,17 +707,12 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
     Ok(())
 }
 
-/// Fetch spends of `nullifiers`, resuming each from where it was last checked.
+/// Fetches spends of `nullifiers`, resuming each from where it was last checked.
 ///
-/// The resume point comes from the indexer's `scanned_through`, not from the
-/// rows: an unspent nullifier matches nothing, so there is no last row to take a
-/// position from. That is the whole difficulty here and the reason this cannot
-/// be modelled on the tag path, whose cursor rides on rows it actually returns.
-///
-/// The position is per-nullifier rather than one shared value because it is only
-/// sound for the set that was asked about: a scan over {A, B, C} says nothing
-/// about D. A nullifier with no entry is queried from zero, which is wasteful
-/// rather than wrong.
+/// The resume point comes from `scanned_through`, not from rows: an unspent
+/// nullifier matches nothing. Positions are per nullifier, since a scan over
+/// {A, B, C} says nothing about D. A nullifier with no entry is read from
+/// zero.
 fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
     indexer: &I,
     nullifiers: &[[u8; 32]],
@@ -744,9 +722,6 @@ fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
     cursors: &mut HashMap<[u8; 32], Vec<u8>>,
     scanned_to_tip: &mut HashSet<[u8; 32]>,
 ) -> Result<(), ClientError> {
-    // In the steady state every known nullifier shares one position and newly
-    // created ones have none, so this is two queries however many the wallet
-    // holds.
     for (start, group) in group_by_resume_point(nullifiers, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
             let furthest = read_chunk(start.clone(), |cursor| {
@@ -816,17 +791,11 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
     Ok(())
 }
 
-/// Reads new proofless deposits, resuming from where the last sync stopped.
+/// Reads new proofless deposits from the encrypted-utxo stream, resuming from
+/// where the last sync stopped.
 ///
-/// Resume points are per tag and persisted on the wallet, for the same reason
-/// [`fetch_shielded_transactions_incremental`] keeps them that way: the tag set
-/// grows, and a tag learned late has to be scanned from the beginning while
-/// tags learned earlier are far ahead.
-///
-/// Without the persisted cursor this paged the entire encrypted-utxo history for
-/// every tag on every sync and then discarded all but the deposits client-side --
-/// 909ms to keep 2.5 rows on devnet, a third of the sync phase, growing with
-/// history. The rows it re-read were ones it had already seen and dropped.
+/// Resume points are per tag and persisted, as for the transaction stream: a tag
+/// learned late must be read from the beginning while others are far ahead.
 fn fetch_proofless_deposits<I>(
     indexer: &I,
     tags: &[ViewTag],
@@ -1036,9 +1005,8 @@ mod tests {
         entries: Vec<(u64, ViewTag)>,
         /// (slot, nullifier) pairs: the transaction at `slot` spent `nullifier`.
         spends: Vec<(u64, [u8; 32])>,
-        /// (slot, view tag) pairs in the encrypted-utxo stream, which proofless
-        /// deposits are read from. A separate stream from `entries`, and paged
-        /// separately.
+        /// (slot, view tag) pairs in the encrypted-utxo stream. Paged separately
+        /// from `entries`.
         utxo_entries: Vec<(u64, ViewTag)>,
         /// Every (tags, cursor) pair the client asked for, for call accounting.
         calls: std::sync::Mutex<Vec<(usize, Option<u64>)>>,
@@ -1103,8 +1071,7 @@ mod tests {
             (transactions, next)
         }
 
-        /// The nullifier stream, same ordering and same cursor rule. Entries are
-        /// (slot, nullifier): the transaction at `slot` spent `nullifier`.
+        /// The nullifier stream, same ordering and cursor rule.
         fn matching_nullifiers(
             &self,
             nullifiers: &[[u8; 32]],
@@ -1130,9 +1097,9 @@ mod tests {
             rows.truncate(limit);
 
             let next = rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec());
-            // Photon.s rule: the position is reported only when the limit did
-            // not cut the scan short, and it is the tip of the whole stream --
-            // not of the matching rows, of which there are usually none.
+            // Photon reports the position only when the limit did not cut the
+            // scan short, and it is the tip of the whole stream, not of the
+            // matching rows.
             let scanned_through = (rows.len() < limit)
                 .then(|| self.stream_tip().map(|slot| slot.to_be_bytes().to_vec()))
                 .flatten();
@@ -1233,9 +1200,8 @@ mod tests {
                     .cloned()
                     .collect(),
                 next_cursor: None,
-                // This mock answers everything in one page and never paginates,
-                // so it has nothing to report; the resume path is covered by
-                // TaggedIndexer instead.
+                // Answers in one page and never paginates; resumption is covered
+                // by TaggedIndexer.
                 scanned_through: None,
             })
         }
@@ -1478,7 +1444,7 @@ mod tests {
     /// twentieth.
     #[test]
     fn spent_utxos_drop_out_of_the_nullifier_query() {
-        let owner = ShieldedKeypair::new().expect("keypair");
+        let owner = ShieldedKeypair::new_p256().expect("keypair");
         let mut wallet = wallet_with_utxos(&owner, &[(SOL_MINT, 100, 1), (SOL_MINT, 200, 2)]);
 
         assert_eq!(
@@ -1578,7 +1544,7 @@ mod tests {
     /// even though they share [`advance`]. Covers all three streams at once.
     #[tokio::test]
     async fn the_async_paths_resume_every_stream() {
-        let keypair = ShieldedKeypair::new().expect("keypair");
+        let keypair = ShieldedKeypair::new_p256().expect("keypair");
         let tag = keypair.viewing_key.get_sender_view_tag(0).expect("tag");
         let unspent = [7u8; 32];
         let indexer = TaggedIndexer {

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -520,6 +520,36 @@ fn wallet_query_nullifiers(wallet: &Wallet) -> Vec<[u8; 32]> {
         .collect()
 }
 
+/// Bucket keys by the position their stream was last read to.
+///
+/// A chunk carries one cursor, so keys at different positions cannot share a
+/// request: a key learned this sync would resume from a position it was never
+/// scanned to and skip its history permanently. `None` (never queried) is its
+/// own group. Keys already read to the tip earlier in this same sync are
+/// dropped, since a second request would only return rows the accumulator
+/// already holds.
+///
+/// Shared by the tag and nullifier streams, and by the sync and async halves of
+/// each: the bucketing is the same rule four times over, and only the query it
+/// feeds differs.
+fn group_by_resume_point<K: Copy + Eq + std::hash::Hash>(
+    keys: &[K],
+    cursors: &HashMap<K, Vec<u8>>,
+    scanned_to_tip: &HashSet<K>,
+) -> HashMap<Option<Vec<u8>>, Vec<K>> {
+    let mut groups: HashMap<Option<Vec<u8>>, Vec<K>> = HashMap::new();
+    for key in keys {
+        if scanned_to_tip.contains(key) {
+            continue;
+        }
+        groups
+            .entry(cursors.get(key).cloned())
+            .or_default()
+            .push(*key);
+    }
+    groups
+}
+
 /// Fetch shielded transactions for `tags`, resuming each tag from where it was
 /// last seen.
 ///
@@ -550,20 +580,7 @@ fn fetch_shielded_transactions_incremental<I: Rpc>(
     scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError> {
     // Group by resume point. `None` (never queried) is its own group.
-    let mut groups: HashMap<Option<Vec<u8>>, Vec<ViewTag>> = HashMap::new();
-    for tag in tags {
-        // Already read to the tip earlier in this same sync -- a second request
-        // would return the same rows the accumulator already holds.
-        if scanned_to_tip.contains(tag) {
-            continue;
-        }
-        groups
-            .entry(cursors.get(tag).cloned())
-            .or_default()
-            .push(*tag);
-    }
-
-    for (start, group) in groups {
+    for (start, group) in group_by_resume_point(tags, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
             let mut cursor = start.clone();
             let mut furthest = start.clone();
@@ -619,20 +636,7 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
     cursors: &mut HashMap<ViewTag, Vec<u8>>,
     scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError> {
-    let mut groups: HashMap<Option<Vec<u8>>, Vec<ViewTag>> = HashMap::new();
-    for tag in tags {
-        // Already read to the tip earlier in this same sync -- a second request
-        // would return the same rows the accumulator already holds.
-        if scanned_to_tip.contains(tag) {
-            continue;
-        }
-        groups
-            .entry(cursors.get(tag).cloned())
-            .or_default()
-            .push(*tag);
-    }
-
-    for (start, group) in groups {
+    for (start, group) in group_by_resume_point(tags, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
             let mut cursor = start.clone();
             let mut furthest = start.clone();
@@ -699,18 +703,7 @@ fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
     // Group by resume point, exactly as the tag path does. In the steady state
     // every known nullifier shares one position and newly created ones have
     // none, so this is two queries however many UTXOs the wallet holds.
-    let mut groups: HashMap<Option<Vec<u8>>, Vec<[u8; 32]>> = HashMap::new();
-    for nullifier in nullifiers {
-        if scanned_to_tip.contains(nullifier) {
-            continue;
-        }
-        groups
-            .entry(cursors.get(nullifier).cloned())
-            .or_default()
-            .push(*nullifier);
-    }
-
-    for (start, group) in groups {
+    for (start, group) in group_by_resume_point(nullifiers, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
             let mut cursor = start.clone();
             let mut resume = None;
@@ -758,18 +751,7 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
     cursors: &mut HashMap<[u8; 32], Vec<u8>>,
     scanned_to_tip: &mut HashSet<[u8; 32]>,
 ) -> Result<(), ClientError> {
-    let mut groups: HashMap<Option<Vec<u8>>, Vec<[u8; 32]>> = HashMap::new();
-    for nullifier in nullifiers {
-        if scanned_to_tip.contains(nullifier) {
-            continue;
-        }
-        groups
-            .entry(cursors.get(nullifier).cloned())
-            .or_default()
-            .push(*nullifier);
-    }
-
-    for (start, group) in groups {
+    for (start, group) in group_by_resume_point(nullifiers, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
             let mut cursor = start.clone();
             let mut resume = None;

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -123,10 +123,8 @@ where
             //
             // Cursors come out of the wallet and go back rather than staying
             // borrowed, because `wallet` is needed mutably further down.
-            // Split per stream for the round: the three threads below each need
-            // their own `&mut`, and one map cannot be borrowed mutably three
-            // times. The variants keep the keys apart, so merging after the join
-            // is lossless.
+            // Three threads, three `&mut`. Variants keep the keys disjoint, so
+            // the merge after the join is lossless.
             let (mut cursors, mut nullifier_cursors, mut proofless_cursors) =
                 split_by_stream(std::mem::take(&mut wallet.cursors));
             let tag_keys = stream_keys(&tags, CursorStream::Tags);
@@ -304,8 +302,7 @@ where
         let before = (transactions.len(), proofless_deposits.len());
         let tags = wallet_query_tags(wallet, &material, config.tag_window)?;
         let nullifiers = wallet_query_nullifiers(wallet);
-        // One map for every stream now, so it comes out of the wallet once and
-        // goes back once.
+        // Sequential here, so one borrow serves all three.
         let mut cursors = std::mem::take(&mut wallet.cursors);
         let tag_keys = stream_keys(&tags, CursorStream::Tags);
         let nullifier_keys = stream_keys(&nullifiers, CursorStream::Nullifiers);
@@ -594,12 +591,10 @@ where
     }
 }
 
-/// Watermarks keyed by stream: for each key, the position read through.
+/// Per key, the position read through.
 type StreamCursors = HashMap<CursorStream, Vec<u8>>;
 
-/// Splits watermarks into one map per stream, so concurrent fetches hold
-/// disjoint `&mut` instead of contending on one map. The caller merges them
-/// back; the variants keep the keys from colliding.
+/// One map per stream, so concurrent fetches borrow disjointly. Caller merges.
 fn split_by_stream(cursors: StreamCursors) -> (StreamCursors, StreamCursors, StreamCursors) {
     let mut tags = HashMap::new();
     let mut nullifiers = HashMap::new();
@@ -614,12 +609,12 @@ fn split_by_stream(cursors: StreamCursors) -> (StreamCursors, StreamCursors, Str
     (tags, nullifiers, proofless)
 }
 
-/// Labels each of a stream's keys with the stream it belongs to.
+/// Labels a stream's keys with the stream.
 fn stream_keys(values: &[[u8; 32]], stream: fn([u8; 32]) -> CursorStream) -> Vec<CursorStream> {
     values.iter().copied().map(stream).collect()
 }
 
-/// How many keys the wallet has a watermark for on one stream.
+/// Keys with a watermark on one stream.
 fn stream_len(wallet: &Wallet, matches: fn(&CursorStream) -> bool) -> usize {
     wallet.cursors.keys().filter(|key| matches(key)).count()
 }

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -125,6 +125,7 @@ where
             // borrowed, because `wallet` is needed mutably further down.
             let mut cursors = std::mem::take(&mut wallet.sync_cursors);
             let mut nullifier_cursors = std::mem::take(&mut wallet.nullifier_cursors);
+            let mut proofless_cursors = std::mem::take(&mut wallet.proofless_cursors);
             let mut by_nullifier: HashMap<String, ShieldedTransaction> = HashMap::new();
             // One gate for the whole round, not one per call: every query in a
             // round should read the chain at the same freshness bound, and
@@ -165,6 +166,7 @@ where
                         &mut proofless_deposits,
                         config,
                         gate,
+                        &mut proofless_cursors,
                         &mut proofless_scanned_to_tip,
                     )
                 });
@@ -177,6 +179,7 @@ where
 
             wallet.sync_cursors = cursors;
             wallet.nullifier_cursors = nullifier_cursors;
+            wallet.proofless_cursors = proofless_cursors;
             // Propagate a panic rather than swallowing it into a sync error: a
             // panicked fetch means a bug here, not an unreachable indexer.
             let tag_result = tag_result.unwrap_or_else(|payload| resume_unwind(payload));
@@ -312,15 +315,19 @@ where
         .await;
         wallet.nullifier_cursors = nullifier_cursors;
         nullifiers_fetched?;
-        fetch_proofless_deposits_async(
+        let mut proofless_cursors = std::mem::take(&mut wallet.proofless_cursors);
+        let fetched_proofless = fetch_proofless_deposits_async(
             indexer,
             &tags,
             &mut proofless_deposits,
             config,
             freshness_gate.take(),
+            &mut proofless_cursors,
             &mut proofless_scanned_to_tip,
         )
-        .await?;
+        .await;
+        wallet.proofless_cursors = proofless_cursors;
+        fetched_proofless?;
 
         txs = transactions.values().cloned().collect::<Vec<_>>();
         txs.sort_by_key(|a| (a.slot, a.tx_signature));
@@ -788,101 +795,136 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
     Ok(())
 }
 
+/// Reads new proofless deposits, resuming from where the last sync stopped.
+///
+/// Resume points are per tag and persisted on the wallet, for the same reason
+/// [`fetch_shielded_transactions_incremental`] keeps them that way: the tag set
+/// grows, and a tag learned late has to be scanned from the beginning while
+/// tags learned earlier are far ahead.
+///
+/// Without the persisted cursor this paged the entire encrypted-utxo history for
+/// every tag on every sync and then discarded all but the deposits client-side --
+/// 909ms to keep 2.5 rows on devnet, a third of the sync phase, growing with
+/// history. The rows it re-read were ones it had already seen and dropped.
 fn fetch_proofless_deposits<I>(
     indexer: &I,
     tags: &[ViewTag],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    cursors: &mut HashMap<ViewTag, Vec<u8>>,
     scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError>
 where
     I: Rpc,
 {
-    let pending: Vec<ViewTag> = tags
-        .iter()
-        .copied()
-        .filter(|tag| !scanned_to_tip.contains(tag))
-        .collect();
-    for chunk in pending.chunks(config.tag_query_chunk) {
-        let mut cursor = None;
-        loop {
-            let response = indexer.get_encrypted_utxos_by_tags(
-                chunk.to_vec(),
-                cursor,
-                Some(config.page_limit),
-                rpc_config,
-            )?;
-            for item in response.matches {
-                if item.tx_viewing_pk.is_some() || item.salt.is_some() {
-                    continue;
+    for (start, group) in group_by_resume_point(tags, cursors, scanned_to_tip) {
+        for chunk in group.chunks(config.tag_query_chunk) {
+            let mut cursor = start.clone();
+            let mut furthest = start.clone();
+            loop {
+                let response = indexer.get_encrypted_utxos_by_tags(
+                    chunk.to_vec(),
+                    cursor,
+                    Some(config.page_limit),
+                    rpc_config,
+                )?;
+                let last_page = response.matches.len() < config.page_limit as usize;
+                for item in response.matches {
+                    if item.tx_viewing_pk.is_some() || item.salt.is_some() {
+                        continue;
+                    }
+                    let key = format!(
+                        "{}:{}",
+                        item.tx_signature, item.output_slot.output_context.leaf_index
+                    );
+                    if out.contains_key(&key) {
+                        continue;
+                    }
+                    if let Some(view) = proofless_deposit_from_indexed_match(item)? {
+                        out.insert(key, view);
+                    }
                 }
-                let key = format!(
-                    "{}:{}",
-                    item.tx_signature, item.output_slot.output_context.leaf_index
-                );
-                if out.contains_key(&key) {
-                    continue;
+                if response.next_cursor.is_some() {
+                    furthest = response.next_cursor.clone();
                 }
-                if let Some(view) = proofless_deposit_from_indexed_match(item)? {
-                    out.insert(key, view);
+                cursor = response.next_cursor;
+                if last_page || cursor.is_none() {
+                    break;
                 }
             }
-            cursor = response.next_cursor;
-            if cursor.is_none() {
-                break;
+            // Sound only because the stream is globally ordered: every tag in
+            // this chunk has now been read to that position.
+            if let Some(position) = furthest {
+                for tag in chunk {
+                    cursors.insert(*tag, position.clone());
+                }
             }
+            scanned_to_tip.extend(chunk.iter().copied());
         }
-        scanned_to_tip.extend(chunk.iter().copied());
     }
     Ok(())
 }
 
+/// Async twin of [`fetch_proofless_deposits`].
+///
+/// Kept deliberately parallel rather than shared, for the reason given on
+/// [`fetch_shielded_transactions_incremental_async`]: an async client that did
+/// not get the persisted cursor would keep re-reading the whole encrypted-utxo
+/// history on every sync.
 async fn fetch_proofless_deposits_async<I: AsyncRpc>(
     indexer: &I,
     tags: &[ViewTag],
     out: &mut HashMap<String, ShieldedTransaction>,
     config: SyncWalletConfig,
     rpc_config: Option<IndexerRpcConfig>,
+    cursors: &mut HashMap<ViewTag, Vec<u8>>,
     scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError> {
-    let pending: Vec<ViewTag> = tags
-        .iter()
-        .copied()
-        .filter(|tag| !scanned_to_tip.contains(tag))
-        .collect();
-    for chunk in pending.chunks(config.tag_query_chunk) {
-        let mut cursor = None;
-        loop {
-            let response = indexer
-                .get_encrypted_utxos_by_tags(
-                    chunk.to_vec(),
-                    cursor,
-                    Some(config.page_limit),
-                    rpc_config,
-                )
-                .await?;
-            for item in response.matches {
-                if item.tx_viewing_pk.is_some() || item.salt.is_some() {
-                    continue;
+    for (start, group) in group_by_resume_point(tags, cursors, scanned_to_tip) {
+        for chunk in group.chunks(config.tag_query_chunk) {
+            let mut cursor = start.clone();
+            let mut furthest = start.clone();
+            loop {
+                let response = indexer
+                    .get_encrypted_utxos_by_tags(
+                        chunk.to_vec(),
+                        cursor,
+                        Some(config.page_limit),
+                        rpc_config,
+                    )
+                    .await?;
+                let last_page = response.matches.len() < config.page_limit as usize;
+                for item in response.matches {
+                    if item.tx_viewing_pk.is_some() || item.salt.is_some() {
+                        continue;
+                    }
+                    let key = format!(
+                        "{}:{}",
+                        item.tx_signature, item.output_slot.output_context.leaf_index
+                    );
+                    if out.contains_key(&key) {
+                        continue;
+                    }
+                    if let Some(view) = proofless_deposit_from_indexed_match(item)? {
+                        out.insert(key, view);
+                    }
                 }
-                let key = format!(
-                    "{}:{}",
-                    item.tx_signature, item.output_slot.output_context.leaf_index
-                );
-                if out.contains_key(&key) {
-                    continue;
+                if response.next_cursor.is_some() {
+                    furthest = response.next_cursor.clone();
                 }
-                if let Some(view) = proofless_deposit_from_indexed_match(item)? {
-                    out.insert(key, view);
+                cursor = response.next_cursor;
+                if last_page || cursor.is_none() {
+                    break;
                 }
             }
-            cursor = response.next_cursor;
-            if cursor.is_none() {
-                break;
+            if let Some(position) = furthest {
+                for tag in chunk {
+                    cursors.insert(*tag, position.clone());
+                }
             }
+            scanned_to_tip.extend(chunk.iter().copied());
         }
-        scanned_to_tip.extend(chunk.iter().copied());
     }
     Ok(())
 }
@@ -993,10 +1035,16 @@ mod tests {
         entries: Vec<(u64, ViewTag)>,
         /// (slot, nullifier) pairs: the transaction at `slot` spent `nullifier`.
         spends: Vec<(u64, [u8; 32])>,
+        /// (slot, view tag) pairs in the encrypted-utxo stream, which proofless
+        /// deposits are read from. A separate stream from `entries`, and paged
+        /// separately.
+        utxo_entries: Vec<(u64, ViewTag)>,
         /// Every (tags, cursor) pair the client asked for, for call accounting.
         calls: std::cell::RefCell<Vec<(usize, Option<u64>)>>,
         /// The same, for the nullifier stream.
         nullifier_calls: std::cell::RefCell<Vec<(usize, Option<u64>)>>,
+        /// The same, for the encrypted-utxo stream.
+        utxo_calls: std::cell::RefCell<Vec<(usize, Option<u64>)>>,
     }
 
     impl TaggedIndexer {
@@ -1196,20 +1244,57 @@ mod tests {
             Ok(Vec::new())
         }
 
+        /// Pages the encrypted-utxo stream on the same rule as the tag stream,
+        /// so a resume can be observed rather than assumed. The rows carry no
+        /// decryptable payload -- this pins which positions were asked for, not
+        /// what came back.
         fn get_encrypted_utxos_by_tags(
             &self,
-            _tags: Vec<ViewTag>,
-            _cursor: Option<Vec<u8>>,
-            _limit: Option<u32>,
+            tags: Vec<ViewTag>,
+            cursor: Option<Vec<u8>>,
+            limit: Option<u32>,
             _config: Option<IndexerRpcConfig>,
         ) -> Result<GetEncryptedUtxosByTagsResponse, ClientError> {
+            let limit = limit.unwrap_or(1_000).max(1) as usize;
+            let after = cursor.as_ref().map(|bytes| {
+                u64::from_be_bytes(bytes.as_slice().try_into().expect("8-byte cursor"))
+            });
+            self.utxo_calls.borrow_mut().push((tags.len(), after));
+
+            let mut rows: Vec<_> = self
+                .utxo_entries
+                .iter()
+                .filter(|(slot, tag)| tags.contains(tag) && after.is_none_or(|after| *slot > after))
+                .collect();
+            rows.sort_by_key(|(slot, _)| *slot);
+            rows.truncate(limit);
+
+            let next_cursor = rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec());
+            let matches = rows
+                .into_iter()
+                .map(|(slot, tag)| EncryptedUtxoMatch {
+                    slot: *slot,
+                    tx_signature: Signature::from([*slot as u8; 64]),
+                    output_slot: OutputSlot {
+                        view_tag: *tag,
+                        output_context: OutputContext {
+                            hash: [0u8; 32],
+                            tree: Address::default(),
+                            leaf_index: *slot,
+                        },
+                        payload: Vec::new(),
+                    },
+                    tx_viewing_pk: None,
+                    salt: None,
+                })
+                .collect();
             Ok(GetEncryptedUtxosByTagsResponse {
                 context: Context {
                     block_time: 0,
                     slot: 1,
                 },
-                matches: Vec::new(),
-                next_cursor: None,
+                matches,
+                next_cursor,
             })
         }
 
@@ -1481,6 +1566,65 @@ mod tests {
             *indexer.nullifier_calls.borrow(),
             vec![(1, Some(50))],
             "the second sync resumes at 50 rather than rescanning from zero"
+        );
+    }
+
+    /// A second sync resumes the encrypted-utxo stream instead of re-reading it.
+    ///
+    /// This is the test the change that introduced `proofless_cursors` said it
+    /// could not write: the old mock answered every page with `next_cursor:
+    /// None`, so the client looked incremental while re-reading everything. It
+    /// pins what the client *sends* -- that the second sync carries the position
+    /// the first one reached. Whether photon reports that position the same way
+    /// is the local stack's job, not this one's.
+    #[test]
+    fn a_second_sync_resumes_the_proofless_stream() {
+        let tag = ViewTag::from([5u8; 32]);
+        let indexer = TaggedIndexer {
+            utxo_entries: vec![(10, tag), (50, tag)],
+            ..Default::default()
+        };
+
+        let config = SyncWalletConfig::default();
+        let mut out = HashMap::new();
+        let mut cursors: HashMap<ViewTag, Vec<u8>> = HashMap::new();
+
+        fetch_proofless_deposits(
+            &indexer,
+            &[tag],
+            &mut out,
+            config,
+            None,
+            &mut cursors,
+            &mut HashSet::new(),
+        )
+        .expect("first sync");
+
+        assert_eq!(
+            cursors
+                .get(&tag)
+                .map(|c| u64::from_be_bytes(c.as_slice().try_into().expect("8-byte cursor"))),
+            Some(50),
+            "the scan read to the last row, so that is where it resumes"
+        );
+
+        // A fresh scanned_to_tip, as a later sync would have.
+        indexer.utxo_calls.borrow_mut().clear();
+        fetch_proofless_deposits(
+            &indexer,
+            &[tag],
+            &mut out,
+            config,
+            None,
+            &mut cursors,
+            &mut HashSet::new(),
+        )
+        .expect("second sync");
+
+        assert_eq!(
+            *indexer.utxo_calls.borrow(),
+            vec![(1, Some(50))],
+            "the second sync resumes at 50 rather than re-reading the stream"
         );
     }
 
@@ -1925,6 +2069,7 @@ mod tests {
             &mut out,
             SyncWalletConfig::default(),
             None,
+            &mut HashMap::new(),
             &mut HashSet::new(),
         )
         .expect("decode proofless payload");
@@ -2044,6 +2189,7 @@ mod tests {
             &mut out,
             SyncWalletConfig::default(),
             None,
+            &mut HashMap::new(),
             &mut HashSet::new(),
         )
         .expect("skip encrypted row");

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -493,8 +493,23 @@ fn indexer_rpc_config(config: SyncWalletConfig) -> Option<IndexerRpcConfig> {
     })
 }
 
+/// Nullifiers still worth asking about: the unspent ones.
+///
+/// This query asks "was this UTXO spent, and in which transaction". A nullifier
+/// appears at most once on chain -- that is what it is for -- so once the
+/// spending transaction has been seen the answer is final and re-asking returns
+/// the same row forever. `spent` is set precisely when that transaction is in
+/// hand, so it is the exact condition for dropping a nullifier from the query.
+///
+/// The set therefore shrinks as a wallet ages rather than growing with it: cost
+/// tracks the unspent UTXO count, not history.
 fn wallet_query_nullifiers(wallet: &Wallet) -> Vec<[u8; 32]> {
-    wallet.utxos.iter().map(|utxo| utxo.nullifier).collect()
+    wallet
+        .utxos
+        .iter()
+        .filter(|utxo| !utxo.spent)
+        .map(|utxo| utxo.nullifier)
+        .collect()
 }
 
 /// Fetch shielded transactions for `tags`, resuming each tag from where it was
@@ -926,8 +941,12 @@ mod tests {
         /// (slot, view tag) pairs. Signature is derived from the slot so the sort
         /// key is total, as it is in photon.
         entries: Vec<(u64, ViewTag)>,
+        /// (slot, nullifier) pairs: the transaction at `slot` spent `nullifier`.
+        spends: Vec<(u64, [u8; 32])>,
         /// Every (tags, cursor) pair the client asked for, for call accounting.
         calls: std::cell::RefCell<Vec<(usize, Option<u64>)>>,
+        /// The same, for the nullifier stream.
+        nullifier_calls: std::cell::RefCell<Vec<(usize, Option<u64>)>>,
     }
 
     impl TaggedIndexer {
@@ -976,6 +995,48 @@ mod tests {
                     }],
                     messages: Vec::new(),
                     nullifiers: Vec::new(),
+                    proofless: false,
+                })
+                .collect();
+            (transactions, next)
+        }
+
+        /// The nullifier stream, same ordering and same cursor rule. Entries are
+        /// (slot, nullifier): the transaction at `slot` spent `nullifier`.
+        fn matching_nullifiers(
+            &self,
+            nullifiers: &[[u8; 32]],
+            cursor: Option<Vec<u8>>,
+            limit: usize,
+        ) -> (Vec<ShieldedTransaction>, Option<Vec<u8>>) {
+            let after = cursor.as_ref().map(|bytes| {
+                u64::from_be_bytes(bytes.as_slice().try_into().expect("8-byte cursor"))
+            });
+            self.nullifier_calls
+                .borrow_mut()
+                .push((nullifiers.len(), after));
+
+            let mut rows: Vec<_> = self
+                .spends
+                .iter()
+                .filter(|(slot, nullifier)| {
+                    nullifiers.contains(nullifier) && after.is_none_or(|after| *slot > after)
+                })
+                .collect();
+            rows.sort_by_key(|(slot, _)| *slot);
+            rows.truncate(limit);
+
+            let next = rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec());
+            let transactions = rows
+                .into_iter()
+                .map(|(slot, nullifier)| ShieldedTransaction {
+                    slot: *slot,
+                    tx_signature: Signature::from([*slot as u8; 64]),
+                    tx_viewing_pk: None,
+                    salt: None,
+                    output_slots: Vec::new(),
+                    messages: Vec::new(),
+                    nullifiers: vec![*nullifier],
                     proofless: false,
                 })
                 .collect();
@@ -1101,20 +1162,27 @@ mod tests {
             })
         }
 
+        /// Faithful to the server in the same way the tag method is: it honours
+        /// the cursor and reports the last row's position even on a short page.
+        /// The previous stub ignored both and always answered `None`, which is
+        /// what let the nullifier path look incremental in tests while rescanning
+        /// from zero against real photon.
         fn get_shielded_transactions_by_nullifiers(
             &self,
-            _nullifiers: Vec<ViewTag>,
-            _cursor: Option<Vec<u8>>,
-            _limit: Option<u32>,
+            nullifiers: Vec<[u8; 32]>,
+            cursor: Option<Vec<u8>>,
+            limit: Option<u32>,
             _config: Option<IndexerRpcConfig>,
         ) -> Result<GetShieldedTransactionsByNullifiersResponse, ClientError> {
+            let limit = limit.unwrap_or(1_000).max(1) as usize;
+            let (transactions, next_cursor) = self.matching_nullifiers(&nullifiers, cursor, limit);
             Ok(GetShieldedTransactionsByNullifiersResponse {
                 context: Context {
                     block_time: 0,
                     slot: 1,
                 },
-                transactions: Vec::new(),
-                next_cursor: None,
+                transactions,
+                next_cursor,
             })
         }
     }
@@ -1231,6 +1299,58 @@ mod tests {
             *indexer.calls.borrow(),
             vec![(1, None), (1, Some(50))],
             "one request for the rows, one more that returns none and ends the loop"
+        );
+    }
+
+    /// A spent UTXO is never asked about again.
+    ///
+    /// A nullifier appears at most once on chain -- that is what it is for -- so
+    /// once the spending transaction is in hand the answer is final. Asking again
+    /// returns the same row forever. The query set therefore tracks the unspent
+    /// UTXO count rather than growing with history: on a devnet wallet holding
+    /// 293 UTXOs of which 237 were already spent, dropping them took the round-0
+    /// nullifier fetch from 732ms to 83ms, a third of total sync time to a
+    /// twentieth.
+    #[test]
+    fn spent_utxos_drop_out_of_the_nullifier_query() {
+        let owner = ShieldedKeypair::new().expect("keypair");
+        let mut wallet = wallet_with_utxos(&owner, &[(SOL_MINT, 100, 1), (SOL_MINT, 200, 2)]);
+
+        assert_eq!(
+            wallet_query_nullifiers(&wallet).len(),
+            2,
+            "both UTXOs are unspent, so both are still open questions"
+        );
+
+        let spent_nullifier = wallet.utxos.first().expect("first utxo").nullifier;
+        wallet.utxos.first_mut().expect("first utxo").spent = true;
+
+        let queried = wallet_query_nullifiers(&wallet);
+        assert_eq!(queried.len(), 1, "the spent UTXO is no longer asked about");
+        assert!(
+            !queried.contains(&spent_nullifier),
+            "and it is specifically the spent one that was dropped"
+        );
+
+        // The narrowed set is what actually reaches the indexer.
+        let indexer = TaggedIndexer {
+            spends: vec![(10, spent_nullifier)],
+            ..Default::default()
+        };
+        fetch_shielded_transactions_by_nullifiers(
+            &indexer,
+            &queried,
+            &mut HashMap::new(),
+            SyncWalletConfig::default(),
+            None,
+            &mut HashSet::new(),
+        )
+        .expect("fetch");
+
+        assert_eq!(
+            *indexer.nullifier_calls.borrow(),
+            vec![(1, None)],
+            "one request carrying one nullifier, not the whole utxo history"
         );
     }
 

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -532,13 +532,7 @@ fn wallet_query_nullifiers(wallet: &Wallet) -> Vec<[u8; 32]> {
 /// A chunk carries one cursor, so keys at different positions cannot share a
 /// request: a key learned this sync would resume from a position it was never
 /// scanned to and skip its history permanently. `None` (never queried) is its
-/// own group. Keys already read to the tip earlier in this same sync are
-/// dropped, since a second request would only return rows the accumulator
-/// already holds.
-///
-/// Shared by the tag and nullifier streams, and by the sync and async halves of
-/// each: the bucketing is the same rule four times over, and only the query it
-/// feeds differs.
+/// own group. Keys already read to the tip earlier in this sync are dropped.
 fn group_by_resume_point<K: Copy + Eq + std::hash::Hash>(
     keys: &[K],
     cursors: &HashMap<K, Vec<u8>>,
@@ -555,6 +549,63 @@ fn group_by_resume_point<K: Copy + Eq + std::hash::Hash>(
             .push(*key);
     }
     groups
+}
+
+/// One page of a cursor-ordered stream, reduced to what paging needs.
+struct Page {
+    /// Rows the server returned, before any client-side filtering. A page short
+    /// of the limit means the server ran out of rows, not out of room.
+    rows: usize,
+    next_cursor: Option<Vec<u8>>,
+    /// Where the server says its scan reached. Only the nullifier stream reports
+    /// this, and only it needs to: its pages are normally empty, so there is no
+    /// last row to take a position from.
+    scanned_through: Option<Vec<u8>>,
+}
+
+/// Read one chunk to the end of its stream, returning the position reached.
+///
+/// Every stream pages the same way and differs only in the request it makes, so
+/// the rule that a short page ends the read lives here rather than in each
+/// caller. Paging until `next_cursor` is `None` instead costs one extra request
+/// per chunk per sync, to be told the stream is empty.
+fn read_chunk<F>(
+    start: Option<Vec<u8>>,
+    page_limit: u32,
+    mut request: F,
+) -> Result<Option<Vec<u8>>, ClientError>
+where
+    F: FnMut(Option<Vec<u8>>) -> Result<Page, ClientError>,
+{
+    let mut cursor = start.clone();
+    let mut furthest = start;
+    loop {
+        let page = request(cursor)?;
+        let Some(next) = advance(&mut furthest, page, page_limit) else {
+            return Ok(furthest);
+        };
+        cursor = Some(next);
+    }
+}
+
+/// Fold one page into the position read so far, and say where to read next.
+///
+/// The async paths drive their own loop rather than calling [`read_chunk`]: an
+/// `AsyncFnMut` cannot carry the `Send` bound its callers need, and a test
+/// asserts the sync future is `Send`. They share this instead, so the rule for
+/// when a read ends is written once even though the loop is not.
+///
+/// `None` ends the read: either the page was short of the limit, so the server
+/// had no more rows, or it offered no cursor to continue from.
+fn advance(furthest: &mut Option<Vec<u8>>, page: Page, page_limit: u32) -> Option<Vec<u8>> {
+    // The server's own scan position when it reports one, else the last row it
+    // returned, else stay put.
+    *furthest = page
+        .scanned_through
+        .or_else(|| page.next_cursor.clone())
+        .or_else(|| furthest.take());
+    page.next_cursor
+        .filter(|_| page.rows >= page_limit as usize)
 }
 
 /// Fetch shielded transactions for `tags`, resuming each tag from where it was
@@ -586,18 +637,16 @@ fn fetch_shielded_transactions_incremental<I: Rpc>(
     cursors: &mut HashMap<ViewTag, Vec<u8>>,
     scanned_to_tip: &mut HashSet<ViewTag>,
 ) -> Result<(), ClientError> {
-    // Group by resume point. `None` (never queried) is its own group.
     for (start, group) in group_by_resume_point(tags, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
-            let mut cursor = start.clone();
-            let mut furthest = start.clone();
-            loop {
+            let furthest = read_chunk(start.clone(), config.page_limit, |cursor| {
                 let response = indexer.get_shielded_transactions_by_tags(
                     chunk.to_vec(),
-                    cursor.clone(),
+                    cursor,
                     Some(config.page_limit),
                     rpc_config,
                 )?;
+                let rows = response.transactions.len();
                 for tx in response.transactions {
                     if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
                         continue;
@@ -605,35 +654,28 @@ fn fetch_shielded_transactions_incremental<I: Rpc>(
                     let key = tx.tx_signature.to_string();
                     out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
-                if response.next_cursor.is_some() {
-                    furthest = response.next_cursor.clone();
-                }
-                cursor = response.next_cursor;
-                if cursor.is_none() {
-                    break;
-                }
-            }
+                Ok(Page {
+                    rows,
+                    next_cursor: response.next_cursor,
+                    scanned_through: None,
+                })
+            })?;
 
-            // Advance every tag in this chunk to the end of the stream. Only sound
-            // because the ordering is global: each of these tags has now been
-            // scanned to that position.
+            // Sound only because the ordering is global: every tag in the chunk
+            // has now been read to that one position.
             if let Some(position) = furthest {
                 for tag in chunk {
                     cursors.insert(*tag, position.clone());
                 }
             }
-            // The loop above only exits once the stream is exhausted.
             scanned_to_tip.extend(chunk.iter().copied());
         }
     }
     Ok(())
 }
 
-/// Async twin of [`fetch_shielded_transactions_incremental`].
-///
-/// Kept deliberately parallel rather than shared: the sync and async paths differ
-/// only in `.await`, and an async client that did not get the per-tag cursor rule
-/// would carry the multi-device bug the sync path just fixed.
+/// Async twin of [`fetch_shielded_transactions_incremental`]. Drives its own
+/// loop rather than calling [`read_chunk`]; see [`advance`].
 async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
     indexer: &I,
     tags: &[ViewTag],
@@ -651,11 +693,12 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
                 let response = indexer
                     .get_shielded_transactions_by_tags(
                         chunk.to_vec(),
-                        cursor.clone(),
+                        cursor,
                         Some(config.page_limit),
                         rpc_config,
                     )
                     .await?;
+                let rows = response.transactions.len();
                 for tx in response.transactions {
                     if tx.proofless || tx.tx_viewing_pk.is_none() || tx.salt.is_none() {
                         continue;
@@ -663,20 +706,22 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
                     let key = tx.tx_signature.to_string();
                     out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
-                if response.next_cursor.is_some() {
-                    furthest = response.next_cursor.clone();
-                }
-                cursor = response.next_cursor;
-                if cursor.is_none() {
+                let page = Page {
+                    rows,
+                    next_cursor: response.next_cursor,
+                    scanned_through: None,
+                };
+                let Some(next) = advance(&mut furthest, page, config.page_limit) else {
                     break;
-                }
+                };
+                cursor = Some(next);
             }
+
             if let Some(position) = furthest {
                 for tag in chunk {
                     cursors.insert(*tag, position.clone());
                 }
             }
-            // The loop above only exits once the stream is exhausted.
             scanned_to_tip.extend(chunk.iter().copied());
         }
     }
@@ -694,10 +739,6 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
 /// sound for the set that was asked about: a scan over {A, B, C} says nothing
 /// about D. A nullifier with no entry is queried from zero, which is wasteful
 /// rather than wrong.
-///
-/// `scanned_through` is absent on a page the limit truncated, because nothing
-/// can then be claimed beyond it; the loop keeps paging and takes the position
-/// from the short page that ends it.
 fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
     indexer: &I,
     nullifiers: &[[u8; 32]],
@@ -707,34 +748,31 @@ fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
     cursors: &mut HashMap<[u8; 32], Vec<u8>>,
     scanned_to_tip: &mut HashSet<[u8; 32]>,
 ) -> Result<(), ClientError> {
-    // Group by resume point, exactly as the tag path does. In the steady state
-    // every known nullifier shares one position and newly created ones have
-    // none, so this is two queries however many UTXOs the wallet holds.
+    // In the steady state every known nullifier shares one position and newly
+    // created ones have none, so this is two queries however many the wallet
+    // holds.
     for (start, group) in group_by_resume_point(nullifiers, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
-            let mut cursor = start.clone();
-            let mut resume = None;
-            loop {
+            let furthest = read_chunk(start.clone(), config.page_limit, |cursor| {
                 let response = indexer.get_shielded_transactions_by_nullifiers(
                     chunk.to_vec(),
                     cursor,
                     Some(config.page_limit),
                     rpc_config,
                 )?;
+                let rows = response.transactions.len();
                 for tx in response.transactions.into_iter().filter(|tx| !tx.proofless) {
                     let key = tx.tx_signature.to_string();
                     out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
-                if let Some(position) = response.scanned_through {
-                    resume = Some(position);
-                }
-                cursor = response.next_cursor;
-                if cursor.is_none() {
-                    break;
-                }
-            }
+                Ok(Page {
+                    rows,
+                    next_cursor: response.next_cursor,
+                    scanned_through: response.scanned_through,
+                })
+            })?;
 
-            if let Some(position) = resume {
+            if let Some(position) = furthest {
                 for nullifier in chunk {
                     cursors.insert(*nullifier, position.clone());
                 }
@@ -745,10 +783,8 @@ fn fetch_shielded_transactions_by_nullifiers<I: Rpc>(
     Ok(())
 }
 
-/// Async twin of [`fetch_shielded_transactions_by_nullifiers`], kept deliberately
-/// parallel rather than shared for the same reason as the tag pair: the two
-/// differ only in `.await`, and an async client that missed the per-nullifier
-/// resume rule would rescan the whole stream on every sync.
+/// Async twin of [`fetch_shielded_transactions_by_nullifiers`]. Drives its own
+/// loop rather than calling [`read_chunk`]; see [`advance`].
 async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
     indexer: &I,
     nullifiers: &[[u8; 32]],
@@ -761,7 +797,7 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
     for (start, group) in group_by_resume_point(nullifiers, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
             let mut cursor = start.clone();
-            let mut resume = None;
+            let mut furthest = start.clone();
             loop {
                 let response = indexer
                     .get_shielded_transactions_by_nullifiers(
@@ -771,20 +807,23 @@ async fn fetch_shielded_transactions_by_nullifiers_async<I: AsyncRpc>(
                         rpc_config,
                     )
                     .await?;
+                let rows = response.transactions.len();
                 for tx in response.transactions.into_iter().filter(|tx| !tx.proofless) {
                     let key = tx.tx_signature.to_string();
                     out.entry(key).or_insert(convert_sync_transaction(tx)?);
                 }
-                if let Some(position) = response.scanned_through {
-                    resume = Some(position);
-                }
-                cursor = response.next_cursor;
-                if cursor.is_none() {
+                let page = Page {
+                    rows,
+                    next_cursor: response.next_cursor,
+                    scanned_through: response.scanned_through,
+                };
+                let Some(next) = advance(&mut furthest, page, config.page_limit) else {
                     break;
-                }
+                };
+                cursor = Some(next);
             }
 
-            if let Some(position) = resume {
+            if let Some(position) = furthest {
                 for nullifier in chunk {
                     cursors.insert(*nullifier, position.clone());
                 }
@@ -820,16 +859,14 @@ where
 {
     for (start, group) in group_by_resume_point(tags, cursors, scanned_to_tip) {
         for chunk in group.chunks(config.tag_query_chunk) {
-            let mut cursor = start.clone();
-            let mut furthest = start.clone();
-            loop {
+            let furthest = read_chunk(start.clone(), config.page_limit, |cursor| {
                 let response = indexer.get_encrypted_utxos_by_tags(
                     chunk.to_vec(),
                     cursor,
                     Some(config.page_limit),
                     rpc_config,
                 )?;
-                let last_page = response.matches.len() < config.page_limit as usize;
+                let rows = response.matches.len();
                 for item in response.matches {
                     if item.tx_viewing_pk.is_some() || item.salt.is_some() {
                         continue;
@@ -845,16 +882,13 @@ where
                         out.insert(key, view);
                     }
                 }
-                if response.next_cursor.is_some() {
-                    furthest = response.next_cursor.clone();
-                }
-                cursor = response.next_cursor;
-                if last_page || cursor.is_none() {
-                    break;
-                }
-            }
-            // Sound only because the stream is globally ordered: every tag in
-            // this chunk has now been read to that position.
+                Ok(Page {
+                    rows,
+                    next_cursor: response.next_cursor,
+                    scanned_through: None,
+                })
+            })?;
+
             if let Some(position) = furthest {
                 for tag in chunk {
                     cursors.insert(*tag, position.clone());
@@ -866,12 +900,8 @@ where
     Ok(())
 }
 
-/// Async twin of [`fetch_proofless_deposits`].
-///
-/// Kept deliberately parallel rather than shared, for the reason given on
-/// [`fetch_shielded_transactions_incremental_async`]: an async client that did
-/// not get the persisted cursor would keep re-reading the whole encrypted-utxo
-/// history on every sync.
+/// Async twin of [`fetch_proofless_deposits`]. Drives its own loop rather than
+/// calling [`read_chunk`]; see [`advance`].
 async fn fetch_proofless_deposits_async<I: AsyncRpc>(
     indexer: &I,
     tags: &[ViewTag],
@@ -894,7 +924,7 @@ async fn fetch_proofless_deposits_async<I: AsyncRpc>(
                         rpc_config,
                     )
                     .await?;
-                let last_page = response.matches.len() < config.page_limit as usize;
+                let rows = response.matches.len();
                 for item in response.matches {
                     if item.tx_viewing_pk.is_some() || item.salt.is_some() {
                         continue;
@@ -910,14 +940,17 @@ async fn fetch_proofless_deposits_async<I: AsyncRpc>(
                         out.insert(key, view);
                     }
                 }
-                if response.next_cursor.is_some() {
-                    furthest = response.next_cursor.clone();
-                }
-                cursor = response.next_cursor;
-                if last_page || cursor.is_none() {
+                let page = Page {
+                    rows,
+                    next_cursor: response.next_cursor,
+                    scanned_through: None,
+                };
+                let Some(next) = advance(&mut furthest, page, config.page_limit) else {
                     break;
-                }
+                };
+                cursor = Some(next);
             }
+
             if let Some(position) = furthest {
                 for tag in chunk {
                     cursors.insert(*tag, position.clone());
@@ -1040,11 +1073,11 @@ mod tests {
         /// separately.
         utxo_entries: Vec<(u64, ViewTag)>,
         /// Every (tags, cursor) pair the client asked for, for call accounting.
-        calls: std::cell::RefCell<Vec<(usize, Option<u64>)>>,
+        calls: std::sync::Mutex<Vec<(usize, Option<u64>)>>,
         /// The same, for the nullifier stream.
-        nullifier_calls: std::cell::RefCell<Vec<(usize, Option<u64>)>>,
+        nullifier_calls: std::sync::Mutex<Vec<(usize, Option<u64>)>>,
         /// The same, for the encrypted-utxo stream.
-        utxo_calls: std::cell::RefCell<Vec<(usize, Option<u64>)>>,
+        utxo_calls: std::sync::Mutex<Vec<(usize, Option<u64>)>>,
     }
 
     impl TaggedIndexer {
@@ -1060,7 +1093,10 @@ mod tests {
             let after = cursor.as_ref().map(|bytes| {
                 u64::from_be_bytes(bytes.as_slice().try_into().expect("8-byte cursor"))
             });
-            self.calls.borrow_mut().push((tags.len(), after));
+            self.calls
+                .lock()
+                .expect("calls poisoned")
+                .push((tags.len(), after));
 
             let mut rows: Vec<_> = self
                 .entries
@@ -1111,7 +1147,8 @@ mod tests {
                 u64::from_be_bytes(bytes.as_slice().try_into().expect("8-byte cursor"))
             });
             self.nullifier_calls
-                .borrow_mut()
+                .lock()
+                .expect("calls poisoned")
                 .push((nullifiers.len(), after));
 
             let mut rows: Vec<_> = self
@@ -1259,7 +1296,10 @@ mod tests {
             let after = cursor.as_ref().map(|bytes| {
                 u64::from_be_bytes(bytes.as_slice().try_into().expect("8-byte cursor"))
             });
-            self.utxo_calls.borrow_mut().push((tags.len(), after));
+            self.utxo_calls
+                .lock()
+                .expect("calls poisoned")
+                .push((tags.len(), after));
 
             let mut rows: Vec<_> = self
                 .utxo_entries
@@ -1404,12 +1444,12 @@ mod tests {
         )
         .expect("round 1");
 
-        // Each chunk costs two requests now: one for the rows, one that comes
-        // back empty and ends the stream. What matters is that no request ever
-        // carries two tags -- the early tag is never re-queried.
+        // One request per round, each carrying one tag: the early tag is already
+        // at the tip and is never re-queried, and neither round pays for a
+        // second request just to learn its page was the last.
         assert_eq!(
-            *indexer.calls.borrow(),
-            vec![(1, None), (1, Some(10)), (1, None), (1, Some(50))],
+            *indexer.calls.lock().expect("calls poisoned"),
+            vec![(1, None), (1, None)],
             "round 1 must ask for the late tag alone, not both tags again"
         );
     }
@@ -1453,9 +1493,10 @@ mod tests {
             "a short page still records the tip, so the next sync resumes there"
         );
         assert_eq!(
-            *indexer.calls.borrow(),
-            vec![(1, None), (1, Some(50))],
-            "one request for the rows, one more that returns none and ends the loop"
+            *indexer.calls.lock().expect("calls poisoned"),
+            vec![(1, None)],
+            "a page short of the limit ends the read: asking again only to be \
+             told the stream is empty costs a round trip per chunk per sync"
         );
     }
 
@@ -1506,10 +1547,134 @@ mod tests {
         .expect("fetch");
 
         assert_eq!(
-            *indexer.nullifier_calls.borrow(),
+            *indexer.nullifier_calls.lock().expect("calls poisoned"),
             vec![(1, None)],
             "one request carrying one nullifier, not the whole utxo history"
         );
+    }
+
+    /// A full page keeps reading; a short one stops. Every stream pages through
+    /// [`advance`], so this is the rule for all three.
+    #[test]
+    fn a_full_page_continues_and_a_short_page_ends_the_read() {
+        let page = |rows, next: Option<u64>| Page {
+            rows,
+            next_cursor: next.map(|slot| slot.to_be_bytes().to_vec()),
+            scanned_through: None,
+        };
+
+        let mut furthest = None;
+        assert_eq!(
+            advance(&mut furthest, page(10, Some(50)), 10),
+            Some(50u64.to_be_bytes().to_vec()),
+            "a page at the limit may have been truncated, so keep reading"
+        );
+
+        let mut furthest = None;
+        assert!(
+            advance(&mut furthest, page(3, Some(50)), 10).is_none(),
+            "a short page means the server ran out of rows, not out of room"
+        );
+        assert_eq!(
+            furthest,
+            Some(50u64.to_be_bytes().to_vec()),
+            "and it still records where it read to"
+        );
+
+        // The nullifier stream's pages are normally empty, so its position comes
+        // from the server rather than from a row.
+        let mut furthest = None;
+        assert!(advance(
+            &mut furthest,
+            Page {
+                rows: 0,
+                next_cursor: None,
+                scanned_through: Some(99u64.to_be_bytes().to_vec()),
+            },
+            10,
+        )
+        .is_none());
+        assert_eq!(furthest, Some(99u64.to_be_bytes().to_vec()));
+    }
+
+    /// The async twins page and resume like the blocking ones.
+    ///
+    /// They drive their own loop, so a change to one is not caught by the other
+    /// even though they share [`advance`]. Covers all three streams at once.
+    #[tokio::test]
+    async fn the_async_paths_resume_every_stream() {
+        let keypair = ShieldedKeypair::new().expect("keypair");
+        let tag = keypair.viewing_key.get_sender_view_tag(0).expect("tag");
+        let unspent = [7u8; 32];
+        let indexer = TaggedIndexer {
+            entries: vec![(10, tag), (50, tag)],
+            spends: vec![(20, [9u8; 32])],
+            utxo_entries: vec![(30, tag)],
+            ..Default::default()
+        };
+        let config = SyncWalletConfig::default();
+
+        let mut tag_cursors = HashMap::new();
+        fetch_shielded_transactions_incremental_async(
+            &indexer,
+            &[tag],
+            &mut HashMap::new(),
+            config,
+            None,
+            &mut tag_cursors,
+            &mut HashSet::new(),
+        )
+        .await
+        .expect("tags");
+        assert_eq!(tag_cursors.get(&tag).map(slot_of), Some(50));
+
+        let mut nullifier_cursors = HashMap::new();
+        fetch_shielded_transactions_by_nullifiers_async(
+            &indexer,
+            &[unspent],
+            &mut HashMap::new(),
+            config,
+            None,
+            &mut nullifier_cursors,
+            &mut HashSet::new(),
+        )
+        .await
+        .expect("nullifiers");
+        assert_eq!(
+            nullifier_cursors.get(&unspent).map(slot_of),
+            Some(50),
+            "no spend matched, so the position comes from the reported scan"
+        );
+
+        let mut proofless_cursors = HashMap::new();
+        fetch_proofless_deposits_async(
+            &indexer,
+            &[tag],
+            &mut HashMap::new(),
+            config,
+            None,
+            &mut proofless_cursors,
+            &mut HashSet::new(),
+        )
+        .await
+        .expect("proofless");
+        assert_eq!(proofless_cursors.get(&tag).map(slot_of), Some(30));
+
+        // One request per stream: each page was short of the limit.
+        assert_eq!(indexer.calls.lock().expect("calls poisoned").len(), 1);
+        assert_eq!(
+            indexer
+                .nullifier_calls
+                .lock()
+                .expect("calls poisoned")
+                .len(),
+            1
+        );
+        assert_eq!(indexer.utxo_calls.lock().expect("calls poisoned").len(), 1);
+    }
+
+    fn slot_of(cursor: &Vec<u8>) -> u64 {
+        u64::from_be_bytes(cursor.as_slice().try_into().expect("8-byte cursor"))
     }
 
     /// A second sync resumes the nullifier stream instead of walking it again.
@@ -1550,7 +1715,11 @@ mod tests {
         );
 
         // A fresh scanned_to_tip, as a later sync would have.
-        indexer.nullifier_calls.borrow_mut().clear();
+        indexer
+            .nullifier_calls
+            .lock()
+            .expect("calls poisoned")
+            .clear();
         fetch_shielded_transactions_by_nullifiers(
             &indexer,
             &[unspent],
@@ -1563,7 +1732,7 @@ mod tests {
         .expect("second sync");
 
         assert_eq!(
-            *indexer.nullifier_calls.borrow(),
+            *indexer.nullifier_calls.lock().expect("calls poisoned"),
             vec![(1, Some(50))],
             "the second sync resumes at 50 rather than rescanning from zero"
         );
@@ -1609,7 +1778,7 @@ mod tests {
         );
 
         // A fresh scanned_to_tip, as a later sync would have.
-        indexer.utxo_calls.borrow_mut().clear();
+        indexer.utxo_calls.lock().expect("calls poisoned").clear();
         fetch_proofless_deposits(
             &indexer,
             &[tag],
@@ -1622,7 +1791,7 @@ mod tests {
         .expect("second sync");
 
         assert_eq!(
-            *indexer.utxo_calls.borrow(),
+            *indexer.utxo_calls.lock().expect("calls poisoned"),
             vec![(1, Some(50))],
             "the second sync resumes at 50 rather than re-reading the stream"
         );
@@ -1685,7 +1854,7 @@ mod tests {
         );
 
         // Second sync has learned the late tag.
-        indexer.calls.borrow_mut().clear();
+        indexer.calls.lock().expect("calls poisoned").clear();
         let mut second = HashMap::new();
         fetch_shielded_transactions_incremental(
             &indexer,
@@ -1701,7 +1870,7 @@ mod tests {
         // Asserting on what was REQUESTED rather than what was decrypted: the
         // invariant is which rows the indexer was asked for, and fabricating
         // decryptable P256 payloads would test the crypto instead.
-        let calls = indexer.calls.borrow();
+        let calls = indexer.calls.lock().expect("calls poisoned");
         assert!(
             calls.iter().any(|(_, after)| after.is_none()),
             "the newly discovered tag must be scanned from the beginning, not from \
@@ -1711,6 +1880,49 @@ mod tests {
             calls.iter().any(|(_, after)| *after == Some(50)),
             "the already-synced tag should resume rather than rescan; calls were {calls:?}"
         );
+    }
+
+    /// Delegates to the blocking impl so the async paths can be driven by the
+    /// same paging mock. They keep their own loop, so nothing else checks that
+    /// they page and resume the way the blocking paths do.
+    #[async_trait::async_trait]
+    impl AsyncRpc for TaggedIndexer {
+        async fn get_program_accounts(
+            &self,
+            program_id: Address,
+        ) -> Result<Vec<(Address, solana_account::Account)>, ClientError> {
+            Rpc::get_program_accounts(self, program_id)
+        }
+
+        async fn get_encrypted_utxos_by_tags(
+            &self,
+            tags: Vec<ViewTag>,
+            cursor: Option<Vec<u8>>,
+            limit: Option<u32>,
+            config: Option<IndexerRpcConfig>,
+        ) -> Result<GetEncryptedUtxosByTagsResponse, ClientError> {
+            Rpc::get_encrypted_utxos_by_tags(self, tags, cursor, limit, config)
+        }
+
+        async fn get_shielded_transactions_by_tags(
+            &self,
+            tags: Vec<ViewTag>,
+            cursor: Option<Vec<u8>>,
+            limit: Option<u32>,
+            config: Option<IndexerRpcConfig>,
+        ) -> Result<GetShieldedTransactionsByTagsResponse, ClientError> {
+            Rpc::get_shielded_transactions_by_tags(self, tags, cursor, limit, config)
+        }
+
+        async fn get_shielded_transactions_by_nullifiers(
+            &self,
+            nullifiers: Vec<ViewTag>,
+            cursor: Option<Vec<u8>>,
+            limit: Option<u32>,
+            config: Option<IndexerRpcConfig>,
+        ) -> Result<GetShieldedTransactionsByNullifiersResponse, ClientError> {
+            Rpc::get_shielded_transactions_by_nullifiers(self, nullifiers, cursor, limit, config)
+        }
     }
 
     #[async_trait::async_trait]

--- a/services/photon/src/api/method/rings.rs
+++ b/services/photon/src/api/method/rings.rs
@@ -16,7 +16,7 @@ pub use get_shielded_transactions_by_tags::get_shielded_transactions_by_tags;
 
 #[cfg(test)]
 mod tests {
-    use super::common::{decode_cursor, encode_cursor, validate_proof_leaves};
+    use super::common::{decode_cursor, encode_cursor, validate_proof_leaves, CursorKind};
     use super::get_encrypted_utxos_by_tags::EncryptedUtxoCursor;
     use super::get_shielded_transactions_by_tags::ShieldedTxCursor;
     use crate::api::error::PhotonApiError;
@@ -48,9 +48,11 @@ mod tests {
             event_index: 3,
             output_index: 5,
         };
-        let encrypted_cursor = Base64String(encode_cursor(&encrypted).unwrap());
+        let encrypted_cursor =
+            Base64String(encode_cursor(CursorKind::EncryptedUtxos, &encrypted).unwrap());
         assert_eq!(
-            decode_cursor::<EncryptedUtxoCursor>(&encrypted_cursor).unwrap(),
+            decode_cursor::<EncryptedUtxoCursor>(CursorKind::EncryptedUtxos, &encrypted_cursor)
+                .unwrap(),
             encrypted
         );
 
@@ -59,15 +61,31 @@ mod tests {
             signature,
             event_index: 8,
         };
-        let shielded_cursor = Base64String(encode_cursor(&shielded).unwrap());
+        let shielded_cursor =
+            Base64String(encode_cursor(CursorKind::ShieldedTxByTags, &shielded).unwrap());
         assert_eq!(
-            decode_cursor::<ShieldedTxCursor>(&shielded_cursor).unwrap(),
+            decode_cursor::<ShieldedTxCursor>(CursorKind::ShieldedTxByTags, &shielded_cursor)
+                .unwrap(),
             shielded
         );
 
-        let mut malformed_cursor = shielded_cursor.0;
+        let mut malformed_cursor = shielded_cursor.0.clone();
         malformed_cursor.push(1);
-        assert!(decode_cursor::<ShieldedTxCursor>(&Base64String(malformed_cursor)).is_err());
+        assert!(decode_cursor::<ShieldedTxCursor>(
+            CursorKind::ShieldedTxByTags,
+            &Base64String(malformed_cursor)
+        )
+        .is_err());
+
+        // The tags and nullifiers streams share this cursor byte for byte and
+        // order by the same key, so a cursor from one would otherwise decode
+        // cleanly in the other and resume mid-scan, skipping every match before
+        // that position without reporting anything.
+        assert!(decode_cursor::<ShieldedTxCursor>(
+            CursorKind::ShieldedTxByNullifiers,
+            &shielded_cursor
+        )
+        .is_err());
     }
 
     #[test]

--- a/services/photon/src/api/method/rings.rs
+++ b/services/photon/src/api/method/rings.rs
@@ -77,10 +77,8 @@ mod tests {
         )
         .is_err());
 
-        // The tags and nullifiers streams share this cursor byte for byte and
-        // order by the same key, so a cursor from one would otherwise decode
-        // cleanly in the other and resume mid-scan, skipping every match before
-        // that position without reporting anything.
+        // Tags and nullifiers share this cursor byte for byte, so without the
+        // kind one resumes mid-scan in the other and skips silently.
         assert!(decode_cursor::<ShieldedTxCursor>(
             CursorKind::ShieldedTxByNullifiers,
             &shielded_cursor

--- a/services/photon/src/api/method/rings/common.rs
+++ b/services/photon/src/api/method/rings/common.rs
@@ -325,12 +325,41 @@ pub(super) fn tx_cursor_sql_condition(
     ))
 }
 
-pub(super) fn decode_cursor<T: Decode<()>>(cursor: &Base64String) -> Result<T, PhotonApiError> {
+/// Which stream a cursor came from, carried as its first byte.
+///
+/// Without it the tags and nullifiers streams cannot be told apart: they share
+/// `ShieldedTxCursor` byte for byte and order by the same key, so a cursor from
+/// one decodes cleanly in the other and resumes at that position in a
+/// differently filtered scan -- skipping every match before it and reporting
+/// success. The encrypted-utxo stream is only distinguishable today because its
+/// cursor happens to be two bytes longer, which is accident rather than design
+/// and stops being true the moment either shape changes.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum CursorKind {
+    EncryptedUtxos = 1,
+    ShieldedTxByTags = 2,
+    ShieldedTxByNullifiers = 3,
+}
+
+pub(super) fn decode_cursor<T: Decode<()>>(
+    kind: CursorKind,
+    cursor: &Base64String,
+) -> Result<T, PhotonApiError> {
+    let (tag, body) = cursor
+        .0
+        .split_first()
+        .ok_or_else(|| PhotonApiError::ValidationError("Invalid cursor".to_string()))?;
+    if *tag != kind as u8 {
+        return Err(PhotonApiError::ValidationError(
+            "Invalid cursor: it belongs to a different query".to_string(),
+        ));
+    }
+
     let config = cursor_bincode_config();
-    let (decoded, bytes_read) = bincode::decode_from_slice(&cursor.0, config)
+    let (decoded, bytes_read) = bincode::decode_from_slice(body, config)
         .map_err(|_| PhotonApiError::ValidationError("Invalid cursor".to_string()))?;
 
-    if bytes_read != cursor.0.len() {
+    if bytes_read != body.len() {
         return Err(PhotonApiError::ValidationError(
             "Invalid cursor: trailing bytes".to_string(),
         ));
@@ -339,10 +368,17 @@ pub(super) fn decode_cursor<T: Decode<()>>(cursor: &Base64String) -> Result<T, P
     Ok(decoded)
 }
 
-pub(super) fn encode_cursor<T: Encode>(cursor: &T) -> Result<Vec<u8>, PhotonApiError> {
+pub(super) fn encode_cursor<T: Encode>(
+    kind: CursorKind,
+    cursor: &T,
+) -> Result<Vec<u8>, PhotonApiError> {
     let config = cursor_bincode_config();
-    bincode::encode_to_vec(cursor, config)
-        .map_err(|_| PhotonApiError::UnexpectedError("Failed to encode cursor".to_string()))
+    let body = bincode::encode_to_vec(cursor, config)
+        .map_err(|_| PhotonApiError::UnexpectedError("Failed to encode cursor".to_string()))?;
+    let mut encoded = Vec::with_capacity(1 + body.len());
+    encoded.push(kind as u8);
+    encoded.extend_from_slice(&body);
+    Ok(encoded)
 }
 
 fn cursor_bincode_config() -> impl bincode::config::Config {

--- a/services/photon/src/api/method/rings/common.rs
+++ b/services/photon/src/api/method/rings/common.rs
@@ -325,15 +325,11 @@ pub(super) fn tx_cursor_sql_condition(
     ))
 }
 
-/// Which stream a cursor came from, carried as its first byte.
+/// Which stream minted a cursor, as its first byte.
 ///
-/// Without it the tags and nullifiers streams cannot be told apart: they share
-/// `ShieldedTxCursor` byte for byte and order by the same key, so a cursor from
-/// one decodes cleanly in the other and resumes at that position in a
-/// differently filtered scan -- skipping every match before it and reporting
-/// success. The encrypted-utxo stream is only distinguishable today because its
-/// cursor happens to be two bytes longer, which is accident rather than design
-/// and stops being true the moment either shape changes.
+/// Tags and nullifiers share `ShieldedTxCursor` byte for byte, so one resumes
+/// cleanly in the other and skips every match before it. Encrypted-utxo cursors
+/// differ only by length, which is accident, not design.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(super) enum CursorKind {
     EncryptedUtxos = 1,

--- a/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
@@ -1,7 +1,7 @@
 use super::common::{
     bind_u64_as_i64, cursor_sort_key, decode_cursor, encode_cursor, next_cursor_from_rows,
     rings_output_slot_from_parts, signature_from_bytes, tags_sql, tx_cursor_sql_condition,
-    u16_from_i16, u64_from_i64, validate_tags,
+    u16_from_i16, u64_from_i64, validate_tags, CursorKind,
 };
 use crate::api::error::PhotonApiError;
 use crate::common::indexer_context::extract as extract_context;
@@ -47,7 +47,7 @@ pub async fn get_encrypted_utxos_by_tags(
     let cursor = request
         .cursor
         .as_ref()
-        .map(decode_cursor::<EncryptedUtxoCursor>)
+        .map(|c| decode_cursor::<EncryptedUtxoCursor>(CursorKind::EncryptedUtxos, c))
         .transpose()?;
 
     let context = extract_context(conn).await?;
@@ -159,5 +159,5 @@ fn encrypted_utxo_cursor_from_row(row: &EncryptedUtxoRow) -> Result<Vec<u8>, Pho
         event_index,
         output_index: u16_from_i16(row.output_index, "output index")?,
     };
-    encode_cursor(&cursor)
+    encode_cursor(CursorKind::EncryptedUtxos, &cursor)
 }

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -4,6 +4,7 @@ use super::common::{
     bind_u64_as_i64, cursor_sort_key, decode_cursor, encode_cursor, hash_from_vec, int_list_sql,
     next_cursor_from_rows, rings_output_slot_from_parts, signature_from_bytes, tags_sql,
     tx_cursor_sql_condition, u16_from_i16, u64_from_i64, validate_nullifiers, validate_tags,
+    CursorKind,
 };
 use crate::api::error::PhotonApiError;
 use crate::common::indexer_context::extract as extract_context;
@@ -133,8 +134,14 @@ async fn get_shielded_transactions(
     limit: u64,
     match_by: MatchBy,
 ) -> Result<ShieldedTransactionPage, PhotonApiError> {
+    // The kind follows the query, so a cursor from the sibling stream is
+    // rejected rather than silently resumed in a differently filtered scan.
+    let cursor_kind = match match_by {
+        MatchBy::Tags => CursorKind::ShieldedTxByTags,
+        MatchBy::Nullifiers => CursorKind::ShieldedTxByNullifiers,
+    };
     let cursor = encoded_cursor
-        .map(decode_cursor::<ShieldedTxCursor>)
+        .map(|c| decode_cursor::<ShieldedTxCursor>(cursor_kind, c))
         .transpose()?;
     let context = extract_context(conn).await?;
     let tx = conn.begin().await?;
@@ -142,14 +149,16 @@ async fn get_shielded_transactions(
 
     let matched_txs =
         fetch_matching_rings_transactions(&tx, values, cursor.as_ref(), limit, match_by).await?;
-    let next_cursor = next_cursor_from_rows(&matched_txs, shielded_tx_cursor_from_row)?;
+    let next_cursor = next_cursor_from_rows(&matched_txs, |row| {
+        shielded_tx_cursor_from_row(row, cursor_kind)
+    })?;
 
     // A full page means the limit cut the scan short, so nothing can be claimed
     // beyond it. Only the nullifier stream needs the position: a tag query's
     // cursor advances on the rows it returns.
     let truncated = matched_txs.len() as u64 >= limit;
     let scanned_through = match match_by {
-        MatchBy::Nullifiers if !truncated => scan_position(&tx).await?,
+        MatchBy::Nullifiers if !truncated => scan_position(&tx, cursor_kind).await?,
         _ => None,
     };
 
@@ -177,7 +186,13 @@ async fn get_shielded_transactions(
 /// Sound while positions are only appended: a row later inserted below this one
 /// would be skipped by anyone resuming here. Per-tag cursors already assume the
 /// same.
-async fn scan_position(tx: &DatabaseTransaction) -> Result<Option<Base64String>, PhotonApiError> {
+/// The kind comes from the caller rather than being hardcoded: this position is
+/// handed back as a cursor, so it has to be labelled with the stream that will
+/// resume from it.
+async fn scan_position(
+    tx: &DatabaseTransaction,
+    kind: CursorKind,
+) -> Result<Option<Base64String>, PhotonApiError> {
     let backend = tx.get_database_backend();
     // Not `ORDER BY slot, signature, event_index DESC LIMIT 1`: no index covers
     // that ordering, so it would sort the whole table. Pinning the slot first is
@@ -205,6 +220,7 @@ async fn scan_position(tx: &DatabaseTransaction) -> Result<Option<Base64String>,
         row.slot,
         &row.signature,
         row.event_index,
+        kind,
     )?)))
 }
 
@@ -465,14 +481,18 @@ fn shielded_tx_cursor_sql(
     Ok(format!("AND {condition}"))
 }
 
-fn shielded_tx_cursor_from_row(row: &MatchedRingsTxRow) -> Result<Vec<u8>, PhotonApiError> {
-    shielded_tx_cursor(row.slot, &row.signature, row.event_index)
+fn shielded_tx_cursor_from_row(
+    row: &MatchedRingsTxRow,
+    kind: CursorKind,
+) -> Result<Vec<u8>, PhotonApiError> {
+    shielded_tx_cursor(row.slot, &row.signature, row.event_index, kind)
 }
 
 fn shielded_tx_cursor(
     slot: i64,
     signature: &[u8],
     event_index: i16,
+    kind: CursorKind,
 ) -> Result<Vec<u8>, PhotonApiError> {
     let (slot, signature, event_index) = cursor_sort_key(slot, signature, event_index)?;
     let cursor = ShieldedTxCursor {
@@ -480,7 +500,7 @@ fn shielded_tx_cursor(
         signature,
         event_index,
     };
-    encode_cursor(&cursor)
+    encode_cursor(kind, &cursor)
 }
 
 #[cfg(test)]

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -49,8 +49,7 @@ struct RingsMessageRow {
     payload: Vec<u8>,
 }
 
-/// Just enough of a row to build a cursor from, for the lookup that reports
-/// where a scan stopped and has no transaction to hydrate.
+/// Just enough of a row to build a cursor from.
 #[derive(FromQueryResult, Debug)]
 struct ScanPositionRow {
     slot: i64,
@@ -123,8 +122,7 @@ struct ShieldedTransactionPage {
     context: zolana_indexer_api::Context,
     transactions: Vec<ShieldedTransaction>,
     next_cursor: Option<Base64String>,
-    /// Only ever set for [`MatchBy::Nullifiers`]; nothing else has a response
-    /// field to carry it in.
+    /// Set only for [`MatchBy::Nullifiers`]; no other response carries it.
     scanned_through: Option<Base64String>,
 }
 
@@ -146,13 +144,9 @@ async fn get_shielded_transactions(
         fetch_matching_rings_transactions(&tx, values, cursor.as_ref(), limit, match_by).await?;
     let next_cursor = next_cursor_from_rows(&matched_txs, shielded_tx_cursor_from_row)?;
 
-    // Only the nullifier response has a field to report this in, and only that
-    // stream needs one: a tag query returns the wallet's own transactions, so
-    // its cursor advances on the rows themselves.
-    //
     // A full page means the limit cut the scan short, so nothing can be claimed
-    // about what lies beyond it. Anything less means the scan ran out of rows,
-    // not out of room, and where it stopped is a sound resume point.
+    // beyond it. Only the nullifier stream needs the position: a tag query's
+    // cursor advances on the rows it returns.
     let truncated = matched_txs.len() as u64 >= limit;
     let scanned_through = match match_by {
         MatchBy::Nullifiers if !truncated => scan_position(&tx).await?,
@@ -177,24 +171,17 @@ async fn get_shielded_transactions(
 
 /// The last position in the transaction stream, as a cursor.
 ///
-/// A scan that was not cut short by its limit reached exactly here, so this is
-/// what "I looked this far and found nothing more" means concretely.
+/// Read inside the caller's transaction, so it describes the snapshot the scan
+/// saw. `None` only when the table is empty.
 ///
-/// Read inside the caller's transaction so it describes the same snapshot the
-/// scan saw. `None` only when the table is empty, which leaves the caller
-/// resuming from zero -- correct, and there is nothing to skip anyway.
-///
-/// Soundness rests on positions only ever being appended: a row inserted later
-/// at a position below this one would be skipped by anyone who resumed here.
-/// That is the same assumption the per-tag cursors already run on, since they
-/// resume from the last row they saw.
+/// Sound while positions are only appended: a row later inserted below this one
+/// would be skipped by anyone resuming here. Per-tag cursors already assume the
+/// same.
 async fn scan_position(tx: &DatabaseTransaction) -> Result<Option<Base64String>, PhotonApiError> {
     let backend = tx.get_database_backend();
-    // Deliberately not one `ORDER BY slot, signature, event_index DESC LIMIT 1`:
-    // no index covers that ordering, so it sorts the whole table on every
-    // request. Pinning the slot first is an index lookup on
-    // `idx_rings_transactions_slot_id`, and the handful of rows sharing that
-    // slot are all that gets sorted.
+    // Not `ORDER BY slot, signature, event_index DESC LIMIT 1`: no index covers
+    // that ordering, so it would sort the whole table. Pinning the slot first is
+    // an index lookup on `idx_rings_transactions_slot_id`.
     let sql = "SELECT
             pt.slot AS slot,
             pt.signature AS signature,
@@ -598,9 +585,8 @@ mod tests {
         assert!(response.transactions.is_empty());
     }
 
-    /// An unspent nullifier is the normal case, and it matches nothing. Without
-    /// this the caller has no way to record that it just scanned the whole
-    /// stream, so it scans the whole stream again on the next sync forever.
+    /// An unspent nullifier matches nothing, so without a reported position the
+    /// caller rescans the whole stream on every sync.
     #[tokio::test]
     async fn an_empty_nullifier_page_still_reports_how_far_it_scanned() {
         let db = setup().await;
@@ -624,8 +610,7 @@ mod tests {
             .scanned_through
             .expect("an exhausted scan reports its tip");
 
-        // Resuming there is the point: the same query from that position must
-        // still be empty, and must not walk the stream again.
+        // The same query from that position must still be empty.
         let resumed = get_shielded_transactions_by_nullifiers(
             &db,
             GetRingsByNullifiersRequest {
@@ -644,8 +629,8 @@ mod tests {
         );
     }
 
-    /// The reported position claims "nothing matches at or before here", which
-    /// is only true when the scan ran out of rows rather than out of room.
+    /// The position claims nothing matches at or before it, true only when the
+    /// scan ran out of rows rather than out of room.
     #[tokio::test]
     async fn a_truncated_page_reports_no_scan_position() {
         let db = setup().await;
@@ -667,8 +652,7 @@ mod tests {
         );
     }
 
-    /// A spend is found whether the caller starts from zero or resumes, so the
-    /// reported position cannot be used to skip one.
+    /// The position must not skip a spend that lands after it.
     #[tokio::test]
     async fn resuming_from_a_scan_position_still_finds_a_later_spend() {
         let db = setup().await;

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -113,31 +113,18 @@ pub async fn get_shielded_transactions_by_nullifiers(
     })
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 enum MatchBy {
     Tags,
     Nullifiers,
-}
-
-impl MatchBy {
-    /// Whether to spend an extra lookup telling the caller how far the scan got.
-    ///
-    /// Only the nullifier stream needs it, because only there is an empty page
-    /// the normal answer. A tag query returns the wallet's own transactions, so
-    /// its cursor advances on the rows themselves, and only its response carries
-    /// the field. Deriving this from the match rather than passing it separately
-    /// keeps the two from disagreeing.
-    fn reports_frontier(self) -> bool {
-        self == Self::Nullifiers
-    }
 }
 
 struct ShieldedTransactionPage {
     context: zolana_indexer_api::Context,
     transactions: Vec<ShieldedTransaction>,
     next_cursor: Option<Base64String>,
-    /// Always `None` for a match the response has no field to carry it in; see
-    /// [`MatchBy::reports_frontier`].
+    /// Only ever set for [`MatchBy::Nullifiers`]; nothing else has a response
+    /// field to carry it in.
     scanned_through: Option<Base64String>,
 }
 
@@ -159,14 +146,17 @@ async fn get_shielded_transactions(
         fetch_matching_rings_transactions(&tx, values, cursor.as_ref(), limit, match_by).await?;
     let next_cursor = next_cursor_from_rows(&matched_txs, shielded_tx_cursor_from_row)?;
 
+    // Only the nullifier response has a field to carry a frontier in, and only
+    // that stream needs one: a tag query returns the wallet's own transactions,
+    // so its cursor advances on the rows themselves.
+    //
     // A full page means the limit cut the scan short, so nothing can be claimed
     // about what lies beyond it. Anything less means the scan ran out of rows,
     // not out of room, and the tip it reached is a sound resume point.
     let truncated = matched_txs.len() as u64 >= limit;
-    let scanned_through = if match_by.reports_frontier() && !truncated {
-        stream_tip(&tx).await?
-    } else {
-        None
+    let scanned_through = match match_by {
+        MatchBy::Nullifiers if !truncated => stream_tip(&tx).await?,
+        _ => None,
     };
 
     let transactions = hydrate_shielded_transactions(&tx, matched_txs)

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -68,12 +68,13 @@ pub async fn get_shielded_transactions_by_tags(
     request: GetRingsByTagsRequest,
 ) -> Result<GetShieldedTransactionsByTagsResponse, PhotonApiError> {
     validate_tags(&request.tags)?;
-    let (context, transactions, next_cursor) = get_shielded_transactions(
+    let (context, transactions, next_cursor, _) = get_shielded_transactions(
         conn,
         &request.tags,
         request.cursor.as_ref(),
         request.limit.unwrap_or_default().value(),
         MatchBy::Tags,
+        ReportFrontier::No,
     )
     .await?;
     Ok(GetShieldedTransactionsByTagsResponse {
@@ -88,18 +89,20 @@ pub async fn get_shielded_transactions_by_nullifiers(
     request: GetRingsByNullifiersRequest,
 ) -> Result<GetShieldedTransactionsByNullifiersResponse, PhotonApiError> {
     validate_nullifiers(&request.nullifiers)?;
-    let (context, transactions, next_cursor) = get_shielded_transactions(
+    let (context, transactions, next_cursor, scanned_through) = get_shielded_transactions(
         conn,
         &request.nullifiers,
         request.cursor.as_ref(),
         request.limit.unwrap_or_default().value(),
         MatchBy::Nullifiers,
+        ReportFrontier::Yes,
     )
     .await?;
     Ok(GetShieldedTransactionsByNullifiersResponse {
         context,
         transactions,
         next_cursor,
+        scanned_through,
     })
 }
 
@@ -109,16 +112,30 @@ enum MatchBy {
     Nullifiers,
 }
 
+/// Whether to spend an extra lookup telling the caller how far the scan reached.
+///
+/// Only the nullifier stream needs it, because only there is an empty page the
+/// normal answer. A tag query returns the wallet's own transactions, so its
+/// cursor advances on the rows themselves; asking for the frontier as well would
+/// buy nothing and cost a query on a hot path.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReportFrontier {
+    Yes,
+    No,
+}
+
 async fn get_shielded_transactions(
     conn: &DatabaseConnection,
     values: &[Hash],
     encoded_cursor: Option<&Base64String>,
     limit: u64,
     match_by: MatchBy,
+    report_frontier: ReportFrontier,
 ) -> Result<
     (
         zolana_indexer_api::Context,
         Vec<ShieldedTransaction>,
+        Option<Base64String>,
         Option<Base64String>,
     ),
     PhotonApiError,
@@ -134,6 +151,15 @@ async fn get_shielded_transactions(
         fetch_matching_rings_transactions(&tx, values, cursor.as_ref(), limit, match_by).await?;
     let next_cursor = next_cursor_from_rows(&matched_txs, shielded_tx_cursor_from_row)?;
 
+    // A full page means the limit cut the scan short, so nothing can be claimed
+    // about what lies beyond it. Anything less means the scan ran out of rows,
+    // not out of room, and the tip it reached is a sound resume point.
+    let truncated = matched_txs.len() as u64 >= limit;
+    let scanned_through = match (report_frontier, truncated) {
+        (ReportFrontier::Yes, false) => stream_tip(&tx).await?,
+        _ => None,
+    };
+
     let transactions = hydrate_shielded_transactions(&tx, matched_txs)
         .await?
         .into_iter()
@@ -142,7 +168,50 @@ async fn get_shielded_transactions(
 
     tx.commit().await?;
 
-    Ok((context, transactions, next_cursor))
+    Ok((context, transactions, next_cursor, scanned_through))
+}
+
+/// The greatest position present in the transaction stream, as a cursor.
+///
+/// Read inside the caller's transaction so it describes the same snapshot the
+/// scan saw. `None` only when the table is empty, which leaves the caller
+/// resuming from zero -- correct, and there is nothing to skip anyway.
+///
+/// Soundness rests on positions only ever being appended: a row inserted later
+/// at a position below this tip would be skipped by anyone who resumed here.
+/// That is the same assumption the per-tag cursors already run on, since they
+/// resume from the last row they saw.
+async fn stream_tip(tx: &DatabaseTransaction) -> Result<Option<Base64String>, PhotonApiError> {
+    let backend = tx.get_database_backend();
+    // Deliberately not one `ORDER BY slot, signature, event_index DESC LIMIT 1`:
+    // no index covers that ordering, so it sorts the whole table on every
+    // request. Pinning the slot first is an index lookup on
+    // `idx_rings_transactions_slot_id`, and the handful of rows sharing that
+    // slot are all that gets sorted.
+    let sql = "SELECT
+            pt.rings_tx_id AS rings_tx_id,
+            pt.slot AS slot,
+            pt.signature AS signature,
+            pt.event_index AS event_index,
+            pt.tx_viewing_pk AS tx_viewing_pk,
+            pt.salt AS salt,
+            pt.proofless AS proofless
+         FROM rings_transactions pt
+         WHERE pt.slot = (SELECT MAX(slot) FROM rings_transactions)
+         ORDER BY pt.signature DESC, pt.event_index DESC
+         LIMIT 1"
+        .to_string();
+
+    let Some(row) = tx
+        .query_all(Statement::from_sql_and_values(backend, sql, Vec::new()))
+        .await?
+        .into_iter()
+        .next()
+    else {
+        return Ok(None);
+    };
+    let row = MatchedRingsTxRow::from_query_result(&row, "")?;
+    Ok(Some(Base64String(shielded_tx_cursor_from_row(&row)?)))
 }
 
 pub(super) async fn hydrate_shielded_transactions(
@@ -513,5 +582,159 @@ mod tests {
         .await
         .unwrap();
         assert!(response.transactions.is_empty());
+    }
+
+    /// An unspent nullifier is the normal case, and it matches nothing. Without
+    /// a frontier the caller has no way to record that it just scanned the whole
+    /// stream, so it scans the whole stream again on the next sync forever.
+    #[tokio::test]
+    async fn an_empty_nullifier_page_still_reports_how_far_it_scanned() {
+        let db = setup().await;
+        let response = get_shielded_transactions_by_nullifiers(
+            &db,
+            GetRingsByNullifiersRequest {
+                nullifiers: vec![hash(5)],
+                cursor: None,
+                limit: Some(Limit::new(10).unwrap()),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(response.transactions.is_empty());
+        assert!(
+            response.next_cursor.is_none(),
+            "no rows, so no page to follow"
+        );
+        let frontier = response
+            .scanned_through
+            .expect("an exhausted scan reports its tip");
+
+        // Resuming there is the point: the same query from the frontier must
+        // still be empty, and must not walk the stream again.
+        let resumed = get_shielded_transactions_by_nullifiers(
+            &db,
+            GetRingsByNullifiersRequest {
+                nullifiers: vec![hash(5)],
+                cursor: Some(frontier.clone()),
+                limit: Some(Limit::new(10).unwrap()),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(resumed.transactions.is_empty());
+        assert_eq!(
+            resumed.scanned_through,
+            Some(frontier),
+            "a stream that has not moved reports the same tip"
+        );
+    }
+
+    /// The frontier claims "nothing matches at or before here", which is only
+    /// true when the scan ran out of rows rather than out of room.
+    #[tokio::test]
+    async fn a_truncated_page_reports_no_frontier() {
+        let db = setup().await;
+        let response = get_shielded_transactions_by_nullifiers(
+            &db,
+            GetRingsByNullifiersRequest {
+                nullifiers: vec![hash(3), hash(4)],
+                cursor: None,
+                limit: Some(Limit::new(1).unwrap()),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.transactions.len(), 1);
+        assert!(
+            response.scanned_through.is_none(),
+            "the limit cut the scan short, so nothing can be claimed beyond it"
+        );
+    }
+
+    /// A spend is found whether the caller starts from zero or resumes, so the
+    /// frontier cannot be used to skip one.
+    #[tokio::test]
+    async fn resuming_from_a_frontier_still_finds_a_later_spend() {
+        let db = setup().await;
+        let first = get_shielded_transactions_by_nullifiers(
+            &db,
+            GetRingsByNullifiersRequest {
+                nullifiers: vec![hash(5)],
+                cursor: None,
+                limit: Some(Limit::new(10).unwrap()),
+            },
+        )
+        .await
+        .unwrap();
+        let frontier = first.scanned_through.expect("frontier");
+
+        // A later transaction spends the nullifier the caller is watching.
+        blocks::Entity::insert(blocks::ActiveModel {
+            slot: Set(9),
+            parent_slot: Set(7),
+            parent_blockhash: Set(vec![1; 32]),
+            blockhash: Set(vec![2; 32]),
+            block_height: Set(2),
+            block_time: Set(2),
+        })
+        .exec(&db)
+        .await
+        .unwrap();
+        transactions::Entity::insert(transactions::ActiveModel {
+            signature: Set(vec![2; 64]),
+            slot: Set(9),
+            error: Set(None),
+        })
+        .exec(&db)
+        .await
+        .unwrap();
+        rings_transactions::Entity::insert(rings_transactions::ActiveModel {
+            rings_tx_id: Set(2),
+            signature: Set(vec![2; 64]),
+            event_index: Set(0),
+            slot: Set(9),
+            rings_program_id: Set(vec![9; 32]),
+            source_instruction_tag: Set(1),
+            output_tree: Set(vec![8; 32]),
+            first_output_leaf_index: Set(0),
+            tx_viewing_pk: Set(None),
+            salt: Set(None),
+            proofless: Set(false),
+        })
+        .exec(&db)
+        .await
+        .unwrap();
+        rings_tx_nullifiers::Entity::insert(rings_tx_nullifiers::ActiveModel {
+            nullifier_id: Default::default(),
+            rings_tx_id: Set(2),
+            slot: Set(9),
+            input_index: Set(0),
+            nullifier_tree: Set(vec![7; 32]),
+            // The setup already used seq 0 and 1 in this tree, and the pair
+            // (tree, seq) is unique.
+            input_queue_seq: Set(2),
+            nullifier: Set(vec![5; 32]),
+        })
+        .exec(&db)
+        .await
+        .unwrap();
+
+        let resumed = get_shielded_transactions_by_nullifiers(
+            &db,
+            GetRingsByNullifiersRequest {
+                nullifiers: vec![hash(5)],
+                cursor: Some(frontier),
+                limit: Some(Limit::new(10).unwrap()),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            resumed.transactions.len(),
+            1,
+            "the spend landed after the frontier, so resuming there must still see it"
+        );
     }
 }

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -134,8 +134,7 @@ async fn get_shielded_transactions(
     limit: u64,
     match_by: MatchBy,
 ) -> Result<ShieldedTransactionPage, PhotonApiError> {
-    // The kind follows the query, so a cursor from the sibling stream is
-    // rejected rather than silently resumed in a differently filtered scan.
+    // Follows the query, so a sibling stream's cursor is rejected, not resumed.
     let cursor_kind = match match_by {
         MatchBy::Tags => CursorKind::ShieldedTxByTags,
         MatchBy::Nullifiers => CursorKind::ShieldedTxByNullifiers,
@@ -186,9 +185,8 @@ async fn get_shielded_transactions(
 /// Sound while positions are only appended: a row later inserted below this one
 /// would be skipped by anyone resuming here. Per-tag cursors already assume the
 /// same.
-/// The kind comes from the caller rather than being hardcoded: this position is
-/// handed back as a cursor, so it has to be labelled with the stream that will
-/// resume from it.
+/// Kind from the caller: this position is returned as a cursor, so it carries the
+/// stream that will resume from it.
 async fn scan_position(
     tx: &DatabaseTransaction,
     kind: CursorKind,

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -83,7 +83,6 @@ pub async fn get_shielded_transactions_by_tags(
         request.cursor.as_ref(),
         request.limit.unwrap_or_default().value(),
         MatchBy::Tags,
-        ReportFrontier::No,
     )
     .await?;
     Ok(GetShieldedTransactionsByTagsResponse {
@@ -104,7 +103,6 @@ pub async fn get_shielded_transactions_by_nullifiers(
         request.cursor.as_ref(),
         request.limit.unwrap_or_default().value(),
         MatchBy::Nullifiers,
-        ReportFrontier::Yes,
     )
     .await?;
     Ok(GetShieldedTransactionsByNullifiersResponse {
@@ -115,29 +113,31 @@ pub async fn get_shielded_transactions_by_nullifiers(
     })
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum MatchBy {
     Tags,
     Nullifiers,
 }
 
-/// Whether to spend an extra lookup telling the caller how far the scan reached.
-///
-/// Only the nullifier stream needs it, because only there is an empty page the
-/// normal answer. A tag query returns the wallet's own transactions, so its
-/// cursor advances on the rows themselves; asking for the frontier as well would
-/// buy nothing and cost a query on a hot path.
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum ReportFrontier {
-    Yes,
-    No,
+impl MatchBy {
+    /// Whether to spend an extra lookup telling the caller how far the scan got.
+    ///
+    /// Only the nullifier stream needs it, because only there is an empty page
+    /// the normal answer. A tag query returns the wallet's own transactions, so
+    /// its cursor advances on the rows themselves, and only its response carries
+    /// the field. Deriving this from the match rather than passing it separately
+    /// keeps the two from disagreeing.
+    fn reports_frontier(self) -> bool {
+        self == Self::Nullifiers
+    }
 }
 
 struct ShieldedTransactionPage {
     context: zolana_indexer_api::Context,
     transactions: Vec<ShieldedTransaction>,
     next_cursor: Option<Base64String>,
-    /// Always `None` unless the caller passed [`ReportFrontier::Yes`].
+    /// Always `None` for a match the response has no field to carry it in; see
+    /// [`MatchBy::reports_frontier`].
     scanned_through: Option<Base64String>,
 }
 
@@ -147,7 +147,6 @@ async fn get_shielded_transactions(
     encoded_cursor: Option<&Base64String>,
     limit: u64,
     match_by: MatchBy,
-    report_frontier: ReportFrontier,
 ) -> Result<ShieldedTransactionPage, PhotonApiError> {
     let cursor = encoded_cursor
         .map(decode_cursor::<ShieldedTxCursor>)
@@ -164,9 +163,10 @@ async fn get_shielded_transactions(
     // about what lies beyond it. Anything less means the scan ran out of rows,
     // not out of room, and the tip it reached is a sound resume point.
     let truncated = matched_txs.len() as u64 >= limit;
-    let scanned_through = match (report_frontier, truncated) {
-        (ReportFrontier::Yes, false) => stream_tip(&tx).await?,
-        _ => None,
+    let scanned_through = if match_by.reports_frontier() && !truncated {
+        stream_tip(&tx).await?
+    } else {
+        None
     };
 
     let transactions = hydrate_shielded_transactions(&tx, matched_txs)

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -49,6 +49,15 @@ struct RingsMessageRow {
     payload: Vec<u8>,
 }
 
+/// Just enough of a row to build a cursor from, for the tip lookup that has no
+/// transaction to hydrate.
+#[derive(FromQueryResult, Debug)]
+struct StreamTipRow {
+    slot: i64,
+    signature: Vec<u8>,
+    event_index: i16,
+}
+
 #[derive(FromQueryResult, Debug)]
 struct RingsNullifierRow {
     rings_tx_id: i64,
@@ -68,7 +77,7 @@ pub async fn get_shielded_transactions_by_tags(
     request: GetRingsByTagsRequest,
 ) -> Result<GetShieldedTransactionsByTagsResponse, PhotonApiError> {
     validate_tags(&request.tags)?;
-    let (context, transactions, next_cursor, _) = get_shielded_transactions(
+    let page = get_shielded_transactions(
         conn,
         &request.tags,
         request.cursor.as_ref(),
@@ -78,9 +87,9 @@ pub async fn get_shielded_transactions_by_tags(
     )
     .await?;
     Ok(GetShieldedTransactionsByTagsResponse {
-        context,
-        transactions,
-        next_cursor,
+        context: page.context,
+        transactions: page.transactions,
+        next_cursor: page.next_cursor,
     })
 }
 
@@ -89,7 +98,7 @@ pub async fn get_shielded_transactions_by_nullifiers(
     request: GetRingsByNullifiersRequest,
 ) -> Result<GetShieldedTransactionsByNullifiersResponse, PhotonApiError> {
     validate_nullifiers(&request.nullifiers)?;
-    let (context, transactions, next_cursor, scanned_through) = get_shielded_transactions(
+    let page = get_shielded_transactions(
         conn,
         &request.nullifiers,
         request.cursor.as_ref(),
@@ -99,10 +108,10 @@ pub async fn get_shielded_transactions_by_nullifiers(
     )
     .await?;
     Ok(GetShieldedTransactionsByNullifiersResponse {
-        context,
-        transactions,
-        next_cursor,
-        scanned_through,
+        context: page.context,
+        transactions: page.transactions,
+        next_cursor: page.next_cursor,
+        scanned_through: page.scanned_through,
     })
 }
 
@@ -124,6 +133,14 @@ enum ReportFrontier {
     No,
 }
 
+struct ShieldedTransactionPage {
+    context: zolana_indexer_api::Context,
+    transactions: Vec<ShieldedTransaction>,
+    next_cursor: Option<Base64String>,
+    /// Always `None` unless the caller passed [`ReportFrontier::Yes`].
+    scanned_through: Option<Base64String>,
+}
+
 async fn get_shielded_transactions(
     conn: &DatabaseConnection,
     values: &[Hash],
@@ -131,15 +148,7 @@ async fn get_shielded_transactions(
     limit: u64,
     match_by: MatchBy,
     report_frontier: ReportFrontier,
-) -> Result<
-    (
-        zolana_indexer_api::Context,
-        Vec<ShieldedTransaction>,
-        Option<Base64String>,
-        Option<Base64String>,
-    ),
-    PhotonApiError,
-> {
+) -> Result<ShieldedTransactionPage, PhotonApiError> {
     let cursor = encoded_cursor
         .map(decode_cursor::<ShieldedTxCursor>)
         .transpose()?;
@@ -168,7 +177,12 @@ async fn get_shielded_transactions(
 
     tx.commit().await?;
 
-    Ok((context, transactions, next_cursor, scanned_through))
+    Ok(ShieldedTransactionPage {
+        context,
+        transactions,
+        next_cursor,
+        scanned_through,
+    })
 }
 
 /// The greatest position present in the transaction stream, as a cursor.
@@ -189,13 +203,9 @@ async fn stream_tip(tx: &DatabaseTransaction) -> Result<Option<Base64String>, Ph
     // `idx_rings_transactions_slot_id`, and the handful of rows sharing that
     // slot are all that gets sorted.
     let sql = "SELECT
-            pt.rings_tx_id AS rings_tx_id,
             pt.slot AS slot,
             pt.signature AS signature,
-            pt.event_index AS event_index,
-            pt.tx_viewing_pk AS tx_viewing_pk,
-            pt.salt AS salt,
-            pt.proofless AS proofless
+            pt.event_index AS event_index
          FROM rings_transactions pt
          WHERE pt.slot = (SELECT MAX(slot) FROM rings_transactions)
          ORDER BY pt.signature DESC, pt.event_index DESC
@@ -210,8 +220,12 @@ async fn stream_tip(tx: &DatabaseTransaction) -> Result<Option<Base64String>, Ph
     else {
         return Ok(None);
     };
-    let row = MatchedRingsTxRow::from_query_result(&row, "")?;
-    Ok(Some(Base64String(shielded_tx_cursor_from_row(&row)?)))
+    let row = StreamTipRow::from_query_result(&row, "")?;
+    Ok(Some(Base64String(shielded_tx_cursor(
+        row.slot,
+        &row.signature,
+        row.event_index,
+    )?)))
 }
 
 pub(super) async fn hydrate_shielded_transactions(
@@ -472,8 +486,15 @@ fn shielded_tx_cursor_sql(
 }
 
 fn shielded_tx_cursor_from_row(row: &MatchedRingsTxRow) -> Result<Vec<u8>, PhotonApiError> {
-    let (slot, signature, event_index) =
-        cursor_sort_key(row.slot, &row.signature, row.event_index)?;
+    shielded_tx_cursor(row.slot, &row.signature, row.event_index)
+}
+
+fn shielded_tx_cursor(
+    slot: i64,
+    signature: &[u8],
+    event_index: i16,
+) -> Result<Vec<u8>, PhotonApiError> {
+    let (slot, signature, event_index) = cursor_sort_key(slot, signature, event_index)?;
     let cursor = ShieldedTxCursor {
         slot,
         signature,

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -49,10 +49,10 @@ struct RingsMessageRow {
     payload: Vec<u8>,
 }
 
-/// Just enough of a row to build a cursor from, for the tip lookup that has no
-/// transaction to hydrate.
+/// Just enough of a row to build a cursor from, for the lookup that reports
+/// where a scan stopped and has no transaction to hydrate.
 #[derive(FromQueryResult, Debug)]
-struct StreamTipRow {
+struct ScanPositionRow {
     slot: i64,
     signature: Vec<u8>,
     event_index: i16,
@@ -146,16 +146,16 @@ async fn get_shielded_transactions(
         fetch_matching_rings_transactions(&tx, values, cursor.as_ref(), limit, match_by).await?;
     let next_cursor = next_cursor_from_rows(&matched_txs, shielded_tx_cursor_from_row)?;
 
-    // Only the nullifier response has a field to carry a frontier in, and only
-    // that stream needs one: a tag query returns the wallet's own transactions,
-    // so its cursor advances on the rows themselves.
+    // Only the nullifier response has a field to report this in, and only that
+    // stream needs one: a tag query returns the wallet's own transactions, so
+    // its cursor advances on the rows themselves.
     //
     // A full page means the limit cut the scan short, so nothing can be claimed
     // about what lies beyond it. Anything less means the scan ran out of rows,
-    // not out of room, and the tip it reached is a sound resume point.
+    // not out of room, and where it stopped is a sound resume point.
     let truncated = matched_txs.len() as u64 >= limit;
     let scanned_through = match match_by {
-        MatchBy::Nullifiers if !truncated => stream_tip(&tx).await?,
+        MatchBy::Nullifiers if !truncated => scan_position(&tx).await?,
         _ => None,
     };
 
@@ -175,17 +175,20 @@ async fn get_shielded_transactions(
     })
 }
 
-/// The greatest position present in the transaction stream, as a cursor.
+/// The last position in the transaction stream, as a cursor.
+///
+/// A scan that was not cut short by its limit reached exactly here, so this is
+/// what "I looked this far and found nothing more" means concretely.
 ///
 /// Read inside the caller's transaction so it describes the same snapshot the
 /// scan saw. `None` only when the table is empty, which leaves the caller
 /// resuming from zero -- correct, and there is nothing to skip anyway.
 ///
 /// Soundness rests on positions only ever being appended: a row inserted later
-/// at a position below this tip would be skipped by anyone who resumed here.
+/// at a position below this one would be skipped by anyone who resumed here.
 /// That is the same assumption the per-tag cursors already run on, since they
 /// resume from the last row they saw.
-async fn stream_tip(tx: &DatabaseTransaction) -> Result<Option<Base64String>, PhotonApiError> {
+async fn scan_position(tx: &DatabaseTransaction) -> Result<Option<Base64String>, PhotonApiError> {
     let backend = tx.get_database_backend();
     // Deliberately not one `ORDER BY slot, signature, event_index DESC LIMIT 1`:
     // no index covers that ordering, so it sorts the whole table on every
@@ -210,7 +213,7 @@ async fn stream_tip(tx: &DatabaseTransaction) -> Result<Option<Base64String>, Ph
     else {
         return Ok(None);
     };
-    let row = StreamTipRow::from_query_result(&row, "")?;
+    let row = ScanPositionRow::from_query_result(&row, "")?;
     Ok(Some(Base64String(shielded_tx_cursor(
         row.slot,
         &row.signature,
@@ -596,7 +599,7 @@ mod tests {
     }
 
     /// An unspent nullifier is the normal case, and it matches nothing. Without
-    /// a frontier the caller has no way to record that it just scanned the whole
+    /// this the caller has no way to record that it just scanned the whole
     /// stream, so it scans the whole stream again on the next sync forever.
     #[tokio::test]
     async fn an_empty_nullifier_page_still_reports_how_far_it_scanned() {
@@ -617,17 +620,17 @@ mod tests {
             response.next_cursor.is_none(),
             "no rows, so no page to follow"
         );
-        let frontier = response
+        let scanned_through = response
             .scanned_through
             .expect("an exhausted scan reports its tip");
 
-        // Resuming there is the point: the same query from the frontier must
+        // Resuming there is the point: the same query from that position must
         // still be empty, and must not walk the stream again.
         let resumed = get_shielded_transactions_by_nullifiers(
             &db,
             GetRingsByNullifiersRequest {
                 nullifiers: vec![hash(5)],
-                cursor: Some(frontier.clone()),
+                cursor: Some(scanned_through.clone()),
                 limit: Some(Limit::new(10).unwrap()),
             },
         )
@@ -636,15 +639,15 @@ mod tests {
         assert!(resumed.transactions.is_empty());
         assert_eq!(
             resumed.scanned_through,
-            Some(frontier),
+            Some(scanned_through),
             "a stream that has not moved reports the same tip"
         );
     }
 
-    /// The frontier claims "nothing matches at or before here", which is only
-    /// true when the scan ran out of rows rather than out of room.
+    /// The reported position claims "nothing matches at or before here", which
+    /// is only true when the scan ran out of rows rather than out of room.
     #[tokio::test]
-    async fn a_truncated_page_reports_no_frontier() {
+    async fn a_truncated_page_reports_no_scan_position() {
         let db = setup().await;
         let response = get_shielded_transactions_by_nullifiers(
             &db,
@@ -665,9 +668,9 @@ mod tests {
     }
 
     /// A spend is found whether the caller starts from zero or resumes, so the
-    /// frontier cannot be used to skip one.
+    /// reported position cannot be used to skip one.
     #[tokio::test]
-    async fn resuming_from_a_frontier_still_finds_a_later_spend() {
+    async fn resuming_from_a_scan_position_still_finds_a_later_spend() {
         let db = setup().await;
         let first = get_shielded_transactions_by_nullifiers(
             &db,
@@ -679,7 +682,9 @@ mod tests {
         )
         .await
         .unwrap();
-        let frontier = first.scanned_through.expect("frontier");
+        let scanned_through = first
+            .scanned_through
+            .expect("a scan that reached the end reports where");
 
         // A later transaction spends the nullifier the caller is watching.
         blocks::Entity::insert(blocks::ActiveModel {
@@ -736,7 +741,7 @@ mod tests {
             &db,
             GetRingsByNullifiersRequest {
                 nullifiers: vec![hash(5)],
-                cursor: Some(frontier),
+                cursor: Some(scanned_through),
                 limit: Some(Limit::new(10).unwrap()),
             },
         )
@@ -745,7 +750,7 @@ mod tests {
         assert_eq!(
             resumed.transactions.len(),
             1,
-            "the spend landed after the frontier, so resuming there must still see it"
+            "the spend landed after that position, so resuming there must still see it"
         );
     }
 }

--- a/services/photon/src/openapi/specs/rings.yaml
+++ b/services/photon/src/openapi/specs/rings.yaml
@@ -591,6 +591,24 @@ paths:
                         oneOf:
                         - type: 'null'
                         - $ref: '#/components/schemas/Base64String'
+                      scanned_through:
+                        oneOf:
+                        - type: 'null'
+                        - $ref: '#/components/schemas/Base64String'
+                          description: |-
+                            How far the scan got, when it reached the end rather than filling a page.
+
+                            `next_cursor` cannot answer this: it is the position of the last returned
+                            row, and the useful case here returns no rows at all. A wallet asks about
+                            unspent nullifiers, which by definition have no spending transaction, so
+                            every page comes back empty and the caller learns nothing about how much
+                            of the stream it just paid to scan -- and starts from zero again next
+                            time.
+
+                            Present only on a page the limit did not truncate, which is exactly when
+                            "no more matches exist at or before this position" is true. Resuming a
+                            later query for the same nullifiers here skips only ground already
+                            covered.
                       transactions:
                         type: array
                         items:

--- a/services/photon/src/openapi/specs/rings.yaml
+++ b/services/photon/src/openapi/specs/rings.yaml
@@ -596,19 +596,13 @@ paths:
                         - type: 'null'
                         - $ref: '#/components/schemas/Base64String'
                           description: |-
-                            How far the scan got, when it reached the end rather than filling a page.
+                            Where the scan reached, when it ran out of rows rather than filling a
+                            page.
 
-                            `next_cursor` cannot answer this: it is the position of the last returned
-                            row, and the useful case here returns no rows at all. A wallet asks about
-                            unspent nullifiers, which by definition have no spending transaction, so
-                            every page comes back empty and the caller learns nothing about how much
-                            of the stream it just paid to scan -- and starts from zero again next
-                            time.
-
-                            Present only on a page the limit did not truncate, which is exactly when
-                            "no more matches exist at or before this position" is true. Resuming a
-                            later query for the same nullifiers here skips only ground already
-                            covered.
+                            `next_cursor` is the last returned row's position, and a query for
+                            unspent nullifiers returns none. Present only on a page the limit did not
+                            truncate, which is when "no match exists at or before this position"
+                            holds.
                       transactions:
                         type: array
                         items:

--- a/services/photon/src/openapi/specs/rings.yaml
+++ b/services/photon/src/openapi/specs/rings.yaml
@@ -591,7 +591,7 @@ paths:
                         oneOf:
                         - type: 'null'
                         - $ref: '#/components/schemas/Base64String'
-                      scanned_through:
+                      scannedThrough:
                         oneOf:
                         - type: 'null'
                         - $ref: '#/components/schemas/Base64String'


### PR DESCRIPTION
Every stream the wallet reads now resumes where it stopped. Tags already did;
nullifiers and proofless deposits did not.

## Changes

- **Nullifiers**: query only unspent notes. A nullifier appears at most once on
  chain, so once its spend is known the answer is final. 293 notes to 56 on the
  measured wallet.
- **Photon**: report `scanned_through`, the position a scan reached. Unspent
  nullifiers match nothing, so `next_cursor` — the last row's position — is
  always absent for them, and no client-side change can supply a resume point.
- **Proofless**: persist per-tag cursors, cherry-picked from #207
  (`2a04cc43`). Its other three concerns are unrelated to sync.
- Both SDKs; `group_by_resume_point` / `groupByResumePoint` shared by all three
  streams.

## Measured

`xtask loadtest`, devnet, two wallets, 90s, unaffordable transfer amount so
wallet state is frozen. Round-0 p50, the three fetches concurrent as of #200:

| phase | main | this PR |
| --- | --- | --- |
| `fetch_shielded_by_nullifiers` | **735ms** | **78ms** |
| `fetch_shielded_by_tags` | 465ms | 455ms |
| `fetch_proofless_deposits` | 803ms | 794ms |
| `sync_wallet_total` | 1051ms | 854ms |

Sync gets 19% faster, not 9x: #200 made a round cost the slowest of its three
queries, and the proofless scan is now that. `sync_wallet_total` max also drops
5594ms → 1958ms.

Devnet runs a photon without `scanned_through`, so that run isolates the
narrowed query set. **Resuming is not yet measured end to end** — it needs a
photon deploy. Unit tests cover it on both sides, including resuming from a
reported position and still finding a spend that landed after it.

## Notes

- **Ship photon and the clients together.** Both schemas are strict, so the
  moment photon sent a field the SDKs did not know, the e2e suite failed every
  nullifier query with `CLIENT_INVALID_RPC_RESPONSE`.
- A read ends when the indexer returns no cursor, never on a short page.
  Stopping early saves a request per chunk but makes the non-advancing-cursor
  guard unreachable.
- Cursors live on the in-memory `Wallet`, so they help a long-lived wallet, not
  successive CLI invocations.
- The tag stream still cannot resume a tag that has never matched anything, for
  the same reason nullifiers could not. Masked because a wallet's own tags
  usually match. Follow-up.
