### PR TITLE
prover: answer a status poll with two key reads instead of four queue scans

### DIFF
--- a/prover/server/dedup_cache_test.go
+++ b/prover/server/dedup_cache_test.go
@@ -1,0 +1,162 @@
+package main_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+	"zolana/prover/prover/common"
+	"zolana/prover/server"
+)
+
+// The dedup lookups had no test coverage at all, which is how an O(n) scan of
+// zk_results_queue -- an LRange of every stored proof plus one GET per entry,
+// run on the goroutine that feeds every proof worker, on every job -- survived
+// long enough to cap the production prover at 0.88 jobs/s against 57 jobs/s of
+// capacity. These pin the contract the scan was removed in favour of: the hash
+// index is authoritative, and a miss means "not cached".
+
+func storeIndexedResult(t *testing.T, rq *server.RedisQueue, jobID, inputHash string, durationMs int64) {
+	t.Helper()
+	if err := rq.StoreResult(jobID, &common.ProofWithTiming{ProofDurationMs: durationMs}); err != nil {
+		t.Fatalf("StoreResult: %v", err)
+	}
+	if err := rq.IndexResultByHash(inputHash, jobID); err != nil {
+		t.Fatalf("IndexResultByHash: %v", err)
+	}
+}
+
+func TestFindCachedResultReturnsAnIndexedResult(t *testing.T) {
+	rq := setupRedisQueue(t)
+	defer teardownRedisQueue(t, rq)
+
+	storeIndexedResult(t, rq, "job-cached", "hash-cached", 271)
+
+	proof, jobID, err := rq.FindCachedResult("hash-cached")
+	if err != nil {
+		t.Fatalf("FindCachedResult: %v", err)
+	}
+	if proof == nil {
+		t.Fatal("expected the indexed result to be found")
+	}
+	if jobID != "job-cached" {
+		t.Errorf("jobID = %q, want %q", jobID, "job-cached")
+	}
+	if proof.ProofDurationMs != 271 {
+		t.Errorf("ProofDurationMs = %d, want 271", proof.ProofDurationMs)
+	}
+}
+
+// The deliberate behaviour change. Results sitting in the queue without an
+// index entry are no longer found, because finding them meant reading the whole
+// queue on every cache miss -- and since transfer inputs are unique, every job
+// was a cache miss. Regenerating a proof costs 0.28s; scanning cost more than
+// that within a few hundred queued results, and grew from there.
+func TestFindCachedResultIgnoresUnindexedResults(t *testing.T) {
+	rq := setupRedisQueue(t)
+	defer teardownRedisQueue(t, rq)
+
+	const inputHash = "hash-unindexed"
+	for i := 0; i < 5; i++ {
+		jobID := fmt.Sprintf("unindexed-job-%d", i)
+		payload, err := json.Marshal(&common.ProofWithTiming{ProofDurationMs: 100})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		err = rq.EnqueueProof("zk_results_queue", &server.ProofJob{
+			ID:        jobID,
+			Type:      "result",
+			Payload:   json.RawMessage(payload),
+			CreatedAt: time.Now(),
+		})
+		if err != nil {
+			t.Fatalf("EnqueueProof: %v", err)
+		}
+		// Present and matching -- the old scan keyed off exactly this.
+		if err := rq.StoreInputHash(jobID, inputHash); err != nil {
+			t.Fatalf("StoreInputHash: %v", err)
+		}
+	}
+
+	proof, _, err := rq.FindCachedResult(inputHash)
+	if err != nil {
+		t.Fatalf("FindCachedResult: %v", err)
+	}
+	if proof != nil {
+		t.Error("unindexed results must not be found: locating them requires " +
+			"scanning the whole results queue on every miss")
+	}
+}
+
+// Results carry a TTL; the index hash does not. An entry can therefore outlive
+// what it points at, and must not be reported as a hit.
+func TestFindCachedResultDropsAStaleIndexEntry(t *testing.T) {
+	rq := setupRedisQueue(t)
+	defer teardownRedisQueue(t, rq)
+
+	const inputHash = "hash-expired"
+	if err := rq.IndexResultByHash(inputHash, "job-whose-result-expired"); err != nil {
+		t.Fatalf("IndexResultByHash: %v", err)
+	}
+
+	proof, _, err := rq.FindCachedResult(inputHash)
+	if err != nil {
+		t.Fatalf("FindCachedResult: %v", err)
+	}
+	if proof != nil {
+		t.Error("an index entry pointing at a missing result must not be a hit")
+	}
+
+	remaining, err := rq.Client.HGet(context.Background(), server.ResultsIndexKey, inputHash).Result()
+	if err == nil {
+		t.Errorf("stale index entry should have been removed, still points at %q", remaining)
+	}
+}
+
+func TestFindCachedFailureIgnoresUnindexedFailures(t *testing.T) {
+	rq := setupRedisQueue(t)
+	defer teardownRedisQueue(t, rq)
+
+	const inputHash = "hash-unindexed-failure"
+	jobID := "unindexed-failure"
+	payload, err := json.Marshal(map[string]interface{}{"error": "boom"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	err = rq.EnqueueProof("zk_failed_queue", &server.ProofJob{
+		ID:        jobID + "_failed",
+		Type:      "failed",
+		Payload:   json.RawMessage(payload),
+		CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("EnqueueProof: %v", err)
+	}
+	if err := rq.StoreInputHash(jobID, inputHash); err != nil {
+		t.Fatalf("StoreInputHash: %v", err)
+	}
+
+	failure, _, err := rq.FindCachedFailure(inputHash)
+	if err != nil {
+		t.Fatalf("FindCachedFailure: %v", err)
+	}
+	if failure != nil {
+		t.Error("unindexed failures must not be found, for the same reason as results")
+	}
+}
+
+// A miss is the overwhelmingly common case -- transfer inputs are unique -- so
+// it is the path whose cost matters. It must not touch the queues at all.
+func TestFindCachedResultMissDoesNotReadTheResultsQueue(t *testing.T) {
+	rq := setupRedisQueue(t)
+	defer teardownRedisQueue(t, rq)
+
+	proof, jobID, err := rq.FindCachedResult("hash-never-seen")
+	if err != nil {
+		t.Fatalf("a clean miss must not error: %v", err)
+	}
+	if proof != nil || jobID != "" {
+		t.Errorf("expected an empty miss, got proof=%v jobID=%q", proof, jobID)
+	}
+}

--- a/prover/server/go.mod
+++ b/prover/server/go.mod
@@ -3,6 +3,7 @@ module zolana/prover
 go 1.25.7
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/consensys/gnark v0.15.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/handlers v1.5.2
@@ -22,6 +23,7 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/google/pprof v0.0.0-20260202012954-cb029daf43ef // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
@@ -34,6 +36,7 @@ require (
 	github.com/ronanh/intcomp v1.1.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect

--- a/prover/server/go.sum
+++ b/prover/server/go.sum
@@ -1,5 +1,7 @@
 github.com/Lightprotocol/gnark-lean-extractor/v3 v3.0.0-20250920122823-aa0219463107 h1:Xmabi4NM2Ka6vJpM8iaiKKSDT+AZwYnSdkz/KGrKbB4=
 github.com/Lightprotocol/gnark-lean-extractor/v3 v3.0.0-20250920122823-aa0219463107/go.mod h1:OzXjBrGCWeDcKuvq3Q7/k8gL/2w9mCL6E2bCCcoJqEs=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
@@ -91,6 +93,8 @@ github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=

--- a/prover/server/main.go
+++ b/prover/server/main.go
@@ -885,6 +885,29 @@ func startCleanupRoutines(redisQueue *server.RedisQueue) {
 		}
 	}()
 
+	// Backlog is what autoscaling reacts to, so it has to be published faster
+	// than the scaler's minute-granularity view of it. Six LLen calls is cheap
+	// next to a 3.85 CPU-second proof.
+	go func() {
+		depthTicker := time.NewTicker(10 * time.Second)
+		defer depthTicker.Stop()
+
+		logging.Logger().Info().Msg("Started queue depth publisher (every 10 seconds)")
+
+		for range depthTicker.C {
+			stats, err := redisQueue.GetQueueStats()
+			if err != nil {
+				logging.Logger().Warn().
+					Err(err).
+					Msg("Failed to read queue depths for metrics")
+				continue
+			}
+			for queueName, depth := range stats {
+				server.QueueDepth.WithLabelValues(queueName).Set(float64(depth))
+			}
+		}
+	}()
+
 	// Start cleanup for old proof requests (every 10 minutes)
 	go func() {
 		requestTicker := time.NewTicker(10 * time.Minute)

--- a/prover/server/processing_queue_test.go
+++ b/prover/server/processing_queue_test.go
@@ -1,0 +1,115 @@
+package main_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"zolana/prover/server"
+)
+
+// A worker removes its processing entry by value, because a Redis list offers
+// no other handle. EnqueueProofReturning hands back exactly the bytes stored so
+// that removal is one LREM.
+//
+// The previous implementation searched instead: LLen, then an LINDEX round trip
+// per position until the job id matched, all while holding a semaphore slot.
+// That is O(queue length) round trips per completed proof, and it compounds --
+// on devnet at 220 workers the processing queue climbed from 210 to 751 entries
+// during a single run (at most 128 proofs can be in flight), jobs waited 4.5-7s
+// to be picked up, and the provers idled at 12-33% CPU proving in 0.25s.
+func TestProcessingEntryIsRemovableByTheBytesItWasStoredAs(t *testing.T) {
+	rq := setupRedisQueue(t)
+	defer teardownRedisQueue(t, rq)
+
+	const queue = "zk_transfer_processing_queue"
+	ctx := context.Background()
+
+	var stored []string
+	for _, id := range []string{"job-a_processing", "job-b_processing", "job-c_processing"} {
+		item, err := rq.EnqueueProofReturning(queue, &server.ProofJob{
+			ID:        id,
+			Type:      "processing",
+			Payload:   json.RawMessage(`{"test":"data"}`),
+			CreatedAt: time.Now(),
+		})
+		if err != nil {
+			t.Fatalf("EnqueueProofReturning(%s): %v", id, err)
+		}
+		if item == "" {
+			t.Fatalf("EnqueueProofReturning(%s) returned no bytes", id)
+		}
+		stored = append(stored, item)
+	}
+
+	depth, err := rq.Client.LLen(ctx, queue).Result()
+	if err != nil {
+		t.Fatalf("LLen: %v", err)
+	}
+	if depth != 3 {
+		t.Fatalf("processing queue depth = %d, want 3", depth)
+	}
+
+	// Removing the middle entry must take exactly that one, without touching
+	// its neighbours and without reading the list to find it.
+	removed, err := rq.Client.LRem(ctx, queue, 1, stored[1]).Result()
+	if err != nil {
+		t.Fatalf("LRem: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("LRem removed %d entries, want 1 -- the stored bytes must match what is in the list", removed)
+	}
+
+	remaining, err := rq.Client.LRange(ctx, queue, 0, -1).Result()
+	if err != nil {
+		t.Fatalf("LRange: %v", err)
+	}
+	if len(remaining) != 2 {
+		t.Fatalf("remaining depth = %d, want 2", len(remaining))
+	}
+	for _, item := range remaining {
+		var job server.ProofJob
+		if err := json.Unmarshal([]byte(item), &job); err != nil {
+			t.Fatalf("unmarshal remaining: %v", err)
+		}
+		if job.ID == "job-b_processing" {
+			t.Error("removed the wrong entry: job-b should be gone")
+		}
+	}
+}
+
+// An entry that was never stored has no bytes to match, and removal must be a
+// no-op rather than an error or a scan.
+func TestRemovingAnUnstoredProcessingEntryIsHarmless(t *testing.T) {
+	rq := setupRedisQueue(t)
+	defer teardownRedisQueue(t, rq)
+
+	const queue = "zk_transfer_processing_queue"
+	ctx := context.Background()
+
+	if _, err := rq.EnqueueProofReturning(queue, &server.ProofJob{
+		ID:        "job-kept_processing",
+		Type:      "processing",
+		Payload:   json.RawMessage(`{"test":"data"}`),
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("EnqueueProofReturning: %v", err)
+	}
+
+	removed, err := rq.Client.LRem(ctx, queue, 1, "not-a-stored-entry").Result()
+	if err != nil {
+		t.Fatalf("LRem: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("LRem removed %d entries for a value never stored, want 0", removed)
+	}
+
+	depth, err := rq.Client.LLen(ctx, queue).Result()
+	if err != nil {
+		t.Fatalf("LLen: %v", err)
+	}
+	if depth != 1 {
+		t.Errorf("processing queue depth = %d, want the stored entry untouched", depth)
+	}
+}

--- a/prover/server/redis_queue_test.go
+++ b/prover/server/redis_queue_test.go
@@ -936,21 +936,13 @@ func TestFailedJobStatusHTTPEndpoint(t *testing.T) {
 		"failed_at":    time.Now().Format(time.RFC3339),
 	}
 
-	failedData, err := json.Marshal(failureDetails)
-	if err != nil {
-		t.Fatalf("Failed to marshal failure details: %v", err)
-	}
-
-	failedJob := &server.ProofJob{
-		ID:        jobID + "_failed",
-		Type:      "failed",
-		Payload:   json.RawMessage(failedData),
-		CreatedAt: time.Now(),
-	}
-
-	err = rq.EnqueueProof("zk_failed_queue", failedJob)
-	if err != nil {
-		t.Fatalf("Failed to enqueue failed job: %v", err)
+	// Fail the job the way the workers do. This test used to write straight
+	// into zk_failed_queue and rely on the status endpoint scanning that queue
+	// to find it -- the scan that made every status poll cost O(queue length).
+	// Every producer of a failure now records it in the job metadata too, so
+	// the endpoint is answered with a single GET.
+	if err := rq.MarkJobFailed(jobID, failureDetails); err != nil {
+		t.Fatalf("Failed to mark job failed: %v", err)
 	}
 
 	statusURL := fmt.Sprintf("http://%s/prove/status?job_id=%s", config.ProverAddress, jobID)

--- a/prover/server/redis_queue_test.go
+++ b/prover/server/redis_queue_test.go
@@ -14,23 +14,40 @@ import (
 	"zolana/prover/prover/common"
 	"zolana/prover/server"
 
+	"github.com/alicebob/miniredis/v2"
 	bn254 "github.com/consensys/gnark-crypto/ecc/bn254"
 	groth16bn254 "github.com/consensys/gnark/backend/groth16/bn254"
 	"github.com/google/uuid"
 )
 
-const TestRedisURL = "redis://localhost:6379/15"
+// setupRedisQueue returns a queue backed by an in-process Redis unless
+// TEST_REDIS_URL points at a real one.
+//
+// These tests used to skip themselves whenever nothing was listening on
+// localhost:6379, which on a developer machine and in CI meant always. The
+// whole queue layer was therefore untested by default, and it showed: nothing
+// covered FindCachedResult at all, and an O(n) scan sat in the dedup path --
+// executed on every job, on the goroutine feeding every proof worker -- until
+// it capped the production prover at 0.88 jobs/s against 57 jobs/s of capacity.
+// A skipped test reports success just as loudly as a passing one.
+func redisURLForTest(t *testing.T) string {
+	if redisURL := os.Getenv("TEST_REDIS_URL"); redisURL != "" {
+		return redisURL
+	}
+	// RunT registers its own cleanup, so the server dies with the test.
+	return "redis://" + miniredis.RunT(t).Addr() + "/0"
+}
 
 func setupRedisQueue(t *testing.T) *server.RedisQueue {
-	// Skip if Redis URL not available
-	redisURL := os.Getenv("TEST_REDIS_URL")
-	if redisURL == "" {
-		redisURL = TestRedisURL
-	}
+	return setupRedisQueueAt(t, redisURLForTest(t))
+}
 
+// setupRedisQueueAt is for tests that also need to hand the URL to something
+// else, such as a server config, so both ends talk to the same instance.
+func setupRedisQueueAt(t *testing.T, redisURL string) *server.RedisQueue {
 	rq, err := server.NewRedisQueue(redisURL)
 	if err != nil {
-		t.Skipf("Redis not available for testing: %v", err)
+		t.Fatalf("Redis not available for testing: %v", err)
 	}
 
 	err = rq.Client.FlushDB(context.Background()).Err()
@@ -487,7 +504,11 @@ func TestDequeueTimeout(t *testing.T) {
 	if duration < 400*time.Millisecond {
 		t.Errorf("Timeout duration too short: %v", duration)
 	}
-	if duration > 1*time.Second {
+	// A 1s block cannot return in under 1s, so the old "> 1 * time.Second"
+	// bound was unsatisfiable -- it measured 1.0013s here. The point of the
+	// upper bound is to catch a block that ignores its timeout entirely, so it
+	// needs slack for scheduling.
+	if duration > 3*time.Second {
 		t.Errorf("Timeout duration too long: %v", duration)
 	}
 }
@@ -580,26 +601,32 @@ func TestJobResultStorage(t *testing.T) {
 
 	jobID := "test-result-job"
 
-	mockResult := map[string]interface{}{
-		"proof":  "mock-proof-data",
-		"status": "completed",
-	}
+	// GetResult decodes into common.ProofWithTiming. This test used to store a
+	// free-form map with "proof" as a string and assert the result came back as
+	// a map[string]interface{} -- a contract that no longer exists, and could
+	// not pass. It went unnoticed because the suite skipped itself without a
+	// local Redis.
+	stored := &common.ProofWithTiming{ProofDurationMs: 271}
 
-	err := rq.StoreResult(jobID, mockResult)
+	err := rq.StoreResult(jobID, stored)
 	if err != nil {
-		t.Errorf("Failed to store result: %v", err)
+		t.Fatalf("Failed to store result: %v", err)
 	}
 
 	result, err := rq.GetResult(jobID)
 	if err != nil {
-		t.Errorf("Failed to retrieve result: %v", err)
-	}
-	if result == nil {
-		t.Errorf("Expected result, got nil")
+		t.Fatalf("Failed to retrieve result: %v", err)
 	}
 
-	if _, ok := result.(map[string]interface{}); !ok {
-		t.Errorf("Expected result to be map[string]interface{}, got %T", result)
+	loaded, ok := result.(*common.ProofWithTiming)
+	if !ok {
+		t.Fatalf("Expected result to be *common.ProofWithTiming, got %T", result)
+	}
+	if loaded.ProofDurationMs != stored.ProofDurationMs {
+		t.Errorf(
+			"ProofDurationMs = %d, want %d",
+			loaded.ProofDurationMs, stored.ProofDurationMs,
+		)
 	}
 }
 
@@ -626,6 +653,15 @@ func TestQueuedCommittedProofResultRoundTrip(t *testing.T) {
 	payload, err := json.Marshal(result)
 	if err != nil {
 		t.Fatalf("marshal committed proof result: %v", err)
+	}
+
+	// Both, because the worker does both: StoreResult writes zk_result_<id>,
+	// which is what GetResult reads, and the queue entry is what cleanup ages
+	// out. This test used to enqueue only, and passed because GetResult would
+	// scan the whole results queue on a miss -- a scan that ran on every status
+	// poll and pinned Redis's engine thread at 99%.
+	if err := rq.StoreResult(jobID, result); err != nil {
+		t.Fatalf("store committed proof result: %v", err)
 	}
 	if err := rq.EnqueueProof("zk_results_queue", &server.ProofJob{
 		ID:        jobID,
@@ -659,34 +695,55 @@ func TestQueuedCommittedProofResultRoundTrip(t *testing.T) {
 	}
 }
 
+// CleanupOldResults removes results by age, and only by age.
+//
+// This test used to enqueue 1005 fresh results and expect 1000 to remain,
+// asserting a length cap that no code has ever implemented -- there is no LTrim
+// and no maximum anywhere in the queue. It never failed because it never ran:
+// without a local Redis the whole suite skipped itself. Rewritten to assert the
+// behaviour that exists.
+//
+// Worth knowing: because nothing caps it, zk_results_queue grows unbounded
+// between cleanup passes, and it was that growth which turned the dedup path's
+// O(n) scan from cheap into a production throughput ceiling.
 func TestResultCleanup(t *testing.T) {
 	rq := setupRedisQueue(t)
 	defer teardownRedisQueue(t, rq)
 
-	for i := 0; i < 1005; i++ {
+	// The cutoff is one hour, so these straddle it.
+	const staleCount, freshCount = 3, 2
+	enqueue := func(id string, createdAt time.Time) {
+		t.Helper()
 		job := &server.ProofJob{
-			ID:        fmt.Sprintf("cleanup-job-%d", i),
+			ID:        id,
 			Type:      "result",
 			Payload:   json.RawMessage(`{"test": "data"}`),
-			CreatedAt: time.Now(),
+			CreatedAt: createdAt,
 		}
-		err := rq.EnqueueProof("zk_results_queue", job)
-		if err != nil {
-			t.Fatalf("Failed to enqueue cleanup job %d: %v", i, err)
+		if err := rq.EnqueueProof("zk_results_queue", job); err != nil {
+			t.Fatalf("Failed to enqueue %s: %v", id, err)
 		}
 	}
+	for i := 0; i < staleCount; i++ {
+		enqueue(fmt.Sprintf("stale-result-%d", i), time.Now().Add(-2*time.Hour))
+	}
+	for i := 0; i < freshCount; i++ {
+		enqueue(fmt.Sprintf("fresh-result-%d", i), time.Now())
+	}
 
-	err := rq.CleanupOldResults()
-	if err != nil {
-		t.Errorf("Failed to cleanup old results: %v", err)
+	if err := rq.CleanupOldResults(); err != nil {
+		t.Fatalf("Failed to cleanup old results: %v", err)
 	}
 
 	stats, err := rq.GetQueueStats()
 	if err != nil {
 		t.Fatalf("Failed to get queue stats: %v", err)
 	}
-	if stats["zk_results_queue"] != int64(1000) {
-		t.Errorf("Expected results queue to have 1000 jobs after cleanup, got %d", stats["zk_results_queue"])
+	if stats["zk_results_queue"] != int64(freshCount) {
+		t.Errorf(
+			"Expected only the %d recent results to survive cleanup, got %d",
+			freshCount, stats["zk_results_queue"],
+		)
 	}
 }
 
@@ -848,7 +905,8 @@ func TestFailedJobStatusDetails(t *testing.T) {
 }
 
 func TestFailedJobStatusHTTPEndpoint(t *testing.T) {
-	rq := setupRedisQueue(t)
+	redisURL := redisURLForTest(t)
+	rq := setupRedisQueueAt(t, redisURL)
 	defer teardownRedisQueue(t, rq)
 
 	keyManager := common.NewLazyKeyManager("./proving-keys/", common.DefaultDownloadConfig())
@@ -857,7 +915,7 @@ func TestFailedJobStatusHTTPEndpoint(t *testing.T) {
 		ProverAddress:  "localhost:8082",
 		MetricsAddress: "localhost:9997",
 		Queue: &server.QueueConfig{
-			RedisURL: TestRedisURL,
+			RedisURL: redisURL,
 			Enabled:  true,
 		},
 	}

--- a/prover/server/server/dispatch_stage_test.go
+++ b/prover/server/server/dispatch_stage_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+// The dequeue loop feeds every proof worker, so its per-job cost is a hard
+// ceiling on admission rate. When jobs waited ~105s behind an idle prover there
+// was no way to tell which part of that loop was slow: blocking in BLPop with no
+// work, the dedup lookups, or legitimate backpressure from a full semaphore.
+// These stages separate the three.
+//
+// Asserts on the rolling window rather than the gauges, for the same reason
+// TestQueueWaitTracksMeanAndMax does: a Prometheus Gauge is write-only.
+func TestDispatchStageTracksMeanAndMax(t *testing.T) {
+	dispatchStages.byCircuit = map[string]*window{}
+
+	dispatchStages.observe("zk_transfer_queue|dedup", 1, 0)
+	mean, max, _ := dispatchStages.observe("zk_transfer_queue|dedup", 3, 0)
+
+	if mean != 2 {
+		t.Errorf("mean = %v, want 2", mean)
+	}
+	if max != 3 {
+		t.Errorf("max = %v, want 3", max)
+	}
+}
+
+// The whole point of the breakdown is that a slow stage is attributable. If the
+// stages shared a window, a loop starved in BLPop would be indistinguishable
+// from one stalled in dedup -- which is the confusion that cost four wrong
+// diagnoses of this bottleneck.
+func TestDispatchStagesDoNotShareAWindow(t *testing.T) {
+	dispatchStages.byCircuit = map[string]*window{}
+
+	RecordDispatchStage("zk_transfer_queue", "dequeue", 5*time.Second)
+	RecordDispatchStage("zk_transfer_queue", "dedup", 10*time.Millisecond)
+
+	dequeue, ok := dispatchStages.byCircuit["zk_transfer_queue|dequeue"]
+	if !ok {
+		t.Fatal("no window for the dequeue stage")
+	}
+	dedup, ok := dispatchStages.byCircuit["zk_transfer_queue|dedup"]
+	if !ok {
+		t.Fatal("no window for the dedup stage")
+	}
+	if len(dequeue.samples) != 1 || dequeue.samples[0] != 5 {
+		t.Errorf("dequeue samples = %v, want [5]", dequeue.samples)
+	}
+	if len(dedup.samples) != 1 || dedup.samples[0] != 0.01 {
+		t.Errorf("dedup samples = %v, want [0.01]", dedup.samples)
+	}
+}
+
+// Queues are tracked separately too: the transfer loop and the address-append
+// loop are different goroutines with different workloads.
+func TestDispatchStagesKeepQueuesApart(t *testing.T) {
+	dispatchStages.byCircuit = map[string]*window{}
+
+	RecordDispatchStage("zk_transfer_queue", "dedup", 1*time.Second)
+	RecordDispatchStage("zk_address_append_queue", "dedup", 20*time.Second)
+
+	transfer := dispatchStages.byCircuit["zk_transfer_queue|dedup"]
+	if transfer == nil || transfer.samples[0] != 1 {
+		t.Errorf("transfer dedup = %v, want [1]", transfer)
+	}
+}
+
+// A clock that has gone backwards must not publish a negative stage duration.
+func TestRecordDispatchStageIgnoresNegativeDurations(t *testing.T) {
+	dispatchStages.byCircuit = map[string]*window{}
+
+	RecordDispatchStage("zk_transfer_queue", "dedup", 2*time.Second)
+	RecordDispatchStage("zk_transfer_queue", "dedup", -1*time.Second)
+
+	w, ok := dispatchStages.byCircuit["zk_transfer_queue|dedup"]
+	if !ok {
+		t.Fatal("no window recorded")
+	}
+	if len(w.samples) != 1 {
+		t.Errorf("samples = %v, want the negative sample to be dropped", w.samples)
+	}
+}

--- a/prover/server/server/metrics.go
+++ b/prover/server/server/metrics.go
@@ -177,6 +177,65 @@ var (
 		[]string{"queue"},
 	)
 
+	// Where the dequeue loop's time goes, broken down by stage.
+	//
+	// One goroutine per queue feeds every proof worker, so whatever that loop
+	// spends per job is a hard ceiling on admission rate no matter how much
+	// proving capacity exists behind it. Queue wait told us jobs waited ~105s;
+	// it could not say why. The stages separate the three candidates:
+	//
+	//   dequeue   - blocked in BLPop. High only when there is no work.
+	//   dedup     - the cached-result and cached-failure lookups. This is where
+	//               an O(n) queue scan was costing 100ms + 1.53ms per stored
+	//               result, capping admission at 0.8 jobs/s.
+	//   semaphore - blocked because all workers are busy. This one is healthy
+	//               backpressure; the other two are not.
+	DispatchLast = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prover_dispatch_seconds_last",
+			Help: "Most recent duration of a dequeue-loop stage, by queue and stage",
+		},
+		[]string{"queue", "stage"},
+	)
+
+	DispatchMean = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prover_dispatch_seconds_mean",
+			Help: "Mean duration of a dequeue-loop stage over the last 100 jobs",
+		},
+		[]string{"queue", "stage"},
+	)
+
+	DispatchMax = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prover_dispatch_seconds_max",
+			Help: "Longest duration of a dequeue-loop stage over the last 100 jobs",
+		},
+		[]string{"queue", "stage"},
+	)
+
+	// How many jobs are waiting, published so autoscaling can react to backlog
+	// rather than to CPU.
+	//
+	// CPU does track load here -- 30-43% at 2 tps, 98% at 4 tps -- but it is
+	// bounded at 100%, and target tracking sizes the fleet by metric/target. At
+	// 98% against a 70% target that is a 1.4x step whether five jobs are waiting
+	// or five hundred, so recovering from a burst takes many cooldowns. Backlog
+	// per task is unbounded and moves proportionally to the actual deficit. CPU
+	// also cannot separate "busy" from "backlogged": 98% with an empty queue and
+	// 98% with eighty jobs waiting are the same reading, and only one of them
+	// has clients waiting.
+	//
+	// Every task reports the same global depth, since the queue is one Redis
+	// list. Dividing by running task count is done in the scaling policy.
+	QueueDepth = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "prover_queue_depth",
+			Help: "Jobs currently waiting in each queue",
+		},
+		[]string{"queue"},
+	)
+
 	SystemMemoryUsage = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "prover_system_memory_bytes",
@@ -192,8 +251,15 @@ type MetricTimer struct {
 	startHeapAlloc uint64
 }
 
+// StartProofTimer marks the beginning of one proof *execution*.
+//
+// It deliberately does not touch ProofRequestsTotal. It used to, and since the
+// HTTP handler counts the request too, every queued proof was counted twice --
+// the metric read 498 for a run whose logs show 249 dequeues, 249 starts and
+// 249 completions. Requests are counted once at the routing point in
+// proveHandler; executions are visible through ActiveJobs, the duration gauges,
+// and prover_jobs_processed_total.
 func StartProofTimer(circuitType string) *MetricTimer {
-	ProofRequestsTotal.WithLabelValues(circuitType).Inc()
 	ActiveJobs.Inc()
 
 	// Capture memory state before proof generation
@@ -254,6 +320,24 @@ func RecordQueueWait(queueName string, waited time.Duration) {
 	QueueWaitLast.WithLabelValues(queueName).Set(seconds)
 	QueueWaitMean.WithLabelValues(queueName).Set(mean)
 	QueueWaitMax.WithLabelValues(queueName).Set(max)
+}
+
+// Dispatch stages keep their own window, keyed by queue and stage together.
+var dispatchStages = &rollingStats{byCircuit: map[string]*window{}}
+
+// RecordDispatchStage publishes how long one stage of the dequeue loop took.
+//
+// Stage names are fixed ("dequeue", "dedup", "semaphore") so the series stay
+// bounded; see the DispatchLast comment for what each one means.
+func RecordDispatchStage(queueName, stage string, took time.Duration) {
+	seconds := took.Seconds()
+	if seconds < 0 {
+		return
+	}
+	mean, max, _ := dispatchStages.observe(queueName+"|"+stage, seconds, 0)
+	DispatchLast.WithLabelValues(queueName, stage).Set(seconds)
+	DispatchMean.WithLabelValues(queueName, stage).Set(mean)
+	DispatchMax.WithLabelValues(queueName, stage).Set(max)
 }
 
 // observe records a duration and a memory delta, returning the mean and max

--- a/prover/server/server/proof_requests_counted_once_test.go
+++ b/prover/server/server/proof_requests_counted_once_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// prover_proof_requests_total is what capacity planning divides by, so an
+// inflated value is worse than a missing one: it silently doubles the apparent
+// cost of every transfer. It did. The HTTP handler counted each request and
+// StartProofTimer counted it again when the worker began proving, so the queued
+// path -- the only one production uses -- reported 2x. A 249-transfer run
+// published 498, and the discrepancy was only caught by counting log lines.
+//
+// StartProofTimer now owns execution-side metrics only. Requests are counted
+// once, at the routing point in proveHandler.
+func TestStartProofTimerDoesNotCountRequests(t *testing.T) {
+	const circuit = "transfer-confidential"
+
+	before := testutil.ToFloat64(ProofRequestsTotal.WithLabelValues(circuit))
+
+	timer := StartProofTimer(circuit)
+	timer.ObserveDuration()
+
+	after := testutil.ToFloat64(ProofRequestsTotal.WithLabelValues(circuit))
+
+	if after != before {
+		t.Errorf(
+			"StartProofTimer changed ProofRequestsTotal by %v; the request is "+
+				"already counted by the handler, so counting it here doubles it",
+			after-before,
+		)
+	}
+}
+
+// The execution-side metric StartProofTimer does own. Guards against the
+// opposite mistake: stripping the counter increment and taking ActiveJobs with
+// it, which would leave nothing tracking in-flight proofs -- the gauge that
+// showed the prover pinned at its concurrency limit.
+func TestStartProofTimerTracksActiveJobs(t *testing.T) {
+	const circuit = "transfer-confidential"
+
+	before := testutil.ToFloat64(ActiveJobs)
+
+	timer := StartProofTimer(circuit)
+	during := testutil.ToFloat64(ActiveJobs)
+	if during != before+1 {
+		t.Errorf("ActiveJobs = %v while proving, want %v", during, before+1)
+	}
+
+	timer.ObserveDuration()
+	after := testutil.ToFloat64(ActiveJobs)
+	if after != before {
+		t.Errorf("ActiveJobs = %v after completion, want %v", after, before)
+	}
+}

--- a/prover/server/server/queue.go
+++ b/prover/server/server/queue.go
@@ -164,6 +164,77 @@ func (rq *RedisQueue) DeleteJobMeta(jobID string) error {
 	return rq.Client.Del(rq.Ctx, key).Err()
 }
 
+// MarkJobProcessing records that a worker has picked the job up.
+//
+// The metadata used to be written once at submission and never updated, so
+// "queued" or "processing" could only be told apart by walking both queues.
+// The status endpoint did exactly that, on every poll: see the comment on
+// checkJobExistsDetailed. One SET per job replaces a list scan per poll, and
+// polls outnumber jobs by orders of magnitude.
+//
+// KeepTTL preserves the submission-time expiry, so a job that is never
+// completed still ages out on its original schedule.
+func (rq *RedisQueue) MarkJobProcessing(jobID string) error {
+	return rq.updateJobMeta(jobID, func(meta map[string]interface{}) {
+		meta["status"] = "processing"
+		meta["started_at"] = time.Now()
+	}, redis.KeepTTL)
+}
+
+// MarkJobFailed records a terminal failure and the details a caller needs.
+//
+// The failure details live in the metadata rather than only in
+// zk_failed_queue, because reading them back out of that queue means scanning
+// it. The TTL is refreshed to a full hour here: unlike a success, which is
+// answered by the O(1) result lookup, this record is the only thing that can
+// tell a polling client to stop waiting.
+func (rq *RedisQueue) MarkJobFailed(jobID string, details map[string]interface{}) error {
+	return rq.updateJobMeta(jobID, func(meta map[string]interface{}) {
+		meta["status"] = "failed"
+		meta["failure"] = details
+	}, time.Hour)
+}
+
+// updateJobMeta applies mutate to a job's metadata and writes it back.
+//
+// A missing key is recreated rather than skipped. A job can be failed by the
+// stuck-job reaper after its metadata has expired, and a client polling such a
+// job must still be told to stop rather than being left to time out.
+func (rq *RedisQueue) updateJobMeta(
+	jobID string,
+	mutate func(map[string]interface{}),
+	ttl time.Duration,
+) error {
+	key := fmt.Sprintf("zk_job_meta_%s", jobID)
+	meta := map[string]interface{}{}
+	switch existing, err := rq.Client.Get(rq.Ctx, key).Result(); {
+	case err == redis.Nil:
+		// Recreated below with whatever mutate sets.
+	case err != nil:
+		return fmt.Errorf("failed to read job meta: %w", err)
+	default:
+		if err := json.Unmarshal([]byte(existing), &meta); err != nil {
+			return fmt.Errorf("failed to unmarshal job meta: %w", err)
+		}
+	}
+
+	mutate(meta)
+
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal job meta: %w", err)
+	}
+	// A recreated key cannot inherit a TTL that no longer exists, so it gets a
+	// fresh hour rather than KeepTTL's "no expiry at all".
+	if ttl == redis.KeepTTL && rq.Client.TTL(rq.Ctx, key).Val() < 0 {
+		ttl = time.Hour
+	}
+	if err := rq.Client.Set(rq.Ctx, key, data, ttl).Err(); err != nil {
+		return fmt.Errorf("failed to store job meta: %w", err)
+	}
+	return nil
+}
+
 func (rq *RedisQueue) DequeueProof(queueName string, timeout time.Duration) (*ProofJob, error) {
 	// Check if this queue supports fair queuing
 	if isFairQueueEnabled(queueName) {
@@ -825,7 +896,7 @@ func (rq *RedisQueue) failStuckJobsFromQueue(queueName string, timeoutCutoff tim
 						}
 					}
 
-					failureDetails := map[string]interface{}{
+					details := map[string]interface{}{
 						"original_job": map[string]interface{}{
 							"id":           originalJobID,
 							"type":         "zk_proof",
@@ -838,7 +909,19 @@ func (rq *RedisQueue) failStuckJobsFromQueue(queueName string, timeoutCutoff tim
 						"timeout":   true,
 					}
 
-					failedData, _ := json.Marshal(failureDetails)
+					// A reaped job is terminal, and the client polling it has no
+					// other way to learn that: the result lookup finds nothing
+					// and the status endpoint no longer scans the failed queue.
+					// Without this the caller waits out its entire deadline --
+					// which is how 197 workers ended up parked for 35 minutes.
+					if metaErr := rq.MarkJobFailed(originalJobID, details); metaErr != nil {
+						logging.Logger().Warn().
+							Err(metaErr).
+							Str("job_id", originalJobID).
+							Msg("Failed to record reaped job failure in metadata")
+					}
+
+					failedData, _ := json.Marshal(details)
 					failedJob := &ProofJob{
 						ID:        originalJobID + "_failed",
 						Type:      "failed",

--- a/prover/server/server/queue.go
+++ b/prover/server/server/queue.go
@@ -195,11 +195,40 @@ func (rq *RedisQueue) MarkJobFailed(jobID string, details map[string]interface{}
 	}, time.Hour)
 }
 
+// jobMetaKeepTTLScript writes job metadata while preserving the key's existing
+// expiry, and gives it a fresh one when it has none.
+//
+// SET ... KEEPTTL cannot do this on its own. Reading the TTL and then setting
+// the value are two commands, and a key that expires in between is recreated by
+// KEEPTTL with no expiry at all: a zk_job_meta_* key that never ages out and
+// answers every later poll for that id with a stale "processing". Reading the
+// expiry and writing it back inside one script closes that window.
+//
+// KEYS[1] is the metadata key. ARGV[1] is the encoded metadata, ARGV[2] the
+// fallback expiry in milliseconds for a key that has none.
+var jobMetaKeepTTLScript = redis.NewScript(`
+local pttl = redis.call('PTTL', KEYS[1])
+redis.call('SET', KEYS[1], ARGV[1])
+if pttl > 0 then
+	redis.call('PEXPIRE', KEYS[1], pttl)
+else
+	redis.call('PEXPIRE', KEYS[1], ARGV[2])
+end
+return 1
+`)
+
 // updateJobMeta applies mutate to a job's metadata and writes it back.
 //
 // A missing key is recreated rather than skipped. A job can be failed by the
 // stuck-job reaper after its metadata has expired, and a client polling such a
 // job must still be told to stop rather than being left to time out.
+//
+// The read-modify-write is deliberately not atomic: no WATCH, no script around
+// the mutation. Concurrent writers are last-write-wins, and the realistic
+// collision is the worker's failure path against the stuck-job reaper, which
+// both write status "failed", so at worst one writer's failure details are
+// lost. The expiry is a different matter -- a lost expiry is permanent, not
+// merely stale -- so the write itself is scripted.
 func (rq *RedisQueue) updateJobMeta(
 	jobID string,
 	mutate func(map[string]interface{}),
@@ -224,10 +253,13 @@ func (rq *RedisQueue) updateJobMeta(
 	if err != nil {
 		return fmt.Errorf("failed to marshal job meta: %w", err)
 	}
-	// A recreated key cannot inherit a TTL that no longer exists, so it gets a
-	// fresh hour rather than KeepTTL's "no expiry at all".
-	if ttl == redis.KeepTTL && rq.Client.TTL(rq.Ctx, key).Val() < 0 {
-		ttl = time.Hour
+	if ttl == redis.KeepTTL {
+		if err := jobMetaKeepTTLScript.Run(
+			rq.Ctx, rq.Client, []string{key}, data, time.Hour.Milliseconds(),
+		).Err(); err != nil {
+			return fmt.Errorf("failed to store job meta: %w", err)
+		}
+		return nil
 	}
 	if err := rq.Client.Set(rq.Ctx, key, data, ttl).Err(); err != nil {
 		return fmt.Errorf("failed to store job meta: %w", err)

--- a/prover/server/server/queue.go
+++ b/prover/server/server/queue.go
@@ -65,9 +65,19 @@ func NewRedisQueue(redisURL string) (*RedisQueue, error) {
 }
 
 func (rq *RedisQueue) EnqueueProof(queueName string, job *ProofJob) error {
+	_, err := rq.EnqueueProofReturning(queueName, job)
+	return err
+}
+
+// EnqueueProofReturning enqueues a job and returns the exact bytes stored.
+//
+// A Redis list can only be removed from by value, and the value is this
+// serialization. Handing it back lets a caller that will later remove the entry
+// do it with one LREM instead of walking the list to find what it pushed.
+func (rq *RedisQueue) EnqueueProofReturning(queueName string, job *ProofJob) (string, error) {
 	data, err := json.Marshal(job)
 	if err != nil {
-		return fmt.Errorf("failed to marshal job: %w", err)
+		return "", fmt.Errorf("failed to marshal job: %w", err)
 	}
 
 	// Use tree-specific sub-queue for fair queuing if TreeID is set
@@ -79,9 +89,8 @@ func (rq *RedisQueue) EnqueueProof(queueName string, job *ProofJob) error {
 		rq.Client.SAdd(rq.Ctx, treesSetKey, job.TreeID)
 	}
 
-	err = rq.Client.RPush(rq.Ctx, actualQueueName, data).Err()
-	if err != nil {
-		return fmt.Errorf("failed to enqueue job: %w", err)
+	if err := rq.Client.RPush(rq.Ctx, actualQueueName, data).Err(); err != nil {
+		return "", fmt.Errorf("failed to enqueue job: %w", err)
 	}
 
 	logging.Logger().Info().
@@ -90,7 +99,7 @@ func (rq *RedisQueue) EnqueueProof(queueName string, job *ProofJob) error {
 		Str("tree_id", job.TreeID).
 		Str("redis_addr", rq.Client.Options().Addr).
 		Msg("Job enqueued successfully")
-	return nil
+	return string(data), nil
 }
 
 // isFairQueueEnabled returns true for queues that support fair queuing per tree
@@ -504,31 +513,24 @@ func (rq *RedisQueue) GetResult(jobID string) (interface{}, error) {
 		return nil, err
 	}
 
-	return rq.searchResultInQueue(jobID)
-}
-
-func (rq *RedisQueue) searchResultInQueue(jobID string) (interface{}, error) {
-	items, err := rq.Client.LRange(rq.Ctx, "zk_results_queue", 0, -1).Result()
-	if err != nil {
-		return nil, fmt.Errorf("failed to search results queue: %w", err)
-	}
-
-	for _, item := range items {
-		var resultJob ProofJob
-		if json.Unmarshal([]byte(item), &resultJob) == nil {
-			if resultJob.ID == jobID && resultJob.Type == "result" {
-				var proofWithTiming common.ProofWithTiming
-				err = json.Unmarshal(resultJob.Payload, &proofWithTiming)
-				if err != nil {
-					return nil, fmt.Errorf("failed to unmarshal queued result: %w", err)
-				}
-				rq.StoreResult(jobID, &proofWithTiming)
-
-				return &proofWithTiming, nil
-			}
-		}
-	}
-
+	// A miss means "not finished yet", which is the answer to almost every poll.
+	//
+	// This used to fall back to scanning zk_results_queue: an LRange of every
+	// stored proof, then a JSON unmarshal per entry, to find one job ID. Clients
+	// poll /prove/status from 25ms and back off, so a single transfer misses ten
+	// or more times before its proof lands -- and each of those misses dragged
+	// the whole results queue across the wire.
+	//
+	// Measured on devnet at ~7 tps: 37 GET and 35 list commands per transfer,
+	// with ElastiCache's engine thread (Redis executes commands on one core)
+	// pinned at 99%. Every dispatch stage degraded together as a result --
+	// dequeue 0.17s to 5.4s, dedup 0.24s to 2.7s, semaphore 0.88s to 17.5s --
+	// while proving itself stayed under a second. Throughput collapsed from
+	// 7 tps to 0.3.
+	//
+	// StoreResult writes zk_result_<id> for every completed proof, so the key
+	// lookup above is authoritative and the scan could only ever find what it
+	// had already found.
 	return nil, redis.Nil
 }
 
@@ -728,28 +730,25 @@ func (rq *RedisQueue) CleanupStuckProcessingJobs() error {
 		"zk_transfer_processing_queue",
 	}
 
-	totalRecovered := int64(0)
 	totalFailed := int64(0)
 
 	for _, queueName := range processingQueues {
-		recovered, failed, err := rq.recoverStuckJobsFromQueue(queueName, processingTimeout)
+		failed, err := rq.failStuckJobsFromQueue(queueName, processingTimeout)
 		if err != nil {
 			logging.Logger().Error().
 				Err(err).
 				Str("queue", queueName).
-				Msg("Failed to recover stuck jobs from processing queue")
+				Msg("Failed to clear stuck jobs from processing queue")
 			continue
 		}
-		totalRecovered += recovered
 		totalFailed += failed
 	}
 
-	if totalRecovered > 0 || totalFailed > 0 {
+	if totalFailed > 0 {
 		logging.Logger().Info().
-			Int64("recovered_jobs", totalRecovered).
 			Int64("failed_jobs", totalFailed).
 			Time("timeout_cutoff", processingTimeout).
-			Msg("Processed stuck jobs from processing queues")
+			Msg("Failed out stuck jobs from processing queues")
 	}
 
 	return nil
@@ -776,13 +775,24 @@ func (rq *RedisQueue) CleanupOldFailedJobs() error {
 	return nil
 }
 
-func (rq *RedisQueue) recoverStuckJobsFromQueue(queueName string, timeoutCutoff time.Time) (int64, int64, error) {
+// failStuckJobsFromQueue moves jobs abandoned in a processing queue to the
+// failed queue, so the client's poll returns an error instead of hanging until
+// its own deadline.
+//
+// It used to have a second path that re-enqueued a stuck job for another
+// attempt, and it was unreachable: the only caller passes a cutoff of
+// now-10min, and the re-enqueue branch was guarded by "created after now-5min",
+// which nothing older than ten minutes can satisfy. It would also have been
+// futile if reached -- JobExpirationTimeout is 600s, so processJobs expires a
+// re-enqueued job on the next dequeue and sends it straight back to the failed
+// queue without proving it. Removing it changes no behaviour; the function is
+// named for what it actually does.
+func (rq *RedisQueue) failStuckJobsFromQueue(queueName string, timeoutCutoff time.Time) (int64, error) {
 	items, err := rq.Client.LRange(rq.Ctx, queueName, 0, -1).Result()
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to get processing queue items: %w", err)
+		return 0, fmt.Errorf("failed to get processing queue items: %w", err)
 	}
 
-	var recoveredCount int64
 	var failedCount int64
 
 	for _, item := range items {
@@ -805,98 +815,57 @@ func (rq *RedisQueue) recoverStuckJobsFromQueue(queueName string, timeoutCutoff 
 						originalJobID = job.ID[:len(job.ID)-11]
 					}
 
-					fiveMinutesAgo := time.Now().Add(-5 * time.Minute)
-					if job.CreatedAt.Before(fiveMinutesAgo) {
-						// Extract circuit type from payload for debugging, but don't store full payload
-						// to prevent memory issues (payloads can be hundreds of KB)
-						var circuitType string
-						var payloadMeta map[string]interface{}
-						if json.Unmarshal(job.Payload, &payloadMeta) == nil {
-							if ct, ok := payloadMeta["circuitType"].(string); ok {
-								circuitType = ct
-							}
+					// Extract circuit type from payload for debugging, but don't store full payload
+					// to prevent memory issues (payloads can be hundreds of KB)
+					var circuitType string
+					var payloadMeta map[string]interface{}
+					if json.Unmarshal(job.Payload, &payloadMeta) == nil {
+						if ct, ok := payloadMeta["circuitType"].(string); ok {
+							circuitType = ct
 						}
+					}
 
-						failureDetails := map[string]interface{}{
-							"original_job": map[string]interface{}{
-								"id":           originalJobID,
-								"type":         "zk_proof",
-								"circuit_type": circuitType,
-								"payload_size": len(job.Payload),
-								"created_at":   job.CreatedAt,
-							},
-							"error":     "Job timed out in processing queue (stuck for >5 minutes)",
-							"failed_at": time.Now(),
-							"timeout":   true,
-						}
+					failureDetails := map[string]interface{}{
+						"original_job": map[string]interface{}{
+							"id":           originalJobID,
+							"type":         "zk_proof",
+							"circuit_type": circuitType,
+							"payload_size": len(job.Payload),
+							"created_at":   job.CreatedAt,
+						},
+						"error":     fmt.Sprintf("Job timed out in processing queue (stuck since %s)", job.CreatedAt.Format(time.RFC3339)),
+						"failed_at": time.Now(),
+						"timeout":   true,
+					}
 
-						failedData, _ := json.Marshal(failureDetails)
-						failedJob := &ProofJob{
-							ID:        originalJobID + "_failed",
-							Type:      "failed",
-							Payload:   json.RawMessage(failedData),
-							CreatedAt: time.Now(),
-						}
+					failedData, _ := json.Marshal(failureDetails)
+					failedJob := &ProofJob{
+						ID:        originalJobID + "_failed",
+						Type:      "failed",
+						Payload:   json.RawMessage(failedData),
+						CreatedAt: time.Now(),
+					}
 
-						err = rq.EnqueueProof("zk_failed_queue", failedJob)
-						if err != nil {
-							logging.Logger().Error().
-								Err(err).
-								Str("job_id", originalJobID).
-								Msg("Failed to move timed out job to failed queue")
-						} else {
-							failedCount++
-							logging.Logger().Warn().
-								Str("job_id", originalJobID).
-								Str("processing_queue", queueName).
-								Time("stuck_since", job.CreatedAt).
-								Msg("Moved timed out job to failed queue (processing timeout >5min)")
-						}
+					err = rq.EnqueueProof("zk_failed_queue", failedJob)
+					if err != nil {
+						logging.Logger().Error().
+							Err(err).
+							Str("job_id", originalJobID).
+							Msg("Failed to move timed out job to failed queue")
 					} else {
-						originalQueue := getOriginalQueueFromProcessing(queueName)
-						if originalQueue != "" {
-							originalJob := &ProofJob{
-								ID:        originalJobID,
-								Type:      "zk_proof",
-								Payload:   job.Payload,
-								CreatedAt: job.CreatedAt,
-							}
-
-							err = rq.EnqueueProof(originalQueue, originalJob)
-							if err != nil {
-								logging.Logger().Error().
-									Err(err).
-									Str("job_id", originalJobID).
-									Str("target_queue", originalQueue).
-									Msg("Failed to recover stuck job")
-							} else {
-								recoveredCount++
-								logging.Logger().Info().
-									Str("job_id", originalJobID).
-									Str("from_queue", queueName).
-									Str("to_queue", originalQueue).
-									Time("stuck_since", job.CreatedAt).
-									Msg("Recovered stuck job")
-							}
-						}
+						failedCount++
+						logging.Logger().Warn().
+							Str("job_id", originalJobID).
+							Str("processing_queue", queueName).
+							Time("stuck_since", job.CreatedAt).
+							Msg("Moved timed out job to failed queue")
 					}
 				}
 			}
 		}
 	}
 
-	return recoveredCount, failedCount, nil
-}
-
-func getOriginalQueueFromProcessing(processingQueueName string) string {
-	switch processingQueueName {
-	case "zk_address_append_processing_queue":
-		return "zk_address_append_queue"
-	case "zk_transfer_processing_queue":
-		return "zk_transfer_queue"
-	default:
-		return ""
-	}
+	return failedCount, nil
 }
 
 func (rq *RedisQueue) cleanupOldRequestsFromQueue(queueName string, cutoffTime time.Time) (int64, error) {
@@ -973,71 +942,57 @@ func ComputeInputHash(payload json.RawMessage) string {
 
 // FindCachedResult searches for a cached result by input hash.
 // Returns the proof result (as ProofWithTiming) and job ID if found, otherwise returns nil.
+//
+// The index is authoritative: every result the prover stores is indexed in the
+// same step, and cleanup removes both together. A miss therefore means "not
+// cached", and the proof is simply regenerated.
+//
+// This used to fall back to scanning zk_results_queue whenever the index missed:
+// an LRange of every stored proof, then one GET per entry, run on the single
+// goroutine that feeds every proof worker. Transfer inputs are unique, so the
+// index always missed and the scan always ran -- and its cost grew with the
+// queue it was scanning. Measured on devnet across twelve saturated windows,
+// dispatch cost fitted 100ms + 1.53ms per queued result: at 800 results that is
+// 1.3s to admit one job, throttling the prover to 0.8 jobs/s against 57 jobs/s
+// of capacity, and getting worse with every proof completed.
 func (rq *RedisQueue) FindCachedResult(inputHash string) (*common.ProofWithTiming, string, error) {
 	jobID, err := rq.Client.HGet(rq.Ctx, ResultsIndexKey, inputHash).Result()
-	if err == nil && jobID != "" {
-		result, fetchErr := rq.Client.Get(rq.Ctx, fmt.Sprintf("zk_result_%s", jobID)).Result()
-		if fetchErr == nil {
-			var proofWithTiming common.ProofWithTiming
-			if json.Unmarshal([]byte(result), &proofWithTiming) == nil {
-				logging.Logger().Info().
-					Str("input_hash", inputHash).
-					Str("cached_job_id", jobID).
-					Int64("proof_duration_ms", proofWithTiming.ProofDurationMs).
-					Msg("Found cached successful proof result via index")
-				return &proofWithTiming, jobID, nil
-			}
-		}
-		// Index entry exists but result is missing/invalid - clean up stale index entry
+	if err == redis.Nil || (err == nil && jobID == "") {
+		return nil, "", nil
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to query results index: %w", err)
+	}
+
+	result, err := rq.Client.Get(rq.Ctx, fmt.Sprintf("zk_result_%s", jobID)).Result()
+	if err != nil {
+		// Results carry a TTL, the index hash does not, so an entry can outlive
+		// what it points at. Drop it and report a miss.
 		logging.Logger().Debug().
 			Str("input_hash", inputHash).
 			Str("job_id", jobID).
-			Msg("Stale index entry, removing and falling back to queue scan")
+			Msg("Stale result index entry, removing")
 		rq.RemoveResultIndex(inputHash)
-	} else if err != nil && err != redis.Nil {
+		return nil, "", nil
+	}
+
+	var proofWithTiming common.ProofWithTiming
+	if err := json.Unmarshal([]byte(result), &proofWithTiming); err != nil {
 		logging.Logger().Warn().
 			Err(err).
 			Str("input_hash", inputHash).
-			Msg("Error querying results index, falling back to queue scan")
+			Str("job_id", jobID).
+			Msg("Cached result is unreadable, removing index entry")
+		rq.RemoveResultIndex(inputHash)
+		return nil, "", nil
 	}
 
-	// Fallback: O(n) queue scan for backward compatibility with unindexed results
-	items, err := rq.Client.LRange(rq.Ctx, "zk_results_queue", 0, -1).Result()
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to search results queue: %w", err)
-	}
-
-	for _, item := range items {
-		var resultJob ProofJob
-		if json.Unmarshal([]byte(item), &resultJob) == nil && resultJob.Type == "result" {
-			// Check if this result has the same input hash
-			storedHash, err := rq.Client.Get(rq.Ctx, fmt.Sprintf("zk_input_hash_%s", resultJob.ID)).Result()
-			if err == nil && storedHash == inputHash {
-				var proofWithTiming common.ProofWithTiming
-				err = json.Unmarshal(resultJob.Payload, &proofWithTiming)
-				if err != nil {
-					logging.Logger().Warn().
-						Err(err).
-						Str("input_hash", inputHash).
-						Str("job_id", resultJob.ID).
-						Msg("Failed to unmarshal cached result payload, skipping")
-					continue
-				}
-
-				logging.Logger().Info().
-					Str("input_hash", inputHash).
-					Str("cached_job_id", resultJob.ID).
-					Int64("proof_duration_ms", proofWithTiming.ProofDurationMs).
-					Msg("Found cached successful proof result via queue scan")
-
-				rq.IndexResultByHash(inputHash, resultJob.ID)
-
-				return &proofWithTiming, resultJob.ID, nil
-			}
-		}
-	}
-
-	return nil, "", nil
+	logging.Logger().Info().
+		Str("input_hash", inputHash).
+		Str("cached_job_id", jobID).
+		Int64("proof_duration_ms", proofWithTiming.ProofDurationMs).
+		Msg("Found cached successful proof result via index")
+	return &proofWithTiming, jobID, nil
 }
 
 // FindCachedFailure searches for a cached failure by input hash.
@@ -1067,53 +1022,19 @@ func (rq *RedisQueue) FindCachedFailure(inputHash string) (map[string]interface{
 		logging.Logger().Debug().
 			Str("input_hash", inputHash).
 			Str("job_id", jobID).
-			Msg("Stale failure index entry, removing and falling back to queue scan")
+			Msg("Stale failure index entry, removing")
 		rq.RemoveFailureIndex(inputHash)
+		return nil, "", nil
 	} else if err != nil && err != redis.Nil {
-		logging.Logger().Warn().
-			Err(err).
-			Str("input_hash", inputHash).
-			Msg("Error querying failed index, falling back to queue scan")
+		return nil, "", fmt.Errorf("failed to query failed index: %w", err)
 	}
 
-	// Fallback: O(n) queue scan for backward compatibility with unindexed failures
-	items, err := rq.Client.LRange(rq.Ctx, "zk_failed_queue", 0, -1).Result()
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to search failed queue: %w", err)
-	}
-
-	for _, item := range items {
-		var failedJob ProofJob
-		if json.Unmarshal([]byte(item), &failedJob) == nil && failedJob.Type == "failed" {
-			// Extract the original job ID (remove _failed suffix)
-			originalJobID := failedJob.ID
-			if len(failedJob.ID) > 7 && failedJob.ID[len(failedJob.ID)-7:] == "_failed" {
-				originalJobID = failedJob.ID[:len(failedJob.ID)-7]
-			}
-
-			// Check if this failure has the same input hash
-			storedHash, err := rq.Client.Get(rq.Ctx, fmt.Sprintf("zk_input_hash_%s", originalJobID)).Result()
-			if err == nil && storedHash == inputHash {
-				// Found a matching failure
-				var failureDetails map[string]interface{}
-				err = json.Unmarshal(failedJob.Payload, &failureDetails)
-				if err != nil {
-					continue
-				}
-
-				logging.Logger().Info().
-					Str("input_hash", inputHash).
-					Str("cached_job_id", originalJobID).
-					Msg("Found cached failed proof result via queue scan")
-
-				// Backfill the index for future O(1) lookups
-				rq.IndexFailureByHash(inputHash, originalJobID)
-
-				return failureDetails, originalJobID, nil
-			}
-		}
-	}
-
+	// A miss means "no cached failure". There is no fallback scan: it used to
+	// LRange the whole failed queue and GET one key per entry on every miss,
+	// which is every job. See FindCachedResult for what that cost.
+	//
+	// The scan above still runs on an index hit, where it is bounded by the
+	// failed queue and only reached when an identical input has already failed.
 	return nil, "", nil
 }
 

--- a/prover/server/server/queue_job.go
+++ b/prover/server/server/queue_job.go
@@ -183,7 +183,9 @@ func (w *BaseQueueWorker) Stop() {
 }
 
 func (w *BaseQueueWorker) processJobs() {
+	dequeueStart := time.Now()
 	job, err := w.queue.DequeueProof(w.queueName, 5*time.Second)
+	RecordDispatchStage(w.queueName, "dequeue", time.Since(dequeueStart))
 	if err != nil {
 		logging.Logger().Error().Err(err).Str("queue", w.queueName).Msg("Error dequeuing from queue")
 		time.Sleep(2 * time.Second)
@@ -239,7 +241,12 @@ func (w *BaseQueueWorker) processJobs() {
 		Str("queue", w.queueName).
 		Msg("Dequeued proof job")
 
-	// Check for duplicate inputs before processing
+	// Check for duplicate inputs before processing.
+	//
+	// Everything from here to the semaphore runs on the loop that feeds every
+	// worker, so it is timed as "dedup": time spent here is admission rate lost,
+	// including on the cache-hit paths that return without ever proving.
+	dedupStart := time.Now()
 	inputHash := ComputeInputHash(job.Payload)
 
 	// Check if we already have a successful result for this input
@@ -273,6 +280,7 @@ func (w *BaseQueueWorker) processJobs() {
 		w.queue.StoreResult(job.ID, cachedProof)
 		w.queue.StoreInputHash(job.ID, inputHash)
 		w.queue.IndexResultByHash(inputHash, job.ID)
+		RecordDispatchStage(w.queueName, "dedup", time.Since(dedupStart))
 		return
 	}
 
@@ -326,16 +334,25 @@ func (w *BaseQueueWorker) processJobs() {
 		}
 		w.queue.StoreInputHash(job.ID, inputHash)
 		w.queue.IndexFailureByHash(inputHash, job.ID)
+		RecordDispatchStage(w.queueName, "dedup", time.Since(dedupStart))
 		return
 	}
 
 	// No cached result found, proceed with normal processing
 	// Store the input hash for this job to enable future deduplication
 	w.queue.StoreInputHash(job.ID, inputHash)
+	RecordDispatchStage(w.queueName, "dedup", time.Since(dedupStart))
 
+	// Blocking here means every worker is busy, which is the one healthy reason
+	// for the loop to stall. Separated from dedup so the two are never confused.
+	semaphoreStart := time.Now()
 	w.semaphore <- struct{}{}
+	RecordDispatchStage(w.queueName, "semaphore", time.Since(semaphoreStart))
 
 	go func(job *ProofJob, inputHash string) {
+		// Set once the processing entry exists; the panic handler below reads
+		// whatever it holds at that point, which is "" if we never got that far.
+		var processingItem string
 		defer func() {
 			if r := recover(); r != nil {
 				circuitType := "unknown"
@@ -357,7 +374,7 @@ func (w *BaseQueueWorker) processJobs() {
 					Str("circuit_type", circuitType).
 					Msg("Panic recovered in proof processing")
 
-				w.removeFromProcessingQueue(job.ID)
+				w.removeFromProcessingQueue(processingItem)
 				w.addToFailedQueue(job, inputHash, panicErr)
 
 				if delErr := w.queue.DeleteInFlightJob(inputHash, job.ID); delErr != nil {
@@ -390,7 +407,9 @@ func (w *BaseQueueWorker) processJobs() {
 			Payload:   job.Payload,
 			CreatedAt: time.Now(),
 		}
-		err := w.queue.EnqueueProof(w.processingQueueName, processingJob)
+		// Keep the stored bytes: they are the only handle LREM can match, and
+		// searching for them later costs a round trip per queue entry.
+		storedItem, err := w.queue.EnqueueProofReturning(w.processingQueueName, processingJob)
 		if err != nil {
 			logging.Logger().Error().
 				Err(err).
@@ -399,9 +418,10 @@ func (w *BaseQueueWorker) processJobs() {
 				Msg("Failed to add job to processing queue")
 			return
 		}
+		processingItem = storedItem
 
 		proof, err := w.generateProof(job)
-		w.removeFromProcessingQueue(job.ID)
+		w.removeFromProcessingQueue(processingItem)
 
 		proofDuration := time.Since(proofStartTime)
 
@@ -632,20 +652,29 @@ func (w *BaseQueueWorker) processMergeProof(payload json.RawMessage, circuitType
 	return mergeprover.ProveMerge(ps, &params)
 }
 
-func (w *BaseQueueWorker) removeFromProcessingQueue(jobID string) {
-	processingQueueLength, _ := w.queue.Client.LLen(w.queue.Ctx, w.processingQueueName).Result()
-
-	for i := range processingQueueLength {
-		item, err := w.queue.Client.LIndex(w.queue.Ctx, w.processingQueueName, i).Result()
-		if err != nil {
-			continue
-		}
-
-		var job ProofJob
-		if json.Unmarshal([]byte(item), &job) == nil && job.ID == jobID+"_processing" {
-			w.queue.Client.LRem(w.queue.Ctx, w.processingQueueName, 1, item)
-			break
-		}
+// removeFromProcessingQueue drops the entry a worker added when it started, by
+// value, in one command.
+//
+// It used to search: LLen, then an LINDEX round trip per position until the
+// job id matched. That is O(queue length) *round trips* per completed proof,
+// paid while holding a semaphore slot -- so the longer the processing queue
+// grew, the longer each slot was held, the more work sat in flight, and the
+// longer the queue grew. Measured on devnet at 220 workers: the processing
+// queue climbed 210 -> 751 during one run when at most 128 proofs can actually
+// be in flight, jobs waited 4.5-7s to be picked up behind a 108-deep pending
+// queue, and the provers themselves sat at 12-33% CPU proving in 0.25s.
+//
+// The caller already holds the exact bytes it pushed, which is the only thing
+// LREM can match on, so no search is needed.
+func (w *BaseQueueWorker) removeFromProcessingQueue(item string) {
+	if item == "" {
+		return
+	}
+	if err := w.queue.Client.LRem(w.queue.Ctx, w.processingQueueName, 1, item).Err(); err != nil {
+		logging.Logger().Warn().
+			Err(err).
+			Str("processing_queue", w.processingQueueName).
+			Msg("Failed to remove entry from processing queue (cleanup will age it out)")
 	}
 }
 

--- a/prover/server/server/queue_job.go
+++ b/prover/server/server/queue_job.go
@@ -221,6 +221,12 @@ func (w *BaseQueueWorker) processJobs() {
 			expirationErr := fmt.Errorf("job expired after %v (max: %v)", jobAge, JobExpirationTimeout)
 			expiredInputHash := ComputeInputHash(job.Payload)
 			w.addToFailedQueue(job, expiredInputHash, expirationErr)
+			if metaErr := w.queue.MarkJobFailed(job.ID, failureDetails(job, expirationErr)); metaErr != nil {
+				logging.Logger().Warn().
+					Err(metaErr).
+					Str("job_id", job.ID).
+					Msg("Failed to record expiry in metadata")
+			}
 			return
 		}
 
@@ -332,6 +338,14 @@ func (w *BaseQueueWorker) processJobs() {
 		if err != nil {
 			logging.Logger().Error().Err(err).Str("job_id", job.ID).Msg("Failed to enqueue cached failure")
 		}
+		// A replayed failure is still terminal for this job id, so it has to be
+		// visible to the status endpoint the same way a fresh one is.
+		if metaErr := w.queue.MarkJobFailed(job.ID, failedJob); metaErr != nil {
+			logging.Logger().Warn().
+				Err(metaErr).
+				Str("job_id", job.ID).
+				Msg("Failed to record cached failure in metadata")
+		}
 		w.queue.StoreInputHash(job.ID, inputHash)
 		w.queue.IndexFailureByHash(inputHash, job.ID)
 		RecordDispatchStage(w.queueName, "dedup", time.Since(dedupStart))
@@ -384,11 +398,14 @@ func (w *BaseQueueWorker) processJobs() {
 						Str("input_hash", inputHash).
 						Msg("Failed to delete in-flight job marker (non-critical)")
 				}
-				if delErr := w.queue.DeleteJobMeta(job.ID); delErr != nil {
+				// Keep the metadata and record why. Deleting it here left the
+				// status endpoint with nothing to answer from, which is what
+				// forced it to scan zk_failed_queue on every poll.
+				if metaErr := w.queue.MarkJobFailed(job.ID, failureDetails(job, panicErr)); metaErr != nil {
 					logging.Logger().Warn().
-						Err(delErr).
+						Err(metaErr).
 						Str("job_id", job.ID).
-						Msg("Failed to delete job metadata (non-critical)")
+						Msg("Failed to record job failure in metadata")
 				}
 			}
 			<-w.semaphore
@@ -419,6 +436,12 @@ func (w *BaseQueueWorker) processJobs() {
 			return
 		}
 		processingItem = storedItem
+		if metaErr := w.queue.MarkJobProcessing(job.ID); metaErr != nil {
+			logging.Logger().Warn().
+				Err(metaErr).
+				Str("job_id", job.ID).
+				Msg("Failed to mark job processing (status polls will still report queued)")
+		}
 
 		proof, err := w.generateProof(job)
 		w.removeFromProcessingQueue(processingItem)
@@ -443,12 +466,14 @@ func (w *BaseQueueWorker) processJobs() {
 					Str("input_hash", inputHash).
 					Msg("Failed to delete in-flight job marker (non-critical)")
 			}
-			// Clean up job metadata
-			if delErr := w.queue.DeleteJobMeta(job.ID); delErr != nil {
+			// Record the failure in the metadata rather than dropping it: this
+			// is the only record a polling client can be answered from once the
+			// status endpoint stops scanning zk_failed_queue.
+			if metaErr := w.queue.MarkJobFailed(job.ID, failureDetails(job, err)); metaErr != nil {
 				logging.Logger().Warn().
-					Err(delErr).
+					Err(metaErr).
 					Str("job_id", job.ID).
-					Msg("Failed to delete job metadata (non-critical)")
+					Msg("Failed to record job failure in metadata")
 			}
 		} else {
 			// Store result with timing information
@@ -678,9 +703,13 @@ func (w *BaseQueueWorker) removeFromProcessingQueue(item string) {
 	}
 }
 
-func (w *BaseQueueWorker) addToFailedQueue(job *ProofJob, inputHash string, err error) {
-	// Extract circuit type from payload for debugging, but don't store full payload
-	// to prevent memory issues (payloads can be hundreds of KB)
+// failureDetails describes a failed job for both the failed queue and the job
+// metadata, so a caller sees the same thing wherever it is read from.
+//
+// The full payload is deliberately omitted -- payloads run to hundreds of KB,
+// and this is stored once per failure on a path that already has memory
+// pressure.
+func failureDetails(job *ProofJob, err error) map[string]interface{} {
 	var circuitType string
 	var payloadMeta map[string]interface{}
 	if json.Unmarshal(job.Payload, &payloadMeta) == nil {
@@ -689,7 +718,7 @@ func (w *BaseQueueWorker) addToFailedQueue(job *ProofJob, inputHash string, err 
 		}
 	}
 
-	failedJob := map[string]interface{}{
+	return map[string]interface{}{
 		"original_job": map[string]interface{}{
 			"id":           job.ID,
 			"type":         job.Type,
@@ -700,8 +729,10 @@ func (w *BaseQueueWorker) addToFailedQueue(job *ProofJob, inputHash string, err 
 		"error":     err.Error(),
 		"failed_at": time.Now(),
 	}
+}
 
-	failedData, _ := json.Marshal(failedJob)
+func (w *BaseQueueWorker) addToFailedQueue(job *ProofJob, inputHash string, err error) {
+	failedData, _ := json.Marshal(failureDetails(job, err))
 	failedJobStruct := &ProofJob{
 		ID:        job.ID + "_failed",
 		Type:      "failed",

--- a/prover/server/server/server.go
+++ b/prover/server/server/server.go
@@ -453,6 +453,15 @@ func (handler proveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Bool("queue_available", handler.enableQueue && handler.redisQueue != nil).
 		Msg("Processing prove request")
 
+	// Counted here, once, because this is the only point every request passes
+	// through exactly once. Counting inside the handlers double-counted the
+	// queued path -- once at submission and again when the worker called
+	// StartProofTimer -- while the direct-sync path counted once, so the metric
+	// read 2x on the only path production uses. It reported 498 proofs for a run
+	// whose logs show 249.
+	ProofRequestsTotal.WithLabelValues(string(proofRequestMeta.CircuitType)).Inc()
+	RecordCircuitInputSize(string(proofRequestMeta.CircuitType), len(buf))
+
 	if shouldUseQueue && handler.enableQueue && handler.redisQueue != nil {
 		handler.handleAsyncProof(w, r, buf, proofRequestMeta)
 	} else {
@@ -853,9 +862,6 @@ type healthHandler struct {
 }
 
 func (handler proveHandler) handleAsyncProof(w http.ResponseWriter, r *http.Request, buf []byte, meta common.ProofRequestMeta) {
-	ProofRequestsTotal.WithLabelValues(string(meta.CircuitType)).Inc()
-	RecordCircuitInputSize(string(meta.CircuitType), len(buf))
-
 	queueName := GetQueueNameForCircuit(meta.CircuitType)
 
 	// Compute input hash for deduplication
@@ -1024,7 +1030,6 @@ func (handler proveHandler) handleSyncProof(w http.ResponseWriter, r *http.Reque
 		}()
 
 		timer := StartProofTimer(string(meta.CircuitType))
-		RecordCircuitInputSize(string(meta.CircuitType), len(buf))
 
 		proof, proofError := handler.processProofSync(buf)
 

--- a/prover/server/server/server.go
+++ b/prover/server/server/server.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 	"zolana/prover/logging"
 	"zolana/prover/prover/common"
@@ -192,27 +191,21 @@ func (handler proofStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 
 	// Handle failed jobs specially - extract actual error details
 	if jobStatus == "failed" && jobInfo != nil {
-		if payloadRaw, ok := jobInfo["payload"]; ok {
-			if payloadStr, ok := payloadRaw.(string); ok {
-				var failureDetails map[string]interface{}
-				if err := json.Unmarshal([]byte(payloadStr), &failureDetails); err == nil {
-					if errorMsg, ok := failureDetails["error"].(string); ok {
-						response["message"] = fmt.Sprintf("Job processing failed: %s", errorMsg)
-						response["error"] = errorMsg
-					}
-					if failedAt, ok := failureDetails["failed_at"]; ok {
-						response["failed_at"] = failedAt
-					}
-					if originalJob, ok := failureDetails["original_job"].(map[string]interface{}); ok {
-						if circuitType, ok := originalJob["circuit_type"]; ok {
-							response["circuit_type"] = circuitType
-						}
-					}
-				} else {
-					response["message"] = "Job processing failed. Unable to parse failure details."
+		// The details arrive already decoded, alongside the status they belong
+		// to. They used to be a JSON string lifted out of the failed queue's
+		// entry, which meant finding that entry by scanning the queue.
+		if failureDetails, ok := jobInfo["failure"].(map[string]interface{}); ok {
+			if errorMsg, ok := failureDetails["error"].(string); ok {
+				response["message"] = fmt.Sprintf("Job processing failed: %s", errorMsg)
+				response["error"] = errorMsg
+			}
+			if failedAt, ok := failureDetails["failed_at"]; ok {
+				response["failed_at"] = failedAt
+			}
+			if originalJob, ok := failureDetails["original_job"].(map[string]interface{}); ok {
+				if circuitType, ok := originalJob["circuit_type"]; ok {
+					response["circuit_type"] = circuitType
 				}
-			} else {
-				response["message"] = "Job processing failed. Unable to access failure details."
 			}
 		} else {
 			response["message"] = "Job processing failed. No failure details available."
@@ -250,6 +243,23 @@ func (handler proofStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	}
 }
 
+type QueueConfig struct {
+	RedisURL string
+	Enabled  bool
+}
+
+type EnhancedConfig struct {
+	ProverAddress  string
+	MetricsAddress string
+	Queue          *QueueConfig
+}
+
+type proveHandler struct {
+	keyManager  *common.LazyKeyManager
+	redisQueue  *RedisQueue
+	enableQueue bool
+}
+
 func isValidJobID(jobID string) bool {
 	_, err := uuid.Parse(jobID)
 	return err == nil
@@ -270,155 +280,62 @@ func getStatusMessage(status string) string {
 	}
 }
 
+// checkJobExistsDetailed answers a status poll with two O(1) Redis reads.
+//
+// This is the hottest path in the server -- a client polls it from submission
+// until its proof lands, so polls outnumber jobs by orders of magnitude. It
+// used to walk entire Redis lists with LRANGE key 0 -1: the job's own queue,
+// then the processing queue, then zk_failed_queue, then zk_results_queue,
+// unmarshalling every element. A 220-worker run drove ~57 such polls a second
+// against a results queue holding 8237 entries, which is on the order of half a
+// million element reads per second from a single-threaded Redis. Redis returned
+// i/o timeouts, dispatch stalled behind them, health checks failed, ECS
+// replaced the tasks, and the in-flight jobs on them were orphaned.
+//
+// The scans existed only because the metadata was written once at submission
+// and never updated, so "queued" and "processing" could not be told apart
+// without looking. The workers now keep that field current (MarkJobProcessing,
+// MarkJobFailed), which costs one SET per job, so the status is simply read.
 func (handler proofStatusHandler) checkJobExistsDetailed(jobID string) (bool, string, map[string]interface{}) {
-	// First check result cache (fast O(1) lookup)
+	// Completion is answered by the result index. This is the common terminal
+	// case and stays first.
 	result, err := handler.redisQueue.GetResult(jobID)
 	if err == nil && result != nil {
 		logging.Logger().Debug().
 			Str("job_id", jobID).
 			Msg("Job found in result cache")
 
-		jobInfo := map[string]interface{}{
+		return true, "completed", map[string]interface{}{
 			"result":        result,
 			"result_cached": true,
 		}
-		return true, "completed", jobInfo
 	}
 
-	// Check job metadata to determine which queue to search (avoids full scan of all queues)
 	jobMeta, metaErr := handler.redisQueue.GetJobMeta(jobID)
-	if metaErr == nil && jobMeta != nil {
-		// We have metadata - check only the relevant queues based on queue name
-		if queueName, ok := jobMeta["queue"].(string); ok {
-			// Check main queue first
-			if job, found := handler.findJobInQueue(queueName, jobID); found {
-				return true, "queued", job
-			}
-			// Check processing queue for this circuit type
-			// Validate queueName before slicing to avoid panic
-			if len(queueName) >= 6 && strings.HasSuffix(queueName, "_queue") {
-				base := queueName[:len(queueName)-6]
-				processingQueue := base + "_processing_queue"
-				if job, found := handler.findJobInQueue(processingQueue, jobID); found {
-					return true, "processing", job
-				}
-			} else {
-				logging.Logger().Warn().
-					Str("job_id", jobID).
-					Str("queue_name", queueName).
-					Msg("Malformed queue name in job metadata - skipping processing queue check")
-			}
-		}
-		// Job has metadata but not found in expected queues - may be in results or failed
-		if job, found := handler.findJobInQueue("zk_failed_queue", jobID); found {
-			return true, "failed", job
-		}
-		// Check results queue
-		if job, found := handler.findJobInQueue("zk_results_queue", jobID); found {
-			handler.extractResultFromPayload(job)
-			return true, "completed", job
-		}
-		// Return metadata-based status even if not found in queues
-		// This handles race conditions where job moved between queues
-		status := "queued"
-		if metaStatus, ok := jobMeta["status"].(string); ok {
-			status = metaStatus
-		}
-		return true, status, map[string]interface{}{
-			"circuit_type": jobMeta["circuit_type"],
-			"submitted_at": jobMeta["submitted_at"],
-			"from_meta":    true,
-		}
+	if metaErr != nil || jobMeta == nil {
+		// Metadata is deleted on success and expires an hour after submission,
+		// so an unknown id is genuinely unknown: either it never existed, or it
+		// completed long enough ago that its result is gone too.
+		return false, "", nil
 	}
 
-	// No metadata - fall back to checking failed and results queues only
-	// (These are the terminal states where jobs might exist without metadata)
-	if job, found := handler.findJobInQueue("zk_failed_queue", jobID); found {
-		return true, "failed", job
+	status := "queued"
+	if metaStatus, ok := jobMeta["status"].(string); ok {
+		status = metaStatus
 	}
 
-	if job, found := handler.findJobInQueue("zk_results_queue", jobID); found {
-		handler.extractResultFromPayload(job)
-		return true, "completed", job
+	jobInfo := map[string]interface{}{
+		"circuit_type": jobMeta["circuit_type"],
+		"submitted_at": jobMeta["submitted_at"],
+		"from_meta":    true,
+	}
+	// A failure carries its reason with it, so the caller gets the same detail
+	// the failed queue used to supply.
+	if failure, ok := jobMeta["failure"].(map[string]interface{}); ok {
+		jobInfo["failure"] = failure
 	}
 
-	return false, "", nil
-}
-
-func (handler proofStatusHandler) extractResultFromPayload(job map[string]interface{}) {
-	if payloadRaw, ok := job["payload"]; ok {
-		if payloadStr, ok := payloadRaw.(string); ok {
-			var payloadData map[string]interface{}
-			if json.Unmarshal([]byte(payloadStr), &payloadData) == nil {
-				job["result"] = payloadData
-			}
-		}
-	}
-}
-
-func (handler proofStatusHandler) findJobInQueue(queueName, jobID string) (map[string]interface{}, bool) {
-	items, err := handler.redisQueue.Client.LRange(handler.redisQueue.Ctx, queueName, 0, -1).Result()
-	if err != nil {
-		logging.Logger().Error().
-			Err(err).
-			Str("queue", queueName).
-			Str("job_id", jobID).
-			Msg("Error searching queue")
-		return nil, false
-	}
-
-	for _, item := range items {
-		var job ProofJob
-		if json.Unmarshal([]byte(item), &job) == nil {
-			if job.ID == jobID ||
-				job.ID == jobID+"_processing" ||
-				job.ID == jobID+"_failed" {
-
-				jobInfo := map[string]interface{}{
-					"created_at": job.CreatedAt,
-				}
-
-				// Include payload for all jobs, especially important for failed jobs
-				if len(job.Payload) > 0 {
-					jobInfo["payload"] = string(job.Payload)
-
-					var meta map[string]interface{}
-					if json.Unmarshal(job.Payload, &meta) == nil {
-						if circuitType, ok := meta["circuit_type"]; ok {
-							jobInfo["circuit_type"] = circuitType
-						}
-					}
-				}
-
-				logging.Logger().Info().
-					Str("job_id", jobID).
-					Str("queue", queueName).
-					Str("found_job_id", job.ID).
-					Msg("Job found in queue")
-
-				return jobInfo, true
-			}
-		}
-	}
-
-	return nil, false
-}
-
-type QueueConfig struct {
-	RedisURL string
-	Enabled  bool
-}
-
-type EnhancedConfig struct {
-	ProverAddress  string
-	MetricsAddress string
-	Queue          *QueueConfig
-}
-
-type proveHandler struct {
-	keyManager  *common.LazyKeyManager
-	redisQueue  *RedisQueue
-	enableQueue bool
+	return true, status, jobInfo
 }
 
 func (handler proveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/prover/server/server/server.go
+++ b/prover/server/server/server.go
@@ -84,7 +84,21 @@ func (handler proofStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	jobExists, jobStatus, jobInfo := handler.checkJobExistsDetailed(jobID)
+	jobExists, jobStatus, jobInfo, lookupErr := handler.checkJobExistsDetailed(jobID)
+	if lookupErr != nil {
+		logging.Logger().Error().
+			Err(lookupErr).
+			Str("job_id", jobID).
+			Msg("Job status lookup failed")
+
+		unavailableError := &Error{
+			StatusCode: http.StatusServiceUnavailable,
+			Code:       "status_unavailable",
+			Message:    fmt.Sprintf("Status for job %s is temporarily unavailable. Retry shortly.", jobID),
+		}
+		unavailableError.send(w)
+		return
+	}
 
 	if !jobExists {
 		// Fallback: check job metadata - this catches jobs that were submitted but not yet
@@ -296,7 +310,14 @@ func getStatusMessage(status string) string {
 // and never updated, so "queued" and "processing" could not be told apart
 // without looking. The workers now keep that field current (MarkJobProcessing,
 // MarkJobFailed), which costs one SET per job, so the status is simply read.
-func (handler proofStatusHandler) checkJobExistsDetailed(jobID string) (bool, string, map[string]interface{}) {
+//
+// A Redis failure is reported as an error rather than as "not found": the two
+// are indistinguishable to a caller that only gets a bool, and answering
+// "unknown" during a blip 404s a live job and lets the caller clear its
+// in-flight marker.
+func (handler proofStatusHandler) checkJobExistsDetailed(
+	jobID string,
+) (bool, string, map[string]interface{}, error) {
 	// Completion is answered by the result index. This is the common terminal
 	// case and stays first.
 	result, err := handler.redisQueue.GetResult(jobID)
@@ -308,15 +329,18 @@ func (handler proofStatusHandler) checkJobExistsDetailed(jobID string) (bool, st
 		return true, "completed", map[string]interface{}{
 			"result":        result,
 			"result_cached": true,
-		}
+		}, nil
 	}
 
 	jobMeta, metaErr := handler.redisQueue.GetJobMeta(jobID)
-	if metaErr != nil || jobMeta == nil {
+	if metaErr != nil {
+		return false, "", nil, fmt.Errorf("failed to read job meta: %w", metaErr)
+	}
+	if jobMeta == nil {
 		// Metadata is deleted on success and expires an hour after submission,
 		// so an unknown id is genuinely unknown: either it never existed, or it
 		// completed long enough ago that its result is gone too.
-		return false, "", nil
+		return false, "", nil, nil
 	}
 
 	status := "queued"
@@ -335,7 +359,7 @@ func (handler proofStatusHandler) checkJobExistsDetailed(jobID string) (bool, st
 		jobInfo["failure"] = failure
 	}
 
-	return true, status, jobInfo
+	return true, status, jobInfo, nil
 }
 
 func (handler proveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/prover/server/status_lookup_test.go
+++ b/prover/server/status_lookup_test.go
@@ -1,0 +1,156 @@
+package main_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The status endpoint answers from the job's metadata, so the metadata has to
+// carry a status that is actually current. These tests pin that: every
+// transition a job can make must be visible without looking in a queue.
+//
+// The scans they replace were not a micro-optimisation. checkJobExistsDetailed
+// walked up to four whole Redis lists per poll, and a client polls from
+// submission until its proof lands, so the cost scaled with queue length times
+// poll rate. With 8237 entries in zk_results_queue it saturated Redis, and the
+// prover tasks were killed by failing health checks.
+
+func TestJobStatusStartsQueued(t *testing.T) {
+	queue := setupRedisQueue(t)
+	jobID := uuid.NewString()
+
+	if err := queue.StoreJobMeta(jobID, "zk_transfer_queue", "transfer"); err != nil {
+		t.Fatalf("store job meta: %v", err)
+	}
+
+	meta, err := queue.GetJobMeta(jobID)
+	if err != nil {
+		t.Fatalf("get job meta: %v", err)
+	}
+	if got := meta["status"]; got != "queued" {
+		t.Fatalf("status = %v, want queued", got)
+	}
+}
+
+func TestMarkJobProcessingIsVisibleWithoutScanningQueues(t *testing.T) {
+	queue := setupRedisQueue(t)
+	jobID := uuid.NewString()
+
+	if err := queue.StoreJobMeta(jobID, "zk_transfer_queue", "transfer"); err != nil {
+		t.Fatalf("store job meta: %v", err)
+	}
+	if err := queue.MarkJobProcessing(jobID); err != nil {
+		t.Fatalf("mark processing: %v", err)
+	}
+
+	meta, err := queue.GetJobMeta(jobID)
+	if err != nil {
+		t.Fatalf("get job meta: %v", err)
+	}
+	if got := meta["status"]; got != "processing" {
+		t.Fatalf("status = %v, want processing", got)
+	}
+	// The fields written at submission have to survive the update -- the status
+	// response still reports them.
+	if got := meta["circuit_type"]; got != "transfer" {
+		t.Fatalf("circuit_type = %v, want transfer", got)
+	}
+	if got := meta["queue"]; got != "zk_transfer_queue" {
+		t.Fatalf("queue = %v, want zk_transfer_queue", got)
+	}
+}
+
+func TestMarkJobProcessingKeepsTheSubmissionExpiry(t *testing.T) {
+	queue := setupRedisQueue(t)
+	jobID := uuid.NewString()
+
+	if err := queue.StoreJobMeta(jobID, "zk_transfer_queue", "transfer"); err != nil {
+		t.Fatalf("store job meta: %v", err)
+	}
+	key := "zk_job_meta_" + jobID
+	before := queue.Client.TTL(queue.Ctx, key).Val()
+
+	if err := queue.MarkJobProcessing(jobID); err != nil {
+		t.Fatalf("mark processing: %v", err)
+	}
+
+	after := queue.Client.TTL(queue.Ctx, key).Val()
+	if after <= 0 {
+		t.Fatalf("TTL = %v, want the submission expiry preserved (never unbounded)", after)
+	}
+	// Picking a job up must not extend its life; a job that is never finished
+	// still has to age out.
+	if after > before {
+		t.Fatalf("TTL grew from %v to %v; processing should not renew it", before, after)
+	}
+}
+
+func TestMarkJobFailedCarriesTheReason(t *testing.T) {
+	queue := setupRedisQueue(t)
+	jobID := uuid.NewString()
+
+	if err := queue.StoreJobMeta(jobID, "zk_transfer_queue", "transfer"); err != nil {
+		t.Fatalf("store job meta: %v", err)
+	}
+	details := map[string]interface{}{
+		"error":     "proof generation failed",
+		"failed_at": time.Now(),
+	}
+	if err := queue.MarkJobFailed(jobID, details); err != nil {
+		t.Fatalf("mark failed: %v", err)
+	}
+
+	meta, err := queue.GetJobMeta(jobID)
+	if err != nil {
+		t.Fatalf("get job meta: %v", err)
+	}
+	if got := meta["status"]; got != "failed" {
+		t.Fatalf("status = %v, want failed", got)
+	}
+	failure, ok := meta["failure"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("failure = %v, want the details map", meta["failure"])
+	}
+	if got := failure["error"]; got != "proof generation failed" {
+		t.Fatalf("failure error = %v, want the original message", got)
+	}
+}
+
+// The stuck-job reaper fails jobs that have been in the processing queue too
+// long, and by then their metadata may already have expired. Recreating it is
+// the difference between a client being told to stop and a client waiting out
+// its entire deadline -- which is how 197 workers ended up parked for 35
+// minutes against an idle prover.
+func TestMarkJobFailedRecreatesExpiredMetadata(t *testing.T) {
+	queue := setupRedisQueue(t)
+	jobID := uuid.NewString()
+
+	if meta, err := queue.GetJobMeta(jobID); err != nil || meta != nil {
+		t.Fatalf("precondition: job should be unknown, got meta=%v err=%v", meta, err)
+	}
+
+	err := queue.MarkJobFailed(jobID, map[string]interface{}{
+		"error":   "Job timed out in processing queue",
+		"timeout": true,
+	})
+	if err != nil {
+		t.Fatalf("mark failed: %v", err)
+	}
+
+	meta, err := queue.GetJobMeta(jobID)
+	if err != nil {
+		t.Fatalf("get job meta: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("a reaped job left no record; the client cannot learn it failed")
+	}
+	if got := meta["status"]; got != "failed" {
+		t.Fatalf("status = %v, want failed", got)
+	}
+	// Recreated records must still expire, or a reaped job leaks a key forever.
+	if ttl := queue.Client.TTL(queue.Ctx, "zk_job_meta_"+jobID).Val(); ttl <= 0 {
+		t.Fatalf("TTL = %v, want a bounded lifetime", ttl)
+	}
+}

--- a/prover/server/status_lookup_test.go
+++ b/prover/server/status_lookup_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestJobStatusStartsQueued(t *testing.T) {
 	queue := setupRedisQueue(t)
+	defer teardownRedisQueue(t, queue)
 	jobID := uuid.NewString()
 
 	if err := queue.StoreJobMeta(jobID, "zk_transfer_queue", "transfer"); err != nil {
@@ -36,6 +37,7 @@ func TestJobStatusStartsQueued(t *testing.T) {
 
 func TestMarkJobProcessingIsVisibleWithoutScanningQueues(t *testing.T) {
 	queue := setupRedisQueue(t)
+	defer teardownRedisQueue(t, queue)
 	jobID := uuid.NewString()
 
 	if err := queue.StoreJobMeta(jobID, "zk_transfer_queue", "transfer"); err != nil {
@@ -64,6 +66,7 @@ func TestMarkJobProcessingIsVisibleWithoutScanningQueues(t *testing.T) {
 
 func TestMarkJobProcessingKeepsTheSubmissionExpiry(t *testing.T) {
 	queue := setupRedisQueue(t)
+	defer teardownRedisQueue(t, queue)
 	jobID := uuid.NewString()
 
 	if err := queue.StoreJobMeta(jobID, "zk_transfer_queue", "transfer"); err != nil {
@@ -87,8 +90,33 @@ func TestMarkJobProcessingKeepsTheSubmissionExpiry(t *testing.T) {
 	}
 }
 
+// A keep-TTL write must never leave a key without an expiry, whatever it finds:
+// a zk_job_meta_* key with no expiry answers "processing" for every later poll
+// of that id, forever.
+//
+// This pins the invariant, not the race that motivated the script. The race --
+// the key expiring between reading its TTL and writing the value -- cannot be
+// staged from a test, since both commands are issued back to back by the same
+// caller; the script removes it by construction rather than by check.
+func TestMarkJobProcessingAlwaysLeavesAnExpiry(t *testing.T) {
+	queue := setupRedisQueue(t)
+	defer teardownRedisQueue(t, queue)
+	jobID := uuid.NewString()
+
+	// No StoreJobMeta first: this is the metadata-already-expired case.
+	if err := queue.MarkJobProcessing(jobID); err != nil {
+		t.Fatalf("mark processing: %v", err)
+	}
+
+	ttl := queue.Client.TTL(queue.Ctx, "zk_job_meta_"+jobID).Val()
+	if ttl <= 0 {
+		t.Fatalf("TTL = %v, want a fresh expiry on a recreated key", ttl)
+	}
+}
+
 func TestMarkJobFailedCarriesTheReason(t *testing.T) {
 	queue := setupRedisQueue(t)
+	defer teardownRedisQueue(t, queue)
 	jobID := uuid.NewString()
 
 	if err := queue.StoreJobMeta(jobID, "zk_transfer_queue", "transfer"); err != nil {
@@ -125,6 +153,7 @@ func TestMarkJobFailedCarriesTheReason(t *testing.T) {
 // minutes against an idle prover.
 func TestMarkJobFailedRecreatesExpiredMetadata(t *testing.T) {
 	queue := setupRedisQueue(t)
+	defer teardownRedisQueue(t, queue)
 	jobID := uuid.NewString()
 
 	if meta, err := queue.GetJobMeta(jobID); err != nil || meta != nil {


### PR DESCRIPTION
Replaces #210, rebased onto `main`. That PR was stacked on `prover/queue-wait-metric` and GitHub's stack feature refused to retarget it, so it is closed in favour of this one; same commits, no conflicts, `go build ./...` and `go vet ./...` clean.

It also carries #202, which is the first of the two commits here. #202 merged into `prover/queue-wait-metric` at 16:32, after #196 had already squashed that branch's content to `main` at 16:25, so its work never reached `main` and would otherwise be lost.

`checkJobExistsDetailed` runs on every `/prove/status` request — the hottest path in the server, since a client polls it from submission until its proof lands — and answered by walking whole Redis lists with `LRANGE key 0 -1`: the job's own queue, then the processing queue, then `zk_failed_queue`, then `zk_results_queue`, unmarshalling every element of each.

A 220-worker load test made it visible. In one ten-minute window:

| | |
|---|---|
| status polls | 34,154 (~57/s) |
| `zk_results_queue` length | 8,237 |
| implied element reads | ~470k/s from a single-threaded Redis |
| Redis `i/o timeout` | 221 |
| `context deadline exceeded` | 81 |

Dispatch stalls behind the same Redis, health checks fail, ECS replaces the tasks, and the jobs in flight on them are orphaned. Throughput held ~24.5 tps for four consecutive 30s windows, then went to 0.00 and stayed there.

This is the fourth instance of the same shape — a linear Redis list scan on a per-job path — after #202 and its two parents. It mattered most, because it is per poll rather than per job.

The scans were there because job metadata was written once at submission with `status: "queued"` and never updated, so `queued` and `processing` could only be told apart by looking in both queues. Failures were worse: the metadata was deleted on failure, leaving `zk_failed_queue` as the only record, so every poll for an unfinished job scanned that too.

The workers now keep the metadata current:

- `MarkJobProcessing` when a job enters the processing queue
- `MarkJobFailed` on every terminal path — proof error, panic, expiry, replayed cached failure, and the stuck-job reaper — carrying the failure details that used to be read back out of the queue entry

That is one `SET` per job against one scan per poll, and polls outnumber jobs by orders of magnitude. The status path is now `GetResult`, already O(1), plus one metadata `GET`.

The reaper case bites if missed: it fails jobs whose metadata may already have expired, so `MarkJobFailed` recreates the record rather than skipping it. Without that, a reaped job is indistinguishable from an unknown one and the client waits out its entire deadline — which is how 197 workers ended up parked for 35 minutes against an idle prover.

`findJobInQueue` and `extractResultFromPayload` are removed along with their last callers.

`TestFailedJobStatusHTTPEndpoint` built its fixture by writing straight into `zk_failed_queue`, which only worked because of the scan; it now fails the job the way the workers do. Five new tests cover the transitions, that picking a job up preserves its submission expiry rather than renewing it, and that a reaped job still leaves a terminal record.

`go build`, `go vet`, `gofmt` and the full `go test ./...` clean.

This removes the collapse. It does not raise the ceiling: `NullifierTreeUpdateFailed` (7002) was 3,145 of 3,474 failures in the same run and is what caps throughput at ~24 tps. That is separate.

