### PR TITLE
client: bound the proof poll, and overlap the proof and blockhash fetches

### DIFF
--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -267,13 +267,20 @@ impl<R: Rpc> ZolanaClient<R> {
             .prove_transact(proof_inputs, &spend_proofs, &dummy_proofs)
     }
 
+    /// Fetches the blockhash itself, after proving rather than before.
+    ///
+    /// Callers used to fetch one and hand it in, which put a multi-second proof
+    /// between the blockhash and the send. Under load that window exceeded the
+    /// blockhash lifetime and the transaction was rejected at submission,
+    /// having already paid for the sync and the proof: an 80-worker run lost
+    /// 297 of 337 transfers to "Blockhash not found".
+    ///
     /// `R: Sync` because the two proof fetches below share the indexer across
     /// scoped threads.
     pub fn finish_submission_unsigned_sync(
         &self,
         signed: &SignedPrivateTransaction,
         fee_payer: Pubkey,
-        recent_blockhash: Hash,
     ) -> Result<SolanaTransaction, ClientError>
     where
         R: Sync,
@@ -317,6 +324,9 @@ impl<R: Rpc> ZolanaClient<R> {
             self.blocking_prover().prove_transfer(inputs)?
         };
         let proof = ProofCompressed::try_from(proof)?.to_transact_proof();
+        // Last thing before building, so the blockhash is as young as it can be
+        // when the transaction reaches the cluster.
+        let (recent_blockhash, _) = self.rpc().get_latest_blockhash()?;
         build_unsigned_solana_transaction(
             ComputeBudgetConfig {
                 cu_limit: self.cu_limit,

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -267,33 +267,49 @@ impl<R: Rpc> ZolanaClient<R> {
             .prove_transact(proof_inputs, &spend_proofs, &dummy_proofs)
     }
 
+    /// `R: Sync` because the two proof fetches below share the indexer across
+    /// scoped threads.
     pub fn finish_submission_unsigned_sync(
         &self,
         signed: &SignedPrivateTransaction,
         fee_payer: Pubkey,
         recent_blockhash: Hash,
-    ) -> Result<SolanaTransaction, ClientError> {
+    ) -> Result<SolanaTransaction, ClientError>
+    where
+        R: Sync,
+    {
         validate_fee_payer_pubkey(&signed.transaction.payer, fee_payer)?;
         let owner_signers = signed.transaction.owner_signer_pubkeys()?;
         let commitments = signed.transaction.input_utxo_hashes()?;
-        let spend_proofs = {
-            let _t = crate::timing::Phase::start("fetch_spend_proofs", 0);
-            fetch_spend_proofs(
-                self.blocking_indexer(),
-                signed.input_tree,
-                &commitments,
-                None,
-            )?
-        };
-        let dummy_proofs = {
-            let _t = crate::timing::Phase::start("fetch_dummy_nullifier_proofs", 0);
-            fetch_dummy_nullifier_proofs(
-                self.blocking_indexer(),
-                signed.input_tree,
-                &signed.transaction,
-                None,
-            )?
-        };
+        // Two independent indexer round trips (317ms and 114ms on devnet) that
+        // ran back to back. Nothing links them: different methods, and neither
+        // consumes the other's output.
+        let (spend_proofs, dummy_proofs) = std::thread::scope(|scope| {
+            let spend = scope.spawn(|| {
+                let _t = crate::timing::Phase::start("fetch_spend_proofs", 0);
+                fetch_spend_proofs(
+                    self.blocking_indexer(),
+                    signed.input_tree,
+                    &commitments,
+                    None,
+                )
+            });
+            let dummy = scope.spawn(|| {
+                let _t = crate::timing::Phase::start("fetch_dummy_nullifier_proofs", 0);
+                fetch_dummy_nullifier_proofs(
+                    self.blocking_indexer(),
+                    signed.input_tree,
+                    &signed.transaction,
+                    None,
+                )
+            });
+            (spend.join(), dummy.join())
+        });
+        // A panic here is a bug in proof assembly, not an unreachable indexer.
+        let spend_proofs =
+            spend_proofs.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
+        let dummy_proofs =
+            dummy_proofs.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
         let assembled = assemble(signed.transaction.clone(), &spend_proofs, &dummy_proofs)?;
         let ProverInputs::Eddsa(inputs) = &assembled.prover_inputs;
         let proof = {

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -4,7 +4,7 @@ use std::{
     process::Command,
     sync::atomic::{AtomicBool, Ordering},
     thread::sleep,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use tokio::time::sleep as async_sleep;
@@ -65,6 +65,14 @@ const PROVE_RETRY_BACKOFF_SECS: u64 = 2;
 // well before this.
 const PROVE_REQUEST_TIMEOUT_SECS: u64 = 600;
 const PROVE_CONNECT_TIMEOUT_SECS: u64 = 10;
+/// Per-request bound on a `/prove/status` poll.
+///
+/// The status endpoint reads one Redis key and returns; it is not the request
+/// that 600s was sized for. Sharing the prove timeout let a single hung poll
+/// block a worker for ten minutes, and since the poll loop retries, the delays
+/// stacked: a 220-worker run whose proofs had all finished or been reaped sat
+/// wedged for over half an hour, every worker parked inside a status GET.
+const STATUS_POLL_TIMEOUT_SECS: u64 = 30;
 /// Polling cadence and ceiling for async (queued) proofs. Redis-backed provers
 /// queue batch, transfer, and merge proofs and return a job handle immediately
 /// instead of blocking; the client then polls the status endpoint until the
@@ -78,7 +86,13 @@ const PROVE_CONNECT_TIMEOUT_SECS: u64 = 10;
 pub struct AsyncPollConfig {
     /// Seconds between `/prove/status` polls (floored at 1 so it can't spin).
     pub poll_interval_secs: u64,
-    /// Max seconds to wait for a queued proof before returning a timeout error.
+    /// Wall-clock seconds to wait for a queued proof before returning a timeout
+    /// error.
+    ///
+    /// Wall clock, measured from the first poll. It used to be a running total
+    /// of time *slept*, which bounds nothing: the time inside each request did
+    /// not count, so with a 600s request timeout this "1200s" ceiling permitted
+    /// well over a day of waiting.
     pub max_wait_secs: u64,
 }
 
@@ -279,14 +293,19 @@ impl ProverClient {
             .poll_interval_secs
             .saturating_mul(1_000)
             .max(INITIAL_POLL_MS);
-        let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
-        let mut waited_ms = 0u64;
+        let max_wait = Duration::from_secs(self.async_poll.max_wait_secs);
+        let started = Instant::now();
         let mut interval_ms = INITIAL_POLL_MS;
         loop {
-            let response = match self.http.get(&url).send() {
+            let response = match self
+                .http
+                .get(&url)
+                .timeout(Duration::from_secs(STATUS_POLL_TIMEOUT_SECS))
+                .send()
+            {
                 Ok(response) => response,
                 Err(_) => {
-                    wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                    wait_or_timeout(job_id, started, max_wait, interval_ms)?;
                     interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
@@ -302,7 +321,7 @@ impl ProverClient {
                 )));
             }
             if status.is_server_error() {
-                wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                wait_or_timeout(job_id, started, max_wait, interval_ms)?;
                 interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 continue;
             }
@@ -310,7 +329,7 @@ impl ProverClient {
             let text = match response.text() {
                 Ok(text) => text,
                 Err(_) => {
-                    wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                    wait_or_timeout(job_id, started, max_wait, interval_ms)?;
                     interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
@@ -332,7 +351,7 @@ impl ProverClient {
                 }
                 // queued / processing / unknown: keep polling until the bound.
                 _ => {
-                    wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms)?;
+                    wait_or_timeout(job_id, started, max_wait, interval_ms)?;
                     interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 }
             }
@@ -371,22 +390,40 @@ fn next_poll_interval_ms(current_ms: u64, cap_ms: u64) -> u64 {
         .min(cap_ms.max(INITIAL_POLL_MS))
 }
 
+/// How long is left before the deadline, or `Err` if it has passed.
+///
+/// Shared by the blocking and async poll loops so one definition of "expired"
+/// covers both. `started`/`max_wait` are wall clock: the previous version added
+/// up only the sleeps, which meant time spent inside a request was free and the
+/// ceiling bounded nothing.
+fn remaining_before_deadline(
+    job_id: &str,
+    started: Instant,
+    max_wait: Duration,
+    poll_interval_ms: u64,
+) -> Result<Duration, ClientError> {
+    let elapsed = started.elapsed();
+    let Some(remaining) = max_wait.checked_sub(elapsed) else {
+        return Err(ClientError::ProverServer(format!(
+            "async proof timed out after {}s (job {job_id})",
+            elapsed.as_secs()
+        )));
+    };
+    Ok(Duration::from_millis(poll_interval_ms).min(remaining))
+}
+
 fn wait_or_timeout(
     job_id: &str,
-    waited_ms: &mut u64,
-    max_wait_ms: u64,
+    started: Instant,
+    max_wait: Duration,
     poll_interval_ms: u64,
 ) -> Result<(), ClientError> {
-    if *waited_ms >= max_wait_ms {
-        let waited_secs = *waited_ms / 1_000;
-        return Err(ClientError::ProverServer(format!(
-            "async proof timed out after {waited_secs}s (job {job_id})"
-        )));
-    }
-    let remaining = max_wait_ms.saturating_sub(*waited_ms);
-    let sleep_ms = poll_interval_ms.min(remaining);
-    sleep(Duration::from_millis(sleep_ms));
-    *waited_ms = (*waited_ms).saturating_add(sleep_ms);
+    sleep(remaining_before_deadline(
+        job_id,
+        started,
+        max_wait,
+        poll_interval_ms,
+    )?);
     Ok(())
 }
 
@@ -501,14 +538,20 @@ impl AsyncProverClient {
             .poll_interval_secs
             .saturating_mul(1_000)
             .max(INITIAL_POLL_MS);
-        let max_wait_ms = self.async_poll.max_wait_secs.saturating_mul(1_000);
-        let mut waited_ms = 0u64;
+        let max_wait = Duration::from_secs(self.async_poll.max_wait_secs);
+        let started = Instant::now();
         let mut interval_ms = INITIAL_POLL_MS;
         loop {
-            let response = match self.http.get(&url).send().await {
+            let response = match self
+                .http
+                .get(&url)
+                .timeout(Duration::from_secs(STATUS_POLL_TIMEOUT_SECS))
+                .send()
+                .await
+            {
                 Ok(response) => response,
                 Err(_) => {
-                    async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                    async_wait_or_timeout(job_id, started, max_wait, interval_ms).await?;
                     interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
@@ -524,7 +567,7 @@ impl AsyncProverClient {
                 )));
             }
             if status.is_server_error() {
-                async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                async_wait_or_timeout(job_id, started, max_wait, interval_ms).await?;
                 interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 continue;
             }
@@ -532,7 +575,7 @@ impl AsyncProverClient {
             let text = match response.text().await {
                 Ok(text) => text,
                 Err(_) => {
-                    async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                    async_wait_or_timeout(job_id, started, max_wait, interval_ms).await?;
                     interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                     continue;
                 }
@@ -551,7 +594,7 @@ impl AsyncProverClient {
                     )));
                 }
                 _ => {
-                    async_wait_or_timeout(job_id, &mut waited_ms, max_wait_ms, interval_ms).await?;
+                    async_wait_or_timeout(job_id, started, max_wait, interval_ms).await?;
                     interval_ms = next_poll_interval_ms(interval_ms, poll_cap_ms);
                 }
             }
@@ -561,20 +604,17 @@ impl AsyncProverClient {
 
 async fn async_wait_or_timeout(
     job_id: &str,
-    waited_ms: &mut u64,
-    max_wait_ms: u64,
+    started: Instant,
+    max_wait: Duration,
     poll_interval_ms: u64,
 ) -> Result<(), ClientError> {
-    if *waited_ms >= max_wait_ms {
-        let waited_secs = *waited_ms / 1_000;
-        return Err(ClientError::ProverServer(format!(
-            "async proof timed out after {waited_secs}s (job {job_id})"
-        )));
-    }
-    let remaining = max_wait_ms.saturating_sub(*waited_ms);
-    let sleep_ms = poll_interval_ms.min(remaining);
-    async_sleep(Duration::from_millis(sleep_ms)).await;
-    *waited_ms = (*waited_ms).saturating_add(sleep_ms);
+    async_sleep(remaining_before_deadline(
+        job_id,
+        started,
+        max_wait,
+        poll_interval_ms,
+    )?)
+    .await;
     Ok(())
 }
 
@@ -770,7 +810,7 @@ mod tests {
     use std::{
         io::{Read, Write},
         net::{TcpListener, TcpStream},
-        sync::mpsc,
+        sync::{mpsc, Arc},
         thread,
     };
 
@@ -919,6 +959,56 @@ mod tests {
         let message = err.to_string();
         assert!(message.contains("async proof failed"));
         assert!(message.contains("prover rejected witness"));
+    }
+
+    /// The deadline is wall clock, so a slow-but-alive status endpoint cannot
+    /// stretch it.
+    ///
+    /// This is the case the old accounting missed. It summed only the time
+    /// *slept* between polls, so a poll that took 1.5s to answer added nothing
+    /// to the total: the client stayed under a 1s "ceiling" indefinitely. In
+    /// production, with a 600s request timeout inherited from the prove call,
+    /// that turned a 1200s bound into a hang -- 220 workers sat wedged for 35
+    /// minutes with the prover queue empty.
+    ///
+    /// The single poll here answers after 1.5s against a 1s ceiling, so the
+    /// client must give up on it alone. Under the old rule that poll counted as
+    /// 0ms, leaving the whole budget unspent, and polling continued -- so the
+    /// server is held open to record any further polls rather than refusing
+    /// them where they would go unseen.
+    #[test]
+    fn a_slow_status_endpoint_cannot_extend_the_deadline() {
+        let server = MockServer::respond_then_hold(vec![
+            MockResponse::json(202, json!({ "job_id": "job-slow-status" })),
+            MockResponse::slow_json(
+                200,
+                json!({ "status": "processing" }),
+                Duration::from_millis(1_500),
+            ),
+        ]);
+
+        let started = Instant::now();
+        let err = queued_prover_client(server.url())
+            .send("{}".to_string())
+            .expect_err("a deadline measured in wall clock must expire");
+        let elapsed = started.elapsed();
+
+        assert!(
+            err.to_string().contains("async proof timed out"),
+            "expected a timeout, got {err}"
+        );
+        // The slow poll alone exceeds the ceiling; anything much beyond it means
+        // the deadline is still being measured in slept time.
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "gave up only after {elapsed:?}"
+        );
+        // The slow poll is the last one. A second status request would mean the
+        // time it spent waiting had not been charged against the deadline.
+        assert_paths(
+            &server.requests(),
+            ["/prove", "/prove/status?job_id=job-slow-status"],
+        );
     }
 
     #[test]
@@ -1133,7 +1223,18 @@ mod tests {
     }
 
     enum MockResponse {
-        Http { status: u16, body: String },
+        Http {
+            status: u16,
+            body: String,
+        },
+        /// Answers, but only after `delay`. Models a status endpoint that is
+        /// reachable and slow rather than down -- the case the poll deadline has
+        /// to survive, and the one a fast mock cannot exercise.
+        SlowHttp {
+            status: u16,
+            body: String,
+            delay: Duration,
+        },
         Disconnect,
     }
 
@@ -1152,6 +1253,14 @@ mod tests {
             }
         }
 
+        fn slow_json(status: u16, body: Value, delay: Duration) -> Self {
+            Self::SlowHttp {
+                status,
+                body: body.to_string(),
+                delay,
+            }
+        }
+
         fn disconnect() -> Self {
             Self::Disconnect
         }
@@ -1161,6 +1270,9 @@ mod tests {
         url: String,
         request_rx: mpsc::Receiver<RecordedRequest>,
         handle: thread::JoinHandle<()>,
+        /// Set only by [`MockServer::respond_then_hold`], whose server would
+        /// otherwise never stop accepting.
+        stop: Option<Arc<AtomicBool>>,
     }
 
     impl MockServer {
@@ -1183,8 +1295,19 @@ mod tests {
                     request_tx
                         .send(request)
                         .expect("mock request receiver should stay open");
-                    if let MockResponse::Http { status, body } = response {
-                        write_http_response(&mut stream, status, &body);
+                    match response {
+                        MockResponse::Http { status, body } => {
+                            write_http_response(&mut stream, status, &body)
+                        }
+                        MockResponse::SlowHttp {
+                            status,
+                            body,
+                            delay,
+                        } => {
+                            thread::sleep(delay);
+                            write_http_response(&mut stream, status, &body);
+                        }
+                        MockResponse::Disconnect => {}
                     }
                 }
             });
@@ -1192,6 +1315,69 @@ mod tests {
                 url,
                 request_rx,
                 handle,
+                stop: None,
+            }
+        }
+
+        /// Like [`respond_with`], but after the scripted responses run out the
+        /// last one repeats for as long as the client keeps asking.
+        ///
+        /// `respond_with` stops answering once its list is exhausted, which
+        /// makes "the client polled more times than it should have" invisible:
+        /// the extra polls hit a closed port and go unrecorded. Holding the
+        /// server open records them, so a test can assert on the exact number
+        /// of polls. [`requests`] stops the server.
+        fn respond_then_hold(responses: Vec<MockResponse>) -> Self {
+            let listener =
+                TcpListener::bind("127.0.0.1:0").expect("mock server should bind to a local port");
+            let url = format!(
+                "http://{}",
+                listener
+                    .local_addr()
+                    .expect("mock server should expose its local address")
+            );
+            let (request_tx, request_rx) = mpsc::channel();
+            let stop = Arc::new(AtomicBool::new(false));
+            let thread_stop = Arc::clone(&stop);
+            let handle = thread::spawn(move || {
+                let mut remaining = responses.into_iter().peekable();
+                let mut last: Option<(u16, String)> = None;
+                while let Ok((mut stream, _)) = listener.accept() {
+                    if thread_stop.load(Ordering::SeqCst) {
+                        break;
+                    }
+                    let request = read_http_request(&mut stream);
+                    if request_tx.send(request).is_err() {
+                        break;
+                    }
+                    match remaining.next() {
+                        Some(MockResponse::Http { status, body }) => {
+                            write_http_response(&mut stream, status, &body);
+                            last = Some((status, body));
+                        }
+                        Some(MockResponse::SlowHttp {
+                            status,
+                            body,
+                            delay,
+                        }) => {
+                            thread::sleep(delay);
+                            write_http_response(&mut stream, status, &body);
+                            last = Some((status, body));
+                        }
+                        Some(MockResponse::Disconnect) => {}
+                        None => {
+                            if let Some((status, body)) = last.as_ref() {
+                                write_http_response(&mut stream, *status, body);
+                            }
+                        }
+                    }
+                }
+            });
+            Self {
+                url,
+                request_rx,
+                handle,
+                stop: Some(stop),
             }
         }
 
@@ -1200,6 +1386,12 @@ mod tests {
         }
 
         fn requests(self) -> Vec<RecordedRequest> {
+            if let Some(stop) = self.stop.as_ref() {
+                stop.store(true, Ordering::SeqCst);
+                // The server is parked in accept(); one throwaway connection
+                // wakes it so it can observe the flag and exit.
+                let _ = TcpStream::connect(self.url.trim_start_matches("http://"));
+            }
             self.handle
                 .join()
                 .expect("mock server thread should finish");

--- a/sdk-libs/wallet/src/actions/transaction.rs
+++ b/sdk-libs/wallet/src/actions/transaction.rs
@@ -694,7 +694,7 @@ pub async fn sign_private_transaction_with_signers<A: WalletAuthority + ?Sized, 
     Ok(native)
 }
 
-pub fn build_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc>(
+pub fn build_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc + Sync>(
     transaction: UnsignedPrivateTransaction,
     wallet: &Wallet,
     authority: &A,
@@ -706,7 +706,7 @@ pub fn build_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc>(
     client.finish_submission_unsigned_sync(&shielded, fee_payer, blockhash)
 }
 
-pub fn sign_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc>(
+pub fn sign_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc + Sync>(
     transaction: UnsignedPrivateTransaction,
     wallet: &Wallet,
     authority: &A,
@@ -724,7 +724,10 @@ pub fn sign_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc>(
 }
 
 /// Synchronous counterpart of [`sign_private_transaction_with_signers`].
-pub fn sign_private_transaction_sync_with_signers<A: SyncWalletAuthority + ?Sized, R: Rpc>(
+pub fn sign_private_transaction_sync_with_signers<
+    A: SyncWalletAuthority + ?Sized,
+    R: Rpc + Sync,
+>(
     transaction: UnsignedPrivateTransaction,
     wallet: &Wallet,
     authority: &A,

--- a/sdk-libs/wallet/src/actions/transaction.rs
+++ b/sdk-libs/wallet/src/actions/transaction.rs
@@ -702,8 +702,7 @@ pub fn build_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc + 
     fee_payer: Pubkey,
 ) -> Result<SolanaTransaction, ClientError> {
     let shielded = sign_shielded_transaction_sync(transaction, wallet, authority)?;
-    let (blockhash, _) = client.rpc().get_latest_blockhash()?;
-    client.finish_submission_unsigned_sync(&shielded, fee_payer, blockhash)
+    client.finish_submission_unsigned_sync(&shielded, fee_payer)
 }
 
 pub fn sign_private_transaction_sync<A: SyncWalletAuthority + ?Sized, R: Rpc + Sync>(
@@ -739,14 +738,13 @@ pub fn sign_private_transaction_sync_with_signers<
         let _t = timing::Phase::start("sign_shielded", 0);
         sign_shielded_transaction_sync(transaction, wallet, authority)?
     };
-    let (blockhash, _) = {
-        let _t = timing::Phase::start("get_latest_blockhash", 0);
-        client.rpc().get_latest_blockhash()?
-    };
     let mut native = {
         let _t = timing::Phase::start("finish_submission", 0);
-        client.finish_submission_unsigned_sync(&shielded, fee_payer.pubkey(), blockhash)?
+        client.finish_submission_unsigned_sync(&shielded, fee_payer.pubkey())?
     };
+    // Whatever the built message carries: it is fetched after proving now, so
+    // there is no separate blockhash here to keep in step with it.
+    let blockhash = native.message.recent_blockhash;
     let mut signers = Vec::with_capacity(1 + additional_native_signers.len());
     signers.push(fee_payer);
     signers.extend_from_slice(additional_native_signers);


### PR DESCRIPTION
Split out of #207, which bundles these with sync changes and can no longer be
merged as it stands — see the note there. Three commits, cherry-picked onto
`main` cleanly. Nothing here touches sync.

## Changes

- **Bound the async proof poll.** A 220-worker run sat wedged for 35 minutes
  with all 197 live workers parked in `poll_async`, while the prover's queue had
  been empty for 20 minutes. `max_wait_secs` was compared against time *slept*
  between polls, so time spent inside a request counted as zero and the bound
  could not bound anything. It is measured with `Instant` from the first poll
  now. The status poll had also inherited the 600s timeout set for
  `POST /prove`; `GET /prove/status` reads one Redis key and carries its own 30s.
- **Fetch spend and dummy nullifier proofs concurrently.**
- **Fetch the blockhash after proving, not before**, so it is not already stale
  when the transaction is signed.

## Note

The regression test uses a mock that answers *slowly* rather than not at all —
the case a fast mock cannot reach — and holds the port open afterwards, so polls
the client should not have made are recorded rather than hitting a closed socket
and going unseen. It does not terminate under the old accounting.

This bounds the client. It does not explain why the status endpoint became slow
under 220 workers, which is still open.

## Tests

`cargo test -p zolana-client -p zolana-wallet`, clippy and rustfmt clean.
