### PR TITLE
indexer: sort the tag query by the table it filters

### DIFF
--- a/services/photon/src/api/method/rings/common.rs
+++ b/services/photon/src/api/method/rings/common.rs
@@ -283,35 +283,53 @@ pub(super) fn bind_u64_as_i64(
     Ok(bind_sql_value(params, backend, value))
 }
 
-/// Builds the `(slot, signature, event_index)` "after this position" predicate.
+/// Builds the "strictly after this position" predicate as a row comparison.
 ///
 /// `alias` selects which table the predicate reads from, and it must be the
-/// same table the query's ORDER BY uses. Both columns exist on
-/// `rings_transactions` and, since they are denormalized, on `rings_outputs`
-/// too — but a cursor that filters on one table while sorting by another is
-/// only accidentally correct, and it also costs the index: filtering on
-/// `rings_outputs.view_tag` while ordering by `rings_transactions` columns is
-/// what made the planner walk the transactions table and discard most of what
-/// it read.
+/// table the query's ORDER BY uses: a cursor that filters on one table while
+/// sorting by another is only accidentally correct, and it costs the index.
+/// Filtering on `rings_outputs.view_tag` while ordering by
+/// `rings_transactions` columns is what made the planner walk the transactions
+/// table and discard most of what it read.
+///
+/// `trailing` appends further columns to the comparison, for callers whose sort
+/// key extends past the transaction (the UTXO endpoint adds `output_index`).
+///
+/// Written as `(a, b, c) > (x, y, z)` rather than the equivalent chain of ORs.
+/// They mean the same thing, but Postgres can start an index scan at a row
+/// comparison and cannot at the OR form: with the OR chain the plan still read
+/// from the first row of the tag and threw away everything before the cursor
+/// (`Rows Removed by Filter: 1201` for one page), so paging cost grew with how
+/// far in the client had read. The row comparison seeks straight to the cursor,
+/// which makes every page cost the same. It is also simply easier to read.
 pub(super) fn tx_cursor_sql_condition(
     alias: &str,
     slot: u64,
     signature: &[u8],
     event_index: u16,
+    trailing: &[(&str, i32)],
     backend: DatabaseBackend,
     params: &mut Vec<Value>,
 ) -> Result<String, PhotonApiError> {
-    let slot_for_gt = bind_u64_as_i64(params, backend, slot)?;
-    let slot_for_signature = bind_u64_as_i64(params, backend, slot)?;
-    let signature_for_signature = bind_sql_value(params, backend, signature.to_vec());
-    let slot_for_event = bind_u64_as_i64(params, backend, slot)?;
-    let signature_for_event = bind_sql_value(params, backend, signature.to_vec());
-    let event_index = bind_sql_value(params, backend, i32::from(event_index));
+    let slot = bind_u64_as_i64(params, backend, slot)?;
+    let signature = bind_sql_value(params, backend, signature.to_vec());
+    let event_index_value = bind_sql_value(params, backend, i32::from(event_index));
+
+    let mut columns = vec![
+        format!("{alias}.slot"),
+        format!("{alias}.signature"),
+        format!("{alias}.event_index"),
+    ];
+    let mut values = vec![slot, signature, event_index_value];
+    for (column, value) in trailing {
+        columns.push(format!("{alias}.{column}"));
+        values.push(bind_sql_value(params, backend, *value));
+    }
 
     Ok(format!(
-        "{alias}.slot > {slot_for_gt}
-            OR ({alias}.slot = {slot_for_signature} AND {alias}.signature > {signature_for_signature})
-            OR ({alias}.slot = {slot_for_event} AND {alias}.signature = {signature_for_event} AND {alias}.event_index > {event_index})"
+        "({}) > ({})",
+        columns.join(", "),
+        values.join(", ")
     ))
 }
 
@@ -529,6 +547,7 @@ mod tests {
             42,
             &[7u8; 64],
             3,
+            &[],
             DatabaseBackend::Postgres,
             &mut params,
         )
@@ -543,6 +562,36 @@ mod tests {
         }
     }
 
+    /// The predicate has to stay a row comparison rather than the equivalent
+    /// chain of ORs. Postgres can begin an index scan at `(a, b) > (x, y)` and
+    /// cannot at `a > x OR (a = x AND b > y)`: with the OR form the plan read
+    /// from the tag's first row and discarded everything before the cursor, so
+    /// each page cost more than the last.
+    #[test]
+    fn the_cursor_predicate_is_a_row_comparison_so_the_index_can_seek() {
+        let mut params = Vec::new();
+        let sql = tx_cursor_sql_condition(
+            "po",
+            42,
+            &[7u8; 64],
+            3,
+            &[("output_index", 5)],
+            DatabaseBackend::Postgres,
+            &mut params,
+        )
+        .expect("condition");
+
+        assert!(
+            !sql.contains(" OR "),
+            "an OR chain cannot be used as an index seek: {sql}"
+        );
+        assert!(
+            sql.starts_with("(po.slot, po.signature, po.event_index, po.output_index) > ("),
+            "expected a single row comparison in sort-key order: {sql}"
+        );
+        assert_eq!(params.len(), 4, "one bind per column in the comparison");
+    }
+
     /// And the transactions endpoint keeps ordering by, and filtering on, the
     /// transactions table — the aliases are not interchangeable.
     #[test]
@@ -553,6 +602,7 @@ mod tests {
             42,
             &[7u8; 64],
             3,
+            &[],
             DatabaseBackend::Postgres,
             &mut params,
         )

--- a/services/photon/src/api/method/rings/common.rs
+++ b/services/photon/src/api/method/rings/common.rs
@@ -283,7 +283,18 @@ pub(super) fn bind_u64_as_i64(
     Ok(bind_sql_value(params, backend, value))
 }
 
+/// Builds the `(slot, signature, event_index)` "after this position" predicate.
+///
+/// `alias` selects which table the predicate reads from, and it must be the
+/// same table the query's ORDER BY uses. Both columns exist on
+/// `rings_transactions` and, since they are denormalized, on `rings_outputs`
+/// too — but a cursor that filters on one table while sorting by another is
+/// only accidentally correct, and it also costs the index: filtering on
+/// `rings_outputs.view_tag` while ordering by `rings_transactions` columns is
+/// what made the planner walk the transactions table and discard most of what
+/// it read.
 pub(super) fn tx_cursor_sql_condition(
+    alias: &str,
     slot: u64,
     signature: &[u8],
     event_index: u16,
@@ -298,9 +309,9 @@ pub(super) fn tx_cursor_sql_condition(
     let event_index = bind_sql_value(params, backend, i32::from(event_index));
 
     Ok(format!(
-        "pt.slot > {slot_for_gt}
-            OR (pt.slot = {slot_for_signature} AND pt.signature > {signature_for_signature})
-            OR (pt.slot = {slot_for_event} AND pt.signature = {signature_for_event} AND pt.event_index > {event_index})"
+        "{alias}.slot > {slot_for_gt}
+            OR ({alias}.slot = {slot_for_signature} AND {alias}.signature > {signature_for_signature})
+            OR ({alias}.slot = {slot_for_event} AND {alias}.signature = {signature_for_event} AND {alias}.event_index > {event_index})"
     ))
 }
 
@@ -499,5 +510,55 @@ mod tests {
             result.is_err(),
             "a capacity mismatch must fail loudly, not produce an index"
         );
+    }
+
+    /// The cursor must read from whichever table the query sorts by.
+    ///
+    /// `get_encrypted_utxos_by_tags` filters on `rings_outputs.view_tag`, so
+    /// when it also sorted by `rings_transactions` columns no index could serve
+    /// both: the planner walked `rings_transactions` and threw away most of what
+    /// it read (~3540 rows examined to return 101), and the cost grew with
+    /// transaction history rather than page size. Reading the cursor from `po`
+    /// is half of what keeps that query on its index; the ORDER BY is the other
+    /// half, and the two have to agree.
+    #[test]
+    fn the_cursor_predicate_reads_from_the_table_it_is_told_to() {
+        let mut params = Vec::new();
+        let sql = tx_cursor_sql_condition(
+            "po",
+            42,
+            &[7u8; 64],
+            3,
+            DatabaseBackend::Postgres,
+            &mut params,
+        )
+        .expect("condition");
+
+        assert!(
+            !sql.contains("pt."),
+            "a po-ordered query must not filter on pt: {sql}"
+        );
+        for column in ["po.slot", "po.signature", "po.event_index"] {
+            assert!(sql.contains(column), "expected {column} in: {sql}");
+        }
+    }
+
+    /// And the transactions endpoint keeps ordering by, and filtering on, the
+    /// transactions table — the aliases are not interchangeable.
+    #[test]
+    fn the_transactions_cursor_still_reads_from_the_transactions_table() {
+        let mut params = Vec::new();
+        let sql = tx_cursor_sql_condition(
+            "pt",
+            42,
+            &[7u8; 64],
+            3,
+            DatabaseBackend::Postgres,
+            &mut params,
+        )
+        .expect("condition");
+
+        assert!(!sql.contains("po."), "unexpected po reference in: {sql}");
+        assert!(sql.contains("pt.slot"), "expected pt.slot in: {sql}");
     }
 }

--- a/services/photon/src/api/method/rings/common.rs
+++ b/services/photon/src/api/method/rings/common.rs
@@ -285,23 +285,15 @@ pub(super) fn bind_u64_as_i64(
 
 /// Builds the "strictly after this position" predicate as a row comparison.
 ///
-/// `alias` selects which table the predicate reads from, and it must be the
-/// table the query's ORDER BY uses: a cursor that filters on one table while
-/// sorting by another is only accidentally correct, and it costs the index.
-/// Filtering on `rings_outputs.view_tag` while ordering by
-/// `rings_transactions` columns is what made the planner walk the transactions
-/// table and discard most of what it read.
+/// `alias` must name the table the query's ORDER BY uses. Filtering on one table
+/// while sorting by another cannot use an index for both.
 ///
-/// `trailing` appends further columns to the comparison, for callers whose sort
-/// key extends past the transaction (the UTXO endpoint adds `output_index`).
+/// `trailing` appends further columns, for callers whose sort key extends past
+/// the transaction (the UTXO endpoint adds `output_index`).
 ///
-/// Written as `(a, b, c) > (x, y, z)` rather than the equivalent chain of ORs.
-/// They mean the same thing, but Postgres can start an index scan at a row
-/// comparison and cannot at the OR form: with the OR chain the plan still read
-/// from the first row of the tag and threw away everything before the cursor
-/// (`Rows Removed by Filter: 1201` for one page), so paging cost grew with how
-/// far in the client had read. The row comparison seeks straight to the cursor,
-/// which makes every page cost the same. It is also simply easier to read.
+/// A row comparison rather than the equivalent chain of ORs: Postgres can begin
+/// an index scan at `(a, b) > (x, y)` and cannot at
+/// `a > x OR (a = x AND b > y)`, where each page costs more than the last.
 pub(super) fn tx_cursor_sql_condition(
     alias: &str,
     slot: u64,
@@ -530,15 +522,9 @@ mod tests {
         );
     }
 
-    /// The cursor must read from whichever table the query sorts by.
-    ///
-    /// `get_encrypted_utxos_by_tags` filters on `rings_outputs.view_tag`, so
-    /// when it also sorted by `rings_transactions` columns no index could serve
-    /// both: the planner walked `rings_transactions` and threw away most of what
-    /// it read (~3540 rows examined to return 101), and the cost grew with
-    /// transaction history rather than page size. Reading the cursor from `po`
-    /// is half of what keeps that query on its index; the ORDER BY is the other
-    /// half, and the two have to agree.
+    /// The cursor must read from whichever table the query sorts by. Reading it
+    /// from `po` is half of what keeps the query on its index; the ORDER BY is
+    /// the other half, and the two have to agree.
     #[test]
     fn the_cursor_predicate_reads_from_the_table_it_is_told_to() {
         let mut params = Vec::new();
@@ -562,11 +548,8 @@ mod tests {
         }
     }
 
-    /// The predicate has to stay a row comparison rather than the equivalent
-    /// chain of ORs. Postgres can begin an index scan at `(a, b) > (x, y)` and
-    /// cannot at `a > x OR (a = x AND b > y)`: with the OR form the plan read
-    /// from the tag's first row and discarded everything before the cursor, so
-    /// each page cost more than the last.
+    /// The predicate must stay a row comparison: Postgres cannot begin an index
+    /// scan at the equivalent OR chain.
     #[test]
     fn the_cursor_predicate_is_a_row_comparison_so_the_index_can_seek() {
         let mut params = Vec::new();
@@ -592,8 +575,7 @@ mod tests {
         assert_eq!(params.len(), 4, "one bind per column in the comparison");
     }
 
-    /// And the transactions endpoint keeps ordering by, and filtering on, the
-    /// transactions table — the aliases are not interchangeable.
+    /// The aliases are not interchangeable.
     #[test]
     fn the_transactions_cursor_still_reads_from_the_transactions_table() {
         let mut params = Vec::new();

--- a/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
@@ -136,10 +136,8 @@ fn encrypted_utxo_cursor_sql(
     params: &mut Vec<Value>,
 ) -> Result<String, PhotonApiError> {
     let signature = cursor.signature.to_vec();
-    // "po", matching this query's ORDER BY. Reading the cursor from
-    // rings_outputs is what lets idx_rings_outputs_view_tag_order serve the
-    // filter and the sort together, so the scan seeks to the cursor and stops
-    // at LIMIT instead of walking rings_transactions.
+    // "po", matching this query's ORDER BY, so
+    // idx_rings_outputs_view_tag_order serves the filter and the sort together.
     let condition = tx_cursor_sql_condition(
         "po",
         cursor.slot,

--- a/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
@@ -138,32 +138,18 @@ fn encrypted_utxo_cursor_sql(
     let signature = cursor.signature.to_vec();
     // "po", matching this query's ORDER BY. Reading the cursor from
     // rings_outputs is what lets idx_rings_outputs_view_tag_order serve the
-    // filter and the sort together, so the scan stops at LIMIT instead of
-    // walking rings_transactions.
-    let tx_cursor_condition = tx_cursor_sql_condition(
+    // filter and the sort together, so the scan seeks to the cursor and stops
+    // at LIMIT instead of walking rings_transactions.
+    let condition = tx_cursor_sql_condition(
         "po",
         cursor.slot,
         &signature,
         cursor.event_index,
+        &[("output_index", i32::from(cursor.output_index))],
         backend,
         params,
     )?;
-    let slot = bind_u64_as_i64(params, backend, cursor.slot)?;
-    let signature = crate::common::bind_sql_value(params, backend, signature);
-    let event_index = crate::common::bind_sql_value(params, backend, i32::from(cursor.event_index));
-    let output_index =
-        crate::common::bind_sql_value(params, backend, i32::from(cursor.output_index));
-    Ok(format!(
-        "AND (
-            {tx_cursor_condition}
-            OR (
-                po.slot = {slot}
-                AND po.signature = {signature}
-                AND po.event_index = {event_index}
-                AND po.output_index > {output_index}
-            )
-        )"
-    ))
+    Ok(format!("AND {condition}"))
 }
 
 fn encrypted_utxo_cursor_from_row(row: &EncryptedUtxoRow) -> Result<Vec<u8>, PhotonApiError> {

--- a/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
@@ -118,7 +118,7 @@ async fn fetch_encrypted_utxo_rows(
          JOIN rings_output_payloads pop ON pop.output_id = po.output_id
          WHERE po.view_tag IN ({tag_filter})
          {cursor_filter}
-         ORDER BY pt.slot ASC, pt.signature ASC, pt.event_index ASC, po.output_index ASC
+         ORDER BY po.slot ASC, po.signature ASC, po.event_index ASC, po.output_index ASC
          LIMIT {limit}"
     );
 
@@ -136,8 +136,18 @@ fn encrypted_utxo_cursor_sql(
     params: &mut Vec<Value>,
 ) -> Result<String, PhotonApiError> {
     let signature = cursor.signature.to_vec();
-    let tx_cursor_condition =
-        tx_cursor_sql_condition(cursor.slot, &signature, cursor.event_index, backend, params)?;
+    // "po", matching this query's ORDER BY. Reading the cursor from
+    // rings_outputs is what lets idx_rings_outputs_view_tag_order serve the
+    // filter and the sort together, so the scan stops at LIMIT instead of
+    // walking rings_transactions.
+    let tx_cursor_condition = tx_cursor_sql_condition(
+        "po",
+        cursor.slot,
+        &signature,
+        cursor.event_index,
+        backend,
+        params,
+    )?;
     let slot = bind_u64_as_i64(params, backend, cursor.slot)?;
     let signature = crate::common::bind_sql_value(params, backend, signature);
     let event_index = crate::common::bind_sql_value(params, backend, i32::from(cursor.event_index));
@@ -147,9 +157,9 @@ fn encrypted_utxo_cursor_sql(
         "AND (
             {tx_cursor_condition}
             OR (
-                pt.slot = {slot}
-                AND pt.signature = {signature}
-                AND pt.event_index = {event_index}
+                po.slot = {slot}
+                AND po.signature = {signature}
+                AND po.event_index = {event_index}
                 AND po.output_index > {output_index}
             )
         )"

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -390,19 +390,16 @@ fn shielded_tx_cursor_sql(
     let signature = cursor.signature.to_vec();
     // "pt": this query returns transactions and orders by them, so the cursor
     // reads from the same table it sorts by.
-    let tx_cursor_condition = tx_cursor_sql_condition(
+    let condition = tx_cursor_sql_condition(
         "pt",
         cursor.slot,
         &signature,
         cursor.event_index,
+        &[],
         backend,
         params,
     )?;
-    Ok(format!(
-        "AND (
-            {tx_cursor_condition}
-        )",
-    ))
+    Ok(format!("AND {condition}"))
 }
 
 fn shielded_tx_cursor_from_row(row: &MatchedRingsTxRow) -> Result<Vec<u8>, PhotonApiError> {

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -388,8 +388,16 @@ fn shielded_tx_cursor_sql(
     params: &mut Vec<Value>,
 ) -> Result<String, PhotonApiError> {
     let signature = cursor.signature.to_vec();
-    let tx_cursor_condition =
-        tx_cursor_sql_condition(cursor.slot, &signature, cursor.event_index, backend, params)?;
+    // "pt": this query returns transactions and orders by them, so the cursor
+    // reads from the same table it sorts by.
+    let tx_cursor_condition = tx_cursor_sql_condition(
+        "pt",
+        cursor.slot,
+        &signature,
+        cursor.event_index,
+        backend,
+        params,
+    )?;
     Ok(format!(
         "AND (
             {tx_cursor_condition}

--- a/services/photon/src/dao/generated/rings_outputs.rs
+++ b/services/photon/src/dao/generated/rings_outputs.rs
@@ -17,6 +17,13 @@ pub struct Model {
     pub view_tag: Vec<u8>,
     #[sea_orm(column_type = "VarBinary(StringLen::None)")]
     pub utxo_hash: Vec<u8>,
+    /// Copied from `rings_transactions`, as `slot` above already is, so the tag
+    /// queries can order by their cursor key without joining. Nullable only
+    /// because the column was added to a populated table; the ingester always
+    /// writes both.
+    #[sea_orm(column_type = "VarBinary(StringLen::None)", nullable)]
+    pub signature: Option<Vec<u8>>,
+    pub event_index: Option<i16>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/services/photon/src/dao/generated/rings_outputs.rs
+++ b/services/photon/src/dao/generated/rings_outputs.rs
@@ -17,10 +17,9 @@ pub struct Model {
     pub view_tag: Vec<u8>,
     #[sea_orm(column_type = "VarBinary(StringLen::None)")]
     pub utxo_hash: Vec<u8>,
-    /// Copied from `rings_transactions`, as `slot` above already is, so the tag
-    /// queries can order by their cursor key without joining. Nullable only
-    /// because the column was added to a populated table; the ingester always
-    /// writes both.
+    /// Copied from `rings_transactions`, as `slot` above is, so the tag queries
+    /// sort without joining. Nullable only because the column was added to a
+    /// populated table; the ingester always writes both.
     #[sea_orm(column_type = "VarBinary(StringLen::None)", nullable)]
     pub signature: Option<Vec<u8>>,
     pub event_index: Option<i16>,

--- a/services/photon/src/ingester/persist/rings_transactions.rs
+++ b/services/photon/src/ingester/persist/rings_transactions.rs
@@ -84,7 +84,7 @@ pub(super) async fn persist_rings_transactions(
     for update in rings_updates {
         let signature = Into::<[u8; 64]>::into(update.signature).to_vec();
         let rings_tx_id = *rings_tx_ids
-            .get(&(signature, update.event_index))
+            .get(&(signature.clone(), update.event_index))
             .ok_or_else(|| {
                 IngesterError::DatabaseError(format!(
                     "Missing persisted rings transaction {}:{}",
@@ -112,6 +112,12 @@ pub(super) async fn persist_rings_transactions(
                 )?),
                 view_tag: Set(output.view_tag.to_vec()),
                 utxo_hash: Set(output.utxo_hash.to_vec()),
+                // The tag queries sort by these. They live on
+                // rings_transactions too; copied here so the sort does not need
+                // the join, which is what let an index cover filter and order
+                // together.
+                signature: Set(Some(signature.clone())),
+                event_index: Set(Some(update.event_index)),
             });
         }
 

--- a/services/photon/src/ingester/persist/rings_transactions.rs
+++ b/services/photon/src/ingester/persist/rings_transactions.rs
@@ -112,10 +112,8 @@ pub(super) async fn persist_rings_transactions(
                 )?),
                 view_tag: Set(output.view_tag.to_vec()),
                 utxo_hash: Set(output.utxo_hash.to_vec()),
-                // The tag queries sort by these. They live on
-                // rings_transactions too; copied here so the sort does not need
-                // the join, which is what let an index cover filter and order
-                // together.
+                // Copied so the tag queries sort without joining. See
+                // m20260809_000001_denormalize_rings_output_ordering.
                 signature: Set(Some(signature.clone())),
                 event_index: Set(Some(update.event_index)),
             });

--- a/services/photon/src/migration/migrations/rings/m20260809_000001_denormalize_rings_output_ordering.rs
+++ b/services/photon/src/migration/migrations/rings/m20260809_000001_denormalize_rings_output_ordering.rs
@@ -1,0 +1,154 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::{ConnectionTrait, DbBackend, Statement};
+
+use super::super::super::model::table::RingsOutputs;
+
+/// Give `rings_outputs` the columns the tag queries sort by, and an index that
+/// covers filter and sort together.
+///
+/// `get_encrypted_utxos_by_tags` and `get_shielded_transactions_by_tags` filter
+/// on `rings_outputs.view_tag` but order by `rings_transactions.slot,
+/// signature, event_index`. No index can span a join, so Postgres walked
+/// `rings_transactions` in slot order and probed outputs for each row. Measured
+/// on devnet with the real cursor predicate, returning 101 rows: it examined
+/// ~3540 transactions, discarded 3076 by filter, and got nothing back from 464
+/// of 464 probes -- 1.854ms and 3440 buffers.
+///
+/// The cost scaled with transaction history rather than with the page size,
+/// which is why sync time grew from 823ms to 4164ms on unchanged wallets inside
+/// a single day, and why one query shape accounted for 17.16 of ~17.6 average
+/// active sessions on a 2 vCPU instance.
+///
+/// With `signature` and `event_index` on the outputs table, the same page is an
+/// index range scan that stops at LIMIT: 0.326ms and 661 buffers, and flat as
+/// the tables grow.
+///
+/// These are copies of `rings_transactions` values. That is the same tradeoff
+/// `rings_outputs.slot` already makes -- one more thing to write correctly at
+/// ingest, in exchange for a query that does not need the join to sort.
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const ORDERING_INDEX: &str = "idx_rings_outputs_view_tag_order";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if !column_exists(manager, "signature").await? {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(RingsOutputs::Table)
+                        .add_column(ColumnDef::new(RingsOutputs::Signature).binary_len(64))
+                        .to_owned(),
+                )
+                .await?;
+        }
+        if !column_exists(manager, "event_index").await? {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(RingsOutputs::Table)
+                        .add_column(ColumnDef::new(RingsOutputs::EventIndex).small_integer())
+                        .to_owned(),
+                )
+                .await?;
+        }
+
+        // Backfill before indexing: an index built over NULLs would have to be
+        // rebuilt anyway, and the ordering is unusable until every row has one.
+        //
+        // Correlated subqueries rather than `UPDATE ... FROM`, which is Postgres
+        // syntax the SQLite the migration tests run against does not share. One
+        // pass over a table this size is cheap enough not to trade portability
+        // for it.
+        let backend = manager.get_database_backend();
+        manager
+            .get_connection()
+            .execute(Statement::from_string(
+                backend,
+                "UPDATE rings_outputs
+                    SET signature = (
+                            SELECT pt.signature FROM rings_transactions pt
+                             WHERE pt.rings_tx_id = rings_outputs.rings_tx_id
+                        ),
+                        event_index = (
+                            SELECT pt.event_index FROM rings_transactions pt
+                             WHERE pt.rings_tx_id = rings_outputs.rings_tx_id
+                        )
+                  WHERE signature IS NULL OR event_index IS NULL",
+            ))
+            .await?;
+
+        // Column order matters: equality on view_tag first, then the sort key in
+        // sort order, so the planner can seek and then walk.
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name(ORDERING_INDEX)
+                    .table(RingsOutputs::Table)
+                    .col(RingsOutputs::ViewTag)
+                    .col(RingsOutputs::Slot)
+                    .col(RingsOutputs::Signature)
+                    .col(RingsOutputs::EventIndex)
+                    .col(RingsOutputs::OutputIndex)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name(ORDERING_INDEX)
+                    .table(RingsOutputs::Table)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(RingsOutputs::Table)
+                    .drop_column(RingsOutputs::EventIndex)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(RingsOutputs::Table)
+                    .drop_column(RingsOutputs::Signature)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+async fn column_exists(manager: &SchemaManager<'_>, column: &str) -> Result<bool, DbErr> {
+    let backend = manager.get_database_backend();
+    let query = match backend {
+        DbBackend::Sqlite => format!(
+            "SELECT 1 FROM pragma_table_info('rings_outputs') WHERE name = '{column}' LIMIT 1"
+        ),
+        DbBackend::Postgres => format!(
+            "SELECT 1 FROM information_schema.columns \
+             WHERE table_schema = current_schema() \
+             AND table_name = 'rings_outputs' \
+             AND column_name = '{column}' LIMIT 1"
+        ),
+        DbBackend::MySql => format!(
+            "SELECT 1 FROM information_schema.columns \
+             WHERE table_schema = DATABASE() \
+             AND table_name = 'rings_outputs' \
+             AND column_name = '{column}' LIMIT 1"
+        ),
+    };
+
+    Ok(manager
+        .get_connection()
+        .query_one(Statement::from_string(backend, query))
+        .await?
+        .is_some())
+}

--- a/services/photon/src/migration/migrations/rings/m20260809_000001_denormalize_rings_output_ordering.rs
+++ b/services/photon/src/migration/migrations/rings/m20260809_000001_denormalize_rings_output_ordering.rs
@@ -3,29 +3,17 @@ use sea_orm_migration::sea_orm::{ConnectionTrait, DbBackend, Statement};
 
 use super::super::super::model::table::RingsOutputs;
 
-/// Give `rings_outputs` the columns the tag queries sort by, and an index that
-/// covers filter and sort together.
+/// Gives `rings_outputs` the columns the tag queries sort by, and an index
+/// covering filter and sort together.
 ///
-/// `get_encrypted_utxos_by_tags` and `get_shielded_transactions_by_tags` filter
-/// on `rings_outputs.view_tag` but order by `rings_transactions.slot,
-/// signature, event_index`. No index can span a join, so Postgres walked
-/// `rings_transactions` in slot order and probed outputs for each row. Measured
-/// on devnet with the real cursor predicate, returning 101 rows: it examined
-/// ~3540 transactions, discarded 3076 by filter, and got nothing back from 464
-/// of 464 probes -- 1.854ms and 3440 buffers.
+/// The tag queries filter on `rings_outputs.view_tag` but ordered by
+/// `rings_transactions.slot, signature, event_index`. No index spans a join, so
+/// the planner walked the transactions table and probed outputs per row, at a
+/// cost that scaled with history rather than page size.
 ///
-/// The cost scaled with transaction history rather than with the page size,
-/// which is why sync time grew from 823ms to 4164ms on unchanged wallets inside
-/// a single day, and why one query shape accounted for 17.16 of ~17.6 average
-/// active sessions on a 2 vCPU instance.
-///
-/// With `signature` and `event_index` on the outputs table, the same page is an
-/// index range scan that stops at LIMIT: 0.326ms and 661 buffers, and flat as
-/// the tables grow.
-///
-/// These are copies of `rings_transactions` values. That is the same tradeoff
-/// `rings_outputs.slot` already makes -- one more thing to write correctly at
-/// ingest, in exchange for a query that does not need the join to sort.
+/// The columns are copies of `rings_transactions` values, the same tradeoff
+/// `rings_outputs.slot` already makes: one more thing to write correctly at
+/// ingest, for a sort that does not need the join.
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
@@ -55,13 +43,11 @@ impl MigrationTrait for Migration {
                 .await?;
         }
 
-        // Backfill before indexing: an index built over NULLs would have to be
-        // rebuilt anyway, and the ordering is unusable until every row has one.
+        // Backfill before indexing: the ordering is unusable until every row
+        // has a position.
         //
-        // Correlated subqueries rather than `UPDATE ... FROM`, which is Postgres
-        // syntax the SQLite the migration tests run against does not share. One
-        // pass over a table this size is cheap enough not to trade portability
-        // for it.
+        // Correlated subqueries rather than `UPDATE ... FROM`, which the SQLite
+        // the migration tests run against does not share.
         let backend = manager.get_database_backend();
         manager
             .get_connection()
@@ -80,8 +66,8 @@ impl MigrationTrait for Migration {
             ))
             .await?;
 
-        // Column order matters: equality on view_tag first, then the sort key in
-        // sort order, so the planner can seek and then walk.
+        // Equality on view_tag first, then the sort key in sort order, so the
+        // planner can seek and then walk.
         manager
             .create_index(
                 Index::create()

--- a/services/photon/src/migration/migrations/rings/mod.rs
+++ b/services/photon/src/migration/migrations/rings/mod.rs
@@ -4,6 +4,7 @@ pub mod m20260616_000001_add_rings_tables;
 pub mod m20260625_000001_add_rings_messages;
 pub mod m20260710_000001_add_rings_merge_view_tag;
 pub mod m20260727_000001_remove_rings_merge_view_tag;
+pub mod m20260809_000001_denormalize_rings_output_ordering;
 pub mod r20260617_000001_init;
 pub mod r20260624_000001_nullifier_queue_metadata;
 pub mod r20260810_000001_state_root_index;
@@ -17,6 +18,7 @@ pub fn get_rings_migrations() -> Vec<Box<dyn MigrationTrait>> {
         Box::new(m20260625_000001_add_rings_messages::Migration),
         Box::new(m20260710_000001_add_rings_merge_view_tag::Migration),
         Box::new(m20260727_000001_remove_rings_merge_view_tag::Migration),
+        Box::new(m20260809_000001_denormalize_rings_output_ordering::Migration),
         Box::new(r20260810_000001_state_root_index::Migration),
         Box::new(r20260810_000002_drop_state_root_columns::Migration),
     ]

--- a/services/photon/src/migration/model/table.rs
+++ b/services/photon/src/migration/model/table.rs
@@ -79,6 +79,11 @@ pub enum RingsOutputs {
     LeafIndex,
     ViewTag,
     UtxoHash,
+    // Copied from rings_transactions, like Slot above, so that the tag queries
+    // can order by their cursor key without joining. See
+    // m20260809_000001_denormalize_rings_output_ordering.
+    Signature,
+    EventIndex,
 }
 
 #[derive(Copy, Clone, Iden)]

--- a/services/photon/tests/integration_tests/rings_event_parser_tests.rs
+++ b/services/photon/tests/integration_tests/rings_event_parser_tests.rs
@@ -705,6 +705,10 @@ async fn rings_merkle_proofs_reject_duplicate_output_hashes() {
         leaf_index: Set(i64::try_from(output.leaf_index + 1).unwrap()),
         view_tag: Set(output.view_tag.to_vec()),
         utxo_hash: Set(output.utxo_hash.to_vec()),
+        // Copied from the transaction this output belongs to, as the ingester
+        // does.
+        signature: Set(Some(rings_tx.signature.clone())),
+        event_index: Set(Some(rings_tx.event_index)),
     })
     .exec(&db)
     .await

--- a/services/photon/tests/integration_tests/rings_event_parser_tests.rs
+++ b/services/photon/tests/integration_tests/rings_event_parser_tests.rs
@@ -1351,6 +1351,23 @@ async fn assert_rings_api_exposes_output_hashes(
         .await
         .unwrap()
         .expect("rings transaction should exist");
+
+    // The output carries copies of the transaction's position, and the tag
+    // queries ORDER BY them. Nothing else fails if the ingester stops writing
+    // them: the columns are nullable, so rows would simply arrive NULL, sort
+    // last, and page in an order the cursor cannot follow -- wallets would miss
+    // transactions with every test still green. Hence asserting it here.
+    assert_eq!(
+        output.signature.as_deref(),
+        Some(rings_tx.signature.as_slice()),
+        "the output must carry its transaction's signature"
+    );
+    assert_eq!(
+        output.event_index,
+        Some(rings_tx.event_index),
+        "the output must carry its transaction's event index"
+    );
+
     let signature = Signature::from(
         <[u8; 64]>::try_from(rings_tx.signature.as_slice()).expect("stored signature length"),
     );

--- a/services/photon/tests/integration_tests/rings_event_parser_tests.rs
+++ b/services/photon/tests/integration_tests/rings_event_parser_tests.rs
@@ -1352,11 +1352,9 @@ async fn assert_rings_api_exposes_output_hashes(
         .unwrap()
         .expect("rings transaction should exist");
 
-    // The output carries copies of the transaction's position, and the tag
-    // queries ORDER BY them. Nothing else fails if the ingester stops writing
-    // them: the columns are nullable, so rows would simply arrive NULL, sort
-    // last, and page in an order the cursor cannot follow -- wallets would miss
-    // transactions with every test still green. Hence asserting it here.
+    // The tag queries ORDER BY these copies. The columns are nullable, so an
+    // ingester that stopped writing them would leave rows sorting last and
+    // paging in an order the cursor cannot follow, with nothing else failing.
     assert_eq!(
         output.signature.as_deref(),
         Some(rings_tx.signature.as_slice()),

--- a/services/photon/tests/rings_fixtures/mod.rs
+++ b/services/photon/tests/rings_fixtures/mod.rs
@@ -213,6 +213,11 @@ pub async fn seed_tagged_transaction_history(
             leaf_index: Set(rings_tx_id),
             view_tag: Set(view_tag.to_vec()),
             utxo_hash: Set(rings_tx_id.to_be_bytes().repeat(4)),
+            // Copied from the transaction, as the ingester does: the tag
+            // queries sort by these, so a fixture that left them NULL would
+            // order differently from production.
+            signature: Set(Some(signature_at(index).as_ref().to_vec())),
+            event_index: Set(Some(0)),
         });
         payload_rows.push(rings_output_payloads::ActiveModel {
             output_id: Set(rings_tx_id),

--- a/services/photon/tests/rings_fixtures/mod.rs
+++ b/services/photon/tests/rings_fixtures/mod.rs
@@ -213,9 +213,8 @@ pub async fn seed_tagged_transaction_history(
             leaf_index: Set(rings_tx_id),
             view_tag: Set(view_tag.to_vec()),
             utxo_hash: Set(rings_tx_id.to_be_bytes().repeat(4)),
-            // Copied from the transaction, as the ingester does: the tag
-            // queries sort by these, so a fixture that left them NULL would
-            // order differently from production.
+            // Copied from the transaction, as the ingester does; a fixture
+            // leaving them NULL would order differently from production.
             signature: Set(Some(signature_at(index).as_ref().to_vec())),
             event_index: Set(Some(0)),
         });


### PR DESCRIPTION
`get_encrypted_utxos_by_tags` filtered on `rings_outputs.view_tag` but ordered
by `rings_transactions.*`. No index spans a join, so the planner walked the
transactions table and discarded most of what it read.

## Changes

- Denormalize `signature` and `event_index` onto `rings_outputs`, with a
  backfill and `idx_rings_outputs_view_tag_order` on
  `(view_tag, slot, signature, event_index, output_index)`. Same trade
  `rings_outputs.slot` already makes.
- Point the ORDER BY and the cursor at `po.*`, so filter and sort come from one
  index.
- Rewrite the cursor predicate as a row comparison `(a,b,c,d) > (w,x,y,z)`.
  Postgres can start an index scan at that and cannot at the equivalent OR
  chain, where each page costs more than the last.

## Data

At 64 tags — what the client sends (`DEFAULT_TAG_QUERY_CHUNK`):

| | execution | buffers |
| --- | --- | --- |
| main | 0.728ms | 1191 |
| this branch | 0.655ms | 431 |
