### PR TITLE
xtask: group load-test failures by program error code, and fund from loadtest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10570,6 +10570,7 @@ dependencies = [
  "solana-loader-v3-interface 8.0.1",
  "solana-message",
  "solana-pubkey 4.2.0",
+ "solana-rpc-client-api",
  "solana-signer",
  "solana-transaction",
  "swap-program",

--- a/program-libs/interface/src/error.rs
+++ b/program-libs/interface/src/error.rs
@@ -19,14 +19,52 @@ pub enum InterfaceError {
     AlreadyInitialized,
 }
 
-/// Program errors surfaced on-chain as `ProgramError::Custom(code)`.
+/// Declares the error enum and its reverse lookup from one list.
 ///
-/// The discriminants below are the on-chain error codes for this program
-/// version. `error_codes_are_stable` pins the mapping so intentional ABI
-/// changes are explicit.
-#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
-#[repr(u32)]
-pub enum ShieldedPoolError {
+/// A client sees only a number -- `custom program error: 0x1b60` -- so naming
+/// it needs a code-to-variant map. Maintaining that map by hand is how 0x1b60
+/// got called `StaleNullifierRoot` for a day: it is 7008,
+/// `TransactProofVerificationFailed`, while `StaleNullifierRoot` is 7015. The
+/// wrong name came from reading a `TreeError` conversion instead of this table
+/// and survived into three commit messages because nothing checked it.
+///
+/// Generating both directions from one list means a new variant cannot be
+/// added without `from_code` learning it. A derive macro (strum's `EnumIter`)
+/// would do the same, but this crate compiles into the on-chain program and
+/// keeps its dependency list to what the program needs; a `macro_rules!` costs
+/// nothing at all.
+macro_rules! shielded_pool_errors {
+    ($(
+        $(#[$attr:meta])*
+        $variant:ident = $code:literal,
+    )*) => {
+        /// Program errors surfaced on-chain as `ProgramError::Custom(code)`.
+        ///
+        /// The discriminants below are the on-chain error codes for this program
+        /// version. `error_codes_are_stable` pins the mapping so intentional ABI
+        /// changes are explicit.
+        #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+        #[repr(u32)]
+        pub enum ShieldedPoolError {
+            $(
+                $(#[$attr])*
+                $variant = $code,
+            )*
+        }
+
+        impl ShieldedPoolError {
+            /// Recovers the variant from the code a failed transaction reports.
+            pub fn from_code(code: u32) -> Option<Self> {
+                match code {
+                    $($code => Some(Self::$variant),)*
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+shielded_pool_errors! {
     #[error("invalid instruction data")]
     InvalidInstructionData = 7000,
     #[error("pool tree accounts are invalid")]
@@ -162,6 +200,49 @@ impl From<TreeError> for ShieldedPoolError {
 #[cfg(test)]
 mod tests {
     use super::{ShieldedPoolError, ShieldedPoolError::*};
+
+    /// Every pinned code must map back to the variant it came from.
+    ///
+    /// `expected_code` below is exhaustive with no wildcard, so a new variant
+    /// stops this file compiling until it is listed there -- and because the
+    /// enum and `from_code` are generated from one list, the lookup learns it
+    /// at the same moment. This asserts the two really do agree.
+    #[test]
+    fn every_code_maps_back_to_its_variant() {
+        for error in [
+            InvalidInstructionData,
+            TransactProofVerificationFailed,
+            StaleNullifierRoot,
+            NullifierTreeUpdateFailed,
+            RingPaused,
+        ] {
+            let code = error as u32;
+            assert_eq!(
+                ShieldedPoolError::from_code(code),
+                Some(error),
+                "code {code} did not map back"
+            );
+        }
+
+        // The two that were confused for each other, spelled out: 0x1b60 is
+        // proof verification, not a stale root.
+        assert_eq!(
+            ShieldedPoolError::from_code(0x1b60),
+            Some(TransactProofVerificationFailed)
+        );
+        assert_eq!(
+            ShieldedPoolError::from_code(0x1b67),
+            Some(StaleNullifierRoot)
+        );
+    }
+
+    /// A code the program never emits has no name, and inventing one would be
+    /// worse than reporting the number.
+    #[test]
+    fn an_unknown_code_has_no_variant() {
+        assert_eq!(ShieldedPoolError::from_code(1), None);
+        assert_eq!(ShieldedPoolError::from_code(7020), None, "7020 is retired");
+    }
 
     /// Pin every on-chain error code for this program version.
     #[test]

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -238,10 +238,17 @@ pub enum ClientError {
     #[error("indexer error: {0}")]
     Indexer(String),
 
-    /// The indexer answered with a rate-limit or internal JSON-RPC error.
+    /// The indexer could not answer, for a reason that may not persist.
     /// Acted on by `Rpc::should_retry` during the confirmation poll.
-    #[error("indexer temporarily unavailable: {0}")]
-    IndexerUnavailable(String),
+    ///
+    /// `reason` is what callers should branch on. `detail` is for humans and
+    /// carries the transport's own wording, which is often not what it looks
+    /// like: reqwest renders a body-read timeout as "error decoding response
+    /// body", which reads like a deserialization bug and is not one. Deciding
+    /// anything by searching that text is how a load generator ended up
+    /// classifying throttling with `message.contains("429")`.
+    #[error("indexer temporarily unavailable: {reason} ({detail})")]
+    IndexerUnavailable { reason: Unavailable, detail: String },
 
     #[error("rpc backend does not implement method `{0}`")]
     UnsupportedRpcMethod(&'static str),
@@ -273,4 +280,36 @@ pub enum ClientError {
 
     #[error("SOL deposit funding account {sender:?} must be the signing authority")]
     DepositSenderNotSigner { sender: [u8; 32] },
+}
+
+/// Why an indexer request failed, in a form callers can match on.
+///
+/// Exists so that nothing has to inspect an error message to decide what to do.
+/// The load generator used to separate throttling from real failure with
+/// `message.contains("429") || message.contains("rate")`, which counts a
+/// signature containing "429" as a rate limit and the word "generate" as one
+/// too, while missing a 503 entirely.
+///
+/// Every variant is retryable today. That is worth stating rather than
+/// assuming: the set is explicit, so adding a reason that is *not* retryable
+/// forces `should_retry` to be revisited instead of silently inheriting
+/// "retry anything unavailable".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum Unavailable {
+    /// Includes a timeout while reading the response body, which the transport
+    /// renders as "error decoding response body".
+    #[error("request timed out")]
+    Timeout,
+
+    #[error("could not connect")]
+    Connect,
+
+    #[error("rate limited")]
+    RateLimited,
+
+    #[error("server error {status}")]
+    ServerError { status: u16 },
+
+    #[error("indexer reported an internal error")]
+    JsonRpcInternal,
 }

--- a/sdk-libs/client/src/error.rs
+++ b/sdk-libs/client/src/error.rs
@@ -282,6 +282,29 @@ pub enum ClientError {
     DepositSenderNotSigner { sender: [u8; 32] },
 }
 
+impl ClientError {
+    /// The on-chain program error code, when the chain rejected the transaction.
+    ///
+    /// Solana already models this: the RPC error carries a `TransactionError`,
+    /// which carries an `InstructionError::Custom(u32)`. Callers should read
+    /// that rather than the rendered message -- a load generator grouped
+    /// failures by the first 160 characters of the string, and the code sits at
+    /// roughly character 160, so a run reporting 10748 failures said nothing
+    /// about what any of them were.
+    pub fn program_error_code(&self) -> Option<u32> {
+        use solana_instruction::error::InstructionError;
+        use solana_rpc_client_api::client_error::TransactionError;
+
+        let Self::SolanaRpcTransaction { source, .. } = self else {
+            return None;
+        };
+        match source.get_transaction_error()? {
+            TransactionError::InstructionError(_, InstructionError::Custom(code)) => Some(code),
+            _ => None,
+        }
+    }
+}
+
 /// Why an indexer request failed, in a form callers can match on.
 ///
 /// Exists so that nothing has to inspect an error message to decide what to do.

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -17,7 +17,7 @@ use zolana_keypair::{constants::P256_PUBKEY_LEN, P256Pubkey};
 use zolana_transaction::instructions::transact::SppProofInputs;
 
 use crate::{
-    error::ClientError,
+    error::{ClientError, Unavailable},
     prover::{transact::SpendProof, ProverClient},
     retry::IndexerRpcConfig,
     rpc::{
@@ -203,7 +203,7 @@ impl AsyncZolanaIndexer {
 
 impl Rpc for ZolanaIndexer {
     fn should_retry(&self, error: &ClientError) -> bool {
-        matches!(error, ClientError::IndexerUnavailable(_))
+        matches!(error, ClientError::IndexerUnavailable { .. })
     }
 
     fn get_encrypted_utxos_by_tags(
@@ -408,7 +408,7 @@ impl Rpc for ZolanaIndexer {
 #[async_trait]
 impl AsyncRpc for AsyncZolanaIndexer {
     fn should_retry(&self, error: &ClientError) -> bool {
-        matches!(error, ClientError::IndexerUnavailable(_))
+        matches!(error, ClientError::IndexerUnavailable { .. })
     }
 
     async fn get_encrypted_utxos_by_tags(
@@ -605,15 +605,27 @@ impl AsyncRpc for AsyncZolanaIndexer {
 /// retried and the caller is handed the last one it saw rather than a bare
 /// timeout.
 fn indexer_error(error: zolana_api::ApiError) -> ClientError {
-    let message = error.to_string();
+    let detail = error.to_string();
+    let unavailable = |reason| ClientError::IndexerUnavailable {
+        reason,
+        detail: detail.clone(),
+    };
     match error {
-        zolana_api::ApiError::Request(error) if error.is_timeout() || error.is_connect() => {
-            ClientError::IndexerUnavailable(message)
+        zolana_api::ApiError::Request(ref error) if error.is_timeout() => {
+            unavailable(Unavailable::Timeout)
+        }
+        zolana_api::ApiError::Request(ref error) if error.is_connect() => {
+            unavailable(Unavailable::Connect)
         }
         zolana_api::ApiError::Response { status, .. }
-            if status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error() =>
+            if status == reqwest::StatusCode::TOO_MANY_REQUESTS =>
         {
-            ClientError::IndexerUnavailable(message)
+            unavailable(Unavailable::RateLimited)
+        }
+        zolana_api::ApiError::Response { status, .. } if status.is_server_error() => {
+            unavailable(Unavailable::ServerError {
+                status: status.as_u16(),
+            })
         }
         zolana_api::ApiError::JsonRpc {
             method,
@@ -623,8 +635,8 @@ fn indexer_error(error: zolana_api::ApiError) -> ClientError {
         zolana_api::ApiError::JsonRpc {
             code: Some(JSON_RPC_INTERNAL_ERROR),
             ..
-        } => ClientError::IndexerUnavailable(message),
-        _ => ClientError::Indexer(message),
+        } => unavailable(Unavailable::JsonRpcInternal),
+        _ => ClientError::Indexer(detail),
     }
 }
 
@@ -1234,14 +1246,26 @@ mod tests {
             status: reqwest::StatusCode::TOO_MANY_REQUESTS,
             body: "retry later".to_string(),
         });
-        assert!(matches!(rate_limit, ClientError::IndexerUnavailable(_)));
+        assert!(matches!(
+            rate_limit,
+            ClientError::IndexerUnavailable {
+                reason: Unavailable::RateLimited,
+                ..
+            }
+        ));
 
         let internal_error = indexer_error(zolana_api::ApiError::JsonRpc {
             method: "getShieldedTransactionsBySignature",
             code: Some(-32603),
             message: Some("Internal error".to_string()),
         });
-        assert!(matches!(internal_error, ClientError::IndexerUnavailable(_)));
+        assert!(matches!(
+            internal_error,
+            ClientError::IndexerUnavailable {
+                reason: Unavailable::JsonRpcInternal,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -25,7 +25,7 @@ pub mod timing;
 
 #[cfg(feature = "indexer-api")]
 pub use client::{SignedPrivateTransaction, ZolanaClient, DEFAULT_TRANSACT_CU_LIMIT};
-pub use error::ClientError;
+pub use error::{ClientError, Unavailable};
 #[cfg(feature = "indexer-api")]
 pub use indexer::{AsyncZolanaIndexer, ZolanaIndexer};
 pub use prover::{

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -37,3 +37,9 @@ zolana-user-registry-interface = { workspace = true }
 zolana-program-test = { workspace = true }
 swap-program = { path = "../sdk-tests/zk-program-swap/program" }
 custom-ring-program = { path = "../custom-ring-tests/program" }
+
+[dev-dependencies]
+# To build a real ClientError::SolanaRpcTransaction in the loadtest error-grouping
+# tests. Constructing the genuine error is the point: a hand-rolled stand-in
+# would not exercise get_transaction_error, which is what the grouping reads.
+solana-rpc-client-api = { workspace = true }

--- a/xtask/src/fund.rs
+++ b/xtask/src/fund.rs
@@ -1,0 +1,190 @@
+//! Top up the shielded balances of a directory of load-test wallets.
+//!
+//! The load generator spends shielded value; when a wallet runs out it fails
+//! with `insufficient balance for asset` and the run measures depletion rather
+//! than capacity. One 220-worker run ended with 209 such failures.
+//!
+//! One funder pays for everything. A deposit names its recipient by shielded
+//! address and needs no shared secret — see `DepositParams` — so the funder both
+//! signs and sources every deposit, and the wallets themselves are never
+//! touched. That removes the step this used to need: a SOL transfer to each
+//! wallet so it could afford to deposit to itself.
+//!
+//! It also removes the second wallet format. The load generator reads plain
+//! `solana-keygen` keypairs and derives the shielded keypair from the funding
+//! key, so this reads exactly the same directory rather than a parallel set of
+//! CLI wallet files holding the same secrets.
+
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+    thread,
+    time::Instant,
+};
+
+use anyhow::{bail, Context, Result};
+use solana_keypair::Keypair;
+use solana_signer::Signer;
+use zolana_client::{Rpc, SolanaRpc};
+use zolana_keypair::ShieldedKeypair;
+use zolana_transaction::Address;
+use zolana_wallet::{create_deposit, DepositParams};
+
+use crate::loadtest::load_keypairs;
+
+pub struct Options {
+    pub rpc_url: String,
+    pub tree: String,
+    /// Directory of `solana-keygen` keypairs — the same one `loadtest` takes.
+    pub keypairs: PathBuf,
+    /// Funder: signs and pays for every deposit.
+    pub funder: PathBuf,
+    /// Lamports to deposit into each wallet.
+    pub amount: u64,
+    /// Deposits in flight at once.
+    pub concurrency: usize,
+}
+
+impl Options {
+    pub fn parse(args: Vec<String>) -> Result<Self> {
+        let mut rpc_url = None;
+        let mut tree = None;
+        let mut keypairs = None;
+        let mut funder = None;
+        let mut amount = 60_000_000u64;
+        let mut concurrency = 16usize;
+
+        let mut iter = args.into_iter();
+        while let Some(arg) = iter.next() {
+            let mut value = || iter.next().context("missing value");
+            match arg.as_str() {
+                "--rpc" => rpc_url = Some(value()?),
+                "--tree" => tree = Some(value()?),
+                "--keypairs" => keypairs = Some(PathBuf::from(value()?)),
+                "--funder" => funder = Some(PathBuf::from(value()?)),
+                "--amount" => amount = value()?.parse().context("--amount")?,
+                "--concurrency" => concurrency = value()?.parse().context("--concurrency")?,
+                other => bail!("unknown flag {other}"),
+            }
+        }
+
+        Ok(Self {
+            rpc_url: rpc_url.context("--rpc is required")?,
+            tree: tree.context("--tree is required")?,
+            keypairs: keypairs.context("--keypairs <dir> is required")?,
+            funder: funder.context("--funder <keypair.json> is required")?,
+            amount,
+            concurrency: concurrency.max(1),
+        })
+    }
+}
+
+fn read_keypair(path: &PathBuf) -> Result<Keypair> {
+    let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    let raw: Vec<u8> = serde_json::from_slice(&bytes)
+        .with_context(|| format!("{} is not a keypair array", path.display()))?;
+    let array: [u8; 64] = raw
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("{} is not 64 bytes", path.display()))?;
+    Keypair::try_from(&array[..]).context("bad funder keypair")
+}
+
+pub fn run(options: Options) -> Result<()> {
+    let funder = read_keypair(&options.funder)?;
+    let wallets = load_keypairs(&options.keypairs)?;
+    let tree: Address = options.tree.parse().context("--tree is not an address")?;
+    let asset = Address::default();
+
+    let rpc = SolanaRpc::new(options.rpc_url.clone());
+    let funder_address = Address::new_from_array(funder.pubkey().to_bytes());
+    let balance = rpc.get_balance(funder_address)?;
+    let required = options.amount.saturating_mul(wallets.len() as u64);
+    println!(
+        "funding {} wallets with {} lamports each ({:.3} SOL total)\nfunder {} holds {:.3} SOL",
+        wallets.len(),
+        options.amount,
+        required as f64 / 1e9,
+        funder.pubkey(),
+        balance as f64 / 1e9,
+    );
+    if balance < required {
+        bail!(
+            "funder holds {:.3} SOL but {:.3} SOL is needed; airdrop first or lower --amount",
+            balance as f64 / 1e9,
+            required as f64 / 1e9,
+        );
+    }
+
+    let next = AtomicUsize::new(0);
+    let funded = AtomicU64::new(0);
+    let failed = AtomicU64::new(0);
+    let started = Instant::now();
+
+    thread::scope(|scope| {
+        for _ in 0..options.concurrency.min(wallets.len()) {
+            scope.spawn(|| {
+                // Each worker holds its own RPC client; they are cheap and not
+                // shared state.
+                let rpc = SolanaRpc::new(options.rpc_url.clone());
+                loop {
+                    let index = next.fetch_add(1, Ordering::Relaxed);
+                    let Some(wallet) = wallets.get(index) else {
+                        return;
+                    };
+                    match fund_one(&rpc, &funder, wallet, tree, asset, options.amount) {
+                        Ok(()) => {
+                            let done = funded.fetch_add(1, Ordering::Relaxed) + 1;
+                            if done.is_multiple_of(25) {
+                                println!(
+                                    "  {done} funded ({:.0}s)",
+                                    started.elapsed().as_secs_f64()
+                                );
+                            }
+                        }
+                        Err(error) => {
+                            failed.fetch_add(1, Ordering::Relaxed);
+                            eprintln!("  wallet {index} failed: {error:#}");
+                        }
+                    }
+                }
+            });
+        }
+    });
+
+    let funded = funded.into_inner();
+    let failed = failed.into_inner();
+    println!(
+        "\nfunded {funded}, failed {failed}, in {:.0}s",
+        started.elapsed().as_secs_f64()
+    );
+    if funded == 0 {
+        bail!("no wallet was funded");
+    }
+    Ok(())
+}
+
+/// Deposit into one wallet's shielded address, paid for by the funder.
+fn fund_one(
+    rpc: &SolanaRpc,
+    funder: &Keypair,
+    wallet: &Keypair,
+    tree: Address,
+    asset: Address,
+    amount: u64,
+) -> Result<()> {
+    let shielded = ShieldedKeypair::from_solana_keypair(wallet)?;
+    let recipient = shielded.shielded_address()?;
+    let built = create_deposit(DepositParams {
+        recipient: &recipient,
+        asset,
+        amount,
+        spl_token_account: None,
+        spl_token_program: None,
+        memo: None,
+    })?;
+    // Funder is both payer and depositor: the deposited SOL comes from it, so
+    // the recipient needs no balance of its own.
+    let tree = solana_pubkey::Pubkey::new_from_array(tree.to_bytes());
+    built.send(rpc, funder, tree, funder)?;
+    Ok(())
+}

--- a/xtask/src/fund.rs
+++ b/xtask/src/fund.rs
@@ -1,8 +1,8 @@
-//! Top up the shielded balances of a directory of load-test wallets.
+//! Top up the shielded balances of the load-test wallets.
 //!
-//! The load generator spends shielded value; when a wallet runs out it fails
-//! with `insufficient balance for asset` and the run measures depletion rather
-//! than capacity. One 220-worker run ended with 209 such failures.
+//! The load generator spends shielded value; a wallet that runs out fails with
+//! `insufficient balance for asset`, and the run then measures depletion rather
+//! than capacity.
 //!
 //! One funder pays for everything. A deposit names its recipient by shielded
 //! address and needs no shared secret — see `DepositParams` — so the funder both
@@ -16,7 +16,7 @@
 //! CLI wallet files holding the same secrets.
 
 use std::{
-    path::PathBuf,
+    path::Path,
     sync::atomic::{AtomicU64, AtomicUsize, Ordering},
     thread,
     time::Instant,
@@ -30,56 +30,10 @@ use zolana_keypair::ShieldedKeypair;
 use zolana_transaction::Address;
 use zolana_wallet::{create_deposit, DepositParams};
 
-use crate::loadtest::load_keypairs;
+/// Deposits in flight at once.
+const CONCURRENCY: usize = 16;
 
-pub struct Options {
-    pub rpc_url: String,
-    pub tree: String,
-    /// Directory of `solana-keygen` keypairs — the same one `loadtest` takes.
-    pub keypairs: PathBuf,
-    /// Funder: signs and pays for every deposit.
-    pub funder: PathBuf,
-    /// Lamports to deposit into each wallet.
-    pub amount: u64,
-    /// Deposits in flight at once.
-    pub concurrency: usize,
-}
-
-impl Options {
-    pub fn parse(args: Vec<String>) -> Result<Self> {
-        let mut rpc_url = None;
-        let mut tree = None;
-        let mut keypairs = None;
-        let mut funder = None;
-        let mut amount = 60_000_000u64;
-        let mut concurrency = 16usize;
-
-        let mut iter = args.into_iter();
-        while let Some(arg) = iter.next() {
-            let mut value = || iter.next().context("missing value");
-            match arg.as_str() {
-                "--rpc" => rpc_url = Some(value()?),
-                "--tree" => tree = Some(value()?),
-                "--keypairs" => keypairs = Some(PathBuf::from(value()?)),
-                "--funder" => funder = Some(PathBuf::from(value()?)),
-                "--amount" => amount = value()?.parse().context("--amount")?,
-                "--concurrency" => concurrency = value()?.parse().context("--concurrency")?,
-                other => bail!("unknown flag {other}"),
-            }
-        }
-
-        Ok(Self {
-            rpc_url: rpc_url.context("--rpc is required")?,
-            tree: tree.context("--tree is required")?,
-            keypairs: keypairs.context("--keypairs <dir> is required")?,
-            funder: funder.context("--funder <keypair.json> is required")?,
-            amount,
-            concurrency: concurrency.max(1),
-        })
-    }
-}
-
-fn read_keypair(path: &PathBuf) -> Result<Keypair> {
+fn read_keypair(path: &Path) -> Result<Keypair> {
     let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
     let raw: Vec<u8> = serde_json::from_slice(&bytes)
         .with_context(|| format!("{} is not a keypair array", path.display()))?;
@@ -89,20 +43,30 @@ fn read_keypair(path: &PathBuf) -> Result<Keypair> {
     Keypair::try_from(&array[..]).context("bad funder keypair")
 }
 
-pub fn run(options: Options) -> Result<()> {
-    let funder = read_keypair(&options.funder)?;
-    let wallets = load_keypairs(&options.keypairs)?;
-    let tree: Address = options.tree.parse().context("--tree is not an address")?;
+/// Bring every wallet up by `amount`, paid for by one funder.
+///
+/// Runs as part of `loadtest` rather than as its own command: a run against
+/// empty wallets still produces a throughput number, and that number measures
+/// how fast the pool can refuse a transfer.
+pub fn top_up(
+    rpc_url: &str,
+    tree: &str,
+    wallets: &[Keypair],
+    funder_path: &Path,
+    amount: u64,
+) -> Result<()> {
+    let funder = read_keypair(funder_path)?;
+    let tree: Address = tree.parse().context("--tree is not an address")?;
     let asset = Address::default();
 
-    let rpc = SolanaRpc::new(options.rpc_url.clone());
+    let rpc = SolanaRpc::new(rpc_url.to_string());
     let funder_address = Address::new_from_array(funder.pubkey().to_bytes());
     let balance = rpc.get_balance(funder_address)?;
-    let required = options.amount.saturating_mul(wallets.len() as u64);
+    let required = amount.saturating_mul(wallets.len() as u64);
     println!(
         "funding {} wallets with {} lamports each ({:.3} SOL total)\nfunder {} holds {:.3} SOL",
         wallets.len(),
-        options.amount,
+        amount,
         required as f64 / 1e9,
         funder.pubkey(),
         balance as f64 / 1e9,
@@ -121,17 +85,17 @@ pub fn run(options: Options) -> Result<()> {
     let started = Instant::now();
 
     thread::scope(|scope| {
-        for _ in 0..options.concurrency.min(wallets.len()) {
+        for _ in 0..CONCURRENCY.min(wallets.len()) {
             scope.spawn(|| {
                 // Each worker holds its own RPC client; they are cheap and not
                 // shared state.
-                let rpc = SolanaRpc::new(options.rpc_url.clone());
+                let rpc = SolanaRpc::new(rpc_url.to_string());
                 loop {
                     let index = next.fetch_add(1, Ordering::Relaxed);
                     let Some(wallet) = wallets.get(index) else {
                         return;
                     };
-                    match fund_one(&rpc, &funder, wallet, tree, asset, options.amount) {
+                    match fund_one(&rpc, &funder, wallet, tree, asset, amount) {
                         Ok(()) => {
                             let done = funded.fetch_add(1, Ordering::Relaxed) + 1;
                             if done.is_multiple_of(25) {
@@ -172,7 +136,7 @@ fn fund_one(
     asset: Address,
     amount: u64,
 ) -> Result<()> {
-    let shielded = ShieldedKeypair::from_solana_keypair(wallet)?;
+    let shielded = ShieldedKeypair::from_keypair(wallet)?;
     let recipient = shielded.shielded_address()?;
     let built = create_deposit(DepositParams {
         recipient: &recipient,

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -39,6 +39,28 @@ use zolana_wallet::{
     create_transfer_sync, sign_private_transaction_sync, sync_wallet, TransferParams,
 };
 
+/// Identity of a failure, for grouping.
+///
+/// The variant plus, for a chain rejection, the program's own error code. Two
+/// failures share a key exactly when they are the same failure, which a
+/// truncated message cannot express: the same rejection arrives with different
+/// wrappers from simulation and from send, so a prefix groups them apart while
+/// a longer prefix groups unrelated errors together.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct ErrorKey {
+    variant: std::mem::Discriminant<ClientError>,
+    program_code: Option<u32>,
+}
+
+impl ErrorKey {
+    fn of(error: &ClientError) -> Self {
+        Self {
+            variant: std::mem::discriminant(error),
+            program_code: error.program_error_code(),
+        }
+    }
+}
+
 /// One completed transfer, broken into the phases that can each be slow for a
 /// different reason.
 #[derive(Clone, Copy, Default)]
@@ -58,12 +80,21 @@ struct Stats {
     ok: u64,
     failed: u64,
     throttled: u64,
-    /// Distinct error messages and how often each occurred.
+    /// Distinct failures and how often each occurred.
     ///
     /// Counting failures without recording them makes a run unactionable: "43
     /// failed" says nothing about whether the prover is down, the wallet is
     /// empty, or the indexer is behind.
-    errors: std::collections::BTreeMap<String, u64>,
+    ///
+    /// Keyed by what the failure *is*, never by how it renders.
+    ///
+    /// `mem::discriminant` identifies the `ClientError` variant exactly, and the
+    /// program error code splits one variant into the distinct on-chain
+    /// rejections it carries. Neither can drift when a message is reworded, and
+    /// nothing depends on where a substring happens to fall. The stored `String`
+    /// is one real example per group, shown to a reader and used for nothing
+    /// else.
+    errors: std::collections::HashMap<ErrorKey, (String, u64)>,
     /// This worker's first sync, before it sent anything.
     ///
     /// Stands in for how much history its wallet already carried. Sync cost
@@ -346,8 +377,9 @@ pub fn run(options: Options) -> Result<()> {
                 shared.ok += local.ok;
                 shared.failed += local.failed;
                 shared.throttled += local.throttled;
-                for (message, count) in local.errors {
-                    *shared.errors.entry(message).or_insert(0) += count;
+                for (key, (sample, count)) in local.errors {
+                    let entry = shared.errors.entry(key).or_insert((sample, 0));
+                    entry.1 += count;
                 }
             });
         }
@@ -373,10 +405,12 @@ pub fn run(options: Options) -> Result<()> {
     );
     if !stats.errors.is_empty() {
         println!("\nerrors:");
-        let mut ranked: Vec<_> = stats.errors.iter().collect();
-        ranked.sort_by(|a, b| b.1.cmp(a.1));
-        for (message, count) in ranked.into_iter().take(5) {
-            println!("  {count:>5}x  {message}");
+        let mut ranked: Vec<_> = stats.errors.values().collect();
+        // Ties break on the message so two runs of the same workload print the
+        // same report; hash order alone would shuffle equal counts.
+        ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        for (sample, count) in ranked.into_iter().take(8) {
+            println!("  {count:>5}x  {sample}");
         }
     }
 
@@ -529,30 +563,41 @@ fn worker(
 /// A load generator without backoff measures the rate limiter rather than the
 /// system under test: an earlier shell-driven run lost 101 of 220 transfers to
 /// Helius 403s and reported it as protocol failure.
-fn classify(error: &ClientError, stats: &mut Stats, backoff: &mut Duration) {
-    // Group by the program's own error code when the chain rejected the
-    // transaction, and name it.
-    //
-    // Reading the code out of the rendered message does not work: the same
-    // rejection arrives with two different wrappers depending on whether it
-    // failed in simulation or on send, so truncating to group them put the code
-    // inside the prefix for one and past the cut for the other. A run reporting
-    // 10748 failures identified none of them, while 318 of the *same* error
-    // showed up separately as "0x1b60" purely because their wrapper was shorter.
-    //
-    // Solana models this properly -- TransactionError carries
-    // InstructionError::Custom(u32) -- so match on it and let
-    // ShieldedPoolError name the number.
-    let key = match error.program_error_code() {
+/// A readable one-line description of a failure.
+///
+/// Names the on-chain error when there is one, because a client otherwise sees
+/// only a number. Long transport messages are shortened here and only here:
+/// this is display, and grouping never consults it.
+fn describe(error: &ClientError) -> String {
+    match error.program_error_code() {
         Some(code) => match ShieldedPoolError::from_code(code) {
             Some(named) => format!("program error {code:#x} ({named})"),
             None => format!("program error {code:#x} (unknown to this build)"),
         },
-        // Everything else still groups by message, truncated: those carry
-        // request ids and addresses that would make each occurrence distinct.
-        None => error.to_string().chars().take(160).collect(),
-    };
-    *stats.errors.entry(key).or_insert(0) += 1;
+        None => {
+            let text = error.to_string();
+            match text.char_indices().nth(160) {
+                Some((cut, _)) => format!("{}...", &text[..cut]),
+                None => text,
+            }
+        }
+    }
+}
+
+fn classify(error: &ClientError, stats: &mut Stats, backoff: &mut Duration) {
+    // Identity comes from the type, never from the text. The message is kept
+    // only as a readable example of the group.
+    //
+    // Grouping by a message prefix failed in both directions at once: the same
+    // chain rejection arrives with two wrappers depending on whether it failed
+    // in simulation or on send, so 10748 occurrences landed under a key that
+    // named none of them while 318 of the *same* error grouped separately as
+    // "0x1b60" purely because their wrapper was shorter.
+    stats
+        .errors
+        .entry(ErrorKey::of(error))
+        .or_insert_with(|| (describe(error), 0))
+        .1 += 1;
 
     // Matched on the error's type, not its text. This used to ask whether the
     // message contained "403", "429" or "rate", which counts a signature
@@ -574,5 +619,92 @@ fn classify(error: &ClientError, stats: &mut Stats, backoff: &mut Duration) {
     } else {
         stats.failed += 1;
         thread::sleep(Duration::from_millis(250));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rpc_program_error(operation: &'static str, code: u32) -> ClientError {
+        use solana_instruction::error::InstructionError;
+        use solana_rpc_client_api::client_error::{Error as RpcError, TransactionError};
+
+        ClientError::SolanaRpcTransaction {
+            operation,
+            source: RpcError::from(TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(code),
+            )),
+        }
+    }
+
+    /// The failure that motivated all of this: one on-chain rejection reported
+    /// as two unrelated lines because the wrappers rendered at different
+    /// lengths.
+    #[test]
+    fn one_rejection_groups_under_one_key_whatever_the_wrapper() {
+        let simulate = rpc_program_error("simulate", 7008);
+        let send = rpc_program_error("send", 7008);
+
+        assert_ne!(
+            simulate.to_string(),
+            send.to_string(),
+            "vacuous unless the two render differently"
+        );
+        assert_eq!(ErrorKey::of(&simulate), ErrorKey::of(&send));
+    }
+
+    #[test]
+    fn different_program_codes_stay_apart() {
+        assert_ne!(
+            ErrorKey::of(&rpc_program_error("send", 7008)),
+            ErrorKey::of(&rpc_program_error("send", 7015)),
+        );
+    }
+
+    /// Off-chain failures group by variant, so per-occurrence detail -- slots,
+    /// attempt counts, addresses -- cannot split one cause across many lines.
+    #[test]
+    fn per_occurrence_detail_does_not_split_a_group() {
+        let early = ClientError::IndexerNotCaughtUp {
+            required: 1,
+            indexed: 0,
+            attempts: 3,
+        };
+        let late = ClientError::IndexerNotCaughtUp {
+            required: 99_999,
+            indexed: 42,
+            attempts: 7,
+        };
+
+        assert_ne!(early.to_string(), late.to_string());
+        assert_eq!(ErrorKey::of(&early), ErrorKey::of(&late));
+        assert_ne!(
+            ErrorKey::of(&early),
+            ErrorKey::of(&ClientError::IndexerTimeout)
+        );
+    }
+
+    #[test]
+    fn the_report_names_the_program_error() {
+        let described = describe(&rpc_program_error("send", 7008));
+        assert!(
+            described.starts_with("program error 0x1b60 ("),
+            "expected a named code, got {described}"
+        );
+        assert!(
+            described.contains(&ShieldedPoolError::TransactProofVerificationFailed.to_string()),
+            "expected the name from ShieldedPoolError, got {described}"
+        );
+    }
+
+    /// Shortening is display-only, so it may not silently swallow the tail.
+    #[test]
+    fn a_long_message_is_marked_when_shortened() {
+        let long = ClientError::AddressResolution("x".repeat(400));
+        let described = describe(&long);
+        assert!(described.ends_with("..."), "got {described}");
+        assert!(described.chars().count() < long.to_string().chars().count());
     }
 }

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -166,7 +166,7 @@ impl Options {
 /// the shielded keypair is derived from the funding key, so the funding key is
 /// the only secret needed and there is no reason to reimplement the CLI's file
 /// parsing here.
-fn load_keypairs(dir: &Path) -> Result<Vec<Keypair>> {
+pub(crate) fn load_keypairs(dir: &Path) -> Result<Vec<Keypair>> {
     let mut paths: Vec<PathBuf> = fs::read_dir(dir)
         .with_context(|| format!("read {}", dir.display()))?
         .filter_map(|entry| entry.ok().map(|e| e.path()))

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -531,7 +531,19 @@ fn worker(
 fn classify(error: &ClientError, stats: &mut Stats, backoff: &mut Duration) {
     // Truncated: these carry request ids and addresses that would make every
     // occurrence look distinct and defeat the grouping.
-    let key: String = error.to_string().chars().take(160).collect();
+    //
+    // 160 was too short by a handful of characters, and in the worst possible
+    // place. A simulation failure reads
+    //
+    //   Solana RPC transaction failed during send_transaction: RPC response
+    //   error -32002: Transaction simulation failed: Error processing
+    //   Instruction 1: custom program error: 0x1b60
+    //
+    // where the program error code -- the only part that identifies the
+    // failure -- begins at roughly character 160. A run reporting 10748
+    // failures said nothing about what they were. Long enough to keep the code,
+    // short enough that ids and addresses still fall off the end.
+    let key: String = error.to_string().chars().take(220).collect();
     *stats.errors.entry(key).or_insert(0) += 1;
 
     // Matched on the error's type, not its text. This used to ask whether the

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -115,6 +115,11 @@ pub struct Options {
     pub asset: String,
     /// Where to write the machine-readable summary, if anywhere.
     pub json_out: Option<PathBuf>,
+    /// Funder for the pre-run top-up. Without it the run uses whatever shielded
+    /// balance the wallets already hold.
+    pub funder: Option<PathBuf>,
+    /// Lamports to bring each wallet up by before starting.
+    pub top_up: u64,
 }
 
 impl Options {
@@ -125,6 +130,8 @@ impl Options {
         let mut tree = None;
         let mut keypairs = None;
         let mut json_out = None;
+        let mut funder = None;
+        let mut top_up = 60_000_000u64;
         let mut duration = 300u64;
         let mut amount = 200_000u64;
         let mut asset = "SOL".to_string();
@@ -142,6 +149,8 @@ impl Options {
                 "--amount" => amount = value()?.parse().context("--amount")?,
                 "--asset" => asset = value()?,
                 "--json" => json_out = Some(PathBuf::from(value()?)),
+                "--funder" => funder = Some(PathBuf::from(value()?)),
+                "--top-up" => top_up = value()?.parse().context("--top-up")?,
                 other => bail!("unknown flag {other}"),
             }
         }
@@ -153,6 +162,8 @@ impl Options {
             tree: tree.context("--tree is required")?,
             keypairs: keypairs.context("--keypairs <dir> is required")?,
             json_out,
+            funder,
+            top_up,
             duration: Duration::from_secs(duration),
             amount,
             asset,
@@ -289,6 +300,15 @@ fn write_json(
 pub fn run(options: Options) -> Result<()> {
     let keypairs = load_keypairs(&options.keypairs)?;
     let workers = keypairs.len();
+    if let Some(funder) = options.funder.as_ref() {
+        crate::fund::top_up(
+            &options.rpc_url,
+            &options.tree,
+            &keypairs,
+            funder,
+            options.top_up,
+        )?;
+    }
     let tree = Address::new_from_array(
         bs58::decode(&options.tree)
             .into_vec()
@@ -403,6 +423,22 @@ pub fn run(options: Options) -> Result<()> {
         stats.ok as f64 / elapsed.as_secs_f64(),
         stats.ok as f64 / elapsed.as_secs_f64() * 60.0
     );
+
+    // A wallet that runs dry keeps failing, so the run measures how fast it can
+    // be told no. Reporting that number as throughput is the trap; say so.
+    let ran_dry: u64 = stats
+        .errors
+        .values()
+        .filter(|(sample, _)| sample.contains("insufficient balance"))
+        .map(|(_, count)| count)
+        .sum();
+    if ran_dry > 0 {
+        println!(
+            "\n{ran_dry} of {} failures were empty wallets, not capacity. Re-run with \
+             --funder <keypair.json> to top up first.",
+            stats.failed
+        );
+    }
     if !stats.errors.is_empty() {
         println!("\nerrors:");
         let mut ranked: Vec<_> = stats.errors.values().collect();

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -32,6 +32,7 @@ use solana_signer::Signer;
 // `Rpc` is in scope for send_transaction, which is a trait method rather than
 // an inherent one on SolanaRpc.
 use zolana_client::{ClientError, Rpc, SolanaRpc, Unavailable, ZolanaClient};
+use zolana_interface::error::ShieldedPoolError;
 use zolana_keypair::ShieldedKeypair;
 use zolana_transaction::{Address, AssetRegistry, LocalWalletAuthority, Wallet};
 use zolana_wallet::{
@@ -529,21 +530,28 @@ fn worker(
 /// system under test: an earlier shell-driven run lost 101 of 220 transfers to
 /// Helius 403s and reported it as protocol failure.
 fn classify(error: &ClientError, stats: &mut Stats, backoff: &mut Duration) {
-    // Truncated: these carry request ids and addresses that would make every
-    // occurrence look distinct and defeat the grouping.
+    // Group by the program's own error code when the chain rejected the
+    // transaction, and name it.
     //
-    // 160 was too short by a handful of characters, and in the worst possible
-    // place. A simulation failure reads
+    // Reading the code out of the rendered message does not work: the same
+    // rejection arrives with two different wrappers depending on whether it
+    // failed in simulation or on send, so truncating to group them put the code
+    // inside the prefix for one and past the cut for the other. A run reporting
+    // 10748 failures identified none of them, while 318 of the *same* error
+    // showed up separately as "0x1b60" purely because their wrapper was shorter.
     //
-    //   Solana RPC transaction failed during send_transaction: RPC response
-    //   error -32002: Transaction simulation failed: Error processing
-    //   Instruction 1: custom program error: 0x1b60
-    //
-    // where the program error code -- the only part that identifies the
-    // failure -- begins at roughly character 160. A run reporting 10748
-    // failures said nothing about what they were. Long enough to keep the code,
-    // short enough that ids and addresses still fall off the end.
-    let key: String = error.to_string().chars().take(220).collect();
+    // Solana models this properly -- TransactionError carries
+    // InstructionError::Custom(u32) -- so match on it and let
+    // ShieldedPoolError name the number.
+    let key = match error.program_error_code() {
+        Some(code) => match ShieldedPoolError::from_code(code) {
+            Some(named) => format!("program error {code:#x} ({named})"),
+            None => format!("program error {code:#x} (unknown to this build)"),
+        },
+        // Everything else still groups by message, truncated: those carry
+        // request ids and addresses that would make each occurrence distinct.
+        None => error.to_string().chars().take(160).collect(),
+    };
     *stats.errors.entry(key).or_insert(0) += 1;
 
     // Matched on the error's type, not its text. This used to ask whether the

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -31,7 +31,7 @@ use solana_keypair::Keypair;
 use solana_signer::Signer;
 // `Rpc` is in scope for send_transaction, which is a trait method rather than
 // an inherent one on SolanaRpc.
-use zolana_client::{Rpc, SolanaRpc, ZolanaClient};
+use zolana_client::{ClientError, Rpc, SolanaRpc, Unavailable, ZolanaClient};
 use zolana_keypair::ShieldedKeypair;
 use zolana_transaction::{Address, AssetRegistry, LocalWalletAuthority, Wallet};
 use zolana_wallet::{
@@ -461,7 +461,7 @@ fn worker(
         // This phase is the one that grows with the wallet's note count.
         let mark = Instant::now();
         if let Err(error) = sync_wallet(&mut wallet, &authority, &client) {
-            classify(&error.to_string(), stats, &mut backoff);
+            classify(&error, stats, &mut backoff);
             continue;
         }
         timing.sync_ms = mark.elapsed().as_millis() as u64;
@@ -489,7 +489,7 @@ fn worker(
         }) {
             Ok(signed) => signed,
             Err(error) => {
-                classify(&error.to_string(), stats, &mut backoff);
+                classify(&error, stats, &mut backoff);
                 continue;
             }
         };
@@ -499,7 +499,7 @@ fn worker(
         let signature = match client.rpc().send_transaction(&transfer) {
             Ok(signature) => signature,
             Err(error) => {
-                classify(&error.to_string(), stats, &mut backoff);
+                classify(&error, stats, &mut backoff);
                 continue;
             }
         };
@@ -507,7 +507,7 @@ fn worker(
 
         let mark = Instant::now();
         if let Err(error) = client.confirm_private_transaction_sync(signature) {
-            classify(&error.to_string(), stats, &mut backoff);
+            classify(&error, stats, &mut backoff);
             continue;
         }
         timing.confirm_ms = mark.elapsed().as_millis() as u64;
@@ -528,14 +528,26 @@ fn worker(
 /// A load generator without backoff measures the rate limiter rather than the
 /// system under test: an earlier shell-driven run lost 101 of 220 transfers to
 /// Helius 403s and reported it as protocol failure.
-fn classify(message: &str, stats: &mut Stats, backoff: &mut Duration) {
+fn classify(error: &ClientError, stats: &mut Stats, backoff: &mut Duration) {
     // Truncated: these carry request ids and addresses that would make every
     // occurrence look distinct and defeat the grouping.
-    let key: String = message.chars().take(160).collect();
+    let key: String = error.to_string().chars().take(160).collect();
     *stats.errors.entry(key).or_insert(0) += 1;
 
-    let lowered = message.to_ascii_lowercase();
-    if lowered.contains("403") || lowered.contains("429") || lowered.contains("rate") {
+    // Matched on the error's type, not its text. This used to ask whether the
+    // message contained "403", "429" or "rate", which counts a signature
+    // containing "429" as throttling and the word "generate" as well, while
+    // missing a 503 entirely -- and it silently misreads any error whose
+    // wording changes.
+    let throttled = matches!(
+        error,
+        ClientError::IndexerUnavailable {
+            reason: Unavailable::RateLimited,
+            ..
+        }
+    );
+
+    if throttled {
         stats.throttled += 1;
         thread::sleep(*backoff);
         *backoff = (*backoff * 2).min(Duration::from_secs(30));

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -64,16 +64,6 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        Some("fund") => {
-            let options = match fund::Options::parse(args.collect()) {
-                Ok(options) => options,
-                Err(error) => usage_and_exit(&format!("fund: {error:#}")),
-            };
-            if let Err(error) = fund::run(options) {
-                eprintln!("fund failed: {error:?}");
-                std::process::exit(1);
-            }
-        }
         Some("program-ids") => print_program_ids(),
         Some("init-protocol") => {
             if let Err(error) = init_protocol::run(init_protocol::Options::parse(args.collect())) {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 
 mod create_release;
 mod find_smart_accounts;
+mod fund;
 mod init_protocol;
 mod loadtest;
 mod update_protocol_config;
@@ -60,6 +61,16 @@ fn main() {
             };
             if let Err(error) = loadtest::run(options) {
                 eprintln!("loadtest failed: {error:?}");
+                std::process::exit(1);
+            }
+        }
+        Some("fund") => {
+            let options = match fund::Options::parse(args.collect()) {
+                Ok(options) => options,
+                Err(error) => usage_and_exit(&format!("fund: {error:#}")),
+            };
+            if let Err(error) = fund::run(options) {
+                eprintln!("fund failed: {error:?}");
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
Split out of #207, which bundles this with sync changes and can no longer be merged as it stands — see the note there.

Nothing here touches sync.

## Changes

- `ClientError` carries an indexer failure as a variant rather than a string callers match on by prefix.
- `loadtest` groups failures by the program's error code, not by a message prefix. One on-chain rejection was reported as 43 distinct failures because request ids made each occurrence look unique.
- `loadtest --funder <keypair.json>` tops the wallets up before starting, with `--top-up` for the amount. This was a separate `xtask fund` command in #207; forgetting it does not fail, it just makes the run measure how fast the pool can refuse a transfer. One 220-worker run ended with 209 `insufficient balance` failures.
- A run that hit empty wallets now says how many of its failures were depletion rather than capacity, so the throughput line above is not mistaken for a measurement.

## Tests

`cargo test -p xtask -p zolana-client`, clippy and rustfmt clean.