### PR TITLE
feat: let a hardware-resident keypair back a wallet authority

### DIFF
--- a/cli/src/wallet_cli/material.rs
+++ b/cli/src/wallet_cli/material.rs
@@ -22,7 +22,7 @@ use zolana_transaction::{
 };
 use zolana_wallet::{
     AnonymousRecipientSlot, ApprovalRequest, EncryptedSplit, EncryptedTransfer,
-    LocalWalletAuthority, P256Signature, SyncWalletAuthority,
+    KeypairWalletAuthority, P256Signature, SyncWalletAuthority,
 };
 
 use super::{resolve::ResolvedSyncOptions, util::parse_hex_array};
@@ -101,7 +101,7 @@ impl SyncWalletAuthority for WalletMaterial {
         assets: &AssetRegistry,
     ) -> std::result::Result<EncryptedTransfer, TransactionError> {
         SyncWalletAuthority::encrypt_confidential_transfer(
-            &LocalWalletAuthority::new(self.solana_pubkey(), &self.keypair),
+            &KeypairWalletAuthority::new(self.solana_pubkey(), &self.keypair),
             first_nullifier,
             outputs,
             assets,
@@ -116,7 +116,7 @@ impl SyncWalletAuthority for WalletMaterial {
         recipients: &[AnonymousRecipientSlot],
     ) -> std::result::Result<EncryptedTransfer, TransactionError> {
         SyncWalletAuthority::encrypt_anonymous_transfer(
-            &LocalWalletAuthority::new(self.solana_pubkey(), &self.keypair),
+            &KeypairWalletAuthority::new(self.solana_pubkey(), &self.keypair),
             first_nullifier,
             sender_view_tag,
             sender,
@@ -131,7 +131,7 @@ impl SyncWalletAuthority for WalletMaterial {
         bundle: &SplitBundlePlaintext,
     ) -> std::result::Result<EncryptedSplit, TransactionError> {
         SyncWalletAuthority::encrypt_split(
-            &LocalWalletAuthority::new(self.solana_pubkey(), &self.keypair),
+            &KeypairWalletAuthority::new(self.solana_pubkey(), &self.keypair),
             first_nullifier,
             view_tag,
             bundle,
@@ -151,7 +151,7 @@ impl SyncWalletAuthority for WalletMaterial {
         message_hash: &[u8; 32],
     ) -> std::result::Result<P256Signature, TransactionError> {
         SyncWalletAuthority::sign_p256(
-            &LocalWalletAuthority::new(self.solana_pubkey(), &self.keypair),
+            &KeypairWalletAuthority::new(self.solana_pubkey(), &self.keypair),
             message_hash,
         )
     }

--- a/custom-ring-tests/test/tests/ring.rs
+++ b/custom-ring-tests/test/tests/ring.rs
@@ -67,7 +67,7 @@ use zolana_transaction::{
     instructions::transact::{
         encrypt_transaction_data, get_transaction_viewing_key, ExternalData, SppProofOutputUtxo,
     },
-    owner_utxo_hash, Data, LocalWalletAuthority, RingDepositPlaintext, Utxo, DEFAULT_TAG_WINDOW,
+    owner_utxo_hash, Data, KeypairWalletAuthority, RingDepositPlaintext, Utxo, DEFAULT_TAG_WINDOW,
     SOL_ASSET_ID, SOL_MINT,
 };
 use zolana_tree::TreeAccount;
@@ -548,7 +548,8 @@ fn auditor_sees_every_ring_transfer() -> Result<()> {
 
     // 9. Normal operation is undisturbed: the recipient still discovers its
     //    output through `Wallet::sync` on its own view tag, with no auditor key.
-    let recipient_authority = LocalWalletAuthority::new(Address::default(), &env.recipient.keypair);
+    let recipient_authority =
+        KeypairWalletAuthority::new(Address::default(), &env.recipient.keypair);
     env.recipient.wallet.sync(
         &recipient_authority,
         std::slice::from_ref(&indexed),

--- a/program-tests/shielded-pool/tests/deposit/functional.rs
+++ b/program-tests/shielded-pool/tests/deposit/functional.rs
@@ -19,7 +19,7 @@ use zolana_test_utils::litesvm_asserts::{
 };
 use zolana_transaction::{
     derive_blinding, owner_utxo_hash, serialization::RingDepositPlaintext, AssetRegistry, Data,
-    LocalWalletAuthority, Utxo, Wallet, DEFAULT_TAG_WINDOW, SOL_MINT,
+    KeypairWalletAuthority, Utxo, Wallet, DEFAULT_TAG_WINDOW, SOL_MINT,
 };
 
 use shielded_pool_tests::support::{
@@ -67,7 +67,7 @@ fn sol_deposit_moves_lamports_emits_the_exact_output_and_updates_the_indexer() {
             expected_amount: 750_000_000,
             expected_asset: [0u8; 32],
             root_before,
-            authority: &LocalWalletAuthority::new(Pubkey::default(), &recipient_key),
+            authority: &KeypairWalletAuthority::new(Pubkey::default(), &recipient_key),
         },
     );
     assert_eq!(recipient.utxos.len(), 1);
@@ -241,7 +241,7 @@ fn bootstrap_deposits_keep_indexer_wallet_and_tree_in_sync() {
         AssetRegistry::default(),
     )
     .expect("wallet");
-    let authority = LocalWalletAuthority::new(Address::default(), &recipient_keypair);
+    let authority = KeypairWalletAuthority::new(Address::default(), &recipient_keypair);
 
     let mut owner_utxo_hashes = Vec::new();
     let mut view_tags = Vec::new();
@@ -374,7 +374,7 @@ fn ring_sol_deposit_settles_and_indexes_the_exact_output() {
             expected_asset: [0u8; 32],
             expected_ring_program_id: RING_TEST_PROGRAM_ID,
             root_before,
-            authority: &LocalWalletAuthority::new(Address::default(), &recipient_key),
+            authority: &KeypairWalletAuthority::new(Address::default(), &recipient_key),
         },
     );
     assert_eq!(recipient.utxos.len(), 1);
@@ -599,7 +599,7 @@ fn ring_spl_deposit_settles_and_indexes_the_exact_output() {
             expected_asset: mint.to_bytes(),
             expected_ring_program_id: RING_TEST_PROGRAM_ID,
             root_before,
-            authority: &LocalWalletAuthority::new(Address::default(), &recipient_key),
+            authority: &KeypairWalletAuthority::new(Address::default(), &recipient_key),
         },
     );
     assert_eq!(recipient.utxos.len(), 1);

--- a/program-tests/shielded-pool/tests/localnet/deposit.rs
+++ b/program-tests/shielded-pool/tests/localnet/deposit.rs
@@ -16,7 +16,7 @@ use zolana_program_test::{
     RING_TEST_PROGRAM_ID,
 };
 use zolana_transaction::{
-    AssetRegistry, LocalWalletAuthority, SyncWalletAuthority, Wallet, DEFAULT_TAG_WINDOW,
+    AssetRegistry, KeypairWalletAuthority, SyncWalletAuthority, Wallet, DEFAULT_TAG_WINDOW,
 };
 
 use shielded_pool_tests::support::localnet::{
@@ -83,7 +83,7 @@ fn deposit_sol_on_localnet_prints_signatures() -> TestResult {
     assert_eq!(direct_root_after, indexer.root());
     assert_wallet_discovers(
         &mut direct_recipient,
-        &LocalWalletAuthority::new(Pubkey::default(), &direct_keypair),
+        &KeypairWalletAuthority::new(Pubkey::default(), &direct_keypair),
         &direct_view,
     )?;
 
@@ -160,7 +160,7 @@ fn deposit_sol_on_localnet_prints_signatures() -> TestResult {
     assert_eq!(ring_root_after, indexer.root());
     assert_wallet_discovers(
         &mut ring_recipient,
-        &LocalWalletAuthority::new(Pubkey::default(), &ring_keypair),
+        &KeypairWalletAuthority::new(Pubkey::default(), &ring_keypair),
         &ring_view,
     )?;
 

--- a/program-tests/shielded-pool/tests/localnet/photon.rs
+++ b/program-tests/shielded-pool/tests/localnet/photon.rs
@@ -61,7 +61,7 @@ use zolana_test_utils::{
 };
 use zolana_transaction::{
     serialization::confidential::{Confidential, ConfidentialOutputPlaintext},
-    AssetRegistry, Data, LocalWalletAuthority, Utxo, Wallet, WalletUtxo, DEFAULT_TAG_WINDOW,
+    AssetRegistry, Data, KeypairWalletAuthority, Utxo, Wallet, WalletUtxo, DEFAULT_TAG_WINDOW,
     SOL_MINT,
 };
 use zolana_tree::TreeAccount;

--- a/program-tests/shielded-pool/tests/localnet/photon/encrypted_transfer.rs
+++ b/program-tests/shielded-pool/tests/localnet/photon/encrypted_transfer.rs
@@ -179,7 +179,7 @@ fn shield_encrypted_transfer_recovered_by_decryption() -> TestResult {
     // decrypting it. `Wallet::store` keeps only recipient-owned UTXOs, so the
     // sender's change slot (encrypted to the sender) is not stored.
     let mut wallet = Wallet::new(recipient.shielded_address()?, AssetRegistry::default())?;
-    let authority = LocalWalletAuthority::new(Pubkey::default(), &recipient);
+    let authority = KeypairWalletAuthority::new(Pubkey::default(), &recipient);
     wallet.sync(
         &authority,
         std::slice::from_ref(&indexed),

--- a/program-tests/shielded-pool/tests/spl_interface/functional.rs
+++ b/program-tests/shielded-pool/tests/spl_interface/functional.rs
@@ -8,7 +8,7 @@ use zolana_program_test::{test_blinding, ZolanaProgramTest};
 use zolana_test_utils::litesvm_asserts::{
     litesvm_assert_create_spl_interface, litesvm_assert_spl_deposit, SplDepositAssertArgs,
 };
-use zolana_transaction::{AssetRegistry, LocalWalletAuthority, Wallet};
+use zolana_transaction::{AssetRegistry, KeypairWalletAuthority, Wallet};
 
 use shielded_pool_tests::support::fixtures::{register_mint, spl_depositor, Pool};
 
@@ -182,7 +182,7 @@ fn spl_deposit_moves_tokens_emits_the_exact_output_and_updates_the_indexer() {
             vault_before,
             user_token_before: user_before,
             root_before,
-            authority: &LocalWalletAuthority::new(Address::default(), &recipient_key),
+            authority: &KeypairWalletAuthority::new(Address::default(), &recipient_key),
         },
     );
     assert_eq!(recipient.utxos.len(), 1);

--- a/program-tests/test-utils/src/lifecycle/deposit.rs
+++ b/program-tests/test-utils/src/lifecycle/deposit.rs
@@ -7,7 +7,7 @@ use solana_signer::Signer;
 use zolana_event::indexed_events_from_instruction_groups;
 use zolana_interface::SHIELDED_POOL_PROGRAM_ID;
 use zolana_program_test::deposit_output_from_event;
-use zolana_transaction::{Address, LocalWalletAuthority, Wallet, SOL_MINT};
+use zolana_transaction::{Address, KeypairWalletAuthority, Wallet, SOL_MINT};
 
 use super::{Deposit, DepositRecord, LifecycleHarness, SplDepositAccounts};
 use crate::{
@@ -124,7 +124,7 @@ impl LifecycleHarness {
             .map_err(|e| anyhow!("proofless output decode failed: {e:?}"))?;
 
         let mut wallet = Wallet::new(keypair.shielded_address()?, self.assets.clone())?;
-        let authority = LocalWalletAuthority::new(Address::default(), &keypair);
+        let authority = KeypairWalletAuthority::new(Address::default(), &keypair);
         match &record.spl {
             None => assert_deposit(
                 &self.rpc,

--- a/program-tests/test-utils/src/lifecycle/wallet_sync.rs
+++ b/program-tests/test-utils/src/lifecycle/wallet_sync.rs
@@ -1,7 +1,7 @@
 //! Wallet synchronization and explicit UTXO assertions.
 
 use anyhow::Result;
-use zolana_transaction::{Address, LocalWalletAuthority, Utxo, DEFAULT_TAG_WINDOW};
+use zolana_transaction::{Address, KeypairWalletAuthority, Utxo, DEFAULT_TAG_WINDOW};
 
 use super::LifecycleHarness;
 use crate::localnet::ZERO;
@@ -17,7 +17,7 @@ impl LifecycleHarness {
         let assets = self.assets.clone();
         let actor = self.actor_mut(name);
         actor.wallet.registry = assets;
-        let authority = LocalWalletAuthority::new(Address::default(), &actor.keypair);
+        let authority = KeypairWalletAuthority::new(Address::default(), &actor.keypair);
         actor
             .wallet
             .sync(&authority, &indexed, 0, DEFAULT_TAG_WINDOW)?;
@@ -60,7 +60,7 @@ impl LifecycleHarness {
         let assets = self.assets.clone();
         let actor = self.actor_mut(name);
         actor.wallet.registry = assets;
-        let authority = LocalWalletAuthority::new(Address::default(), &actor.keypair);
+        let authority = KeypairWalletAuthority::new(Address::default(), &actor.keypair);
         actor
             .wallet
             .sync(&authority, &indexed, 0, DEFAULT_TAG_WINDOW)?;

--- a/program-tests/test-utils/src/ring/mod.rs
+++ b/program-tests/test-utils/src/ring/mod.rs
@@ -28,7 +28,7 @@ use zolana_interface::{
 };
 use zolana_program_test::RING_TEST_PROGRAM_ID;
 use zolana_transaction::{
-    serialization::confidential::Confidential, LocalWalletAuthority, ShieldedTransaction, Utxo,
+    serialization::confidential::Confidential, KeypairWalletAuthority, ShieldedTransaction, Utxo,
     WalletUtxo, DEFAULT_TAG_WINDOW,
 };
 
@@ -164,7 +164,7 @@ impl RingHarness {
         self.ensure_fresh_actor(name)?;
         let indexed = self.indexed.clone();
         let actor = self.actor_mut(name);
-        let authority = LocalWalletAuthority::new(Address::default(), &actor.keypair);
+        let authority = KeypairWalletAuthority::new(Address::default(), &actor.keypair);
         actor
             .wallet
             .sync(&authority, &indexed, 0, DEFAULT_TAG_WINDOW)?;

--- a/program-tests/test-utils/src/ring/ring_deposit.rs
+++ b/program-tests/test-utils/src/ring/ring_deposit.rs
@@ -19,8 +19,8 @@ use zolana_program_test::{
     ring_deposit_output_from_event, test_blinding, Rejection, RING_TEST_PROGRAM_ID,
 };
 use zolana_transaction::{
-    owner_utxo_hash, serialization::RingDepositPlaintext, Data, LocalWalletAuthority, Utxo, Wallet,
-    SOL_MINT,
+    owner_utxo_hash, serialization::RingDepositPlaintext, Data, KeypairWalletAuthority, Utxo,
+    Wallet, SOL_MINT,
 };
 
 use super::{RingDepositRecord, RingHarness, SplRingDepositAccounts};
@@ -237,7 +237,7 @@ impl RingHarness {
             .map_err(|e| anyhow!("encrypted ring deposit output decode failed: {e:?}"))?;
 
         let mut wallet = Wallet::new(keypair.shielded_address()?, self.assets.clone())?;
-        let authority = LocalWalletAuthority::new(Address::default(), &keypair);
+        let authority = KeypairWalletAuthority::new(Address::default(), &keypair);
         let expected_asset = match &record.spl {
             None => SOL_MINT,
             Some(spl) => Address::new_from_array(spl.mint.to_bytes()),

--- a/sdk-libs/keypair/src/derivation.rs
+++ b/sdk-libs/keypair/src/derivation.rs
@@ -66,6 +66,13 @@ pub const INFO_PDA_VIEW_KEY: &[u8] = b"TSPP/pda_view/v1";
 /// [`ed25519_derivation_message`], never this bare payload.
 pub const ED25519_DERIVATION_MSG: &[u8] = b"TSPP/derive/v1";
 
+/// An ed25519 `derivation_seed` is the RFC 8032 signature over
+/// [`ed25519_derivation_message`].
+pub const ED25519_SEED_LEN: usize = 64;
+
+/// A P-256 `derivation_seed` is the x-coordinate of `ECDH(signing_sk, P_derive)`.
+pub const P256_SEED_LEN: usize = 32;
+
 /// Every payload under this prefix is a derivation-seed payload (the PDA
 /// payload family carries an address, so the guard matches the prefix).
 pub const DERIVATION_PAYLOAD_PREFIX: &[u8] = b"TSPP/derive/";
@@ -263,6 +270,35 @@ pub(crate) fn view_root(secret: &SecretKey) -> Zeroizing<[u8; 32]> {
     out
 }
 
+/// Expands both role secrets from a `derivation_seed` produced outside this
+/// crate, for backends whose signing key is hardware-resident and therefore
+/// cannot go through [`crate::ShieldedKeypair::from_keypair`]: the seed is
+/// whatever the device returns for its rail (an ed25519 signature over
+/// [`ed25519_derivation_message`], or `ECDH(signing_sk, P_derive)`), and the
+/// expansion here is bit-identical to the software path.
+///
+/// A remote backend must derive both roles through this function rather than
+/// reimplementing the HKDF schedule. A divergent expansion yields a well-formed
+/// but *different* identity: every signature still verifies and every address
+/// still looks correct, so nothing downstream catches it.
+///
+/// The seed width is fixed per rail ([`ED25519_SEED_LEN`], [`P256_SEED_LEN`])
+/// and checked here for the same reason. HKDF-Extract accepts any input length,
+/// so a device that returned a truncated seed would otherwise expand cleanly
+/// into that same wrong-but-valid identity.
+pub fn expand_roles(seed: &[u8], curve: Curve) -> Result<(NullifierKey, ViewingKey), KeypairError> {
+    let rail = Rail::from_curve(curve)?;
+    let expected = rail.seed_len();
+    if seed.len() != expected {
+        return Err(KeypairError::InvalidDerivationSeed {
+            got: seed.len(),
+            expected,
+        });
+    }
+    let expansion = RoleExpansion::new(seed, rail);
+    Ok((expansion.nullifier_key()?, expansion.viewing_key()?))
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum Rail {
     Ed25519,
@@ -275,6 +311,15 @@ impl Rail {
             Curve::Ed25519 => Ok(Self::Ed25519),
             Curve::P256 => Ok(Self::Ecdh),
             Curve::Pda => Err(KeypairError::PdaCannotSign),
+        }
+    }
+
+    /// The width of the seed this rail produces: an RFC 8032 signature, or a
+    /// P-256 ECDH x-coordinate.
+    fn seed_len(self) -> usize {
+        match self {
+            Self::Ed25519 => ED25519_SEED_LEN,
+            Self::Ecdh => P256_SEED_LEN,
         }
     }
 

--- a/sdk-libs/keypair/src/error.rs
+++ b/sdk-libs/keypair/src/error.rs
@@ -2,7 +2,10 @@ use solana_signer::SignerError;
 use thiserror::Error;
 use zolana_hasher::HasherError;
 
+/// `non_exhaustive` because backends outside this crate match on these: a new
+/// failure mode should not be a breaking change for them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum KeypairError {
     #[error("invalid public key")]
     InvalidPublicKey,
@@ -30,6 +33,9 @@ pub enum KeypairError {
 
     #[error("a PDA holds no signing secret; the owning program signs via CPI")]
     PdaCannotSign,
+
+    #[error("derivation seed is {got} bytes, expected {expected} on this rail")]
+    InvalidDerivationSeed { got: usize, expected: usize },
 
     #[error("HKDF expansion failed")]
     Hkdf,

--- a/sdk-libs/keypair/src/pda.rs
+++ b/sdk-libs/keypair/src/pda.rs
@@ -15,8 +15,8 @@ use crate::{
     nullifier_key::NullifierKey,
     pubkey::{Curve, P256Pubkey, PublicKey},
     shielded::{CompressedShieldedAddress, ShieldedAddress},
-    traits::{ShieldedKeypairTrait, ViewingKeyTrait},
-    viewing_key::{Salt, ViewTag, ViewingKey},
+    traits::ShieldedKeypairTrait,
+    viewing_key::ViewingKey,
 };
 
 /// Not a `ShieldedKeypair`: it holds no signing secret, so that state is
@@ -181,85 +181,6 @@ impl ShieldedKeypairTrait for ShieldedPda {
     }
 }
 
-/// Forwards to the identity's derived viewing key, so encryption and view-tag
-/// derivation need no special case.
-impl ViewingKeyTrait for ShieldedPda {
-    fn pubkey(&self) -> P256Pubkey {
-        self.viewing_key.pubkey()
-    }
-
-    fn ecdh(&self, counterparty: &P256Pubkey) -> Result<[u8; 32], KeypairError> {
-        self.viewing_key.ecdh(counterparty)
-    }
-
-    fn get_sender_view_tag(&self, tx_count: u64) -> Result<ViewTag, KeypairError> {
-        self.viewing_key.get_sender_view_tag(tx_count)
-    }
-
-    fn get_recipient_request_view_tag(&self, request_count: u64) -> Result<ViewTag, KeypairError> {
-        self.viewing_key
-            .get_recipient_request_view_tag(request_count)
-    }
-
-    fn get_send_shared_view_tag(
-        &self,
-        counterparty: &P256Pubkey,
-        i: u64,
-    ) -> Result<ViewTag, KeypairError> {
-        self.viewing_key.get_send_shared_view_tag(counterparty, i)
-    }
-
-    fn get_recipient_shared_view_tag(
-        &self,
-        counterparty: &P256Pubkey,
-        i: u64,
-    ) -> Result<ViewTag, KeypairError> {
-        self.viewing_key
-            .get_recipient_shared_view_tag(counterparty, i)
-    }
-
-    fn recipient_bootstrap_view_tag(&self) -> ViewTag {
-        self.viewing_key.recipient_bootstrap_view_tag()
-    }
-
-    fn get_transaction_viewing_key(
-        &self,
-        first_nullifier: &[u8; 32],
-    ) -> Result<ViewingKey, KeypairError> {
-        self.viewing_key
-            .get_transaction_viewing_key(first_nullifier)
-    }
-
-    fn encrypt_slot(
-        &self,
-        recipient_pubkey: &P256Pubkey,
-        plaintext: &[u8],
-        salt: Salt,
-        slot_index: u32,
-    ) -> Result<Vec<u8>, KeypairError> {
-        self.viewing_key
-            .encrypt_slot(recipient_pubkey, plaintext, salt, slot_index)
-    }
-
-    fn decrypt_utxo(
-        &self,
-        ciphertext: &[u8],
-        tx_viewing_pubkey: &P256Pubkey,
-        salt: Salt,
-        slot_index: u32,
-    ) -> Result<Vec<u8>, KeypairError> {
-        self.viewing_key
-            .decrypt_utxo(ciphertext, tx_viewing_pubkey, salt, slot_index)
-    }
-
-    fn decrypt_slot_ephemeral(
-        &self,
-        recipient_pubkey: &P256Pubkey,
-        ciphertext: &[u8],
-        salt: Salt,
-        slot_index: u32,
-    ) -> Result<Vec<u8>, KeypairError> {
-        self.viewing_key
-            .decrypt_slot_ephemeral(recipient_pubkey, ciphertext, salt, slot_index)
-    }
-}
+// Forwards to the identity's derived viewing key, so encryption and view-tag
+// derivation need no special case.
+crate::forward_viewing_key_trait!(ShieldedPda => viewing_key);

--- a/sdk-libs/keypair/src/traits/view_key.rs
+++ b/sdk-libs/keypair/src/traits/view_key.rs
@@ -76,9 +76,126 @@ pub trait ViewingKeyTrait {
     ) -> Result<Vec<u8>, KeypairError>;
 }
 
+/// Implements [`ViewingKeyTrait`] for a type that owns a [`ViewingKey`], by
+/// forwarding every method to the named field:
+///
+/// ```ignore
+/// zolana_keypair::forward_viewing_key_trait!(MyBackend => viewing_key);
+/// ```
+///
+/// Call sites inside this crate spell it `crate::forward_viewing_key_trait!`:
+/// an exported macro is only in textual scope after its definition, and some
+/// modules here are declared before this one. A doc comment cannot attach to
+/// the invocation either, so the call sites explain themselves with `//`.
+///
+/// The trait is twelve methods and a host-side viewing key forwards all of
+/// them identically, so writing it out is pure noise that can silently drift
+/// between backends.
+///
+/// A blanket impl over an accessor trait would be the tidier-looking fix and is
+/// the wrong tool: it would make it impossible for a downstream crate to
+/// implement [`ViewingKeyTrait`] by hand, since coherence must assume that type
+/// could pick up the accessor later. Hand-written impls are exactly what a
+/// device-resident viewing key needs — one that performs ECDH in an HSM and can
+/// never produce a `&ViewingKey` to forward to. A macro leaves that door open.
+#[macro_export]
+macro_rules! forward_viewing_key_trait {
+    ($backend:ty => $field:ident) => {
+        impl $crate::ViewingKeyTrait for $backend {
+            fn pubkey(&self) -> $crate::P256Pubkey {
+                self.$field.pubkey()
+            }
+
+            fn ecdh(
+                &self,
+                counterparty: &$crate::P256Pubkey,
+            ) -> ::core::result::Result<[u8; 32], $crate::KeypairError> {
+                self.$field.ecdh(counterparty)
+            }
+
+            fn get_sender_view_tag(
+                &self,
+                tx_count: u64,
+            ) -> ::core::result::Result<$crate::viewing_key::ViewTag, $crate::KeypairError> {
+                self.$field.get_sender_view_tag(tx_count)
+            }
+
+            fn get_recipient_request_view_tag(
+                &self,
+                request_count: u64,
+            ) -> ::core::result::Result<$crate::viewing_key::ViewTag, $crate::KeypairError> {
+                self.$field.get_recipient_request_view_tag(request_count)
+            }
+
+            fn get_send_shared_view_tag(
+                &self,
+                counterparty: &$crate::P256Pubkey,
+                i: u64,
+            ) -> ::core::result::Result<$crate::viewing_key::ViewTag, $crate::KeypairError> {
+                self.$field.get_send_shared_view_tag(counterparty, i)
+            }
+
+            fn get_recipient_shared_view_tag(
+                &self,
+                counterparty: &$crate::P256Pubkey,
+                i: u64,
+            ) -> ::core::result::Result<$crate::viewing_key::ViewTag, $crate::KeypairError> {
+                self.$field.get_recipient_shared_view_tag(counterparty, i)
+            }
+
+            fn recipient_bootstrap_view_tag(&self) -> $crate::viewing_key::ViewTag {
+                self.$field.recipient_bootstrap_view_tag()
+            }
+
+            fn get_transaction_viewing_key(
+                &self,
+                first_nullifier: &[u8; 32],
+            ) -> ::core::result::Result<$crate::ViewingKey, $crate::KeypairError> {
+                self.$field.get_transaction_viewing_key(first_nullifier)
+            }
+
+            fn encrypt_slot(
+                &self,
+                recipient_pubkey: &$crate::P256Pubkey,
+                plaintext: &[u8],
+                salt: $crate::viewing_key::Salt,
+                slot_index: u32,
+            ) -> ::core::result::Result<::std::vec::Vec<u8>, $crate::KeypairError> {
+                self.$field
+                    .encrypt_slot(recipient_pubkey, plaintext, salt, slot_index)
+            }
+
+            fn decrypt_utxo(
+                &self,
+                ciphertext: &[u8],
+                tx_viewing_pubkey: &$crate::P256Pubkey,
+                salt: $crate::viewing_key::Salt,
+                slot_index: u32,
+            ) -> ::core::result::Result<::std::vec::Vec<u8>, $crate::KeypairError> {
+                self.$field
+                    .decrypt_utxo(ciphertext, tx_viewing_pubkey, salt, slot_index)
+            }
+
+            fn decrypt_slot_ephemeral(
+                &self,
+                recipient_pubkey: &$crate::P256Pubkey,
+                ciphertext: &[u8],
+                salt: $crate::viewing_key::Salt,
+                slot_index: u32,
+            ) -> ::core::result::Result<::std::vec::Vec<u8>, $crate::KeypairError> {
+                self.$field
+                    .decrypt_slot_ephemeral(recipient_pubkey, ciphertext, salt, slot_index)
+            }
+        }
+    };
+}
+
 /// Forwards to the inherent `ViewingKey` methods. Inherent methods win method
 /// resolution over trait methods of the same name, so `self.foo()` calls the
 /// concrete impl, not the trait method being defined.
+///
+/// Not written with [`forward_viewing_key_trait!`]: this is the base case the
+/// macro forwards *to*, and it has no field to name.
 impl ViewingKeyTrait for ViewingKey {
     fn pubkey(&self) -> P256Pubkey {
         self.pubkey()
@@ -154,85 +271,6 @@ impl ViewingKeyTrait for ViewingKey {
     }
 }
 
-/// Forwards to the keypair's inner `viewing_key`, so a full [`ShieldedKeypair`]
-/// can stand in wherever a viewing-key backend is required.
-impl ViewingKeyTrait for ShieldedKeypair {
-    fn pubkey(&self) -> P256Pubkey {
-        self.viewing_key.pubkey()
-    }
-
-    fn ecdh(&self, counterparty: &P256Pubkey) -> Result<[u8; 32], KeypairError> {
-        self.viewing_key.ecdh(counterparty)
-    }
-
-    fn get_sender_view_tag(&self, tx_count: u64) -> Result<ViewTag, KeypairError> {
-        self.viewing_key.get_sender_view_tag(tx_count)
-    }
-
-    fn get_recipient_request_view_tag(&self, request_count: u64) -> Result<ViewTag, KeypairError> {
-        self.viewing_key
-            .get_recipient_request_view_tag(request_count)
-    }
-
-    fn get_send_shared_view_tag(
-        &self,
-        counterparty: &P256Pubkey,
-        i: u64,
-    ) -> Result<ViewTag, KeypairError> {
-        self.viewing_key.get_send_shared_view_tag(counterparty, i)
-    }
-
-    fn get_recipient_shared_view_tag(
-        &self,
-        counterparty: &P256Pubkey,
-        i: u64,
-    ) -> Result<ViewTag, KeypairError> {
-        self.viewing_key
-            .get_recipient_shared_view_tag(counterparty, i)
-    }
-
-    fn recipient_bootstrap_view_tag(&self) -> ViewTag {
-        self.viewing_key.recipient_bootstrap_view_tag()
-    }
-
-    fn get_transaction_viewing_key(
-        &self,
-        first_nullifier: &[u8; 32],
-    ) -> Result<ViewingKey, KeypairError> {
-        self.viewing_key
-            .get_transaction_viewing_key(first_nullifier)
-    }
-
-    fn encrypt_slot(
-        &self,
-        recipient_pubkey: &P256Pubkey,
-        plaintext: &[u8],
-        salt: Salt,
-        slot_index: u32,
-    ) -> Result<Vec<u8>, KeypairError> {
-        self.viewing_key
-            .encrypt_slot(recipient_pubkey, plaintext, salt, slot_index)
-    }
-
-    fn decrypt_utxo(
-        &self,
-        ciphertext: &[u8],
-        tx_viewing_pubkey: &P256Pubkey,
-        salt: Salt,
-        slot_index: u32,
-    ) -> Result<Vec<u8>, KeypairError> {
-        self.viewing_key
-            .decrypt_utxo(ciphertext, tx_viewing_pubkey, salt, slot_index)
-    }
-
-    fn decrypt_slot_ephemeral(
-        &self,
-        recipient_pubkey: &P256Pubkey,
-        ciphertext: &[u8],
-        salt: Salt,
-        slot_index: u32,
-    ) -> Result<Vec<u8>, KeypairError> {
-        self.viewing_key
-            .decrypt_slot_ephemeral(recipient_pubkey, ciphertext, salt, slot_index)
-    }
-}
+// Forwards to the keypair's inner `viewing_key`, so a full `ShieldedKeypair`
+// can stand in wherever a viewing-key backend is required.
+crate::forward_viewing_key_trait!(ShieldedKeypair => viewing_key);

--- a/sdk-libs/keypair/tests/cases/derivation.rs
+++ b/sdk-libs/keypair/tests/cases/derivation.rs
@@ -1,16 +1,17 @@
 use zolana_keypair::{
     derivation::{
-        ed25519_derivation_message, is_derivation_input, DERIVATION_PAYLOAD_PREFIX,
+        ed25519_derivation_message, expand_roles, is_derivation_input, DERIVATION_PAYLOAD_PREFIX,
         DOMAIN_MERGE_DUMMY_NULLIFIER, DOMAIN_MERGE_OUTPUT_BLINDING_V1, DOM_SEP_KEY, DOM_SEP_NONCE,
         DOM_SEP_SILO, DST_DERIVE_P_DERIVE, DST_VIEW_ROOT_P_CONST, ED25519_DERIVATION_MSG,
-        ENC_INFO_RING_DEPOSIT, ENC_INFO_TRANSFER, HPKE_PREFIX, INFO_NF_KEY_ECDH,
+        ED25519_SEED_LEN, ENC_INFO_RING_DEPOSIT, ENC_INFO_TRANSFER, HPKE_PREFIX, INFO_NF_KEY_ECDH,
         INFO_NF_KEY_ED25519, INFO_PAIR_DOMAIN_PREFIX, INFO_PAIR_HINT_PREFIX, INFO_PDA_NF_KEY,
         INFO_PDA_VIEW_KEY, INFO_RECIPIENT_REQUEST_VIEW_TAG_PREFIX, INFO_RECIPIENT_VIEW_TAG_SECRET,
         INFO_SENDER_VIEW_TAG_PREFIX, INFO_SENDER_VIEW_TAG_SECRET, INFO_TX_VIEWING,
         INFO_VIEW_KEY_ECDH, INFO_VIEW_KEY_ED25519, MERGE_INFO, OFFCHAIN_MESSAGE_MAGIC,
-        TSPP_APPLICATION_DOMAIN,
+        P256_SEED_LEN, TSPP_APPLICATION_DOMAIN,
     },
     hash::sha256,
+    Curve, KeypairError, ShieldedKeypair, SigningKey,
 };
 
 pub(crate) fn hkdf_tags_pairwise_distinct() {
@@ -97,6 +98,62 @@ pub(crate) fn derivation_inputs_are_detected() {
     let mut truncated = ed25519_derivation_message(&[7u8; 32]);
     truncated.pop();
     assert!(!is_derivation_input(&truncated));
+}
+
+/// `expand_roles` is the entry a remote backend derives through, so it must
+/// produce exactly what the software constructor produces — on both rails. A
+/// divergence here is silent: the identity stays well-formed and every
+/// signature still verifies, it is simply not the user's wallet.
+pub(crate) fn expand_roles_matches_the_software_constructor() {
+    let keys = [
+        SigningKey::from_ed25519_bytes(&[5u8; 32]),
+        SigningKey::from_p256_bytes(&[6u8; 32]).expect("P-256 scalar"),
+    ];
+    for signing_key in keys {
+        let curve = signing_key.curve();
+        let seed = signing_key.derivation_seed().expect("derivation seed");
+        let (nullifier_key, viewing_key) =
+            expand_roles(&seed, curve).expect("roles expand from the seed");
+        let software = ShieldedKeypair::from_keypair(signing_key).expect("software keypair");
+
+        assert_eq!(
+            *nullifier_key.secret(),
+            *software.nullifier_key.secret(),
+            "{curve:?} nullifier secret diverged from the software path"
+        );
+        assert_eq!(
+            *viewing_key.secret_bytes(),
+            *software.viewing_key.secret_bytes(),
+            "{curve:?} viewing secret diverged from the software path"
+        );
+    }
+}
+
+/// HKDF-Extract accepts any input length, so a device that returned a truncated
+/// seed would expand cleanly into a wrong-but-valid identity. The width is fixed
+/// per rail, so reject anything else rather than derive from it.
+pub(crate) fn expand_roles_rejects_a_seed_of_the_wrong_width() {
+    for (curve, expected) in [
+        (Curve::Ed25519, ED25519_SEED_LEN),
+        (Curve::P256, P256_SEED_LEN),
+    ] {
+        for got in [expected - 1, expected + 1, 0] {
+            assert_eq!(
+                expand_roles(&vec![7u8; got], curve).err(),
+                Some(KeypairError::InvalidDerivationSeed { got, expected }),
+                "{curve:?} accepted a {got}-byte seed"
+            );
+        }
+        assert!(expand_roles(&vec![7u8; expected], curve).is_ok());
+    }
+}
+
+/// A PDA holds no signing secret, so it has no seed and no roles to expand.
+pub(crate) fn expand_roles_rejects_the_pda_curve() {
+    assert!(matches!(
+        expand_roles(&[0u8; 64], Curve::Pda),
+        Err(KeypairError::PdaCannotSign)
+    ));
 }
 
 pub(crate) fn poseidon_tags_pairwise_distinct() {

--- a/sdk-libs/keypair/tests/keypair.rs
+++ b/sdk-libs/keypair/tests/keypair.rs
@@ -222,6 +222,13 @@ fn domain_separation_tags_are_pairwise_distinct() {
 }
 
 #[test]
+fn role_expansion_from_a_device_seed_matches_the_software_path() {
+    cases::derivation::expand_roles_matches_the_software_constructor();
+    cases::derivation::expand_roles_rejects_a_seed_of_the_wrong_width();
+    cases::derivation::expand_roles_rejects_the_pda_curve();
+}
+
+#[test]
 fn offchain_derivation_message_is_pinned_and_detected() {
     cases::derivation::application_domain_is_payload_hash();
     cases::derivation::offchain_derivation_message_golden();

--- a/sdk-libs/transaction/src/error.rs
+++ b/sdk-libs/transaction/src/error.rs
@@ -160,6 +160,12 @@ pub enum TransactionError {
     #[error("wallet authority did not provide its current viewing key")]
     MissingCurrentViewingKey,
 
+    /// Raised when the authority is built, not when it is used, so it is
+    /// distinct from [`Self::MissingCurrentViewingKey`]: that one means a scan
+    /// was handed a snapshot without the current key.
+    #[error("viewing keys do not include the keypair's own, so this authority would encrypt to one key and scan with another")]
+    AuthorityViewingKeyMismatch,
+
     #[error("wallet authority error: {0}")]
     Authority(String),
 }

--- a/sdk-libs/transaction/src/lib.rs
+++ b/sdk-libs/transaction/src/lib.rs
@@ -32,7 +32,7 @@ pub use utxo::{derive_blinding, owner_utxo_hash, Blinding, ProofInputUtxo, Utxo}
 pub use wallet::{
     asset::{AssetRegistry, SOL_ASSET_ID, SOL_MINT},
     AnonymousRecipientSlot, ApprovalRequest, AssetBalance, Balances, CursorStream,
-    EncryptedEnvelope, EncryptedSplit, EncryptedTransfer, Filter, LocalWalletAuthority,
+    EncryptedEnvelope, EncryptedSplit, EncryptedTransfer, Filter, KeypairWalletAuthority,
     P256Signature, PrivateTransaction, PrivateTransactionDirection, PrivateTransactionId,
     PrivateTransactionKind, PrivateTransactionStatus, SyncReport, SyncWalletAuthority,
     ViewingKeyEntry, Wallet, WalletAuthority, WalletSyncMaterial, WalletUtxo, DEFAULT_TAG_WINDOW,

--- a/sdk-libs/transaction/src/wallet/authority.rs
+++ b/sdk-libs/transaction/src/wallet/authority.rs
@@ -4,7 +4,7 @@ use zolana_event::MessageData;
 use zolana_keypair::{
     shielded::{ShieldedAddress, ShieldedKeypair},
     viewing_key::{random_salt, Salt, ViewTag},
-    NullifierKey, P256Pubkey, ViewingKey,
+    NullifierKey, P256Pubkey, ShieldedKeypairTrait, ViewingKey, ViewingKeyTrait,
 };
 
 use crate::{
@@ -248,18 +248,67 @@ where
     }
 }
 
-/// Binds local shielded keys to the Solana address that publishes them.
-pub struct LocalWalletAuthority<'a> {
+/// Binds a shielded keypair to the Solana address that publishes it.
+///
+/// Generic over the keypair so a backend whose signing key is hardware-resident
+/// — an HSM, a KMS, a remote custodian — becomes a [`WalletAuthority`] by
+/// implementing [`ShieldedKeypairTrait`] and [`ViewingKeyTrait`], with no
+/// reimplementation of the encryption bodies below. "Local" describes the
+/// encryption and scan material, which is in this process for every backend:
+/// both role secrets are private proof inputs, so no signing device can hold
+/// them on the wallet's behalf.
+///
+/// `K` defaults to [`ShieldedKeypair`], so `LocalWalletAuthority<'_>` keeps
+/// meaning what it did.
+pub struct LocalWalletAuthority<'a, K = ShieldedKeypair> {
     solana_pubkey: Address,
-    keypair: &'a ShieldedKeypair,
+    keypair: &'a K,
+    viewing_keys: Vec<ViewingKey>,
 }
 
-impl<'a> LocalWalletAuthority<'a> {
+impl<'a> LocalWalletAuthority<'a, ShieldedKeypair> {
+    /// Scans with the keypair's own viewing key. Use
+    /// [`Self::with_viewing_keys`] to add rotated-out keys, or for a backend
+    /// that is not a [`ShieldedKeypair`].
     pub fn new(solana_pubkey: impl Into<Address>, keypair: &'a ShieldedKeypair) -> Self {
+        let viewing_keys = vec![keypair.viewing_key.clone()];
         Self {
             solana_pubkey: solana_pubkey.into(),
             keypair,
+            viewing_keys,
         }
+    }
+}
+
+impl<'a, K: ViewingKeyTrait> LocalWalletAuthority<'a, K> {
+    /// Binds any shielded keypair backend to the viewing keys a scan needs:
+    /// every current and historical key.
+    ///
+    /// `viewing_keys` must contain the keypair's own, or this fails with
+    /// [`TransactionError::AuthorityViewingKeyMismatch`]. That check is why this constructor is fallible while
+    /// [`Self::new`] is not: `new` reads the key off the keypair and cannot
+    /// disagree with it, whereas a generic backend cannot hand over its viewing
+    /// key at all — [`ViewingKeyTrait`] deliberately exposes operations rather
+    /// than the secret — so the caller supplies it and the two could drift.
+    ///
+    /// A drift is not cosmetic. The encryption bodies key off the *keypair*
+    /// while a scan keys off this vector, so a wallet built from a mismatched
+    /// pair would encrypt to one key and scan with another. Rejecting it at
+    /// construction fails at the mistake instead of later, inside a scan.
+    pub fn with_viewing_keys(
+        solana_pubkey: impl Into<Address>,
+        keypair: &'a K,
+        viewing_keys: Vec<ViewingKey>,
+    ) -> Result<Self, TransactionError> {
+        let current = keypair.pubkey();
+        if !viewing_keys.iter().any(|key| key.pubkey() == current) {
+            return Err(TransactionError::AuthorityViewingKeyMismatch);
+        }
+        Ok(Self {
+            solana_pubkey: solana_pubkey.into(),
+            keypair,
+            viewing_keys,
+        })
     }
 }
 
@@ -271,18 +320,19 @@ fn recipient_slot_index(i: usize) -> Result<u32, TransactionError> {
     })
 }
 
-/// Shared bodies for every local authority over a [`ShieldedKeypair`]
-/// ([`LocalWalletAuthority`] and the bare keypair impl below), so the
-/// encryption and signing logic exists once.
-fn encrypt_confidential_transfer_with(
-    keypair: &ShieldedKeypair,
+/// Shared bodies for every local authority ([`LocalWalletAuthority`] and the
+/// bare keypair impl below), so the encryption and signing logic exists once.
+///
+/// Written against [`ViewingKeyTrait`] and [`ShieldedKeypairTrait`] rather than
+/// a concrete keypair: these are exactly the capabilities the bodies need, so
+/// any backend that has them gets the same code.
+fn encrypt_confidential_transfer_with<K: ViewingKeyTrait>(
+    keypair: &K,
     first_nullifier: &[u8; 32],
     outputs: &[SppProofOutputUtxo],
     assets: &AssetRegistry,
 ) -> Result<EncryptedTransfer, TransactionError> {
-    let tx = keypair
-        .viewing_key
-        .get_transaction_viewing_key(first_nullifier)?;
+    let tx = keypair.get_transaction_viewing_key(first_nullifier)?;
     let salt = random_salt();
     let slots = encode_confidential_slots(outputs, assets, &tx, salt)?;
     Ok(EncryptedTransfer {
@@ -292,18 +342,16 @@ fn encrypt_confidential_transfer_with(
     })
 }
 
-fn encrypt_anonymous_transfer_with(
-    keypair: &ShieldedKeypair,
+fn encrypt_anonymous_transfer_with<K: ViewingKeyTrait>(
+    keypair: &K,
     first_nullifier: &[u8; 32],
     sender_view_tag: ViewTag,
     sender: &AnonymousTransferSenderPlaintext,
     recipients: &[AnonymousRecipientSlot],
 ) -> Result<EncryptedTransfer, TransactionError> {
-    let tx = keypair
-        .viewing_key
-        .get_transaction_viewing_key(first_nullifier)?;
+    let tx = keypair.get_transaction_viewing_key(first_nullifier)?;
     let salt = random_salt();
-    let self_pubkey = keypair.viewing_key.pubkey();
+    let self_pubkey = keypair.pubkey();
 
     let mut slots = Vec::with_capacity(1 + recipients.len());
     let sender_cx = AnonymousSenderEncode {
@@ -342,15 +390,13 @@ fn encrypt_anonymous_transfer_with(
     })
 }
 
-fn encrypt_split_with(
-    keypair: &ShieldedKeypair,
+fn encrypt_split_with<K: ViewingKeyTrait>(
+    keypair: &K,
     first_nullifier: &[u8; 32],
     view_tag: ViewTag,
     bundle: &SplitBundlePlaintext,
 ) -> Result<EncryptedSplit, TransactionError> {
-    let tx = keypair
-        .viewing_key
-        .get_transaction_viewing_key(first_nullifier)?;
+    let tx = keypair.get_transaction_viewing_key(first_nullifier)?;
     let salt = random_salt();
     let tx_viewing_pk = tx.pubkey();
     let message = Split::encode_plaintext(
@@ -358,7 +404,7 @@ fn encrypt_split_with(
         view_tag,
         &SplitEncode {
             tx,
-            recipient_pubkey: keypair.viewing_key.pubkey(),
+            recipient_pubkey: keypair.pubkey(),
             salt,
             slot_index: 0,
             blinding_seed: bundle.blinding_seed,
@@ -371,8 +417,8 @@ fn encrypt_split_with(
     })
 }
 
-fn sign_p256_with(
-    keypair: &ShieldedKeypair,
+fn sign_p256_with<K: ShieldedKeypairTrait>(
+    keypair: &K,
     message_hash: &[u8; 32],
 ) -> Result<P256Signature, TransactionError> {
     let bytes = keypair
@@ -389,17 +435,19 @@ fn sign_p256_with(
     })
 }
 
-impl SyncWalletAuthority for LocalWalletAuthority<'_> {
+impl<K: ShieldedKeypairTrait + ViewingKeyTrait + Sync> SyncWalletAuthority
+    for LocalWalletAuthority<'_, K>
+{
     fn solana_pubkey(&self) -> Address {
         self.solana_pubkey
     }
 
     fn shielded_address(&self) -> Result<ShieldedAddress, TransactionError> {
-        Ok(self.keypair.shielded_address()?)
+        Ok(ShieldedKeypairTrait::shielded_address(self.keypair)?)
     }
 
     fn viewing_keys(&self) -> Result<Vec<ViewingKey>, TransactionError> {
-        Ok(vec![self.keypair.viewing_key.clone()])
+        Ok(self.viewing_keys.clone())
     }
 
     fn encrypt_confidential_transfer(
@@ -441,7 +489,7 @@ impl SyncWalletAuthority for LocalWalletAuthority<'_> {
     }
 
     fn spend_nullifier_key(&self) -> Result<NullifierKey, TransactionError> {
-        Ok(self.keypair.nullifier_key.clone())
+        Ok(ShieldedKeypairTrait::nullifier_key(self.keypair))
     }
 }
 

--- a/sdk-libs/transaction/src/wallet/authority.rs
+++ b/sdk-libs/transaction/src/wallet/authority.rs
@@ -253,20 +253,22 @@ where
 /// Generic over the keypair so a backend whose signing key is hardware-resident
 /// — an HSM, a KMS, a remote custodian — becomes a [`WalletAuthority`] by
 /// implementing [`ShieldedKeypairTrait`] and [`ViewingKeyTrait`], with no
-/// reimplementation of the encryption bodies below. "Local" describes the
-/// encryption and scan material, which is in this process for every backend:
-/// both role secrets are private proof inputs, so no signing device can hold
-/// them on the wallet's behalf.
+/// reimplementation of the encryption bodies below.
 ///
-/// `K` defaults to [`ShieldedKeypair`], so `LocalWalletAuthority<'_>` keeps
-/// meaning what it did.
-pub struct LocalWalletAuthority<'a, K = ShieldedKeypair> {
+/// Wherever the signing key lives, the encryption and scan material is in this
+/// process: both role secrets are private proof inputs, so no signing device can
+/// hold them on the wallet's behalf.
+///
+/// `K` defaults to [`ShieldedKeypair`] because a software keypair is the
+/// ordinary case, the way `HashMap` defaults its hasher — not to keep older
+/// call sites compiling.
+pub struct KeypairWalletAuthority<'a, K = ShieldedKeypair> {
     solana_pubkey: Address,
     keypair: &'a K,
     viewing_keys: Vec<ViewingKey>,
 }
 
-impl<'a> LocalWalletAuthority<'a, ShieldedKeypair> {
+impl<'a> KeypairWalletAuthority<'a, ShieldedKeypair> {
     /// Scans with the keypair's own viewing key. Use
     /// [`Self::with_viewing_keys`] to add rotated-out keys, or for a backend
     /// that is not a [`ShieldedKeypair`].
@@ -280,7 +282,7 @@ impl<'a> LocalWalletAuthority<'a, ShieldedKeypair> {
     }
 }
 
-impl<'a, K: ViewingKeyTrait> LocalWalletAuthority<'a, K> {
+impl<'a, K: ViewingKeyTrait> KeypairWalletAuthority<'a, K> {
     /// Binds any shielded keypair backend to the viewing keys a scan needs:
     /// every current and historical key.
     ///
@@ -320,8 +322,9 @@ fn recipient_slot_index(i: usize) -> Result<u32, TransactionError> {
     })
 }
 
-/// Shared bodies for every local authority ([`LocalWalletAuthority`] and the
-/// bare keypair impl below), so the encryption and signing logic exists once.
+/// Shared bodies for every authority over a shielded keypair
+/// ([`KeypairWalletAuthority`] and the bare keypair impl below), so the
+/// encryption and signing logic exists once.
 ///
 /// Written against [`ViewingKeyTrait`] and [`ShieldedKeypairTrait`] rather than
 /// a concrete keypair: these are exactly the capabilities the bodies need, so
@@ -436,7 +439,7 @@ fn sign_p256_with<K: ShieldedKeypairTrait>(
 }
 
 impl<K: ShieldedKeypairTrait + ViewingKeyTrait + Sync> SyncWalletAuthority
-    for LocalWalletAuthority<'_, K>
+    for KeypairWalletAuthority<'_, K>
 {
     fn solana_pubkey(&self) -> Address {
         self.solana_pubkey

--- a/sdk-libs/transaction/src/wallet/mod.rs
+++ b/sdk-libs/transaction/src/wallet/mod.rs
@@ -7,7 +7,8 @@ mod sync;
 
 pub use authority::{
     AnonymousRecipientSlot, ApprovalRequest, EncryptedEnvelope, EncryptedSplit, EncryptedTransfer,
-    LocalWalletAuthority, P256Signature, SyncWalletAuthority, WalletAuthority, WalletSyncMaterial,
+    KeypairWalletAuthority, P256Signature, SyncWalletAuthority, WalletAuthority,
+    WalletSyncMaterial,
 };
 pub use state::{
     AssetBalance, Balances, CursorStream, Filter, PrivateTransaction, PrivateTransactionDirection,

--- a/sdk-libs/transaction/tests/behavior.rs
+++ b/sdk-libs/transaction/tests/behavior.rs
@@ -89,6 +89,16 @@ fn merge_recovery_derivations_match_circuit_vectors() {
 }
 
 #[test]
+fn a_remote_keypair_backend_is_a_wallet_authority() {
+    cases::remote_authority::remote_backend_publishes_the_same_identity();
+    cases::remote_authority::remote_backend_signs_through_the_trait();
+    cases::remote_authority::remote_backend_encrypts_with_the_same_transaction_key();
+    cases::remote_authority::historical_viewing_keys_are_carried_through();
+    cases::remote_authority::viewing_keys_must_contain_the_keypairs_own();
+    cases::remote_authority::remote_backend_refuses_derivation_shaped_payloads();
+}
+
+#[test]
 fn plaintext_transfers_are_canonical_and_indexed_by_owner() {
     let mut world = TransactionWorld::default();
     add_keypairs(&mut world, &["alice", "bob", "carol"]);

--- a/sdk-libs/transaction/tests/cases/mod.rs
+++ b/sdk-libs/transaction/tests/cases/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod blinding;
 pub(crate) mod common;
 pub(crate) mod merge_derivation;
 pub(crate) mod plaintext_transfer;
+pub(crate) mod remote_authority;
 pub(crate) mod serialization;
 pub(crate) mod split;
 pub(crate) mod transfer;

--- a/sdk-libs/transaction/tests/cases/remote_authority.rs
+++ b/sdk-libs/transaction/tests/cases/remote_authority.rs
@@ -1,4 +1,4 @@
-//! [`LocalWalletAuthority`] over a keypair that is not a [`ShieldedKeypair`].
+//! [`KeypairWalletAuthority`] over a keypair that is not a [`ShieldedKeypair`].
 //!
 //! This is the case the generic parameter exists for: a backend whose signing
 //! key is device-resident implements [`ShieldedKeypairTrait`] and
@@ -17,7 +17,7 @@ use zolana_keypair::{
     ShieldedKeypairTrait, SigningKey, ViewingKey,
 };
 use zolana_transaction::{
-    Address, AssetRegistry, LocalWalletAuthority, SyncWalletAuthority, TransactionError,
+    Address, AssetRegistry, KeypairWalletAuthority, SyncWalletAuthority, TransactionError,
 };
 
 const SIGNING_SECRET: [u8; 32] = [31u8; 32];
@@ -118,8 +118,8 @@ pub(crate) fn remote_backend_publishes_the_same_identity() {
     let software = software_keypair();
     let remote = RemoteKeypair::mirroring(&software);
 
-    let software_authority = LocalWalletAuthority::new(Address::default(), &software);
-    let remote_authority = LocalWalletAuthority::with_viewing_keys(
+    let software_authority = KeypairWalletAuthority::new(Address::default(), &software);
+    let remote_authority = KeypairWalletAuthority::with_viewing_keys(
         Address::default(),
         &remote,
         vec![software.viewing_key.clone()],
@@ -163,7 +163,7 @@ pub(crate) fn remote_backend_signs_through_the_trait() {
     let message_hash = [7u8; 32];
 
     let signature = {
-        let authority = LocalWalletAuthority::with_viewing_keys(
+        let authority = KeypairWalletAuthority::with_viewing_keys(
             Address::default(),
             &remote,
             vec![software.viewing_key.clone()],
@@ -176,7 +176,7 @@ pub(crate) fn remote_backend_signs_through_the_trait() {
     assert_eq!(
         signature,
         SyncWalletAuthority::sign_p256(
-            &LocalWalletAuthority::new(Address::default(), &software),
+            &KeypairWalletAuthority::new(Address::default(), &software),
             &message_hash,
         )
         .unwrap()
@@ -193,13 +193,13 @@ pub(crate) fn remote_backend_encrypts_with_the_same_transaction_key() {
     let first_nullifier = [3u8; 32];
     let assets = AssetRegistry::default();
 
-    let remote_authority = LocalWalletAuthority::with_viewing_keys(
+    let remote_authority = KeypairWalletAuthority::with_viewing_keys(
         Address::default(),
         &remote,
         vec![software.viewing_key.clone()],
     )
     .expect("the keypair's own viewing key is supplied");
-    let software_authority = LocalWalletAuthority::new(Address::default(), &software);
+    let software_authority = KeypairWalletAuthority::new(Address::default(), &software);
 
     let from_remote = SyncWalletAuthority::encrypt_confidential_transfer(
         &remote_authority,
@@ -226,7 +226,7 @@ pub(crate) fn remote_backend_encrypts_with_the_same_transaction_key() {
 pub(crate) fn remote_backend_refuses_derivation_shaped_payloads() {
     let software = software_keypair();
     let remote = RemoteKeypair::mirroring(&software);
-    let authority = LocalWalletAuthority::with_viewing_keys(
+    let authority = KeypairWalletAuthority::with_viewing_keys(
         Address::default(),
         &remote,
         vec![software.viewing_key.clone()],
@@ -255,7 +255,7 @@ pub(crate) fn historical_viewing_keys_are_carried_through() {
     let remote = RemoteKeypair::mirroring(&software);
     let retired = ViewingKey::from_bytes(&[9u8; 32]).expect("viewing key");
 
-    let authority = LocalWalletAuthority::with_viewing_keys(
+    let authority = KeypairWalletAuthority::with_viewing_keys(
         Address::default(),
         &remote,
         vec![software.viewing_key.clone(), retired.clone()],
@@ -282,7 +282,7 @@ pub(crate) fn viewing_keys_must_contain_the_keypairs_own() {
     let unrelated = ViewingKey::from_bytes(&[4u8; 32]).expect("viewing key");
 
     assert!(matches!(
-        LocalWalletAuthority::with_viewing_keys(
+        KeypairWalletAuthority::with_viewing_keys(
             Address::default(),
             &remote,
             vec![unrelated.clone()],
@@ -290,12 +290,12 @@ pub(crate) fn viewing_keys_must_contain_the_keypairs_own() {
         Err(TransactionError::AuthorityViewingKeyMismatch)
     ));
     assert!(matches!(
-        LocalWalletAuthority::with_viewing_keys(Address::default(), &remote, Vec::new()),
+        KeypairWalletAuthority::with_viewing_keys(Address::default(), &remote, Vec::new()),
         Err(TransactionError::AuthorityViewingKeyMismatch)
     ));
 
     // Extra keys alongside the current one are fine: that is key rotation.
-    assert!(LocalWalletAuthority::with_viewing_keys(
+    assert!(KeypairWalletAuthority::with_viewing_keys(
         Address::default(),
         &remote,
         vec![unrelated, software.viewing_key.clone()],

--- a/sdk-libs/transaction/tests/cases/remote_authority.rs
+++ b/sdk-libs/transaction/tests/cases/remote_authority.rs
@@ -13,9 +13,8 @@ use zolana_keypair::{
     derivation::{self, DERIVATION_PAYLOAD_PREFIX, ED25519_DERIVATION_MSG},
     hash,
     shielded::{CompressedShieldedAddress, ShieldedAddress},
-    viewing_key::{Salt, ViewTag},
     Curve, KeypairError, NullifierKey, P256Pubkey, PublicKey, ShieldedKeypair,
-    ShieldedKeypairTrait, SigningKey, ViewingKey, ViewingKeyTrait,
+    ShieldedKeypairTrait, SigningKey, ViewingKey,
 };
 use zolana_transaction::{
     Address, AssetRegistry, LocalWalletAuthority, SyncWalletAuthority, TransactionError,
@@ -104,88 +103,9 @@ impl ShieldedKeypairTrait for RemoteKeypair {
     }
 }
 
-/// Pure forwarding to the host-side viewing key, which is what every backend
-/// with a host-side viewing key has to write today.
-impl ViewingKeyTrait for RemoteKeypair {
-    fn pubkey(&self) -> P256Pubkey {
-        self.viewing_key.pubkey()
-    }
-
-    fn ecdh(&self, counterparty: &P256Pubkey) -> Result<[u8; 32], KeypairError> {
-        self.viewing_key.ecdh(counterparty)
-    }
-
-    fn get_sender_view_tag(&self, tx_count: u64) -> Result<ViewTag, KeypairError> {
-        self.viewing_key.get_sender_view_tag(tx_count)
-    }
-
-    fn get_recipient_request_view_tag(&self, request_count: u64) -> Result<ViewTag, KeypairError> {
-        self.viewing_key
-            .get_recipient_request_view_tag(request_count)
-    }
-
-    fn get_send_shared_view_tag(
-        &self,
-        counterparty: &P256Pubkey,
-        i: u64,
-    ) -> Result<ViewTag, KeypairError> {
-        self.viewing_key.get_send_shared_view_tag(counterparty, i)
-    }
-
-    fn get_recipient_shared_view_tag(
-        &self,
-        counterparty: &P256Pubkey,
-        i: u64,
-    ) -> Result<ViewTag, KeypairError> {
-        self.viewing_key
-            .get_recipient_shared_view_tag(counterparty, i)
-    }
-
-    fn recipient_bootstrap_view_tag(&self) -> ViewTag {
-        self.viewing_key.recipient_bootstrap_view_tag()
-    }
-
-    fn get_transaction_viewing_key(
-        &self,
-        first_nullifier: &[u8; 32],
-    ) -> Result<ViewingKey, KeypairError> {
-        self.viewing_key
-            .get_transaction_viewing_key(first_nullifier)
-    }
-
-    fn encrypt_slot(
-        &self,
-        recipient_pubkey: &P256Pubkey,
-        plaintext: &[u8],
-        salt: Salt,
-        slot_index: u32,
-    ) -> Result<Vec<u8>, KeypairError> {
-        self.viewing_key
-            .encrypt_slot(recipient_pubkey, plaintext, salt, slot_index)
-    }
-
-    fn decrypt_utxo(
-        &self,
-        ciphertext: &[u8],
-        tx_viewing_pubkey: &P256Pubkey,
-        salt: Salt,
-        slot_index: u32,
-    ) -> Result<Vec<u8>, KeypairError> {
-        self.viewing_key
-            .decrypt_utxo(ciphertext, tx_viewing_pubkey, salt, slot_index)
-    }
-
-    fn decrypt_slot_ephemeral(
-        &self,
-        recipient_pubkey: &P256Pubkey,
-        ciphertext: &[u8],
-        salt: Salt,
-        slot_index: u32,
-    ) -> Result<Vec<u8>, KeypairError> {
-        self.viewing_key
-            .decrypt_slot_ephemeral(recipient_pubkey, ciphertext, salt, slot_index)
-    }
-}
+// The viewing half of a backend with a host-side viewing key: one line, where
+// twelve verbatim forwarding methods used to be.
+zolana_keypair::forward_viewing_key_trait!(RemoteKeypair => viewing_key);
 
 fn software_keypair() -> ShieldedKeypair {
     ShieldedKeypair::from_keypair(SigningKey::from_p256_bytes(&SIGNING_SECRET).expect("P-256"))

--- a/sdk-libs/transaction/tests/cases/remote_authority.rs
+++ b/sdk-libs/transaction/tests/cases/remote_authority.rs
@@ -1,0 +1,384 @@
+//! [`LocalWalletAuthority`] over a keypair that is not a [`ShieldedKeypair`].
+//!
+//! This is the case the generic parameter exists for: a backend whose signing
+//! key is device-resident implements [`ShieldedKeypairTrait`] and
+//! [`ViewingKeyTrait`] and becomes a wallet authority, without reimplementing
+//! any encryption body. The assertions pin it to the software authority, since
+//! a wrong-but-well-formed identity still produces valid signatures and
+//! correct-looking addresses.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use zolana_keypair::{
+    derivation::{self, DERIVATION_PAYLOAD_PREFIX, ED25519_DERIVATION_MSG},
+    hash,
+    shielded::{CompressedShieldedAddress, ShieldedAddress},
+    viewing_key::{Salt, ViewTag},
+    Curve, KeypairError, NullifierKey, P256Pubkey, PublicKey, ShieldedKeypair,
+    ShieldedKeypairTrait, SigningKey, ViewingKey, ViewingKeyTrait,
+};
+use zolana_transaction::{
+    Address, AssetRegistry, LocalWalletAuthority, SyncWalletAuthority, TransactionError,
+};
+
+const SIGNING_SECRET: [u8; 32] = [31u8; 32];
+
+/// Stands in for a remote custodian: the signing key is reachable only through
+/// a call that this double counts, and the role secrets are held beside it —
+/// the same shape as the KMS and Turnkey backends.
+struct RemoteKeypair {
+    device: SigningKey,
+    nullifier_key: NullifierKey,
+    viewing_key: ViewingKey,
+    sign_calls: AtomicUsize,
+}
+
+impl RemoteKeypair {
+    fn mirroring(keypair: &ShieldedKeypair) -> Self {
+        Self {
+            device: SigningKey::from_p256_bytes(&SIGNING_SECRET).expect("P-256 scalar"),
+            nullifier_key: keypair.nullifier_key.clone(),
+            viewing_key: keypair.viewing_key.clone(),
+            sign_calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl ShieldedKeypairTrait for RemoteKeypair {
+    fn signing_pubkey(&self) -> PublicKey {
+        self.device.pubkey()
+    }
+
+    fn viewing_pubkey(&self) -> P256Pubkey {
+        self.viewing_key.pubkey()
+    }
+
+    fn curve(&self) -> Curve {
+        self.device.curve()
+    }
+
+    fn shielded_address(&self) -> Result<ShieldedAddress, KeypairError> {
+        Ok(ShieldedAddress {
+            signing_pubkey: self.signing_pubkey(),
+            nullifier_pubkey: self.nullifier_key.pubkey()?,
+            viewing_pubkey: self.viewing_key.pubkey(),
+        })
+    }
+
+    fn owner_hash(&self) -> Result<[u8; 32], KeypairError> {
+        hash::owner_hash(&self.signing_pubkey(), &self.nullifier_key.pubkey()?)
+    }
+
+    fn compressed_address(&self) -> Result<CompressedShieldedAddress, KeypairError> {
+        Ok(CompressedShieldedAddress {
+            owner_hash: self.owner_hash()?,
+            viewing_pubkey: self.viewing_key.pubkey(),
+        })
+    }
+
+    fn sign_message(&self, message: &[u8]) -> Result<[u8; 64], KeypairError> {
+        if derivation::is_derivation_input(message) {
+            return Err(KeypairError::DerivationInput);
+        }
+        self.sign_hash(&hash::sha256(message))
+    }
+
+    fn sign_hash(&self, hash: &[u8; 32]) -> Result<[u8; 64], KeypairError> {
+        if derivation::is_derivation_input(hash) {
+            return Err(KeypairError::DerivationInput);
+        }
+        self.sign_calls.fetch_add(1, Ordering::SeqCst);
+        self.device.sign_hash(hash)
+    }
+
+    fn nullifier(
+        &self,
+        utxo_hash: &[u8; 32],
+        blinding: &[u8; 32],
+    ) -> Result<[u8; 32], KeypairError> {
+        self.nullifier_key.nullifier(utxo_hash, blinding)
+    }
+
+    fn nullifier_key(&self) -> NullifierKey {
+        self.nullifier_key.clone()
+    }
+}
+
+/// Pure forwarding to the host-side viewing key, which is what every backend
+/// with a host-side viewing key has to write today.
+impl ViewingKeyTrait for RemoteKeypair {
+    fn pubkey(&self) -> P256Pubkey {
+        self.viewing_key.pubkey()
+    }
+
+    fn ecdh(&self, counterparty: &P256Pubkey) -> Result<[u8; 32], KeypairError> {
+        self.viewing_key.ecdh(counterparty)
+    }
+
+    fn get_sender_view_tag(&self, tx_count: u64) -> Result<ViewTag, KeypairError> {
+        self.viewing_key.get_sender_view_tag(tx_count)
+    }
+
+    fn get_recipient_request_view_tag(&self, request_count: u64) -> Result<ViewTag, KeypairError> {
+        self.viewing_key
+            .get_recipient_request_view_tag(request_count)
+    }
+
+    fn get_send_shared_view_tag(
+        &self,
+        counterparty: &P256Pubkey,
+        i: u64,
+    ) -> Result<ViewTag, KeypairError> {
+        self.viewing_key.get_send_shared_view_tag(counterparty, i)
+    }
+
+    fn get_recipient_shared_view_tag(
+        &self,
+        counterparty: &P256Pubkey,
+        i: u64,
+    ) -> Result<ViewTag, KeypairError> {
+        self.viewing_key
+            .get_recipient_shared_view_tag(counterparty, i)
+    }
+
+    fn recipient_bootstrap_view_tag(&self) -> ViewTag {
+        self.viewing_key.recipient_bootstrap_view_tag()
+    }
+
+    fn get_transaction_viewing_key(
+        &self,
+        first_nullifier: &[u8; 32],
+    ) -> Result<ViewingKey, KeypairError> {
+        self.viewing_key
+            .get_transaction_viewing_key(first_nullifier)
+    }
+
+    fn encrypt_slot(
+        &self,
+        recipient_pubkey: &P256Pubkey,
+        plaintext: &[u8],
+        salt: Salt,
+        slot_index: u32,
+    ) -> Result<Vec<u8>, KeypairError> {
+        self.viewing_key
+            .encrypt_slot(recipient_pubkey, plaintext, salt, slot_index)
+    }
+
+    fn decrypt_utxo(
+        &self,
+        ciphertext: &[u8],
+        tx_viewing_pubkey: &P256Pubkey,
+        salt: Salt,
+        slot_index: u32,
+    ) -> Result<Vec<u8>, KeypairError> {
+        self.viewing_key
+            .decrypt_utxo(ciphertext, tx_viewing_pubkey, salt, slot_index)
+    }
+
+    fn decrypt_slot_ephemeral(
+        &self,
+        recipient_pubkey: &P256Pubkey,
+        ciphertext: &[u8],
+        salt: Salt,
+        slot_index: u32,
+    ) -> Result<Vec<u8>, KeypairError> {
+        self.viewing_key
+            .decrypt_slot_ephemeral(recipient_pubkey, ciphertext, salt, slot_index)
+    }
+}
+
+fn software_keypair() -> ShieldedKeypair {
+    ShieldedKeypair::from_keypair(SigningKey::from_p256_bytes(&SIGNING_SECRET).expect("P-256"))
+        .expect("software keypair")
+}
+
+/// Every identity the authority publishes is the same whether the keypair is a
+/// `ShieldedKeypair` or a foreign backend built from the same key material.
+pub(crate) fn remote_backend_publishes_the_same_identity() {
+    let software = software_keypair();
+    let remote = RemoteKeypair::mirroring(&software);
+
+    let software_authority = LocalWalletAuthority::new(Address::default(), &software);
+    let remote_authority = LocalWalletAuthority::with_viewing_keys(
+        Address::default(),
+        &remote,
+        vec![software.viewing_key.clone()],
+    )
+    .expect("the keypair's own viewing key is supplied");
+
+    assert_eq!(
+        SyncWalletAuthority::shielded_address(&remote_authority).unwrap(),
+        SyncWalletAuthority::shielded_address(&software_authority).unwrap()
+    );
+    assert_eq!(
+        SyncWalletAuthority::spend_nullifier_key(&remote_authority)
+            .unwrap()
+            .pubkey()
+            .unwrap(),
+        SyncWalletAuthority::spend_nullifier_key(&software_authority)
+            .unwrap()
+            .pubkey()
+            .unwrap()
+    );
+    assert_eq!(
+        SyncWalletAuthority::viewing_keys(&remote_authority)
+            .unwrap()
+            .iter()
+            .map(|key| key.pubkey())
+            .collect::<Vec<_>>(),
+        SyncWalletAuthority::viewing_keys(&software_authority)
+            .unwrap()
+            .iter()
+            .map(|key| key.pubkey())
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Spend authorization routes through the backend's `sign`, and the signature
+/// is the one the software path produces. ECDSA here is deterministic, so this
+/// is an equality check rather than a verification.
+pub(crate) fn remote_backend_signs_through_the_trait() {
+    let software = software_keypair();
+    let remote = RemoteKeypair::mirroring(&software);
+    let message_hash = [7u8; 32];
+
+    let signature = {
+        let authority = LocalWalletAuthority::with_viewing_keys(
+            Address::default(),
+            &remote,
+            vec![software.viewing_key.clone()],
+        )
+        .expect("the keypair's own viewing key is supplied");
+        SyncWalletAuthority::sign_p256(&authority, &message_hash).unwrap()
+    };
+
+    assert_eq!(remote.sign_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        signature,
+        SyncWalletAuthority::sign_p256(
+            &LocalWalletAuthority::new(Address::default(), &software),
+            &message_hash,
+        )
+        .unwrap()
+    );
+}
+
+/// The encryption bodies run unchanged over the foreign backend: the
+/// per-transaction viewing key is derived from the same viewing secret, so the
+/// published `tx_viewing_pk` matches. (Only that field is deterministic — the
+/// salt is random per call.)
+pub(crate) fn remote_backend_encrypts_with_the_same_transaction_key() {
+    let software = software_keypair();
+    let remote = RemoteKeypair::mirroring(&software);
+    let first_nullifier = [3u8; 32];
+    let assets = AssetRegistry::default();
+
+    let remote_authority = LocalWalletAuthority::with_viewing_keys(
+        Address::default(),
+        &remote,
+        vec![software.viewing_key.clone()],
+    )
+    .expect("the keypair's own viewing key is supplied");
+    let software_authority = LocalWalletAuthority::new(Address::default(), &software);
+
+    let from_remote = SyncWalletAuthority::encrypt_confidential_transfer(
+        &remote_authority,
+        &first_nullifier,
+        &[],
+        &assets,
+    )
+    .unwrap();
+    let from_software = SyncWalletAuthority::encrypt_confidential_transfer(
+        &software_authority,
+        &first_nullifier,
+        &[],
+        &assets,
+    )
+    .unwrap();
+
+    assert_eq!(from_remote.tx_viewing_pk, from_software.tx_viewing_pk);
+}
+
+/// The backend's derivation-seed guard survives the authority indirection. A
+/// backend that signed a derivation-shaped payload would hand back the seed its
+/// own role secrets expand from, so the refusal has to hold on the path a wallet
+/// actually calls, not just on a direct trait call.
+pub(crate) fn remote_backend_refuses_derivation_shaped_payloads() {
+    let software = software_keypair();
+    let remote = RemoteKeypair::mirroring(&software);
+    let authority = LocalWalletAuthority::with_viewing_keys(
+        Address::default(),
+        &remote,
+        vec![software.viewing_key.clone()],
+    )
+    .expect("the keypair's own viewing key is supplied");
+
+    let mut prefixed = [0u8; 32];
+    prefixed[..DERIVATION_PAYLOAD_PREFIX.len()].copy_from_slice(DERIVATION_PAYLOAD_PREFIX);
+
+    assert!(matches!(
+        SyncWalletAuthority::sign_p256(&authority, &prefixed),
+        Err(TransactionError::P256(_))
+    ));
+    assert_eq!(
+        ShieldedKeypairTrait::sign_message(&remote, ED25519_DERIVATION_MSG),
+        Err(KeypairError::DerivationInput)
+    );
+    // Refused before the device is reached.
+    assert_eq!(remote.sign_calls.load(Ordering::SeqCst), 0);
+}
+
+/// A rotated-out viewing key can now be supplied, which the keypair-only
+/// constructor cannot express — a `ShieldedKeypair` holds exactly one.
+pub(crate) fn historical_viewing_keys_are_carried_through() {
+    let software = software_keypair();
+    let remote = RemoteKeypair::mirroring(&software);
+    let retired = ViewingKey::from_bytes(&[9u8; 32]).expect("viewing key");
+
+    let authority = LocalWalletAuthority::with_viewing_keys(
+        Address::default(),
+        &remote,
+        vec![software.viewing_key.clone(), retired.clone()],
+    )
+    .expect("the keypair's own viewing key is supplied");
+
+    assert_eq!(
+        SyncWalletAuthority::viewing_keys(&authority)
+            .unwrap()
+            .iter()
+            .map(|key| key.pubkey())
+            .collect::<Vec<_>>(),
+        vec![software.viewing_key.pubkey(), retired.pubkey()]
+    );
+}
+
+/// A viewing-key set that omits the keypair's own is refused at construction.
+/// The encryption bodies key off the keypair while a scan keys off this vector,
+/// so accepting the pair would build a wallet that encrypts to one key and
+/// scans with another.
+pub(crate) fn viewing_keys_must_contain_the_keypairs_own() {
+    let software = software_keypair();
+    let remote = RemoteKeypair::mirroring(&software);
+    let unrelated = ViewingKey::from_bytes(&[4u8; 32]).expect("viewing key");
+
+    assert!(matches!(
+        LocalWalletAuthority::with_viewing_keys(
+            Address::default(),
+            &remote,
+            vec![unrelated.clone()],
+        ),
+        Err(TransactionError::AuthorityViewingKeyMismatch)
+    ));
+    assert!(matches!(
+        LocalWalletAuthority::with_viewing_keys(Address::default(), &remote, Vec::new()),
+        Err(TransactionError::AuthorityViewingKeyMismatch)
+    ));
+
+    // Extra keys alongside the current one are fine: that is key rotation.
+    assert!(LocalWalletAuthority::with_viewing_keys(
+        Address::default(),
+        &remote,
+        vec![unrelated, software.viewing_key.clone()],
+    )
+    .is_ok());
+}

--- a/sdk-libs/transaction/tests/cases/wallet.rs
+++ b/sdk-libs/transaction/tests/cases/wallet.rs
@@ -6,7 +6,7 @@ use zolana_transaction::{
         OwnerCx, UtxoSerialization,
     },
     wallet::{AssetBalance, PrivateTransactionDirection, PrivateTransactionKind, Wallet},
-    Address, AssetRegistry, Data, LocalWalletAuthority, OutputContext, OutputSlot,
+    Address, AssetRegistry, Data, KeypairWalletAuthority, OutputContext, OutputSlot,
     ShieldedTransaction, Utxo, SOL_ASSET_ID, SOL_MINT,
 };
 
@@ -277,7 +277,7 @@ pub(crate) fn sync_fresh_wallet(world: &mut TransactionWorld, name: String) {
         AssetRegistry::default(),
     )
     .unwrap();
-    let authority = LocalWalletAuthority::new(Address::default(), &keypair);
+    let authority = KeypairWalletAuthority::new(Address::default(), &keypair);
     let report = wallet
         .sync(&authority, &world.sync_transactions, 1_700_000_000, 8)
         .unwrap();

--- a/sdk-libs/transaction/tests/common/mod.rs
+++ b/sdk-libs/transaction/tests/common/mod.rs
@@ -10,8 +10,8 @@ use zolana_transaction::{
         },
         confidential::{Confidential, ConfidentialEncode},
     },
-    Address, AssetRegistry, Data, EncryptedScheme, LocalWalletAuthority, OutputContext, OutputSlot,
-    OwnerCx, ShieldedTransaction, Utxo, UtxoSerialization, Wallet, SOL_MINT,
+    Address, AssetRegistry, Data, EncryptedScheme, KeypairWalletAuthority, OutputContext,
+    OutputSlot, OwnerCx, ShieldedTransaction, Utxo, UtxoSerialization, Wallet, SOL_MINT,
 };
 
 pub fn keypair_from_index(index: u16) -> ShieldedKeypair {
@@ -26,8 +26,8 @@ pub fn keypair_from_index(index: u16) -> ShieldedKeypair {
     ShieldedKeypair::with_viewing_key(signing, viewing).unwrap()
 }
 
-pub fn local_authority(keypair: &ShieldedKeypair) -> LocalWalletAuthority<'_> {
-    LocalWalletAuthority::new(Address::default(), keypair)
+pub fn local_authority(keypair: &ShieldedKeypair) -> KeypairWalletAuthority<'_> {
+    KeypairWalletAuthority::new(Address::default(), keypair)
 }
 
 pub fn wallet_for(keypair: &ShieldedKeypair, registry: AssetRegistry) -> Wallet {

--- a/sdk-libs/transaction/tests/wallet_proofless.rs
+++ b/sdk-libs/transaction/tests/wallet_proofless.rs
@@ -1,7 +1,7 @@
 use zolana_event::{encode_output_data, ProoflessOutput};
 use zolana_keypair::ShieldedKeypair;
 use zolana_transaction::{
-    Address, AssetRegistry, LocalWalletAuthority, OutputContext, OutputSlot, ProofInputUtxo,
+    Address, AssetRegistry, KeypairWalletAuthority, OutputContext, OutputSlot, ProofInputUtxo,
     ShieldedTransaction, Wallet, DEFAULT_TAG_WINDOW, SOL_MINT,
 };
 
@@ -51,7 +51,7 @@ fn self_consistent_deposit(keypair: &ShieldedKeypair, amount: u64) -> ShieldedTr
 #[test]
 fn sync_discovers_and_spends_proofless_deposit() {
     let keypair = ShieldedKeypair::new_p256().expect("shielded keypair");
-    let authority = LocalWalletAuthority::new(Address::default(), &keypair);
+    let authority = KeypairWalletAuthority::new(Address::default(), &keypair);
     let mut wallet = Wallet::new(
         keypair.shielded_address().expect("shielded address"),
         AssetRegistry::default(),

--- a/sdk-libs/transaction/tests/wallet_unified.rs
+++ b/sdk-libs/transaction/tests/wallet_unified.rs
@@ -3,7 +3,7 @@ mod common;
 use common::{
     build_unified_transfer, keypair_from_index, unique31, unique_nullifier, UnifiedTransferSpec,
 };
-use zolana_transaction::{Address, AssetRegistry, LocalWalletAuthority, Wallet};
+use zolana_transaction::{Address, AssetRegistry, KeypairWalletAuthority, Wallet};
 
 const WINDOW: u64 = 8;
 
@@ -27,7 +27,7 @@ fn sync_stores_unified_change_and_recipient_utxos() {
         },
     );
 
-    let alice_authority = LocalWalletAuthority::new(Address::default(), &alice);
+    let alice_authority = KeypairWalletAuthority::new(Address::default(), &alice);
     let mut alice_wallet = Wallet::new(alice.shielded_address().unwrap(), assets.clone()).unwrap();
     alice_wallet
         .sync(&alice_authority, std::slice::from_ref(&tx), 1, WINDOW)
@@ -41,7 +41,7 @@ fn sync_stores_unified_change_and_recipient_utxos() {
         vec![change_utxo]
     );
 
-    let bob_authority = LocalWalletAuthority::new(Address::default(), &bob);
+    let bob_authority = KeypairWalletAuthority::new(Address::default(), &bob);
     let mut bob_wallet = Wallet::new(bob.shielded_address().unwrap(), assets).unwrap();
     bob_wallet
         .sync(&bob_authority, std::slice::from_ref(&tx), 1, WINDOW)

--- a/sdk-libs/ts/README.md
+++ b/sdk-libs/ts/README.md
@@ -38,7 +38,7 @@ import {
   type Transaction,
 } from "@solana/kit";
 import {
-  LocalWalletAuthority,
+  KeypairWalletAuthority,
   ShieldedKeypair,
   SigningKey,
   SOL_MINT,
@@ -65,7 +65,7 @@ const keypair = ShieldedKeypair.fromKeypair(SigningKey.fromEd25519Bytes(ownerSee
 ownerSeed.fill(0);
 
 const wallet = new Wallet({ identity: keypair.shieldedAddress() });
-const authority = new LocalWalletAuthority({
+const authority = new KeypairWalletAuthority({
   solanaPublicKey: feePayer.address,
   keypair,
 });
@@ -238,7 +238,7 @@ contains private note data and must be encrypted at rest.
 Common exports from `@heliuslabs/zolana` include:
 
 - setup: `createZolanaClient`, `ShieldedKeypair`, `Wallet`,
-  `LocalWalletAuthority`;
+  `KeypairWalletAuthority`;
 - transactions: `buildDepositTransaction`, `buildTransferTransaction`,
   `buildWithdrawalTransaction`, `buildSplitTransaction`,
   `buildMergeTransaction`;

--- a/sdk-libs/ts/bench/loadtest.ts
+++ b/sdk-libs/ts/bench/loadtest.ts
@@ -40,7 +40,7 @@ import {
 } from "@solana/kit";
 
 import {
-  LocalWalletAuthority,
+  KeypairWalletAuthority,
   ShieldedKeypair,
   SigningKey,
   Wallet,
@@ -95,7 +95,7 @@ const timedFetch: typeof globalThis.fetch = async (input, init) => {
 interface Actor {
   readonly signer: KeyPairSigner;
   readonly wallet: Wallet;
-  readonly authority: LocalWalletAuthority;
+  readonly authority: KeypairWalletAuthority;
   readonly shieldedAddress: ReturnType<ShieldedKeypair["shieldedAddress"]>;
 }
 
@@ -158,7 +158,7 @@ async function loadActors(dir: string): Promise<Actor[]> {
     actors.push({
       signer,
       wallet: new Wallet({ identity: keypair.shieldedAddress() }),
-      authority: new LocalWalletAuthority({ solanaPublicKey: signer.address, keypair }),
+      authority: new KeypairWalletAuthority({ solanaPublicKey: signer.address, keypair }),
       shieldedAddress: keypair.shieldedAddress(),
     });
   }

--- a/sdk-libs/ts/fixtures/manifest.json
+++ b/sdk-libs/ts/fixtures/manifest.json
@@ -4,7 +4,7 @@
   "files": [
     {
       "path": "transaction/authority-v1.json",
-      "sha256": "376a99ceba08b376b04a8519ea335fdfbfb57024e9a58ba65101ca97c009182b"
+      "sha256": "ac2d7c57e1cdc993dfb85817ef958bf15e490c13ecaf72aec59e853d63edcc5f"
     },
     {
       "path": "transaction/frozen-tests-v1.json",

--- a/sdk-libs/ts/fixtures/transaction/authority-v1.json
+++ b/sdk-libs/ts/fixtures/transaction/authority-v1.json
@@ -39,7 +39,7 @@
   "owningPacket": "P00",
   "responsibility": "authority material, approval input, deterministic P256 signature, and envelope fields",
   "rustPath": "sdk-libs/transaction/src/wallet/authority.rs",
-  "rustSymbol": "WalletAuthority; SyncWalletAuthority; LocalWalletAuthority; envelopes",
+  "rustSymbol": "WalletAuthority; SyncWalletAuthority; KeypairWalletAuthority; envelopes",
   "schema": "zolana-ts-fixtures-v1",
   "version": "1"
 }

--- a/sdk-libs/ts/src/index.ts
+++ b/sdk-libs/ts/src/index.ts
@@ -54,7 +54,7 @@ export {
 } from "./keypair/index.js";
 export {
   Data,
-  LocalWalletAuthority,
+  KeypairWalletAuthority,
   SOL_MINT,
   TransactionError,
   Utxo,

--- a/sdk-libs/ts/src/transaction/index.ts
+++ b/sdk-libs/ts/src/transaction/index.ts
@@ -51,7 +51,7 @@ export { ProofInputUtxo, Utxo, createProofOutput, deriveBlinding, ownerUtxoHash 
 export type { Blinding, ProofOutputInit, ProofOutputUtxo, UtxoInit } from "./utxo.js";
 export {
   AssetRegistry,
-  LocalWalletAuthority,
+  KeypairWalletAuthority,
   SOL_ASSET_ID,
   SOL_MINT,
   Wallet,

--- a/sdk-libs/ts/src/transaction/wallet/authority.ts
+++ b/sdk-libs/ts/src/transaction/wallet/authority.ts
@@ -100,8 +100,8 @@ export interface WalletAuthority {
   requestUserApproval(request: ApprovalRequest): Promise<void>;
 }
 
-/** Binds local shielded keys to the Solana address that publishes them. */
-export class LocalWalletAuthority implements WalletAuthority {
+/** Binds a shielded keypair to the Solana address that publishes it. */
+export class KeypairWalletAuthority implements WalletAuthority {
   readonly #solanaPublicKey: Address;
   readonly #keypair: ShieldedKeypair;
 

--- a/sdk-libs/ts/src/transaction/wallet/index.ts
+++ b/sdk-libs/ts/src/transaction/wallet/index.ts
@@ -1,5 +1,5 @@
 export {
-  LocalWalletAuthority,
+  KeypairWalletAuthority,
   type AnonymousRecipientSlot,
   type ApprovalRequest,
   type EncryptedEnvelope,

--- a/sdk-libs/ts/src/wallet/index.ts
+++ b/sdk-libs/ts/src/wallet/index.ts
@@ -1,7 +1,7 @@
 export { initializePoseidon, isPoseidonInitialized } from "../hasher/index.js";
 export { WALLET_ERROR_CODES, WalletError, type WalletErrorCode } from "./error.js";
 export {
-  LocalWalletAuthority,
+  KeypairWalletAuthority,
   type AnonymousRecipientSlot,
   type ApprovalRequest,
   type EncryptedEnvelope,

--- a/sdk-libs/ts/test/e2e/live-helpers.ts
+++ b/sdk-libs/ts/test/e2e/live-helpers.ts
@@ -17,7 +17,7 @@ import {
 } from "@solana/kit";
 
 import {
-  LocalWalletAuthority,
+  KeypairWalletAuthority,
   ShieldedKeypair,
   SigningKey,
   Wallet,
@@ -33,7 +33,7 @@ export interface Actor {
   readonly signer: KeyPairSigner;
   readonly keypair: ShieldedKeypair;
   readonly wallet: Wallet;
-  readonly authority: LocalWalletAuthority;
+  readonly authority: KeypairWalletAuthority;
 }
 
 export interface LiveHarness {
@@ -70,7 +70,7 @@ export async function actor(
     signer,
     keypair,
     wallet: new Wallet({ identity: keypair.shieldedAddress() }),
-    authority: new LocalWalletAuthority({
+    authority: new KeypairWalletAuthority({
       solanaPublicKey: signer.address,
       keypair,
     }),

--- a/sdk-libs/ts/test/wallet-actions.test.ts
+++ b/sdk-libs/ts/test/wallet-actions.test.ts
@@ -12,7 +12,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { AuthorizedPrivateTransaction, ZolanaClient } from "../src/client/client.js";
 import { SPL_TOKEN_2022_PROGRAM_ID, type Bytes32 } from "../src/interface/index.js";
 import { ShieldedKeypair, SigningKey } from "../src/keypair/index.js";
-import { Data, LocalWalletAuthority, SOL_MINT, Utxo, Wallet } from "../src/transaction/index.js";
+import { Data, KeypairWalletAuthority, SOL_MINT, Utxo, Wallet } from "../src/transaction/index.js";
 import { AssetRegistry } from "../src/transaction/wallet/asset.js";
 import { createSplit, createTransfer, createWithdrawal } from "../src/wallet/actions.js";
 import { buildDepositTransaction, createDeposit } from "../src/wallet/deposit.js";
@@ -154,7 +154,7 @@ describe("private transaction construction", () => {
       authorizePrivateTransaction(
         created.transaction,
         wallet,
-        new LocalWalletAuthority({
+        new KeypairWalletAuthority({
           solanaPublicKey: keypair.shieldedAddress().solanaAddress(),
           keypair,
         }),
@@ -275,7 +275,7 @@ describe("unsigned public transaction builders", () => {
     await buildWithdrawalTransaction({
       client,
       wallet,
-      authority: new LocalWalletAuthority({ solanaPublicKey: payer, keypair }),
+      authority: new KeypairWalletAuthority({ solanaPublicKey: payer, keypair }),
       feePayer: payer,
       recipient: RECIPIENT,
       asset: SPL_MINT,
@@ -309,7 +309,7 @@ describe("unsigned public transaction builders", () => {
     const input = {
       client,
       wallet,
-      authority: new LocalWalletAuthority({ solanaPublicKey: payer, keypair }),
+      authority: new KeypairWalletAuthority({ solanaPublicKey: payer, keypair }),
       feePayer: payer,
       recipient: ShieldedKeypair.generate().shieldedAddress(),
       amount: 25n,
@@ -332,7 +332,7 @@ describe("unsigned public transaction builders", () => {
     await buildSplitTransaction({
       client,
       wallet,
-      authority: new LocalWalletAuthority({ solanaPublicKey: payer, keypair }),
+      authority: new KeypairWalletAuthority({ solanaPublicKey: payer, keypair }),
       feePayer: payer,
     });
 

--- a/sdk-libs/ts/test/wallet-sync.test.ts
+++ b/sdk-libs/ts/test/wallet-sync.test.ts
@@ -8,7 +8,7 @@ import { SHIELDED_POOL_PROGRAM_ID, type Bytes16, type Bytes32 } from "../src/int
 import { StateDiscriminator } from "../src/interface/state.js";
 import {
   Data,
-  LocalWalletAuthority,
+  KeypairWalletAuthority,
   SOL_MINT,
   Utxo,
   Wallet,
@@ -53,7 +53,7 @@ describe("wallet sync", () => {
 
     const report = await syncWallet({
       wallet,
-      authority: new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+      authority: new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair }),
       client,
     });
 
@@ -86,7 +86,7 @@ describe("wallet sync", () => {
       })),
       getShieldedTransactionsByNullifiers: vi.fn(),
     } as unknown as ZolanaClient;
-    const authority = new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair });
+    const authority = new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair });
 
     await syncWallet({ wallet, authority, client });
     const calls = () =>
@@ -123,7 +123,7 @@ describe("wallet sync", () => {
 
     await syncWallet({
       wallet,
-      authority: new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+      authority: new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair }),
       client,
     });
 
@@ -221,7 +221,7 @@ describe("wallet sync", () => {
 
     const report = await syncWallet({
       wallet,
-      authority: new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+      authority: new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair }),
       client,
     });
 
@@ -267,7 +267,7 @@ describe("wallet sync", () => {
 
     const report = await decryptTransactions({
       wallet,
-      authority: new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+      authority: new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair }),
       transactions: [
         {
           slot: 1n,
@@ -426,7 +426,7 @@ describe("wallet sync", () => {
 
     await syncWallet({
       wallet,
-      authority: new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+      authority: new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair }),
       client,
     });
 
@@ -491,7 +491,7 @@ describe("wallet sync", () => {
 
     await syncWallet({
       wallet,
-      authority: new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+      authority: new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair }),
       client,
     });
 
@@ -546,7 +546,7 @@ describe("wallet sync", () => {
       })),
       getShieldedTransactionsByNullifiers,
     } as unknown as ZolanaClient;
-    const authority = new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair });
+    const authority = new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair });
 
     await syncWallet({ wallet, authority, client });
     expect(getShieldedTransactionsByNullifiers.mock.calls[0]?.[0]?.cursor).toBeUndefined();
@@ -588,7 +588,7 @@ describe("wallet sync", () => {
     await expect(
       syncWallet({
         wallet,
-        authority: new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+        authority: new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair }),
         client: {
           getShieldedTransactionsByTags: vi.fn(async () => ({
             context: { blockTime: 1n },
@@ -662,7 +662,7 @@ describe("wallet sync", () => {
 
     await syncWallet({
       wallet,
-      authority: new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+      authority: new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair }),
       client,
     });
 
@@ -691,7 +691,7 @@ describe("wallet sync", () => {
     await expect(
       syncWallet({
         wallet: new Wallet({ identity: keypair.shieldedAddress() }),
-        authority: new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+        authority: new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair }),
         client,
       }),
     ).rejects.toMatchObject({
@@ -736,7 +736,7 @@ describe("wallet sync", () => {
 
     const report = await syncWallet({
       wallet: new Wallet({ identity: keypair.shieldedAddress() }),
-      authority: new LocalWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+      authority: new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair }),
       client,
     });
 

--- a/sdk-libs/wallet/src/actions/transaction.rs
+++ b/sdk-libs/wallet/src/actions/transaction.rs
@@ -1467,7 +1467,7 @@ mod tests {
     fn create_withdrawal_supports_full_u64_amount() {
         let sender = ed25519_keypair(1);
         let authority =
-            crate::wallet_authority::LocalWalletAuthority::new(Pubkey::default(), &sender);
+            crate::wallet_authority::KeypairWalletAuthority::new(Pubkey::default(), &sender);
         let wallet = wallet_with_sol(sender.clone(), u64::MAX);
         let recipient = Pubkey::new_unique();
         let created = create_withdrawal(WithdrawalParams {
@@ -1498,7 +1498,7 @@ mod tests {
     fn create_withdrawal_preserves_two_sol_recipients() {
         let sender = ed25519_keypair(2);
         let authority =
-            crate::wallet_authority::LocalWalletAuthority::new(Pubkey::default(), &sender);
+            crate::wallet_authority::KeypairWalletAuthority::new(Pubkey::default(), &sender);
         let wallet = wallet_with_sol(sender.clone(), 10);
         let user = Pubkey::new_unique();
         let relayer = Pubkey::new_unique();
@@ -1713,7 +1713,7 @@ mod tests {
     fn signing_rejects_input_spent_after_creation() {
         let sender = ShieldedKeypair::new_p256().unwrap();
         let authority =
-            crate::wallet_authority::LocalWalletAuthority::new(Pubkey::default(), &sender);
+            crate::wallet_authority::KeypairWalletAuthority::new(Pubkey::default(), &sender);
         let mut wallet = wallet_with_sol(sender.clone(), 10);
         let unsigned = create_withdrawal(WithdrawalParams {
             wallet: &wallet,
@@ -1746,7 +1746,7 @@ mod tests {
     fn action_path_preserves_input_commitment_hashes() {
         let sender = ed25519_keypair(3);
         let authority =
-            crate::wallet_authority::LocalWalletAuthority::new(Pubkey::default(), &sender);
+            crate::wallet_authority::KeypairWalletAuthority::new(Pubkey::default(), &sender);
         let mut wallet = wallet_with_sol(sender.clone(), 10);
         let data_hash = [13u8; 32];
         let nullifier_pubkey = sender.nullifier_key.pubkey().unwrap();

--- a/sdk-libs/wallet/src/lib.rs
+++ b/sdk-libs/wallet/src/lib.rs
@@ -47,7 +47,8 @@ pub use user_registry::{
 };
 pub use wallet_authority::{
     AnonymousRecipientSlot, ApprovalRequest, EncryptedEnvelope, EncryptedSplit, EncryptedTransfer,
-    LocalWalletAuthority, P256Signature, SyncWalletAuthority, WalletAuthority, WalletSyncMaterial,
+    KeypairWalletAuthority, P256Signature, SyncWalletAuthority, WalletAuthority,
+    WalletSyncMaterial,
 };
 pub use wallet_sync::{
     get_private_token_balances, get_private_transactions, sync_wallet, sync_wallet_async,

--- a/sdk-libs/wallet/src/wallet_authority.rs
+++ b/sdk-libs/wallet/src/wallet_authority.rs
@@ -1,4 +1,5 @@
 pub use zolana_transaction::{
     AnonymousRecipientSlot, ApprovalRequest, EncryptedEnvelope, EncryptedSplit, EncryptedTransfer,
-    LocalWalletAuthority, P256Signature, SyncWalletAuthority, WalletAuthority, WalletSyncMaterial,
+    KeypairWalletAuthority, P256Signature, SyncWalletAuthority, WalletAuthority,
+    WalletSyncMaterial,
 };

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -1032,7 +1032,7 @@ mod tests {
             types::SppProofInputUtxo,
         },
         serialization::Proofless,
-        Address, AssetRegistry, Data, LocalWalletAuthority, OwnerCx, PrivateTransactionDirection,
+        Address, AssetRegistry, Data, KeypairWalletAuthority, OwnerCx, PrivateTransactionDirection,
         PrivateTransactionKind, Utxo, UtxoSerialization, WalletUtxo, SOL_MINT,
     };
 
@@ -1971,8 +1971,8 @@ mod tests {
     const SPL_ASSET_ID: u64 = 2;
     const SPL_MINT: Address = Address::new_from_array([2u8; 32]);
 
-    fn local_authority(keypair: &ShieldedKeypair) -> LocalWalletAuthority<'_> {
-        LocalWalletAuthority::new(Address::default(), keypair)
+    fn local_authority(keypair: &ShieldedKeypair) -> KeypairWalletAuthority<'_> {
+        KeypairWalletAuthority::new(Address::default(), keypair)
     }
 
     fn ed25519_keypair(seed: u8) -> ShieldedKeypair {

--- a/sdk-libs/wallet/tests/transaction.rs
+++ b/sdk-libs/wallet/tests/transaction.rs
@@ -40,7 +40,7 @@ use zolana_transaction::{
 };
 use zolana_wallet::{
     create_transfer, create_withdrawal, sign_shielded_transaction, AnonymousRecipientSlot,
-    ApprovalRequest, EncryptedTransfer, LocalWalletAuthority, P256Signature, SyncWalletAuthority,
+    ApprovalRequest, EncryptedTransfer, KeypairWalletAuthority, P256Signature, SyncWalletAuthority,
     TransferParams, WalletAuthority, WithdrawalLeg, WithdrawalParams,
 };
 
@@ -87,7 +87,7 @@ impl WalletAuthority for AsyncTestAuthority {
     async fn shielded_address(
         &self,
     ) -> Result<zolana_keypair::shielded::ShieldedAddress, TransactionError> {
-        SyncWalletAuthority::shielded_address(&LocalWalletAuthority::new(
+        SyncWalletAuthority::shielded_address(&KeypairWalletAuthority::new(
             self.solana_pubkey(),
             &self.keypair,
         ))
@@ -104,7 +104,7 @@ impl WalletAuthority for AsyncTestAuthority {
         assets: &AssetRegistry,
     ) -> Result<EncryptedTransfer, TransactionError> {
         SyncWalletAuthority::encrypt_confidential_transfer(
-            &LocalWalletAuthority::new(self.solana_pubkey(), &self.keypair),
+            &KeypairWalletAuthority::new(self.solana_pubkey(), &self.keypair),
             first_nullifier,
             outputs,
             assets,
@@ -119,7 +119,7 @@ impl WalletAuthority for AsyncTestAuthority {
         recipients: &[AnonymousRecipientSlot],
     ) -> Result<zolana_wallet::EncryptedTransfer, TransactionError> {
         SyncWalletAuthority::encrypt_anonymous_transfer(
-            &LocalWalletAuthority::new(self.solana_pubkey(), &self.keypair),
+            &KeypairWalletAuthority::new(self.solana_pubkey(), &self.keypair),
             first_nullifier,
             sender_view_tag,
             sender,
@@ -134,7 +134,7 @@ impl WalletAuthority for AsyncTestAuthority {
         bundle: &zolana_transaction::serialization::split::SplitBundlePlaintext,
     ) -> Result<zolana_wallet::EncryptedSplit, TransactionError> {
         SyncWalletAuthority::encrypt_split(
-            &LocalWalletAuthority::new(self.solana_pubkey(), &self.keypair),
+            &KeypairWalletAuthority::new(self.solana_pubkey(), &self.keypair),
             first_nullifier,
             view_tag,
             bundle,
@@ -154,13 +154,13 @@ impl WalletAuthority for AsyncTestAuthority {
     async fn sign_p256(&self, message_hash: &[u8; 32]) -> Result<P256Signature, TransactionError> {
         self.p256_sign_calls.fetch_add(1, Ordering::SeqCst);
         SyncWalletAuthority::sign_p256(
-            &LocalWalletAuthority::new(self.solana_pubkey(), &self.keypair),
+            &KeypairWalletAuthority::new(self.solana_pubkey(), &self.keypair),
             message_hash,
         )
     }
 
     async fn spend_nullifier_key(&self) -> Result<NullifierKey, TransactionError> {
-        SyncWalletAuthority::spend_nullifier_key(&LocalWalletAuthority::new(
+        SyncWalletAuthority::spend_nullifier_key(&KeypairWalletAuthority::new(
             self.solana_pubkey(),
             &self.keypair,
         ))

--- a/sdk-tests/zk-program-swap/sdk/src/index/poll.rs
+++ b/sdk-tests/zk-program-swap/sdk/src/index/poll.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use anyhow::{bail, Result};
 use zolana_client::Rpc;
 use zolana_keypair::ShieldedKeypair;
-use zolana_transaction::{LocalWalletAuthority, ShieldedTransaction, Wallet};
+use zolana_transaction::{KeypairWalletAuthority, ShieldedTransaction, Wallet};
 use zolana_wallet::sync_wallet;
 
 use crate::err;
@@ -22,7 +22,7 @@ pub(crate) fn index_until<I: Rpc + Sync, T>(
         .shielded_address()
         .and_then(|address| address.solana_address())
         .map_err(err)?;
-    let authority = LocalWalletAuthority::new(solana_pubkey, keypair);
+    let authority = KeypairWalletAuthority::new(solana_pubkey, keypair);
     let deadline = Instant::now() + timeout;
     loop {
         sync_wallet(wallet, &authority, indexer).map_err(err)?;

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -36,7 +36,7 @@ use solana_signer::Signer;
 // an inherent one on SolanaRpc.
 use zolana_client::{Rpc, RpcSendTransactionConfig, SolanaRpc, ZolanaClient};
 use zolana_keypair::ShieldedKeypair;
-use zolana_transaction::{Address, AssetRegistry, LocalWalletAuthority, Wallet};
+use zolana_transaction::{Address, AssetRegistry, KeypairWalletAuthority, Wallet};
 use zolana_wallet::{
     create_transfer_sync, sign_private_transaction_sync, sync_wallet, TransferParams,
 };
@@ -462,10 +462,10 @@ fn worker(
         options.prover_url.clone(),
         tree,
     );
-    // LocalWalletAuthority is the canonical implementation of the signing and
+    // KeypairWalletAuthority is the canonical implementation of the signing and
     // viewing surface the sync and transfer paths need. The CLI wraps it in its
     // own type only to add file loading; there is nothing to add here.
-    let authority = LocalWalletAuthority::new(
+    let authority = KeypairWalletAuthority::new(
         Address::new_from_array(funding.pubkey().to_bytes()),
         &shielded,
     );


### PR DESCRIPTION
**Motivation:**
1. `ShieldedKeypairTrait` has no consumer, so implementing it buys a backend nothing. The wallet takes `WalletAuthority`, and both impls are hardwired to `ShieldedKeypair`.
    - a backend can implement `SyncWalletAuthority` by hand, but the four bodies it needs are private free functions here, so it either duplicates protocol-critical encryption glue or holds a throwaway local `ShieldedKeypair` to borrow them — which detaches the published identity from the device key
2. `RoleExpansion` is `pub(crate)`, so an out-of-crate backend cannot expand a device-produced seed at all without reimplementing the HKDF schedule. A divergent expansion yields a valid-looking *different* identity: signatures verify, addresses look right, nothing catches it.
3. The 12-method `ViewingKeyTrait` forwarding block is already written out 3x at 80 lines each, with nothing keeping the copies in step.

**Changes:**
1. add `derivation::expand_roles(seed, curve)`, one public entry for both role secrets
    - validates seed width per rail (64 ed25519, 32 P-256); HKDF-Extract accepts any length, so an unchecked truncated seed would expand into that same wrong-but-valid identity
    - `KeypairError` becomes `#[non_exhaustive]`: out-of-crate backends match on it, so a future failure mode should not be a breaking change for them
    - `RoleExpansion` stays private: publishing it means publishing `Rail` alongside `Curve`, two overlapping public enums for one concept, and no caller wants the type, only the secrets
    - the in-tree KMS tests keep their hand-rolled expansions on purpose. They cross-check the schedule against the published `INFO_*` constants; routing them through this function would make the assertion tautological
2. make `KeypairWalletAuthority` generic over the keypair, `K = ShieldedKeypair`
    - the four helper bodies only ever needed `ViewingKeyTrait` + `ShieldedKeypairTrait`
    - `K = ShieldedKeypair` because a software keypair is the ordinary case, the way `HashMap` defaults its hasher. It also happens to leave existing call sites untouched, but that is not the reason — the type's old name was removed outright, with no alias
    - `with_viewing_keys` takes current + historical keys, which the old constructor could not express (a `ShieldedKeypair` holds one)
    - fallible, with its own `AuthorityViewingKeyMismatch`: encryption keys off the keypair while a scan keys off the vector, so a mismatched pair would encrypt to one key and scan with another. `new` stays infallible, it reads the key off the keypair. Distinct from `MissingCurrentViewingKey`, which means a scan was handed a stale snapshot
3. add `forward_viewing_key_trait!`, applied at all 4 forwarding sites
    - not a blanket impl over an accessor trait: coherence would stop a downstream crate implementing `ViewingKeyTrait` by hand, which is exactly what an HSM-resident viewing key needs
    - `impl ViewingKeyTrait for ViewingKey` stays hand-written, it is the base case the macro forwards to
4. rename `LocalWalletAuthority` -> `KeypairWalletAuthority`, Rust and TypeScript
    - generalizing the type made the old name false: it now accepts a keypair that is explicitly not local
    - no alias, the crate is unpublished so nothing external holds the old name
    - renamed in TS too so the two SDKs do not drift; `authority-v1.json`'s `rustSymbol` moves with it and its manifest digest is recomputed, other 4 fixtures unchanged
    - separate commit, droppable if you would rather keep the name

**Testing:**
1. `a_remote_keypair_backend_is_a_wallet_authority` drives a double that is deliberately not a `ShieldedKeypair`; signing counted through the trait, identity/signature/`tx_viewing_pk` pinned to the software authority. Equality against the software path is the only assertion that catches a wrong-but-well-formed identity.
    - also covers the mismatched-viewing-key rejection, and that the backend's derivation-seed guard still refuses through the authority rather than only on a direct trait call
2. `expand_roles` pinned against `from_keypair` on both rails, comparing secrets rather than pubkeys; plus wrong-width and PDA cases
3. `cargo test -p zolana-keypair -p zolana-transaction -p zolana-wallet`, `clippy --workspace --all-targets -- -D warnings`, `fmt --all --check`, `doc --no-deps`
4. `npm run check:ts`: oxfmt, oxlint, `tsc --noEmit`, 243 vitest tests, build, example project

**Notes:**
1. TS fixtures are sha256-verified against their manifest and `cargo` passes regardless. `npm run check:ts` is needed for anything touching `sdk-libs/ts`, including Rust-looking changes, since fixtures name Rust symbols.
2. a Turnkey backend built on this stacks in `keypair/turnkey-backend`; it is what surfaced a missing `ViewingKeyTrait` impl on one of its own rails.
