### PR TITLE
api: camelCase every indexer and prover wire name

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -63,11 +63,11 @@
 - [ZK Program Interface](#zk-program-interface)
 - [RPC](#rpc)
   - [Indexer](#indexer)
-    - [get_encrypted_utxos_by_tags](#get_encrypted_utxos_by_tags)
-    - [get_shielded_transactions_by_tags](#get_shielded_transactions_by_tags)
-    - [subscribe_to_shielded_transactions_by_tags](#subscribe_to_shielded_transactions_by_tags)
-    - [get_merkle_proofs](#get_merkle_proofs)
-    - [get_non_inclusion_proofs](#get_non_inclusion_proofs)
+    - [getEncryptedUtxosByTags](#getencryptedutxosbytags)
+    - [getShieldedTransactionsByTags](#getshieldedtransactionsbytags)
+    - [subscribeToShieldedTransactionsByTags](#subscribetoshieldedtransactionsbytags)
+    - [getMerkleProofs](#getmerkleproofs)
+    - [getNonInclusionProofs](#getnoninclusionproofs)
   - [Prover](#prover)
   - [Relayer](#relayer)
   - [Ring RPC](#ring-rpc)
@@ -1989,7 +1989,7 @@ All RPC services can be run independently. RPC providers can offer the endpoints
 
 Indexes the SPP program instructions to parse encrypted UTXOs, utxo hashes, nullifiers and private transactions.
 
-**Privacy.** Endpoints that take tags as input (default-ring owner pubkeys, or policy-ring view tags), [`get_encrypted_utxos_by_tags`](#get_encrypted_utxos_by_tags), [`get_shielded_transactions_by_tags`](#get_shielded_transactions_by_tags), [`subscribe_to_shielded_transactions_by_tags`](#subscribe_to_shielded_transactions_by_tags), can run inside a TEE (Trusted Execution Environment) to add partial RPC-level privacy. A client's tag set identifies which transactions it cares about; an operator that sees the plaintext request links the client to those UTXOs. A TEE hides the tag set and ciphertext stream from the operator.
+**Privacy.** Endpoints that take tags as input (default-ring owner pubkeys, or policy-ring view tags), [`getEncryptedUtxosByTags`](#getencryptedutxosbytags), [`getShieldedTransactionsByTags`](#getshieldedtransactionsbytags), [`subscribeToShieldedTransactionsByTags`](#subscribetoshieldedtransactionsbytags), can run inside a TEE (Trusted Execution Environment) to add partial RPC-level privacy. A client's tag set identifies which transactions it cares about; an operator that sees the plaintext request links the client to those UTXOs. A TEE hides the tag set and ciphertext stream from the operator.
 
 Every response is wrapped in a `Context` struct so the client knows the slot the response was assembled at.
 
@@ -2007,7 +2007,7 @@ struct MerkleContext {
 }
 ```
 
-### `get_encrypted_utxos_by_tags`
+### `getEncryptedUtxosByTags`
 
 Returns encrypted UTXO ciphertexts whose tag matches any of the given values.
 
@@ -2035,7 +2035,7 @@ struct EncryptedUtxoMatch {
 }
 ```
 
-### `get_shielded_transactions_by_tags`
+### `getShieldedTransactionsByTags`
 
 Returns full shielded transactions where any output's tag matches. Includes all sibling output slots and the transaction's nullifier set.
 
@@ -2074,7 +2074,7 @@ struct OutputSlot {
 }
 ```
 
-### `subscribe_to_shielded_transactions_by_tags`
+### `subscribeToShieldedTransactionsByTags`
 
 Streaming subscription. Pushes new matches whose tag is in the subscribed set as transactions land. Long-lived connection (WebSocket / gRPC stream).
 
@@ -2083,11 +2083,11 @@ struct SubscribeToTagsRequest {
     tags: Vec<[u8; 32]>,
 }
 
-/// Yields one [`ShieldedTransaction`](#get_shielded_transactions_by_tags) per
-/// matching transaction (same shape as `get_shielded_transactions_by_tags`).
+/// Yields one [`ShieldedTransaction`](#getshieldedtransactionsbytags) per
+/// matching transaction (same shape as `getShieldedTransactionsByTags`).
 ```
 
-### `get_merkle_proofs`
+### `getMerkleProofs`
 
 Returns inclusion proofs for leaves against the given tree (UTXO tree, merge authority tree, etc.), plus the root + `root_seq` needed by the consuming instruction.
 
@@ -2119,7 +2119,7 @@ struct MerkleProof {
 }
 ```
 
-### `get_non_inclusion_proofs`
+### `getNonInclusionProofs`
 
 Returns non-inclusion proofs for leaves against the given tree (nullifier tree, merge authority tree, etc.), plus the root + `root_seq` for the consuming instruction.
 
@@ -2162,7 +2162,7 @@ struct NonInclusionProof {
 
 Generates SPP proofs server-side for clients that opt into server-side proving instead of building proofs locally.
 
-### `generate_spp_proof`
+### `generateSppProof`
 
 Builds an [SPP proof](#spp-proof---solana-privacy-zk-proof) from proof inputs; returns the compressed Groth16 proof for the [`transact`](#transact) or [`ring_transact`](#ring_transact) instruction.
 
@@ -2216,7 +2216,7 @@ A Ring RPC holds the ring's auditor key, if configured, and serves decrypted ana
 
 ### `get_decrypted_utxos_by_owner`
 
-Decrypted analogue of [`get_encrypted_utxos_by_tags`](#get_encrypted_utxos_by_tags). Filters spent UTXOs unless `include_spent`.
+Decrypted analogue of [`getEncryptedUtxosByTags`](#getencryptedutxosbytags). Filters spent UTXOs unless `include_spent`.
 
 ```rust
 struct GetDecryptedUtxosByOwnerRequest {
@@ -2245,7 +2245,7 @@ struct DecryptedUtxoEntry {
 
 ### `get_decrypted_transactions_by_owner`
 
-Decrypted analogue of [`get_shielded_transactions_by_tags`](#get_shielded_transactions_by_tags).
+Decrypted analogue of [`getShieldedTransactionsByTags`](#getshieldedtransactionsbytags).
 
 ```rust
 struct GetDecryptedTransactionsByOwnerRequest {
@@ -2272,7 +2272,7 @@ struct DecryptedTransaction {
 
 ### `subscribe_to_decrypted_transactions_by_owner`
 
-Streaming analogue of [`subscribe_to_shielded_transactions_by_tags`](#subscribe_to_shielded_transactions_by_tags). The RPC closes the stream when `current_slot > bound_slot + 150`; the client re-subscribes with a fresh signature.
+Streaming analogue of [`subscribeToShieldedTransactionsByTags`](#subscribetoshieldedtransactionsbytags). The RPC closes the stream when `current_slot > bound_slot + 150`; the client re-subscribes with a fresh signature.
 
 ```rust
 struct SubscribeToDecryptedTransactionsByOwnerRequest {
@@ -2421,11 +2421,11 @@ Wallet {
 
 2. **Default-ring sync, anonymous-ring sync, and merge sync run as independent parallel branches.**
 
-    1. **Default-ring sync (confidential).** One call: `indexer.get_shielded_transactions_by_tags` with the wallet's `owner_pubkey` tag; matches the wallet's encrypted change bundles, encrypted recipient slots, and [plaintext transfer](#plaintext-transfer) slots. Try the locally retained viewing keys against each encrypted ciphertext (plaintext slots need none); store the UTXOs with each transaction's `nullifiers`. The tag derives from the signing key, so discovery does not depend on the viewing key.
+    1. **Default-ring sync (confidential).** One call: `indexer.getShieldedTransactionsByTags` with the wallet's `owner_pubkey` tag; matches the wallet's encrypted change bundles, encrypted recipient slots, and [plaintext transfer](#plaintext-transfer) slots. Try the locally retained viewing keys against each encrypted ciphertext (plaintext slots need none); store the UTXOs with each transaction's `nullifiers`. The tag derives from the signing key, so discovery does not depend on the viewing key.
 
     2. **Anonymous-ring sync — for each anonymous ring in `known_rings`, for each viewing key `k` in parallel:**
         1. **Phase 1 — scan own view tags (concurrent within `k`).**
-            1. **Fetch loop**, scoped to `k`'s `[created_at, next.created_at)` window. Three parallel streams, each calling `indexer.get_shielded_transactions_by_tags(tags)` in batches of 10 000 tags until its first empty batch:
+            1. **Fetch loop**, scoped to `k`'s `[created_at, next.created_at)` window. Three parallel streams, each calling `indexer.getShieldedTransactionsByTags(tags)` in batches of 10 000 tags until its first empty batch:
                 - `wallet.get_sender_view_tag(n)` under `k` for `n in [i, i+10_000)`,
                 - `wallet.get_recipient_request_view_tag(n)` under `k` for `n in [i, i+10_000)`,
                 - the single `recipient_bootstrap_view_tag` for `k` (one call, not a range).

--- a/prover/server/prover/common/circuit_utils.go
+++ b/prover/server/prover/common/circuit_utils.go
@@ -12,7 +12,7 @@ type Proof struct {
 // ProofWithTiming wraps a proof with timing information for metrics
 type ProofWithTiming struct {
 	Proof           *Proof `json:"proof"`
-	ProofDurationMs int64  `json:"proof_duration_ms"`
+	ProofDurationMs int64  `json:"proofDurationMs"`
 }
 
 type BatchProofSystem struct {

--- a/prover/server/prover/common/marshal.go
+++ b/prover/server/prover/common/marshal.go
@@ -32,8 +32,8 @@ type ProofJSON struct {
 	Ar                 [2]string    `json:"ar"`
 	Bs                 [2][2]string `json:"bs"`
 	Krs                [2]string    `json:"krs"`
-	ProofCommitment    []string     `json:"proof_commitment,omitempty"`
-	ProofCommitmentPok []string     `json:"proof_commitment_pok,omitempty"`
+	ProofCommitment    []string     `json:"proofCommitment,omitempty"`
+	ProofCommitmentPok []string     `json:"proofCommitmentPok,omitempty"`
 }
 
 func (p *Proof) MarshalJSON() ([]byte, error) {

--- a/prover/server/redis_queue_test.go
+++ b/prover/server/redis_queue_test.go
@@ -838,9 +838,9 @@ func TestFailedJobStatusDetails(t *testing.T) {
 	errorMessage := "Proof generation failed: Invalid merkle tree state"
 
 	failureDetails := map[string]interface{}{
-		"original_job": originalJob,
-		"error":        errorMessage,
-		"failed_at":    time.Now(),
+		"originalJob": originalJob,
+		"error":       errorMessage,
+		"failedAt":    time.Now(),
 	}
 
 	failedData, err := json.Marshal(failureDetails)
@@ -895,12 +895,12 @@ func TestFailedJobStatusDetails(t *testing.T) {
 		t.Errorf("Expected error message '%s', got '%s'", errorMessage, retrievedError)
 	}
 
-	if _, ok := parsedFailureDetails["failed_at"]; !ok {
-		t.Errorf("Expected failed_at field in failure details")
+	if _, ok := parsedFailureDetails["failedAt"]; !ok {
+		t.Errorf("Expected failedAt field in failure details")
 	}
 
-	if _, ok := parsedFailureDetails["original_job"]; !ok {
-		t.Errorf("Expected original_job field in failure details")
+	if _, ok := parsedFailureDetails["originalJob"]; !ok {
+		t.Errorf("Expected originalJob field in failure details")
 	}
 }
 
@@ -931,9 +931,9 @@ func TestFailedJobStatusHTTPEndpoint(t *testing.T) {
 	originalJob := createTestJob(jobID, "batch-update")
 
 	failureDetails := map[string]interface{}{
-		"original_job": originalJob,
-		"error":        errorMessage,
-		"failed_at":    time.Now().Format(time.RFC3339),
+		"originalJob": originalJob,
+		"error":       errorMessage,
+		"failedAt":    time.Now().Format(time.RFC3339),
 	}
 
 	// Fail the job the way the workers do. This test used to write straight
@@ -945,7 +945,7 @@ func TestFailedJobStatusHTTPEndpoint(t *testing.T) {
 		t.Fatalf("Failed to mark job failed: %v", err)
 	}
 
-	statusURL := fmt.Sprintf("http://%s/prove/status?job_id=%s", config.ProverAddress, jobID)
+	statusURL := fmt.Sprintf("http://%s/prove/status?jobId=%s", config.ProverAddress, jobID)
 	resp, err := http.Get(statusURL)
 	if err != nil {
 		t.Fatalf("Failed to make HTTP request: %v", err)
@@ -980,12 +980,12 @@ func TestFailedJobStatusHTTPEndpoint(t *testing.T) {
 		t.Errorf("Expected error field to be '%s', got '%s'", errorMessage, errorField)
 	}
 
-	if _, ok := statusResponse["failed_at"]; !ok {
-		t.Errorf("Expected failed_at field in response")
+	if _, ok := statusResponse["failedAt"]; !ok {
+		t.Errorf("Expected failedAt field in response")
 	}
 
-	if jobIDField, ok := statusResponse["job_id"].(string); !ok || jobIDField != jobID {
-		t.Errorf("Expected job_id to be '%s', got %v", jobID, statusResponse["job_id"])
+	if jobIDField, ok := statusResponse["jobId"].(string); !ok || jobIDField != jobID {
+		t.Errorf("Expected jobId to be '%s', got %v", jobID, statusResponse["jobId"])
 	}
 }
 

--- a/prover/server/server/queue.go
+++ b/prover/server/server/queue.go
@@ -113,10 +113,10 @@ func isFairQueueEnabled(queueName string) bool {
 func (rq *RedisQueue) StoreJobMeta(jobID string, queueName string, circuitType string) error {
 	key := fmt.Sprintf("zk_job_meta_%s", jobID)
 	meta := map[string]interface{}{
-		"queue":        queueName,
-		"circuit_type": circuitType,
-		"submitted_at": time.Now(),
-		"status":       "queued",
+		"queue":       queueName,
+		"circuitType": circuitType,
+		"submittedAt": time.Now(),
+		"status":      "queued",
 	}
 	data, err := json.Marshal(meta)
 	if err != nil {
@@ -177,7 +177,7 @@ func (rq *RedisQueue) DeleteJobMeta(jobID string) error {
 func (rq *RedisQueue) MarkJobProcessing(jobID string) error {
 	return rq.updateJobMeta(jobID, func(meta map[string]interface{}) {
 		meta["status"] = "processing"
-		meta["started_at"] = time.Now()
+		meta["startedAt"] = time.Now()
 	}, redis.KeepTTL)
 }
 
@@ -543,22 +543,22 @@ func (rq *RedisQueue) GetQueueHealth() (map[string]interface{}, error) {
 	}
 
 	health := make(map[string]interface{})
-	health["queue_lengths"] = stats
+	health["queueLengths"] = stats
 	health["timestamp"] = time.Now().Unix()
 
-	health["total_pending"] = stats["zk_address_append_queue"] + stats["zk_transfer_queue"]
-	health["total_processing"] = stats["zk_address_append_processing_queue"] + stats["zk_transfer_processing_queue"]
-	health["total_failed"] = stats["zk_failed_queue"]
-	health["total_results"] = stats["zk_results_queue"]
+	health["totalPending"] = stats["zk_address_append_queue"] + stats["zk_transfer_queue"]
+	health["totalProcessing"] = stats["zk_address_append_processing_queue"] + stats["zk_transfer_processing_queue"]
+	health["totalFailed"] = stats["zk_failed_queue"]
+	health["totalResults"] = stats["zk_results_queue"]
 
 	stuckJobs := rq.countStuckJobs()
-	health["stuck_jobs"] = stuckJobs
+	health["stuckJobs"] = stuckJobs
 
 	healthStatus := "healthy"
 	if stuckJobs > 0 {
 		healthStatus = "degraded"
 	}
-	if health["total_failed"].(int64) > 50 {
+	if health["totalFailed"].(int64) > 50 {
 		healthStatus = "unhealthy"
 	}
 	health["status"] = healthStatus

--- a/prover/server/server/queue_job.go
+++ b/prover/server/server/queue_job.go
@@ -117,14 +117,14 @@ type ProofJob struct {
 	ID        string          `json:"id"`
 	Type      string          `json:"type"`
 	Payload   json.RawMessage `json:"payload"`
-	CreatedAt time.Time       `json:"created_at"`
+	CreatedAt time.Time       `json:"createdAt"`
 	// TreeID is the merkle tree pubkey - used for fair queuing across trees
 	// If empty, job goes to the default queue (backwards compatible)
-	TreeID string `json:"tree_id,omitempty"`
+	TreeID string `json:"treeId,omitempty"`
 	// BatchIndex is the batch sequence number within a tree - used to process batches in order
 	// Lower batch indices should be processed first to enable sequential transaction submission
 	// -1 means no batch index (legacy requests, FIFO)
-	BatchIndex int64 `json:"batch_index"`
+	BatchIndex int64 `json:"batchIndex"`
 }
 
 type QueueWorker interface {
@@ -315,15 +315,15 @@ func (w *BaseQueueWorker) processJobs() {
 
 		// Add to failed queue with new job ID (without full payload to save memory)
 		failedJob := map[string]interface{}{
-			"original_job": map[string]interface{}{
-				"id":           job.ID,
-				"type":         job.Type,
-				"payload_size": len(job.Payload),
-				"created_at":   job.CreatedAt,
+			"originalJob": map[string]interface{}{
+				"id":          job.ID,
+				"type":        job.Type,
+				"payloadSize": len(job.Payload),
+				"createdAt":   job.CreatedAt,
 			},
-			"error":       errorMsg,
-			"failed_at":   time.Now(),
-			"cached_from": cachedFailedJobID,
+			"error":      errorMsg,
+			"failedAt":   time.Now(),
+			"cachedFrom": cachedFailedJobID,
 		}
 
 		failedData, _ := json.Marshal(failedJob)
@@ -719,15 +719,15 @@ func failureDetails(job *ProofJob, err error) map[string]interface{} {
 	}
 
 	return map[string]interface{}{
-		"original_job": map[string]interface{}{
-			"id":           job.ID,
-			"type":         job.Type,
-			"circuit_type": circuitType,
-			"payload_size": len(job.Payload),
-			"created_at":   job.CreatedAt,
+		"originalJob": map[string]interface{}{
+			"id":          job.ID,
+			"type":        job.Type,
+			"circuitType": circuitType,
+			"payloadSize": len(job.Payload),
+			"createdAt":   job.CreatedAt,
 		},
-		"error":     err.Error(),
-		"failed_at": time.Now(),
+		"error":    err.Error(),
+		"failedAt": time.Now(),
 	}
 }
 

--- a/prover/server/server/server.go
+++ b/prover/server/server/server.go
@@ -31,9 +31,9 @@ func (handler proofStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	jobID := r.URL.Query().Get("job_id")
+	jobID := r.URL.Query().Get("jobId")
 	if jobID == "" {
-		malformedBodyError(fmt.Errorf("job_id parameter required")).send(w)
+		malformedBodyError(fmt.Errorf("jobId parameter required")).send(w)
 		return
 	}
 
@@ -67,7 +67,7 @@ func (handler proofStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 			Msg("Job completed - returning result")
 
 		response := map[string]interface{}{
-			"job_id": jobID,
+			"jobId":  jobID,
 			"status": "completed",
 			"result": result,
 		}
@@ -119,15 +119,15 @@ func (handler proofStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 				Msg("Job not found in queues but metadata exists - returning queued status")
 
 			response := map[string]interface{}{
-				"job_id":  jobID,
+				"jobId":   jobID,
 				"status":  "queued",
 				"message": "Job is queued and waiting to be processed",
 			}
-			if circuitType, ok := jobMeta["circuit_type"]; ok {
-				response["circuit_type"] = circuitType
+			if circuitType, ok := jobMeta["circuitType"]; ok {
+				response["circuitType"] = circuitType
 			}
-			if submittedAt, ok := jobMeta["submitted_at"]; ok {
-				response["submitted_at"] = submittedAt
+			if submittedAt, ok := jobMeta["submittedAt"]; ok {
+				response["submittedAt"] = submittedAt
 			}
 
 			w.Header().Set("Content-Type", "application/json")
@@ -179,17 +179,17 @@ func (handler proofStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		Str("job_id", jobID).
 		Str("status", jobStatus)
 	if jobInfo != nil {
-		if ct, ok := jobInfo["circuit_type"]; ok {
+		if ct, ok := jobInfo["circuitType"]; ok {
 			logEvent = logEvent.Interface("circuit_type", ct)
 		}
-		if ca, ok := jobInfo["created_at"]; ok {
+		if ca, ok := jobInfo["createdAt"]; ok {
 			logEvent = logEvent.Interface("created_at", ca)
 		}
 	}
 	logEvent.Msg("Job found but not completed")
 
 	response := map[string]interface{}{
-		"job_id": jobID,
+		"jobId":  jobID,
 		"status": jobStatus,
 	}
 
@@ -213,12 +213,12 @@ func (handler proofStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 				response["message"] = fmt.Sprintf("Job processing failed: %s", errorMsg)
 				response["error"] = errorMsg
 			}
-			if failedAt, ok := failureDetails["failed_at"]; ok {
-				response["failed_at"] = failedAt
+			if failedAt, ok := failureDetails["failedAt"]; ok {
+				response["failedAt"] = failedAt
 			}
-			if originalJob, ok := failureDetails["original_job"].(map[string]interface{}); ok {
-				if circuitType, ok := originalJob["circuit_type"]; ok {
-					response["circuit_type"] = circuitType
+			if originalJob, ok := failureDetails["originalJob"].(map[string]interface{}); ok {
+				if circuitType, ok := originalJob["circuitType"]; ok {
+					response["circuitType"] = circuitType
 				}
 			}
 		} else {
@@ -229,11 +229,11 @@ func (handler proofStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		response["message"] = getStatusMessage(jobStatus)
 
 		if jobInfo != nil {
-			if createdAt, ok := jobInfo["created_at"]; ok {
-				response["created_at"] = createdAt
+			if createdAt, ok := jobInfo["createdAt"]; ok {
+				response["createdAt"] = createdAt
 			}
-			if circuitType, ok := jobInfo["circuit_type"]; ok {
-				response["circuit_type"] = circuitType
+			if circuitType, ok := jobInfo["circuitType"]; ok {
+				response["circuitType"] = circuitType
 			}
 		}
 	}
@@ -327,8 +327,8 @@ func (handler proofStatusHandler) checkJobExistsDetailed(
 			Msg("Job found in result cache")
 
 		return true, "completed", map[string]interface{}{
-			"result":        result,
-			"result_cached": true,
+			"result":       result,
+			"resultCached": true,
 		}, nil
 	}
 
@@ -349,9 +349,9 @@ func (handler proofStatusHandler) checkJobExistsDetailed(
 	}
 
 	jobInfo := map[string]interface{}{
-		"circuit_type": jobMeta["circuit_type"],
-		"submitted_at": jobMeta["submitted_at"],
-		"from_meta":    true,
+		"circuitType": jobMeta["circuitType"],
+		"submittedAt": jobMeta["submittedAt"],
+		"fromMeta":    true,
 	}
 	// A failure carries its reason with it, so the caller gets the same detail
 	// the failed queue used to supply.
@@ -438,11 +438,11 @@ func (handler queueStatsHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 
 	response := map[string]interface{}{
-		"queues":        stats,
-		"total_pending": stats["zk_address_append_queue"] + stats["zk_transfer_queue"],
-		"total_active":  stats["zk_address_append_processing_queue"] + stats["zk_transfer_processing_queue"],
-		"total_failed":  stats["zk_failed_queue"],
-		"timestamp":     time.Now().Unix(),
+		"queues":       stats,
+		"totalPending": stats["zk_address_append_queue"] + stats["zk_transfer_queue"],
+		"totalActive":  stats["zk_address_append_processing_queue"] + stats["zk_transfer_processing_queue"],
+		"totalFailed":  stats["zk_failed_queue"],
+		"timestamp":    time.Now().Unix(),
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -488,45 +488,45 @@ func (handler queueCleanupHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	results := make(map[string]interface{})
 
 	if err := handler.redisQueue.CleanupOldRequests(); err != nil {
-		results["old_requests_cleanup"] = map[string]interface{}{
+		results["oldRequestsCleanup"] = map[string]interface{}{
 			"success": false,
 			"error":   err.Error(),
 		}
 	} else {
-		results["old_requests_cleanup"] = map[string]interface{}{
+		results["oldRequestsCleanup"] = map[string]interface{}{
 			"success": true,
 		}
 	}
 
 	if err := handler.redisQueue.CleanupStuckProcessingJobs(); err != nil {
-		results["stuck_jobs_cleanup"] = map[string]interface{}{
+		results["stuckJobsCleanup"] = map[string]interface{}{
 			"success": false,
 			"error":   err.Error(),
 		}
 	} else {
-		results["stuck_jobs_cleanup"] = map[string]interface{}{
+		results["stuckJobsCleanup"] = map[string]interface{}{
 			"success": true,
 		}
 	}
 
 	if err := handler.redisQueue.CleanupOldFailedJobs(); err != nil {
-		results["old_failed_cleanup"] = map[string]interface{}{
+		results["oldFailedCleanup"] = map[string]interface{}{
 			"success": false,
 			"error":   err.Error(),
 		}
 	} else {
-		results["old_failed_cleanup"] = map[string]interface{}{
+		results["oldFailedCleanup"] = map[string]interface{}{
 			"success": true,
 		}
 	}
 
 	if err := handler.redisQueue.CleanupOldResultKeys(); err != nil {
-		results["old_result_keys_cleanup"] = map[string]interface{}{
+		results["oldResultKeysCleanup"] = map[string]interface{}{
 			"success": false,
 			"error":   err.Error(),
 		}
 	} else {
-		results["old_result_keys_cleanup"] = map[string]interface{}{
+		results["oldResultKeysCleanup"] = map[string]interface{}{
 			"success": true,
 		}
 	}
@@ -616,10 +616,10 @@ func RunEnhanced(config *EnhancedConfig, redisQueue *RedisQueue, keyManager *com
 			// If deduplicated to an existing job, return early
 			if dedupResult.IsDeduplicated {
 				response := map[string]interface{}{
-					"job_id":       dedupResult.JobID,
+					"jobId":        dedupResult.JobID,
 					"status":       "already_queued",
 					"queue":        queueName,
-					"circuit_type": string(proofRequestMeta.CircuitType),
+					"circuitType":  string(proofRequestMeta.CircuitType),
 					"message":      "Proof request with identical input already in queue. Returning existing job ID.",
 					"deduplicated": true,
 				}
@@ -687,11 +687,11 @@ func RunEnhanced(config *EnhancedConfig, redisQueue *RedisQueue, keyManager *com
 				Msg("Enqueued proof job")
 
 			response := map[string]interface{}{
-				"job_id":       jobID,
-				"status":       "queued",
-				"queue":        queueName,
-				"circuit_type": string(proofRequestMeta.CircuitType),
-				"message":      fmt.Sprintf("Job queued in %s", queueName),
+				"jobId":       jobID,
+				"status":      "queued",
+				"queue":       queueName,
+				"circuitType": string(proofRequestMeta.CircuitType),
+				"message":     fmt.Sprintf("Job queued in %s", queueName),
 			}
 
 			w.Header().Set("Content-Type", "application/json")
@@ -822,9 +822,9 @@ func (handler proveHandler) handleAsyncProof(w http.ResponseWriter, r *http.Requ
 	// If deduplicated to an existing job, return early
 	if dedupResult.IsDeduplicated {
 		response := map[string]interface{}{
-			"job_id":       dedupResult.JobID,
+			"jobId":        dedupResult.JobID,
 			"status":       "already_queued",
-			"circuit_type": string(meta.CircuitType),
+			"circuitType":  string(meta.CircuitType),
 			"queue":        queueName,
 			"message":      "Proof request with identical input already in queue. Returning existing job ID.",
 			"deduplicated": true,
@@ -903,13 +903,13 @@ func (handler proveHandler) handleAsyncProof(w http.ResponseWriter, r *http.Requ
 	estimatedTime := handler.getEstimatedTime(meta.CircuitType)
 
 	response := map[string]interface{}{
-		"job_id":         jobID,
-		"status":         "queued",
-		"circuit_type":   string(meta.CircuitType),
-		"queue":          queueName,
-		"estimated_time": estimatedTime,
-		"status_url":     fmt.Sprintf("/prove/status?job_id=%s", jobID),
-		"message":        fmt.Sprintf("Proof generation queued for %s circuit. Use status_url to check progress.", meta.CircuitType),
+		"jobId":         jobID,
+		"status":        "queued",
+		"circuitType":   string(meta.CircuitType),
+		"queue":         queueName,
+		"estimatedTime": estimatedTime,
+		"statusUrl":     fmt.Sprintf("/prove/status?jobId=%s", jobID),
+		"message":       fmt.Sprintf("Proof generation queued for %s circuit. Use statusUrl to check progress.", meta.CircuitType),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/prover/server/status_lookup_test.go
+++ b/prover/server/status_lookup_test.go
@@ -56,8 +56,8 @@ func TestMarkJobProcessingIsVisibleWithoutScanningQueues(t *testing.T) {
 	}
 	// The fields written at submission have to survive the update -- the status
 	// response still reports them.
-	if got := meta["circuit_type"]; got != "transfer" {
-		t.Fatalf("circuit_type = %v, want transfer", got)
+	if got := meta["circuitType"]; got != "transfer" {
+		t.Fatalf("circuitType = %v, want transfer", got)
 	}
 	if got := meta["queue"]; got != "zk_transfer_queue" {
 		t.Fatalf("queue = %v, want zk_transfer_queue", got)
@@ -123,8 +123,8 @@ func TestMarkJobFailedCarriesTheReason(t *testing.T) {
 		t.Fatalf("store job meta: %v", err)
 	}
 	details := map[string]interface{}{
-		"error":     "proof generation failed",
-		"failed_at": time.Now(),
+		"error":    "proof generation failed",
+		"failedAt": time.Now(),
 	}
 	if err := queue.MarkJobFailed(jobID, details); err != nil {
 		t.Fatalf("mark failed: %v", err)

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -1534,9 +1534,9 @@ mod tests {
         assert_eq!(
             requests,
             [
-                "/get_merkle_proofs",
-                "/get_non_inclusion_proofs",
-                "/get_shielded_transactions_by_signature",
+                "/getMerkleProofs",
+                "/getNonInclusionProofs",
+                "/getShieldedTransactionsBySignature",
             ]
         );
     }
@@ -1626,7 +1626,7 @@ mod tests {
     fn confirm_private_transaction_sync_times_out_when_indexer_lags() {
         let signature = Signature::from([9u8; 64]);
         let server = MockIndexerServer::respond_with(vec![rpc_result(json!({
-            "context": { "block_time": 12, "slot": 1 },
+            "context": { "blockTime": 12, "slot": 1 },
             "transactions": [],
         }))]);
         let rpc = MockSubmitRpc::new(signature);
@@ -1652,7 +1652,7 @@ mod tests {
         let signature = Signature::from([10u8; 64]);
         let server = MockIndexerServer::respond_with(vec![
             rpc_result(json!({
-                "context": { "block_time": 12, "slot": 1 },
+                "context": { "blockTime": 12, "slot": 1 },
                 "transactions": [],
             })),
             indexed_transaction_by_signature_response(signature),
@@ -1675,8 +1675,8 @@ mod tests {
         assert_eq!(
             server.requests(),
             [
-                "/get_shielded_transactions_by_signature",
-                "/get_shielded_transactions_by_signature",
+                "/getShieldedTransactionsBySignature",
+                "/getShieldedTransactionsBySignature",
             ]
         );
     }
@@ -1705,8 +1705,8 @@ mod tests {
         assert_eq!(
             server.requests(),
             [
-                "/get_shielded_transactions_by_signature",
-                "/get_shielded_transactions_by_signature",
+                "/getShieldedTransactionsBySignature",
+                "/getShieldedTransactionsBySignature",
             ]
         );
     }
@@ -1738,8 +1738,8 @@ mod tests {
         assert_eq!(
             server.requests(),
             [
-                "/get_shielded_transactions_by_signature",
-                "/get_shielded_transactions_by_signature",
+                "/getShieldedTransactionsBySignature",
+                "/getShieldedTransactionsBySignature",
             ]
         );
         let ClientError::PollTimedOut {
@@ -1762,10 +1762,10 @@ mod tests {
     fn confirm_private_transaction_sync_accepts_events_sharing_a_view_tag() {
         let signature = Signature::from([18u8; 64]);
         let server = MockIndexerServer::respond_with(vec![rpc_result(json!({
-            "context": { "block_time": 12, "slot": 1 },
+            "context": { "blockTime": 12, "slot": 1 },
             "transactions": [
-                { "event_index": 0, "transaction": indexed_transaction_json(signature) },
-                { "event_index": 1, "transaction": indexed_transaction_json(signature) },
+                { "eventIndex": 0, "transaction": indexed_transaction_json(signature) },
+                { "eventIndex": 1, "transaction": indexed_transaction_json(signature) },
             ],
         }))]);
         let client = ZolanaClient::new(
@@ -1782,10 +1782,7 @@ mod tests {
             .confirm_private_transaction_sync(signature)
             .expect("events sharing a view tag are not an error");
 
-        assert_eq!(
-            server.requests(),
-            ["/get_shielded_transactions_by_signature"]
-        );
+        assert_eq!(server.requests(), ["/getShieldedTransactionsBySignature"]);
     }
 
     /// Confirmation no longer reads view tags, so the forwarders are the only
@@ -1949,39 +1946,39 @@ mod tests {
 
     fn merkle_response(tree: Address, leaf: [u8; 32]) -> Value {
         rpc_result(json!({
-            "context": { "block_time": 10, "slot": 1 },
+            "context": { "blockTime": 10, "slot": 1 },
             "proofs": [{
                 "leaf": encode_hash(leaf),
-                "merkle_context": {
-                    "tree_type": 0,
+                "merkleContext": {
+                    "treeType": 0,
                     "tree": encode_address(tree),
                 },
                 "path": vec![encode_hash([0u8; 32]); crate::rpc::STATE_TREE_HEIGHT],
-                "leaf_index": 0,
+                "leafIndex": 0,
                 "root": encode_hash([3u8; 32]),
-                "root_seq": 1,
-                "root_index": 0,
+                "rootSeq": 1,
+                "rootIndex": 0,
             }],
         }))
     }
 
     fn nullifier_response(tree: Address, leaf: [u8; 32]) -> Value {
         rpc_result(json!({
-            "context": { "block_time": 10, "slot": 1 },
+            "context": { "blockTime": 10, "slot": 1 },
             "proofs": [{
                 "leaf": encode_hash(leaf),
-                "merkle_context": {
-                    "tree_type": 1,
+                "merkleContext": {
+                    "treeType": 1,
                     "tree": encode_address(tree),
                 },
                 "path": vec![encode_hash([0u8; 32]); crate::rpc::NULLIFIER_TREE_HEIGHT],
-                "low_element": encode_hash([0u8; 32]),
-                "low_element_index": 0,
-                "high_element": encode_hash([u8::MAX; 32]),
-                "high_element_index": 1,
+                "lowElement": encode_hash([0u8; 32]),
+                "lowElementIndex": 0,
+                "highElement": encode_hash([u8::MAX; 32]),
+                "highElementIndex": 1,
                 "root": encode_hash([4u8; 32]),
-                "root_seq": 1,
-                "root_index": 0,
+                "rootSeq": 1,
+                "rootIndex": 0,
             }],
         }))
     }
@@ -1989,14 +1986,14 @@ mod tests {
     fn indexed_transaction_json(signature: Signature) -> Value {
         json!({
             "slot": 11,
-            "tx_signature": signature.to_string(),
-            "tx_viewing_pk": null,
-            "output_slots": [{
-                "view_tag": encode_hash([0u8; 32]),
-                "output_context": {
+            "txSignature": signature.to_string(),
+            "txViewingPk": null,
+            "outputSlots": [{
+                "viewTag": encode_hash([0u8; 32]),
+                "outputContext": {
                     "hash": encode_hash([1u8; 32]),
                     "tree": encode_address(Address::new_from_array([8u8; 32])),
-                    "leaf_index": 0,
+                    "leafIndex": 0,
                 },
                 "payload": "",
             }],
@@ -2008,9 +2005,9 @@ mod tests {
 
     fn indexed_transaction_by_signature_response(signature: Signature) -> Value {
         rpc_result(json!({
-            "context": { "block_time": 11, "slot": 1 },
+            "context": { "blockTime": 11, "slot": 1 },
             "transactions": [{
-                "event_index": 0,
+                "eventIndex": 0,
                 "transaction": indexed_transaction_json(signature),
             }],
         }))

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -643,7 +643,7 @@ fn convert_encrypted_utxo_match(
         output_slot: convert_output_slot(item.output_slot),
         tx_viewing_pk: decode_optional_p256(
             item.tx_viewing_pk,
-            &format!("matches[{index}].tx_viewing_pk"),
+            &format!("matches[{index}].txViewingPk"),
         )?,
         salt: decode_optional_salt(item.salt, &format!("matches[{index}].salt"))?,
     })
@@ -695,7 +695,7 @@ fn convert_shielded_transaction(
     Ok(ShieldedTransaction {
         slot: item.slot,
         tx_signature: item.tx_signature.0,
-        tx_viewing_pk: decode_optional_p256(item.tx_viewing_pk, &format!("{path}.tx_viewing_pk"))?,
+        tx_viewing_pk: decode_optional_p256(item.tx_viewing_pk, &format!("{path}.txViewingPk"))?,
         salt: decode_optional_salt(item.salt, &format!("{path}.salt"))?,
         output_slots: item
             .output_slots
@@ -836,12 +836,10 @@ mod tests {
         let secret = SecretKey::from_slice(&[1u8; 32]).unwrap();
         let public = secret.public_key();
         let point = public.to_encoded_point(true);
-        let key = decode_optional_p256(
-            Some(Base64String(point.as_bytes().to_vec())),
-            "tx_viewing_pk",
-        )
-        .unwrap()
-        .unwrap();
+        let key =
+            decode_optional_p256(Some(Base64String(point.as_bytes().to_vec())), "txViewingPk")
+                .unwrap()
+                .unwrap();
 
         assert_eq!(key.as_bytes(), point.as_bytes());
     }
@@ -855,22 +853,22 @@ mod tests {
         let signature = signature(9);
         let (tx_viewing_pk_bytes, tx_viewing_pk) = compressed_p256_pubkey(3);
         let response = rpc_result(json!({
-            "context": { "block_time": 42, "slot": 1 },
+            "context": { "blockTime": 42, "slot": 1 },
             "matches": [{
                 "slot": 7,
-                "tx_signature": signature.to_string(),
-                "output_slot": {
-                    "view_tag": encode_hash_string(tag_a),
-                    "output_context": {
+                "txSignature": signature.to_string(),
+                "outputSlot": {
+                    "viewTag": encode_hash_string(tag_a),
+                    "outputContext": {
                         "hash": encode_hash_string(utxo_hash),
                         "tree": encode_pubkey_string(output_tree),
-                        "leaf_index": 11,
+                        "leafIndex": 11,
                     },
                     "payload": STANDARD.encode([8, 9, 10]),
                 },
-                "tx_viewing_pk": STANDARD.encode(&tx_viewing_pk_bytes),
+                "txViewingPk": STANDARD.encode(&tx_viewing_pk_bytes),
             }],
-            "next_cursor": STANDARD.encode([5, 6]),
+            "nextCursor": STANDARD.encode([5, 6]),
         }));
         let server = MockServer::respond_once(response);
         let indexer = ZolanaIndexer::new(server.url());
@@ -880,8 +878,8 @@ mod tests {
             .expect("encrypted UTXO lookup");
         let request = server.request();
 
-        assert_eq!(request.path, "/get_encrypted_utxos_by_tags");
-        assert_json_rpc_request(&request.body, "get_encrypted_utxos_by_tags");
+        assert_eq!(request.path, "/getEncryptedUtxosByTags");
+        assert_json_rpc_request(&request.body, "getEncryptedUtxosByTags");
         assert_eq!(
             request.body["params"],
             json!({
@@ -925,17 +923,17 @@ mod tests {
         let nullifier = bytes32(13);
         let signature = signature(14);
         let response = rpc_result(json!({
-            "context": { "block_time": 51, "slot": 1 },
+            "context": { "blockTime": 51, "slot": 1 },
             "transactions": [{
                 "slot": 50,
-                "tx_signature": signature.to_string(),
-                "tx_viewing_pk": null,
-                "output_slots": [{
-                    "view_tag": encode_hash_string(tag),
-                    "output_context": {
+                "txSignature": signature.to_string(),
+                "txViewingPk": null,
+                "outputSlots": [{
+                    "viewTag": encode_hash_string(tag),
+                    "outputContext": {
                         "hash": encode_hash_string(output_hash),
                         "tree": encode_pubkey_string(output_tree),
-                        "leaf_index": 16,
+                        "leafIndex": 16,
                     },
                     "payload": STANDARD.encode([21, 22]),
                 }],
@@ -943,7 +941,7 @@ mod tests {
                 "nullifiers": [encode_hash_string(nullifier)],
                 "proofless": true,
             }],
-            "next_cursor": STANDARD.encode([23]),
+            "nextCursor": STANDARD.encode([23]),
         }));
         let server = MockServer::respond_once(response);
         let indexer = ZolanaIndexer::new(server.url());
@@ -953,8 +951,8 @@ mod tests {
             .expect("shielded transaction lookup");
         let request = server.request();
 
-        assert_eq!(request.path, "/get_shielded_transactions_by_tags");
-        assert_json_rpc_request(&request.body, "get_shielded_transactions_by_tags");
+        assert_eq!(request.path, "/getShieldedTransactionsByTags");
+        assert_json_rpc_request(&request.body, "getShieldedTransactionsByTags");
         assert_eq!(
             request.body["params"],
             json!({
@@ -996,14 +994,14 @@ mod tests {
     fn get_shielded_transactions_by_signature_preserves_event_index() {
         let signature = signature(24);
         let response = rpc_result(json!({
-            "context": { "block_time": 52, "slot": 1 },
+            "context": { "blockTime": 52, "slot": 1 },
             "transactions": [{
-                "event_index": 3,
+                "eventIndex": 3,
                 "transaction": {
                     "slot": 50,
-                    "tx_signature": signature.to_string(),
-                    "tx_viewing_pk": null,
-                    "output_slots": [],
+                    "txSignature": signature.to_string(),
+                    "txViewingPk": null,
+                    "outputSlots": [],
                     "messages": [],
                     "nullifiers": [],
                     "proofless": false,
@@ -1018,11 +1016,11 @@ mod tests {
             .expect("direct shielded transaction lookup");
         let request = server.request();
 
-        assert_eq!(request.path, "/get_shielded_transactions_by_signature");
-        assert_json_rpc_request(&request.body, "get_shielded_transactions_by_signature");
+        assert_eq!(request.path, "/getShieldedTransactionsBySignature");
+        assert_json_rpc_request(&request.body, "getShieldedTransactionsBySignature");
         assert_eq!(
             request.body["params"],
-            json!({ "tx_signature": signature.to_string() })
+            json!({ "txSignature": signature.to_string() })
         );
         let indexed = got
             .transactions
@@ -1038,9 +1036,9 @@ mod tests {
         let nullifier_a = bytes32(24);
         let nullifier_b = bytes32(25);
         let response = rpc_result(json!({
-            "context": { "block_time": 52, "slot": 1 },
+            "context": { "blockTime": 52, "slot": 1 },
             "transactions": [],
-            "next_cursor": null,
+            "nextCursor": null,
         }));
         let server = MockServer::respond_once(response);
         let indexer = ZolanaIndexer::new(server.url());
@@ -1055,8 +1053,8 @@ mod tests {
             .expect("nullifier transaction lookup");
         let request = server.request();
 
-        assert_eq!(request.path, "/get_shielded_transactions_by_nullifiers");
-        assert_json_rpc_request(&request.body, "get_shielded_transactions_by_nullifiers");
+        assert_eq!(request.path, "/getShieldedTransactionsByNullifiers");
+        assert_json_rpc_request(&request.body, "getShieldedTransactionsByNullifiers");
         assert_eq!(
             request.body["params"],
             json!({
@@ -1088,18 +1086,18 @@ mod tests {
         let path = vec![bytes32(34), bytes32(35)];
         let root = bytes32(36);
         let response = rpc_result(json!({
-            "context": { "block_time": 80, "slot": 1 },
+            "context": { "blockTime": 80, "slot": 1 },
             "proofs": [{
                 "leaf": encode_hash_string(leaf_a),
-                "merkle_context": {
-                    "tree_type": 1,
+                "merkleContext": {
+                    "treeType": 1,
                     "tree": encode_pubkey_string(tree),
                 },
                 "path": path.iter().copied().map(encode_hash_string).collect::<Vec<_>>(),
-                "leaf_index": 9,
+                "leafIndex": 9,
                 "root": encode_hash_string(root),
-                "root_seq": 10,
-                "root_index": 11,
+                "rootSeq": 10,
+                "rootIndex": 11,
             }],
         }));
         let server = MockServer::respond_once(response);
@@ -1110,12 +1108,12 @@ mod tests {
             .expect("merkle proofs");
         let request = server.request();
 
-        assert_eq!(request.path, "/get_merkle_proofs");
-        assert_json_rpc_request(&request.body, "get_merkle_proofs");
+        assert_eq!(request.path, "/getMerkleProofs");
+        assert_json_rpc_request(&request.body, "getMerkleProofs");
         assert_eq!(
             request.body["params"],
             json!({
-                "tree_account": encode_pubkey_string(tree),
+                "treeAccount": encode_pubkey_string(tree),
                 "leaves": [encode_hash_string(leaf_a)],
             })
         );
@@ -1148,21 +1146,21 @@ mod tests {
         let path = vec![bytes32(45), bytes32(46)];
         let root = bytes32(47);
         let response = rpc_result(json!({
-            "context": { "block_time": 90, "slot": 1 },
+            "context": { "blockTime": 90, "slot": 1 },
             "proofs": [{
                 "leaf": encode_hash_string(leaf),
-                "merkle_context": {
-                    "tree_type": 2,
+                "merkleContext": {
+                    "treeType": 2,
                     "tree": encode_pubkey_string(tree),
                 },
                 "path": path.iter().copied().map(encode_hash_string).collect::<Vec<_>>(),
-                "low_element": encode_hash_string(low),
-                "low_element_index": 3,
-                "high_element": encode_hash_string(high),
-                "high_element_index": 4,
+                "lowElement": encode_hash_string(low),
+                "lowElementIndex": 3,
+                "highElement": encode_hash_string(high),
+                "highElementIndex": 4,
                 "root": encode_hash_string(root),
-                "root_seq": 12,
-                "root_index": 13,
+                "rootSeq": 12,
+                "rootIndex": 13,
             }],
         }));
         let server = MockServer::respond_once(response);
@@ -1173,12 +1171,12 @@ mod tests {
             .expect("non-inclusion proofs");
         let request = server.request();
 
-        assert_eq!(request.path, "/get_non_inclusion_proofs");
-        assert_json_rpc_request(&request.body, "get_non_inclusion_proofs");
+        assert_eq!(request.path, "/getNonInclusionProofs");
+        assert_json_rpc_request(&request.body, "getNonInclusionProofs");
         assert_eq!(
             request.body["params"],
             json!({
-                "tree_account": encode_pubkey_string(tree),
+                "treeAccount": encode_pubkey_string(tree),
                 "leaves": [encode_hash_string(leaf)],
             })
         );
@@ -1236,7 +1234,7 @@ mod tests {
         assert!(matches!(rate_limit, ClientError::IndexerUnavailable(_)));
 
         let internal_error = indexer_error(zolana_api::ApiError::JsonRpc {
-            method: "get_shielded_transactions_by_signature",
+            method: "getShieldedTransactionsBySignature",
             code: Some(-32603),
             message: Some("Internal error".to_string()),
         });
@@ -1246,13 +1244,13 @@ mod tests {
     #[test]
     fn classifies_non_transient_indexer_errors_without_retry() {
         let method_not_found = indexer_error(zolana_api::ApiError::JsonRpc {
-            method: "get_shielded_transactions_by_signature",
+            method: "getShieldedTransactionsBySignature",
             code: Some(-32601),
             message: Some("Method not found".to_string()),
         });
         assert!(matches!(
             method_not_found,
-            ClientError::UnsupportedRpcMethod("get_shielded_transactions_by_signature")
+            ClientError::UnsupportedRpcMethod("getShieldedTransactionsBySignature")
         ));
 
         let request_error = reqwest::blocking::Client::new()
@@ -1267,17 +1265,17 @@ mod tests {
     fn rejects_malformed_output_slot_hash() {
         let tag = bytes32(51);
         let response = rpc_result(json!({
-            "context": { "block_time": 1, "slot": 1 },
+            "context": { "blockTime": 1, "slot": 1 },
             "transactions": [{
                 "slot": 1,
-                "tx_signature": signature(52).to_string(),
-                "tx_viewing_pk": null,
-                "output_slots": [{
-                    "view_tag": encode_hash_string(tag),
-                    "output_context": {
+                "txSignature": signature(52).to_string(),
+                "txViewingPk": null,
+                "outputSlots": [{
+                    "viewTag": encode_hash_string(tag),
+                    "outputContext": {
                         "hash": bs58::encode([1u8; 31]).into_string(),
                         "tree": encode_pubkey_string(Address::new_from_array(bytes32(53))),
-                        "leaf_index": 1,
+                        "leafIndex": 1,
                     },
                     "payload": STANDARD.encode([1]),
                 }],
@@ -1285,7 +1283,7 @@ mod tests {
                 "nullifiers": [],
                 "proofless": true,
             }],
-            "next_cursor": null,
+            "nextCursor": null,
         }));
         let server = MockServer::respond_once(response);
         let indexer = ZolanaIndexer::new(server.url());
@@ -1297,21 +1295,21 @@ mod tests {
 
         let message = err.to_string();
         assert!(message.contains("wrong size"));
-        assert!(message.contains("result.transactions[0].output_slots[0].output_context.hash"));
+        assert!(message.contains("result.transactions[0].outputSlots[0].outputContext.hash"));
     }
 
     #[test]
     fn by_signature_error_path_includes_transaction_nesting() {
         let signature = signature(61);
         let response = rpc_result(json!({
-            "context": { "block_time": 1, "slot": 1 },
+            "context": { "blockTime": 1, "slot": 1 },
             "transactions": [{
-                "event_index": 0,
+                "eventIndex": 0,
                 "transaction": {
                     "slot": 1,
-                    "tx_signature": signature.to_string(),
-                    "tx_viewing_pk": STANDARD.encode([1u8; 16]),
-                    "output_slots": [],
+                    "txSignature": signature.to_string(),
+                    "txViewingPk": STANDARD.encode([1u8; 16]),
+                    "outputSlots": [],
                     "messages": [],
                     "nullifiers": [],
                     "proofless": false,
@@ -1328,7 +1326,7 @@ mod tests {
 
         assert!(err
             .to_string()
-            .contains("transactions[0].transaction.tx_viewing_pk"));
+            .contains("transactions[0].transaction.txViewingPk"));
     }
 
     fn assert_json_rpc_request(body: &Value, method: &str) {

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -242,11 +242,11 @@ impl ProverClient {
             .map_err(|e| ClientError::ProofParse(format!("invalid response JSON: {e}")))?;
 
         // A Redis-backed prover queues supported proofs and returns a job
-        // handle (`{ job_id, status, status_url }`) instead of a proof; poll the
+        // handle (`{ jobId, status, statusUrl }`) instead of a proof; poll the
         // status endpoint until it completes. A synchronous prover returns the
         // proof directly (plain gnark JSON or a `{ proof, .. }` envelope).
         if value.get("proof").is_none() {
-            if let Some(job_id) = value.get("job_id").and_then(|v| v.as_str()) {
+            if let Some(job_id) = value.get("jobId").and_then(|v| v.as_str()) {
                 return self.poll_async(job_id);
             }
         }
@@ -255,7 +255,7 @@ impl ProverClient {
 
     /// Poll the async job status endpoint until the queued proof completes.
     fn poll_async(&self, job_id: &str) -> Result<Proof, ClientError> {
-        let url = format!("{}/prove/status?job_id={}", self.server_address, job_id);
+        let url = format!("{}/prove/status?jobId={}", self.server_address, job_id);
         // The configured interval caps the backoff rather than setting it. This
         // used to be `.max(1)` and `sleep_secs`, which put a hard 1s floor on
         // every proof: a 270ms proof measured 3.3s end to end, essentially all
@@ -319,7 +319,7 @@ impl ProverClient {
                 .map_err(|e| ClientError::ProofParse(format!("invalid status JSON: {e}")))?;
 
             match value.get("status").and_then(|v| v.as_str()) {
-                // The completed result is a `{ proof, proof_duration_ms }` envelope
+                // The completed result is a `{ proof, proofDurationMs }` envelope
                 // nested under `result`.
                 Some("completed") => {
                     let result = value.get("result").map_or(&value, |result| result);
@@ -476,7 +476,7 @@ impl AsyncProverClient {
                         ClientError::ProofParse(format!("invalid response JSON: {e}"))
                     })?;
                     if value.get("proof").is_none() {
-                        if let Some(job_id) = value.get("job_id").and_then(|v| v.as_str()) {
+                        if let Some(job_id) = value.get("jobId").and_then(|v| v.as_str()) {
                             return self.poll_async(job_id).await;
                         }
                     }
@@ -495,7 +495,7 @@ impl AsyncProverClient {
     }
 
     async fn poll_async(&self, job_id: &str) -> Result<Proof, ClientError> {
-        let url = format!("{}/prove/status?job_id={}", self.server_address, job_id);
+        let url = format!("{}/prove/status?jobId={}", self.server_address, job_id);
         let poll_cap_ms = self
             .async_poll
             .poll_interval_secs
@@ -810,12 +810,12 @@ mod tests {
     #[test]
     fn a_proof_ready_on_the_first_poll_is_not_held_for_a_whole_second() {
         let server = MockServer::respond_with(vec![
-            MockResponse::json(202, json!({ "job_id": "job-1", "status": "queued" })),
+            MockResponse::json(202, json!({ "jobId": "job-1", "status": "queued" })),
             MockResponse::json(
                 200,
                 json!({
                     "status": "completed",
-                    "result": { "proof": gnark_proof(), "proof_duration_ms": 7 },
+                    "result": { "proof": gnark_proof(), "proofDurationMs": 7 },
                 }),
             ),
         ]);
@@ -862,9 +862,9 @@ mod tests {
             MockResponse::json(
                 202,
                 json!({
-                    "job_id": "job-1",
+                    "jobId": "job-1",
                     "status": "queued",
-                    "status_url": "/prove/status?job_id=job-1",
+                    "statusUrl": "/prove/status?jobId=job-1",
                 }),
             ),
             MockResponse::json(200, json!({ "status": "queued" })),
@@ -874,7 +874,7 @@ mod tests {
                     "status": "completed",
                     "result": {
                         "proof": gnark_proof(),
-                        "proof_duration_ms": 7,
+                        "proofDurationMs": 7,
                     },
                 }),
             ),
@@ -888,8 +888,8 @@ mod tests {
             &requests,
             [
                 "/prove",
-                "/prove/status?job_id=job-1",
-                "/prove/status?job_id=job-1",
+                "/prove/status?jobId=job-1",
+                "/prove/status?jobId=job-1",
             ],
         );
         assert_eq!(proof.a, [0u8; 64]);
@@ -901,7 +901,7 @@ mod tests {
     #[test]
     fn poll_async_failed_status_errors() {
         let server = MockServer::respond_with(vec![
-            MockResponse::json(202, json!({ "job_id": "job-failed" })),
+            MockResponse::json(202, json!({ "jobId": "job-failed" })),
             MockResponse::json(
                 200,
                 json!({
@@ -915,7 +915,7 @@ mod tests {
             .expect_err("failed async status should surface");
         let requests = server.requests();
 
-        assert_paths(&requests, ["/prove", "/prove/status?job_id=job-failed"]);
+        assert_paths(&requests, ["/prove", "/prove/status?jobId=job-failed"]);
         let message = err.to_string();
         assert!(message.contains("async proof failed"));
         assert!(message.contains("prover rejected witness"));
@@ -924,7 +924,7 @@ mod tests {
     #[test]
     fn poll_async_times_out_after_max_wait() {
         let server = MockServer::respond_with(vec![
-            MockResponse::json(202, json!({ "job_id": "job-slow" })),
+            MockResponse::json(202, json!({ "jobId": "job-slow" })),
             MockResponse::json(200, json!({ "status": "queued" })),
             MockResponse::json(200, json!({ "status": "processing" })),
         ]);
@@ -937,8 +937,8 @@ mod tests {
             &requests,
             [
                 "/prove",
-                "/prove/status?job_id=job-slow",
-                "/prove/status?job_id=job-slow",
+                "/prove/status?jobId=job-slow",
+                "/prove/status?jobId=job-slow",
             ],
         );
         assert!(err.to_string().contains("async proof timed out after 1s"));
@@ -947,7 +947,7 @@ mod tests {
     #[test]
     fn poll_async_rejects_malformed_status_body() {
         let server = MockServer::respond_with(vec![
-            MockResponse::json(202, json!({ "job_id": "job-bad-json" })),
+            MockResponse::json(202, json!({ "jobId": "job-bad-json" })),
             MockResponse::text(200, "not json"),
         ]);
         let err = queued_prover_client(server.url())
@@ -955,14 +955,14 @@ mod tests {
             .expect_err("malformed status body should fail");
         let requests = server.requests();
 
-        assert_paths(&requests, ["/prove", "/prove/status?job_id=job-bad-json"]);
+        assert_paths(&requests, ["/prove", "/prove/status?jobId=job-bad-json"]);
         assert!(err.to_string().contains("invalid status JSON"));
     }
 
     #[test]
     fn poll_async_client_error_status_fails_fast() {
         let server = MockServer::respond_with(vec![
-            MockResponse::json(202, json!({ "job_id": "missing-job" })),
+            MockResponse::json(202, json!({ "jobId": "missing-job" })),
             MockResponse::json(
                 404,
                 json!({
@@ -976,7 +976,7 @@ mod tests {
             .expect_err("404 status should fail immediately");
         let requests = server.requests();
 
-        assert_paths(&requests, ["/prove", "/prove/status?job_id=missing-job"]);
+        assert_paths(&requests, ["/prove", "/prove/status?jobId=missing-job"]);
         let message = err.to_string();
         assert!(message.contains("status 404 Not Found"));
         assert!(message.contains("job_not_found"));
@@ -985,7 +985,7 @@ mod tests {
     #[test]
     fn poll_async_retries_transient_status_poll_errors() {
         let server = MockServer::respond_with(vec![
-            MockResponse::json(202, json!({ "job_id": "job-transient" })),
+            MockResponse::json(202, json!({ "jobId": "job-transient" })),
             MockResponse::disconnect(),
             MockResponse::json(
                 200,
@@ -993,7 +993,7 @@ mod tests {
                     "status": "completed",
                     "result": {
                         "proof": gnark_proof(),
-                        "proof_duration_ms": 3,
+                        "proofDurationMs": 3,
                     },
                 }),
             ),
@@ -1007,8 +1007,8 @@ mod tests {
             &requests,
             [
                 "/prove",
-                "/prove/status?job_id=job-transient",
-                "/prove/status?job_id=job-transient",
+                "/prove/status?jobId=job-transient",
+                "/prove/status?jobId=job-transient",
             ],
         );
         assert_eq!(proof.a, [0u8; 64]);
@@ -1017,7 +1017,7 @@ mod tests {
     #[tokio::test]
     async fn async_prover_poll_returns_completed_nested_proof() {
         let server = MockServer::respond_with(vec![
-            MockResponse::json(202, json!({ "job_id": "async-job" })),
+            MockResponse::json(202, json!({ "jobId": "async-job" })),
             MockResponse::json(200, json!({ "status": "processing" })),
             MockResponse::json(
                 200,
@@ -1025,7 +1025,7 @@ mod tests {
                     "status": "completed",
                     "result": {
                         "proof": gnark_proof(),
-                        "proof_duration_ms": 4,
+                        "proofDurationMs": 4,
                     },
                 }),
             ),
@@ -1040,8 +1040,8 @@ mod tests {
             &requests,
             [
                 "/prove",
-                "/prove/status?job_id=async-job",
-                "/prove/status?job_id=async-job",
+                "/prove/status?jobId=async-job",
+                "/prove/status?jobId=async-job",
             ],
         );
         assert_eq!(proof.a, [0u8; 64]);
@@ -1052,7 +1052,7 @@ mod tests {
     #[tokio::test]
     async fn async_prover_poll_retries_transient_error() {
         let server = MockServer::respond_with(vec![
-            MockResponse::json(202, json!({ "job_id": "async-transient" })),
+            MockResponse::json(202, json!({ "jobId": "async-transient" })),
             MockResponse::disconnect(),
             MockResponse::json(
                 200,
@@ -1072,8 +1072,8 @@ mod tests {
             &requests,
             [
                 "/prove",
-                "/prove/status?job_id=async-transient",
-                "/prove/status?job_id=async-transient",
+                "/prove/status?jobId=async-transient",
+                "/prove/status?jobId=async-transient",
             ],
         );
     }

--- a/sdk-libs/client/src/prover/proof.rs
+++ b/sdk-libs/client/src/prover/proof.rs
@@ -130,6 +130,7 @@ fn compress_g1(point: &[u8; 64], name: &str) -> Result<[u8; 32], ClientError> {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct GnarkProofJson {
     pub ar: Vec<String>,
     pub bs: Vec<Vec<String>>,
@@ -162,7 +163,7 @@ fn hex_to_be_32(hex_str: &str) -> [u8; 32] {
     result
 }
 
-/// Parse a gnark proof JSON (`{ar, bs, krs, proof_commitment?, proof_commitment_pok?}`)
+/// Parse a gnark proof JSON (`{ar, bs, krs, proofCommitment?, proofCommitmentPok?}`)
 /// into an uncompressed [`Proof`] with `proof_a` negated. The commitment is `Some`
 /// only when both commitment fields are present (P256 rail).
 pub(crate) fn proof_from_gnark_json(json_str: &str) -> Option<Proof> {

--- a/sdk-libs/indexer-api/src/lib.rs
+++ b/sdk-libs/indexer-api/src/lib.rs
@@ -13,13 +13,13 @@ use thiserror::Error;
 
 pub const MIN_PAGE_LIMIT: u64 = 1;
 pub const PAGE_LIMIT: u64 = 1000;
-pub const GET_ENCRYPTED_UTXOS_BY_TAGS: &str = "get_encrypted_utxos_by_tags";
-pub const GET_SHIELDED_TRANSACTIONS_BY_TAGS: &str = "get_shielded_transactions_by_tags";
-pub const GET_SHIELDED_TRANSACTIONS_BY_SIGNATURE: &str = "get_shielded_transactions_by_signature";
-pub const GET_SHIELDED_TRANSACTIONS_BY_NULLIFIERS: &str = "get_shielded_transactions_by_nullifiers";
-pub const GET_MERKLE_PROOFS: &str = "get_merkle_proofs";
-pub const GET_NON_INCLUSION_PROOFS: &str = "get_non_inclusion_proofs";
-pub const GET_NULLIFIER_QUEUE_ELEMENTS: &str = "get_nullifier_queue_elements";
+pub const GET_ENCRYPTED_UTXOS_BY_TAGS: &str = "getEncryptedUtxosByTags";
+pub const GET_SHIELDED_TRANSACTIONS_BY_TAGS: &str = "getShieldedTransactionsByTags";
+pub const GET_SHIELDED_TRANSACTIONS_BY_SIGNATURE: &str = "getShieldedTransactionsBySignature";
+pub const GET_SHIELDED_TRANSACTIONS_BY_NULLIFIERS: &str = "getShieldedTransactionsByNullifiers";
+pub const GET_MERKLE_PROOFS: &str = "getMerkleProofs";
+pub const GET_NON_INCLUSION_PROOFS: &str = "getNonInclusionProofs";
+pub const GET_NULLIFIER_QUEUE_ELEMENTS: &str = "getNullifierQueueElements";
 
 const MAX_BASE58_32_LEN: usize = 44;
 const LIMIT_EXPECTATION: &str = "a value between 1 and 1000";
@@ -488,7 +488,7 @@ impl<'de> Deserialize<'de> for Limit {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Context {
     pub block_time: i64,
@@ -497,7 +497,7 @@ pub struct Context {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetRingsByTagsRequest {
     pub tags: Vec<Hash>,
@@ -508,7 +508,7 @@ pub struct GetRingsByTagsRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetRingsByNullifiersRequest {
     pub nullifiers: Vec<Hash>,
@@ -519,7 +519,7 @@ pub struct GetRingsByNullifiersRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct EncryptedUtxoMatch {
     pub slot: u64,
@@ -531,7 +531,7 @@ pub struct EncryptedUtxoMatch {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetEncryptedUtxosByTagsResponse {
     pub context: Context,
@@ -541,7 +541,7 @@ pub struct GetEncryptedUtxosByTagsResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RingsOutputContext {
     pub hash: Hash,
@@ -550,7 +550,7 @@ pub struct RingsOutputContext {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RingsOutputSlot {
     pub view_tag: Hash,
@@ -559,7 +559,7 @@ pub struct RingsOutputSlot {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RingsMessage {
     pub view_tag: Hash,
@@ -567,7 +567,7 @@ pub struct RingsMessage {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ShieldedTransaction {
     pub slot: u64,
@@ -584,7 +584,7 @@ pub struct ShieldedTransaction {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetShieldedTransactionsByTagsResponse {
     pub context: Context,
@@ -595,14 +595,14 @@ pub struct GetShieldedTransactionsByTagsResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetShieldedTransactionsBySignatureRequest {
     pub tx_signature: SerializableSignature,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct IndexedShieldedTransaction {
     pub event_index: u16,
@@ -610,7 +610,7 @@ pub struct IndexedShieldedTransaction {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetShieldedTransactionsBySignatureResponse {
     pub context: Context,
@@ -618,7 +618,7 @@ pub struct GetShieldedTransactionsBySignatureResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetShieldedTransactionsByNullifiersResponse {
     pub context: Context,
@@ -629,7 +629,7 @@ pub struct GetShieldedTransactionsByNullifiersResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetMerkleProofsRequest {
     pub tree_account: SerializablePubkey,
@@ -637,7 +637,7 @@ pub struct GetMerkleProofsRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetMerkleProofsResponse {
     pub context: Context,
@@ -645,11 +645,11 @@ pub struct GetMerkleProofsResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetNullifierQueueElementsRequest {
     pub tree_account: SerializablePubkey,
-    /// Return elements with `input_queue_seq >= start_seq` (default 0).
+    /// Return elements with `input_queue_seq >= startSeq` (default 0).
     #[serde(default)]
     pub start_seq: u64,
     /// Maximum number of elements to return.
@@ -657,7 +657,7 @@ pub struct GetNullifierQueueElementsRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetNullifierQueueElementsResponse {
     pub context: Context,
@@ -666,7 +666,7 @@ pub struct GetNullifierQueueElementsResponse {
 
 /// One queued nullifier, in on-chain input-queue order.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct NullifierQueueElement {
     pub seq: u64,
@@ -674,7 +674,7 @@ pub struct NullifierQueueElement {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct MerkleContext {
     pub tree_type: u16,
@@ -682,7 +682,7 @@ pub struct MerkleContext {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct MerkleProof {
     pub leaf: Hash,
@@ -695,7 +695,7 @@ pub struct MerkleProof {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetNonInclusionProofsRequest {
     pub tree_account: SerializablePubkey,
@@ -703,7 +703,7 @@ pub struct GetNonInclusionProofsRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GetNonInclusionProofsResponse {
     pub context: Context,
@@ -711,7 +711,7 @@ pub struct GetNonInclusionProofsResponse {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct NonInclusionProof {
     pub leaf: Hash,
@@ -734,20 +734,20 @@ mod tests {
     fn method_markers_have_canonical_names() {
         assert_eq!(
             method::GetEncryptedUtxosByTags::NAME,
-            "get_encrypted_utxos_by_tags"
+            "getEncryptedUtxosByTags"
         );
         assert_eq!(
             method::GetShieldedTransactionsByNullifiers::NAME,
-            "get_shielded_transactions_by_nullifiers"
+            "getShieldedTransactionsByNullifiers"
         );
-        assert_eq!(method::GetMerkleProofs::NAME, "get_merkle_proofs");
+        assert_eq!(method::GetMerkleProofs::NAME, "getMerkleProofs");
         assert_eq!(
             method::GetNullifierQueueElements::NAME,
-            "get_nullifier_queue_elements"
+            "getNullifierQueueElements"
         );
         assert_eq!(
             method::GetShieldedTransactionsBySignature::NAME,
-            "get_shielded_transactions_by_signature"
+            "getShieldedTransactionsBySignature"
         );
     }
 
@@ -768,7 +768,7 @@ mod tests {
     }
 
     #[test]
-    fn response_shape_stays_snake_case() {
+    fn response_shape_stays_camel_case() {
         let value = serde_json::to_value(GetEncryptedUtxosByTagsResponse {
             context: Context {
                 block_time: 3,
@@ -778,13 +778,15 @@ mod tests {
             next_cursor: Some(Base64String(vec![1])),
         })
         .unwrap();
-        assert!(value.get("next_cursor").is_some());
-        assert!(value.get("nextCursor").is_none());
+        assert!(value.get("nextCursor").is_some());
+        assert!(value.get("next_cursor").is_none());
+        assert!(value["context"].get("blockTime").is_some());
+        assert!(value["context"].get("block_time").is_none());
     }
 
     #[test]
     fn signature_lookup_contract_rejects_malformed_signatures() {
-        let invalid = serde_json::json!({ "tx_signature": "not-a-signature" });
+        let invalid = serde_json::json!({ "txSignature": "not-a-signature" });
         assert!(
             serde_json::from_value::<GetShieldedTransactionsBySignatureRequest>(invalid).is_err()
         );
@@ -794,21 +796,21 @@ mod tests {
             tx_signature: SerializableSignature(signature),
         };
         let value = serde_json::to_value(request).unwrap();
-        assert_eq!(value["tx_signature"], signature.to_string());
+        assert_eq!(value["txSignature"], signature.to_string());
     }
 
     #[test]
     fn every_page_limit_uses_the_shared_bounds() {
         let tree = SerializablePubkey::from([3; 32]);
         let request = serde_json::json!({
-            "tree_account": tree.to_string(),
+            "treeAccount": tree.to_string(),
             "limit": PAGE_LIMIT,
         });
         let parsed = serde_json::from_value::<GetNullifierQueueElementsRequest>(request).unwrap();
         assert_eq!(parsed.limit.value(), PAGE_LIMIT);
 
         let invalid = serde_json::json!({
-            "tree_account": tree.to_string(),
+            "treeAccount": tree.to_string(),
             "limit": PAGE_LIMIT + 1,
         });
         assert!(serde_json::from_value::<GetNullifierQueueElementsRequest>(invalid).is_err());

--- a/sdk-libs/ts/api/test/transport.test.ts
+++ b/sdk-libs/ts/api/test/transport.test.ts
@@ -5,7 +5,7 @@ import { ApiError, ZolanaApi } from "../../src/api/index.js";
 const HASH = "11111111111111111111111111111111";
 const SIGNATURE = "1".repeat(64);
 const REQUEST = { treeAccount: HASH, leaves: [HASH] } as never;
-const RESULT = { context: { block_time: 0, slot: 1 }, proofs: [] };
+const RESULT = { context: { blockTime: 0, slot: 1 }, proofs: [] };
 
 function success(result: unknown = RESULT): Response {
   return new Response(
@@ -42,7 +42,7 @@ describe("transport configuration", () => {
 
     expect(injected).toHaveBeenCalledOnce();
     expect(String(injected.mock.calls[0]?.[0])).toBe(
-      "https://rpc.example.test/root/get_merkle_proofs?tenant=one&api-key=test-key",
+      "https://rpc.example.test/root/getMerkleProofs?tenant=one&api-key=test-key",
     );
     expect(injected.mock.calls[0]?.[1]?.redirect).toBe("error");
   });
@@ -57,7 +57,7 @@ describe("transport configuration", () => {
     await api.getMerkleProofs(REQUEST);
 
     expect(String(injected.mock.calls[0]?.[0])).toBe(
-      "https://gateway.example/zolana/get_merkle_proofs?tenant=alpha&api-key=k%2B1",
+      "https://gateway.example/zolana/getMerkleProofs?tenant=alpha&api-key=k%2B1",
     );
   });
 
@@ -70,7 +70,7 @@ describe("transport configuration", () => {
     await api.getMerkleProofs(REQUEST);
 
     expect(String(injected.mock.calls[0]?.[0])).toBe(
-      "https://rpc.example.test/first/get_merkle_proofs",
+      "https://rpc.example.test/first/getMerkleProofs",
     );
   });
 
@@ -78,16 +78,16 @@ describe("transport configuration", () => {
     const injected = vi.fn<typeof globalThis.fetch>(() =>
       Promise.resolve(
         success({
-          context: { block_time: 0, slot: 1 },
+          context: { blockTime: 0, slot: 1 },
           transactions: [
             {
-              event_index: 1,
+              eventIndex: 1,
               transaction: {
                 slot: 2,
-                tx_signature: SIGNATURE,
-                tx_viewing_pk: null,
+                txSignature: SIGNATURE,
+                txViewingPk: null,
                 salt: null,
-                output_slots: [],
+                outputSlots: [],
                 messages: [],
                 nullifiers: [],
                 proofless: false,
@@ -105,10 +105,10 @@ describe("transport configuration", () => {
 
     expect(response.transactions[0]?.eventIndex).toBe(1);
     expect(String(injected.mock.calls[0]?.[0])).toBe(
-      "https://rpc.example.test/get_shielded_transactions_by_signature",
+      "https://rpc.example.test/getShieldedTransactionsBySignature",
     );
     expect(JSON.parse(String(injected.mock.calls[0]?.[1]?.body))).toMatchObject({
-      params: { tx_signature: SIGNATURE },
+      params: { txSignature: SIGNATURE },
     });
   });
 
@@ -116,9 +116,9 @@ describe("transport configuration", () => {
     const injected = vi.fn<typeof globalThis.fetch>(() =>
       Promise.resolve(
         success({
-          context: { block_time: 0, slot: 1 },
+          context: { blockTime: 0, slot: 1 },
           transactions: [],
-          next_cursor: "Ag==",
+          nextCursor: "Ag==",
         }),
       ),
     );
@@ -132,10 +132,10 @@ describe("transport configuration", () => {
 
     expect(response.nextCursor).toBe("Ag==");
     expect(String(injected.mock.calls[0]?.[0])).toBe(
-      "https://rpc.example.test/get_shielded_transactions_by_nullifiers",
+      "https://rpc.example.test/getShieldedTransactionsByNullifiers",
     );
     expect(JSON.parse(String(injected.mock.calls[0]?.[1]?.body))).toMatchObject({
-      method: "get_shielded_transactions_by_nullifiers",
+      method: "getShieldedTransactionsByNullifiers",
       params: { nullifiers: [HASH], cursor: "AQ==", limit: 1000 },
     });
   });
@@ -170,7 +170,7 @@ describe("transport configuration", () => {
       "API_INVALID_CONTEXT",
     );
 
-    expect(error.details).toEqual({ field: "timeoutMs", method: "get_merkle_proofs" });
+    expect(error.details).toEqual({ field: "timeoutMs", method: "getMerkleProofs" });
     expect(injected).not.toHaveBeenCalled();
   });
 });
@@ -273,7 +273,7 @@ describe("integers past the safe-integer bound", () => {
   }
 
   function merkleProofsBody(leafIndex: string, rootSeq: string): string {
-    return `{"id":"test-account","jsonrpc":"2.0","result":{"context":{"block_time":0,"slot":1},"proofs":[{"leaf":"${HASH}","merkle_context":{"tree_type":0,"tree":"${HASH}"},"path":["${HASH}"],"leaf_index":${leafIndex},"root":"${HASH}","root_seq":${rootSeq},"root_index":0}]}}`;
+    return `{"id":"test-account","jsonrpc":"2.0","result":{"context":{"blockTime":0,"slot":1},"proofs":[{"leaf":"${HASH}","merkleContext":{"treeType":0,"tree":"${HASH}"},"path":["${HASH}"],"leafIndex":${leafIndex},"root":"${HASH}","rootSeq":${rootSeq},"rootIndex":0}]}}`;
   }
 
   it("reads a u64 above the safe-integer bound without losing precision", async () => {
@@ -286,7 +286,7 @@ describe("integers past the safe-integer bound", () => {
   });
 
   it("leaves a safe integer and a negative block time as they were sent", async () => {
-    const body = `{"id":"test-account","jsonrpc":"2.0","result":{"context":{"block_time":-1700000000,"slot":1},"proofs":[{"leaf":"${HASH}","merkle_context":{"tree_type":0,"tree":"${HASH}"},"path":["${HASH}"],"leaf_index":9007199254740991,"root":"${HASH}","root_seq":0,"root_index":0}]}}`;
+    const body = `{"id":"test-account","jsonrpc":"2.0","result":{"context":{"blockTime":-1700000000,"slot":1},"proofs":[{"leaf":"${HASH}","merkleContext":{"treeType":0,"tree":"${HASH}"},"path":["${HASH}"],"leafIndex":9007199254740991,"root":"${HASH}","rootSeq":0,"rootIndex":0}]}}`;
     const api = respondWith(body);
 
     const response = await api.getMerkleProofs(REQUEST);
@@ -302,13 +302,13 @@ describe("integers past the safe-integer bound", () => {
 
     const error = await expectApiError(api.getMerkleProofs(REQUEST), "API_INVALID_RESULT");
 
-    expect(error.details?.["path"]).toBe("$.proofs[0].leaf_index");
+    expect(error.details?.["path"]).toBe("$.proofs[0].leafIndex");
     expect(error.details?.["schemaCode"]).toBe("INDEXER_SCHEMA_INVALID_INTEGER");
   });
 
   it("does not rewrite a digit run inside a string payload", async () => {
     const payload = "99999999999999999999";
-    const body = `{"id":"test-account","jsonrpc":"2.0","result":{"context":{"block_time":0,"slot":1},"matches":[{"slot":0,"tx_signature":"${SIGNATURE}","output_slot":{"view_tag":"${HASH}","output_context":{"hash":"${HASH}","tree":"${HASH}","leaf_index":0},"payload":"${payload}"}}]}}`;
+    const body = `{"id":"test-account","jsonrpc":"2.0","result":{"context":{"blockTime":0,"slot":1},"matches":[{"slot":0,"txSignature":"${SIGNATURE}","outputSlot":{"viewTag":"${HASH}","outputContext":{"hash":"${HASH}","tree":"${HASH}","leafIndex":0},"payload":"${payload}"}}]}}`;
     const api = respondWith(body);
 
     const response = await api.getEncryptedUtxosByTags({ tags: [HASH] } as never);

--- a/sdk-libs/ts/src/api/index.ts
+++ b/sdk-libs/ts/src/api/index.ts
@@ -605,7 +605,7 @@ function hasControlCharacter(value: string): boolean {
 
 function safeSchemaPath(path: string): string | undefined {
   const knownField =
-    "(?:block_time|context|hash|high_element|high_element_index|leaf|leaf_index|leaves|limit|low_element|low_element_index|matches|merkle_context|next_cursor|nullifiers|output_context|output_slot|output_slots|path|payload|proofless|proofs|root|root_index|root_seq|salt|slot|tags|transactions|tree|tree_account|tree_type|tx_signature|tx_viewing_pk|view_tag)";
+    "(?:blockTime|context|hash|highElement|highElementIndex|leaf|leafIndex|leaves|limit|lowElement|lowElementIndex|matches|merkleContext|nextCursor|nullifiers|outputContext|outputSlot|outputSlots|path|payload|proofless|proofs|root|rootIndex|rootSeq|salt|slot|tags|transactions|tree|treeAccount|treeType|txSignature|txViewingPk|viewTag)";
   const pattern = new RegExp(`^\\$(?:(?:\\.${knownField})|(?:\\[\\d+\\]))*$`, "u");
   return path.length <= 256 && pattern.test(path) ? path : undefined;
 }

--- a/sdk-libs/ts/src/client/indexer.ts
+++ b/sdk-libs/ts/src/client/indexer.ts
@@ -302,7 +302,7 @@ function convertEncryptedUtxosResponse(
     ),
     ...(response.nextCursor === undefined
       ? {}
-      : { nextCursor: decodeBase64(response.nextCursor, "next_cursor") }),
+      : { nextCursor: decodeBase64(response.nextCursor, "nextCursor") }),
   });
 }
 
@@ -335,7 +335,7 @@ function convertShieldedTransactionsResponse(
     ),
     ...(response.nextCursor === undefined
       ? {}
-      : { nextCursor: decodeBase64(response.nextCursor, "next_cursor") }),
+      : { nextCursor: decodeBase64(response.nextCursor, "nextCursor") }),
   });
 }
 

--- a/sdk-libs/ts/src/client/prover/client.ts
+++ b/sdk-libs/ts/src/client/prover/client.ts
@@ -137,10 +137,10 @@ export class ProverClient {
           }
           if (
             isObject(value) &&
-            typeof value["job_id"] === "string" &&
+            typeof value["jobId"] === "string" &&
             value["proof"] === undefined
           ) {
-            return await this.#poll(value["job_id"], signal);
+            return await this.#poll(value["jobId"], signal);
           }
           return parseProof(value);
         } finally {
@@ -164,7 +164,7 @@ export class ProverClient {
     }
     const url = new URL(this.#url);
     url.pathname = url.pathname.replace(/\/prove$/u, "/prove/status");
-    url.searchParams.set("job_id", jobId);
+    url.searchParams.set("jobId", jobId);
     const intervalCap = Math.max(INITIAL_POLL_INTERVAL_MS, this.#asyncPoll.pollIntervalCapMs);
     let interval = INITIAL_POLL_INTERVAL_MS;
     const maxWaitMs = this.#asyncPoll.maxWaitMs;

--- a/sdk-libs/ts/src/client/prover/proof.ts
+++ b/sdk-libs/ts/src/client/prover/proof.ts
@@ -60,11 +60,10 @@ export function parseProof(value: unknown): Proof {
   a.set(bigintToBytes(y === 0n ? 0n : BN254_BASE_MODULUS - y), 32);
   const b = parseG2(proof["bs"], "$.proof.bs");
   const c = parseG1(proof["krs"], "$.proof.krs");
-  const hasCommitment =
-    present(proof["proof_commitment"]) || present(proof["proof_commitment_pok"]);
+  const hasCommitment = present(proof["proofCommitment"]) || present(proof["proofCommitmentPok"]);
   if (hasCommitment) {
     throw new ClientError("CLIENT_PROOF_PARSE", {
-      details: { path: "$.proof.proof_commitment", reason: "unsupported commitment proof" },
+      details: { path: "$.proof.proofCommitment", reason: "unsupported commitment proof" },
     });
   }
   return Object.freeze({

--- a/sdk-libs/ts/src/indexer/codec.ts
+++ b/sdk-libs/ts/src/indexer/codec.ts
@@ -205,53 +205,47 @@ function optional<T>(
 function context(value: unknown, path: string): IndexerContext {
   // `object` rejects any key not listed here, so a new wire field must be added
   // in the same release that starts sending it.
-  const record = object(value, path, ["block_time", "slot"]);
+  const record = object(value, path, ["blockTime", "slot"]);
   return {
-    blockTime: unboundedI64(record["block_time"], `${path}.block_time`),
+    blockTime: unboundedI64(record["blockTime"], `${path}.blockTime`),
     slot: u64(record["slot"], `${path}.slot`),
   };
 }
 
 function outputContext(value: unknown, path: string): RingsOutputContext {
-  const record = object(value, path, ["hash", "tree", "leaf_index"]);
+  const record = object(value, path, ["hash", "tree", "leafIndex"]);
   return {
     hash: checkedHash(record["hash"], `${path}.hash`),
     tree: checkedAddress(record["tree"], `${path}.tree`),
-    leafIndex: u64(record["leaf_index"], `${path}.leaf_index`),
+    leafIndex: u64(record["leafIndex"], `${path}.leafIndex`),
   };
 }
 
 function outputSlot(value: unknown, path: string): RingsOutputSlot {
-  const record = object(value, path, ["view_tag", "output_context", "payload"]);
+  const record = object(value, path, ["viewTag", "outputContext", "payload"]);
   return {
-    viewTag: checkedHash(record["view_tag"], `${path}.view_tag`),
-    outputContext: outputContext(record["output_context"], `${path}.output_context`),
+    viewTag: checkedHash(record["viewTag"], `${path}.viewTag`),
+    outputContext: outputContext(record["outputContext"], `${path}.outputContext`),
     payload: checkedBase64(record["payload"], `${path}.payload`),
   };
 }
 
 function message(value: unknown, path: string): RingsMessage {
-  const record = object(value, path, ["view_tag", "payload"]);
+  const record = object(value, path, ["viewTag", "payload"]);
   return {
-    viewTag: checkedHash(record["view_tag"], `${path}.view_tag`),
+    viewTag: checkedHash(record["viewTag"], `${path}.viewTag`),
     payload: checkedBase64(record["payload"], `${path}.payload`),
   };
 }
 
 function encryptedUtxoMatch(value: unknown, path: string): EncryptedUtxoMatch {
-  const record = object(value, path, [
-    "slot",
-    "tx_signature",
-    "output_slot",
-    "tx_viewing_pk",
-    "salt",
-  ]);
-  const txViewingPk = optional(record["tx_viewing_pk"], `${path}.tx_viewing_pk`, checkedBase64);
+  const record = object(value, path, ["slot", "txSignature", "outputSlot", "txViewingPk", "salt"]);
+  const txViewingPk = optional(record["txViewingPk"], `${path}.txViewingPk`, checkedBase64);
   const salt = optional(record["salt"], `${path}.salt`, checkedBase64);
   return {
     slot: unboundedU64(record["slot"], `${path}.slot`),
-    txSignature: checkedSignature(record["tx_signature"], `${path}.tx_signature`),
-    outputSlot: outputSlot(record["output_slot"], `${path}.output_slot`),
+    txSignature: checkedSignature(record["txSignature"], `${path}.txSignature`),
+    outputSlot: outputSlot(record["outputSlot"], `${path}.outputSlot`),
     ...(txViewingPk === undefined ? {} : { txViewingPk }),
     ...(salt === undefined ? {} : { salt }),
   };
@@ -260,22 +254,22 @@ function encryptedUtxoMatch(value: unknown, path: string): EncryptedUtxoMatch {
 function indexedTransaction(value: unknown, path: string): IndexedShieldedTransaction {
   const record = object(value, path, [
     "slot",
-    "tx_signature",
-    "tx_viewing_pk",
+    "txSignature",
+    "txViewingPk",
     "salt",
-    "output_slots",
+    "outputSlots",
     "messages",
     "nullifiers",
     "proofless",
   ]);
-  const txViewingPk = optional(record["tx_viewing_pk"], `${path}.tx_viewing_pk`, checkedBase64);
+  const txViewingPk = optional(record["txViewingPk"], `${path}.txViewingPk`, checkedBase64);
   const salt = optional(record["salt"], `${path}.salt`, checkedBase64);
   return {
     slot: unboundedU64(record["slot"], `${path}.slot`),
-    txSignature: checkedSignature(record["tx_signature"], `${path}.tx_signature`),
+    txSignature: checkedSignature(record["txSignature"], `${path}.txSignature`),
     ...(txViewingPk === undefined ? {} : { txViewingPk }),
     ...(salt === undefined ? {} : { salt }),
-    outputSlots: array(record["output_slots"], `${path}.output_slots`, outputSlot),
+    outputSlots: array(record["outputSlots"], `${path}.outputSlots`, outputSlot),
     messages: array(record["messages"], `${path}.messages`, message),
     nullifiers: array(record["nullifiers"], `${path}.nullifiers`, checkedHash),
     proofless: boolean(record["proofless"], `${path}.proofless`),
@@ -286,17 +280,17 @@ function signatureIndexedTransaction(
   value: unknown,
   path: string,
 ): SignatureIndexedShieldedTransaction {
-  const record = object(value, path, ["event_index", "transaction"]);
+  const record = object(value, path, ["eventIndex", "transaction"]);
   return {
-    eventIndex: u16(record["event_index"], `${path}.event_index`),
+    eventIndex: u16(record["eventIndex"], `${path}.eventIndex`),
     transaction: indexedTransaction(record["transaction"], `${path}.transaction`),
   };
 }
 
 function merkleContext(value: unknown, path: string): MerkleProof["merkleContext"] {
-  const record = object(value, path, ["tree_type", "tree"]);
+  const record = object(value, path, ["treeType", "tree"]);
   return {
-    treeType: u16(record["tree_type"], `${path}.tree_type`),
+    treeType: u16(record["treeType"], `${path}.treeType`),
     tree: checkedAddress(record["tree"], `${path}.tree`),
   };
 }
@@ -304,48 +298,48 @@ function merkleContext(value: unknown, path: string): MerkleProof["merkleContext
 function merkleProof(value: unknown, path: string): MerkleProof {
   const record = object(value, path, [
     "leaf",
-    "merkle_context",
+    "merkleContext",
     "path",
-    "leaf_index",
+    "leafIndex",
     "root",
-    "root_seq",
-    "root_index",
+    "rootSeq",
+    "rootIndex",
   ]);
   return {
     leaf: checkedHash(record["leaf"], `${path}.leaf`),
-    merkleContext: merkleContext(record["merkle_context"], `${path}.merkle_context`),
+    merkleContext: merkleContext(record["merkleContext"], `${path}.merkleContext`),
     path: array(record["path"], `${path}.path`, checkedHash),
-    leafIndex: u64(record["leaf_index"], `${path}.leaf_index`),
+    leafIndex: u64(record["leafIndex"], `${path}.leafIndex`),
     root: checkedHash(record["root"], `${path}.root`),
-    rootSeq: unboundedU64(record["root_seq"], `${path}.root_seq`),
-    rootIndex: u16(record["root_index"], `${path}.root_index`),
+    rootSeq: unboundedU64(record["rootSeq"], `${path}.rootSeq`),
+    rootIndex: u16(record["rootIndex"], `${path}.rootIndex`),
   };
 }
 
 function nonInclusionProof(value: unknown, path: string): NonInclusionProof {
   const record = object(value, path, [
     "leaf",
-    "merkle_context",
+    "merkleContext",
     "path",
-    "low_element",
-    "low_element_index",
-    "high_element",
-    "high_element_index",
+    "lowElement",
+    "lowElementIndex",
+    "highElement",
+    "highElementIndex",
     "root",
-    "root_seq",
-    "root_index",
+    "rootSeq",
+    "rootIndex",
   ]);
   return {
     leaf: checkedHash(record["leaf"], `${path}.leaf`),
-    merkleContext: merkleContext(record["merkle_context"], `${path}.merkle_context`),
+    merkleContext: merkleContext(record["merkleContext"], `${path}.merkleContext`),
     path: array(record["path"], `${path}.path`, checkedHash),
-    lowElement: checkedHash(record["low_element"], `${path}.low_element`),
-    lowElementIndex: u64(record["low_element_index"], `${path}.low_element_index`),
-    highElement: checkedHash(record["high_element"], `${path}.high_element`),
-    highElementIndex: u64(record["high_element_index"], `${path}.high_element_index`),
+    lowElement: checkedHash(record["lowElement"], `${path}.lowElement`),
+    lowElementIndex: u64(record["lowElementIndex"], `${path}.lowElementIndex`),
+    highElement: checkedHash(record["highElement"], `${path}.highElement`),
+    highElementIndex: u64(record["highElementIndex"], `${path}.highElementIndex`),
     root: checkedHash(record["root"], `${path}.root`),
-    rootSeq: unboundedU64(record["root_seq"], `${path}.root_seq`),
-    rootIndex: u16(record["root_index"], `${path}.root_index`),
+    rootSeq: unboundedU64(record["rootSeq"], `${path}.rootSeq`),
+    rootIndex: u16(record["rootIndex"], `${path}.rootIndex`),
   };
 }
 
@@ -407,13 +401,13 @@ export function encodeShieldedTransactionsBySignatureRequest(
   value: GetShieldedTransactionsBySignatureRequest,
 ): WireObject {
   return {
-    tx_signature: checkedSignature(value.txSignature, "$.tx_signature"),
+    txSignature: checkedSignature(value.txSignature, "$.txSignature"),
   };
 }
 
 export function decodeEncryptedUtxosResponse(value: unknown): GetEncryptedUtxosByTagsResponse {
-  const record = object(value, "$", ["context", "matches", "next_cursor"]);
-  const nextCursor = optional(record["next_cursor"], "$.next_cursor", checkedBase64);
+  const record = object(value, "$", ["context", "matches", "nextCursor"]);
+  const nextCursor = optional(record["nextCursor"], "$.nextCursor", checkedBase64);
   return {
     context: context(record["context"], "$.context"),
     matches: array(record["matches"], "$.matches", encryptedUtxoMatch),
@@ -424,8 +418,8 @@ export function decodeEncryptedUtxosResponse(value: unknown): GetEncryptedUtxosB
 export function decodeShieldedTransactionsResponse(
   value: unknown,
 ): GetShieldedTransactionsByTagsResponse {
-  const record = object(value, "$", ["context", "transactions", "next_cursor"]);
-  const nextCursor = optional(record["next_cursor"], "$.next_cursor", checkedBase64);
+  const record = object(value, "$", ["context", "transactions", "nextCursor"]);
+  const nextCursor = optional(record["nextCursor"], "$.nextCursor", checkedBase64);
   return {
     context: context(record["context"], "$.context"),
     transactions: array(record["transactions"], "$.transactions", indexedTransaction),
@@ -450,9 +444,9 @@ export function decodeShieldedTransactionsBySignatureResponse(
 }
 
 function decodeLeavesRequest(value: unknown): GetMerkleProofsRequest {
-  const record = object(value, "$", ["tree_account", "leaves"]);
+  const record = object(value, "$", ["treeAccount", "leaves"]);
   return {
-    treeAccount: checkedAddress(record["tree_account"], "$.tree_account"),
+    treeAccount: checkedAddress(record["treeAccount"], "$.treeAccount"),
     leaves: array(record["leaves"], "$.leaves", checkedHash),
   };
 }
@@ -461,10 +455,10 @@ function encodeLeavesRequest(
   value: GetMerkleProofsRequest | GetNonInclusionProofsRequest,
 ): WireObject {
   decodeLeavesRequest({
-    tree_account: value.treeAccount,
+    treeAccount: value.treeAccount,
     leaves: value.leaves,
   });
-  return { tree_account: value.treeAccount, leaves: [...value.leaves] };
+  return { treeAccount: value.treeAccount, leaves: [...value.leaves] };
 }
 
 export function encodeMerkleProofsRequest(value: GetMerkleProofsRequest): WireObject {

--- a/sdk-libs/ts/src/indexer/names.ts
+++ b/sdk-libs/ts/src/indexer/names.ts
@@ -1,6 +1,6 @@
-export const GET_ENCRYPTED_UTXOS_BY_TAGS = "get_encrypted_utxos_by_tags";
-export const GET_SHIELDED_TRANSACTIONS_BY_TAGS = "get_shielded_transactions_by_tags";
-export const GET_SHIELDED_TRANSACTIONS_BY_NULLIFIERS = "get_shielded_transactions_by_nullifiers";
-export const GET_SHIELDED_TRANSACTIONS_BY_SIGNATURE = "get_shielded_transactions_by_signature";
-export const GET_MERKLE_PROOFS = "get_merkle_proofs";
-export const GET_NON_INCLUSION_PROOFS = "get_non_inclusion_proofs";
+export const GET_ENCRYPTED_UTXOS_BY_TAGS = "getEncryptedUtxosByTags";
+export const GET_SHIELDED_TRANSACTIONS_BY_TAGS = "getShieldedTransactionsByTags";
+export const GET_SHIELDED_TRANSACTIONS_BY_NULLIFIERS = "getShieldedTransactionsByNullifiers";
+export const GET_SHIELDED_TRANSACTIONS_BY_SIGNATURE = "getShieldedTransactionsBySignature";
+export const GET_MERKLE_PROOFS = "getMerkleProofs";
+export const GET_NON_INCLUSION_PROOFS = "getNonInclusionProofs";

--- a/sdk-libs/ts/src/wallet/sync.ts
+++ b/sdk-libs/ts/src/wallet/sync.ts
@@ -240,7 +240,7 @@ function checkedNextCursor(
   const key = bytesKey(cursor);
   if (seen.has(key)) {
     throw new ClientError("CLIENT_INVALID_RPC_RESPONSE", {
-      details: { method, path: "$.next_cursor" },
+      details: { method, path: "$.nextCursor" },
     });
   }
   seen.add(key);

--- a/sdk-libs/ts/test/client.test.ts
+++ b/sdk-libs/ts/test/client.test.ts
@@ -112,12 +112,12 @@ async function serviceRequestUrls(
     const requestUrl = input instanceof Request ? input.url : String(input);
     urls.push(requestUrl);
     const path = new URL(requestUrl).pathname;
-    if (path.endsWith("/get_shielded_transactions_by_nullifiers")) {
+    if (path.endsWith("/getShieldedTransactionsByNullifiers")) {
       return new Response(
         JSON.stringify({
           id: "test-account",
           jsonrpc: "2.0",
-          result: { context: { block_time: 1, slot: 1 }, transactions: [] },
+          result: { context: { blockTime: 1, slot: 1 }, transactions: [] },
         }),
         { headers: { "content-type": "application/json" } },
       );
@@ -179,7 +179,7 @@ describe("ZolanaClient", () => {
       name: "uses the RPC endpoint for both omitted services",
       overrides: {},
       expected: [
-        "https://rpc.example.com/zolana/get_shielded_transactions_by_nullifiers",
+        "https://rpc.example.com/zolana/getShieldedTransactionsByNullifiers",
         "https://rpc.example.com/zolana/prove",
       ],
     },
@@ -187,7 +187,7 @@ describe("ZolanaClient", () => {
       name: "keeps an explicit indexer and falls the prover back to RPC",
       overrides: { indexerUrl: INDEXER_URL },
       expected: [
-        "https://indexer.example.com/api/get_shielded_transactions_by_nullifiers",
+        "https://indexer.example.com/api/getShieldedTransactionsByNullifiers",
         "https://rpc.example.com/zolana/prove",
       ],
     },
@@ -195,7 +195,7 @@ describe("ZolanaClient", () => {
       name: "falls the indexer back to RPC and keeps an explicit prover",
       overrides: { proverUrl: PROVER_URL },
       expected: [
-        "https://rpc.example.com/zolana/get_shielded_transactions_by_nullifiers",
+        "https://rpc.example.com/zolana/getShieldedTransactionsByNullifiers",
         "https://prover.example.com/api/prove",
       ],
     },
@@ -203,7 +203,7 @@ describe("ZolanaClient", () => {
       name: "keeps both explicit service endpoints",
       overrides: { indexerUrl: INDEXER_URL, proverUrl: PROVER_URL },
       expected: [
-        "https://indexer.example.com/api/get_shielded_transactions_by_nullifiers",
+        "https://indexer.example.com/api/getShieldedTransactionsByNullifiers",
         "https://prover.example.com/api/prove",
       ],
     },
@@ -219,7 +219,7 @@ describe("ZolanaClient", () => {
     await expect(
       serviceRequestUrls(RPC_URL, { indexerUrl: undefined, proverUrl: undefined }),
     ).resolves.toEqual([
-      "https://rpc.example.com/zolana/get_shielded_transactions_by_nullifiers",
+      "https://rpc.example.com/zolana/getShieldedTransactionsByNullifiers",
       "https://rpc.example.com/zolana/prove",
     ]);
   });
@@ -229,7 +229,7 @@ describe("ZolanaClient", () => {
     const original = rpcUrl.href;
 
     await expect(serviceRequestUrls(rpcUrl)).resolves.toEqual([
-      "https://gateway.example.com/base/get_shielded_transactions_by_nullifiers?cluster=devnet",
+      "https://gateway.example.com/base/getShieldedTransactionsByNullifiers?cluster=devnet",
       "https://gateway.example.com/base/prove?cluster=devnet",
     ]);
     expect(rpcUrl.href).toBe(original);
@@ -385,9 +385,9 @@ describe("ZolanaClient", () => {
             id: "test-account",
             jsonrpc: "2.0",
             result: {
-              context: { block_time: 1, slot: 1 },
+              context: { blockTime: 1, slot: 1 },
               transactions: [],
-              next_cursor: "Ag==",
+              nextCursor: "Ag==",
             },
           }),
           { headers: { "content-type": "application/json" } },
@@ -405,10 +405,10 @@ describe("ZolanaClient", () => {
 
     expect(response.nextCursor).toEqual(Uint8Array.of(2));
     expect(String(fetch.mock.calls[0]?.[0])).toBe(
-      "http://127.0.0.1:8784/get_shielded_transactions_by_nullifiers",
+      "http://127.0.0.1:8784/getShieldedTransactionsByNullifiers",
     );
     expect(JSON.parse(String(fetch.mock.calls[0]?.[1]?.body))).toMatchObject({
-      method: "get_shielded_transactions_by_nullifiers",
+      method: "getShieldedTransactionsByNullifiers",
       params: {
         nullifiers: [getBase58Decoder().decode(nullifier)],
         cursor: "AQ==",

--- a/sdk-libs/ts/test/proof.test.ts
+++ b/sdk-libs/ts/test/proof.test.ts
@@ -39,7 +39,7 @@ describe("proof compression", () => {
   });
 
   it("rejects stale commitments and malformed points", () => {
-    expect(() => parseProof({ ...ZERO_PROOF, proof_commitment: ZERO_POINT })).toThrow(
+    expect(() => parseProof({ ...ZERO_PROOF, proofCommitment: ZERO_POINT })).toThrow(
       expect.objectContaining({ code: "CLIENT_PROOF_PARSE" }),
     );
     expect(() => parseProof({ ...ZERO_PROOF, ar: ["0x1", "0x1"] })).toThrow(
@@ -54,8 +54,8 @@ describe("proof compression", () => {
     const withUnknownFields = parseProof({ ...ZERO_PROOF, curve: "bn254", commitments: 0 });
     const withEmptyCommitments = parseProof({
       ...ZERO_PROOF,
-      proof_commitment: [],
-      proof_commitment_pok: [],
+      proofCommitment: [],
+      proofCommitmentPok: [],
     });
     const bareCoordinates = parseProof({ ...ZERO_PROOF, ar: ["1", "2"] });
     const prefixedCoordinates = parseProof({ ...ZERO_PROOF, ar: ["0x1", "0x2"] });

--- a/sdk-libs/ts/test/prover-client.test.ts
+++ b/sdk-libs/ts/test/prover-client.test.ts
@@ -78,7 +78,7 @@ describe("queued prover polling", () => {
       request++;
       redirects.push(init?.redirect);
       if (request === 1) {
-        return new Response(JSON.stringify({ job_id: "job-hang" }), {
+        return new Response(JSON.stringify({ jobId: "job-hang" }), {
           status: 202,
           headers: { "content-type": "application/json" },
         });
@@ -141,7 +141,7 @@ describe("prover request routing", () => {
       const url = new URL(String(input));
       urls.push(url);
       return urls.length === 1
-        ? new Response(JSON.stringify({ job_id: "job-123" }), {
+        ? new Response(JSON.stringify({ jobId: "job-123" }), {
             status: 202,
             headers: { "content-type": "application/json" },
           })
@@ -159,7 +159,7 @@ describe("prover request routing", () => {
     expect(urls.map((url) => url.pathname)).toEqual(["/zolana/prove", "/zolana/prove/status"]);
     expect(urls[1]?.searchParams.get("api-key")).toBe("k+1");
     expect(urls[1]?.searchParams.get("tenant")).toBe("alpha");
-    expect(urls[1]?.searchParams.get("job_id")).toBe("job-123");
+    expect(urls[1]?.searchParams.get("jobId")).toBe("job-123");
   });
 });
 

--- a/sdk-libs/zolana-api/src/lib.rs
+++ b/sdk-libs/zolana-api/src/lib.rs
@@ -566,7 +566,7 @@ mod tests {
         assert_eq!(api.api_key(), Some("secret"));
         assert_eq!(
             api.url(GET_MERKLE_PROOFS),
-            "https://rpc.example.test/get_merkle_proofs?api-key=secret"
+            "https://rpc.example.test/getMerkleProofs?api-key=secret"
         );
     }
 
@@ -577,7 +577,7 @@ mod tests {
         assert_eq!(api.api_key(), None);
         assert_eq!(
             api.url(GET_ENCRYPTED_UTXOS_BY_TAGS),
-            "http://127.0.0.1:8784/get_encrypted_utxos_by_tags"
+            "http://127.0.0.1:8784/getEncryptedUtxosByTags"
         );
     }
 
@@ -588,7 +588,7 @@ mod tests {
         assert_eq!(api.api_key(), Some("secret"));
         assert_eq!(
             api.url(GetNonInclusionProofs::NAME),
-            "https://rpc.example.test/get_non_inclusion_proofs?api-key=secret"
+            "https://rpc.example.test/getNonInclusionProofs?api-key=secret"
         );
     }
 

--- a/services/photon/README.md
+++ b/services/photon/README.md
@@ -2,12 +2,12 @@
 
 Photon indexes Rings shielded-pool transactions and exposes the Rings JSON-RPC API:
 
-- `get_encrypted_utxos_by_tags`
-- `get_shielded_transactions_by_signature`
-- `get_shielded_transactions_by_tags`
-- `get_merkle_proofs`
-- `get_non_inclusion_proofs`
-- `get_nullifier_queue_elements`
+- `getEncryptedUtxosByTags`
+- `getShieldedTransactionsBySignature`
+- `getShieldedTransactionsByTags`
+- `getMerkleProofs`
+- `getNonInclusionProofs`
+- `getNullifierQueueElements`
 
 Photon is built from the Zolana Cargo workspace so its event parser, tree
 layout, SDK contract, and localnet tests always use the same source revision.

--- a/services/photon/src/api/method/rings.rs
+++ b/services/photon/src/api/method/rings.rs
@@ -104,23 +104,23 @@ mod tests {
         })
         .unwrap();
 
-        assert!(value.get("tx_signature").is_some());
-        assert!(value.get("output_slot").is_some());
-        assert!(value.get("tx_viewing_pk").is_some());
+        assert!(value.get("txSignature").is_some());
+        assert!(value.get("outputSlot").is_some());
+        assert!(value.get("txViewingPk").is_some());
         assert!(value.get("salt").is_some());
-        assert!(value.get("txSignature").is_none());
-        assert!(value.get("outputSlot").is_none());
-        assert!(value.get("txViewingPk").is_none());
-        let output_slot = &value["output_slot"];
-        assert!(output_slot.get("view_tag").is_some());
-        assert!(output_slot.get("output_context").is_some());
+        assert!(value.get("tx_signature").is_none());
+        assert!(value.get("output_slot").is_none());
+        assert!(value.get("tx_viewing_pk").is_none());
+        let output_slot = &value["outputSlot"];
+        assert!(output_slot.get("viewTag").is_some());
+        assert!(output_slot.get("outputContext").is_some());
         assert!(output_slot.get("payload").is_some());
         assert!(output_slot.get("proofless").is_none());
-        let output_context = &output_slot["output_context"];
+        let output_context = &output_slot["outputContext"];
         assert!(output_context.get("hash").is_some());
         assert!(output_context.get("tree").is_some());
-        assert!(output_context.get("leaf_index").is_some());
-        assert!(output_context.get("leafIndex").is_none());
+        assert!(output_context.get("leafIndex").is_some());
+        assert!(output_context.get("leaf_index").is_none());
 
         let value = serde_json::to_value(ShieldedTransaction {
             slot: 1,
@@ -145,21 +145,21 @@ mod tests {
         })
         .unwrap();
 
-        assert!(value.get("tx_signature").is_some());
-        assert!(value.get("tx_viewing_pk").is_some());
-        assert!(value.get("output_slots").is_some());
+        assert!(value.get("txSignature").is_some());
+        assert!(value.get("txViewingPk").is_some());
+        assert!(value.get("outputSlots").is_some());
         assert!(value.get("messages").is_some());
-        assert!(value.get("txSignature").is_none());
-        assert!(value.get("outputSlots").is_none());
+        assert!(value.get("tx_signature").is_none());
+        assert!(value.get("output_slots").is_none());
 
         let message = &value["messages"][0];
-        assert!(message.get("view_tag").is_some());
+        assert!(message.get("viewTag").is_some());
         assert!(message.get("payload").is_some());
 
-        let slot = &value["output_slots"][0];
-        assert!(slot.get("view_tag").is_some());
-        assert!(slot.get("output_context").is_some());
-        assert!(slot.get("outputContext").is_none());
+        let slot = &value["outputSlots"][0];
+        assert!(slot.get("viewTag").is_some());
+        assert!(slot.get("outputContext").is_some());
+        assert!(slot.get("output_context").is_none());
     }
 
     #[test]
@@ -169,8 +169,8 @@ mod tests {
             leaves: vec![hash(9)],
         })
         .unwrap();
-        assert!(request.get("tree_account").is_some());
-        assert!(request.get("treeAccount").is_none());
+        assert!(request.get("treeAccount").is_some());
+        assert!(request.get("tree_account").is_none());
 
         let proof = serde_json::to_value(NonInclusionProof {
             leaf: hash(10),
@@ -189,14 +189,14 @@ mod tests {
         })
         .unwrap();
 
-        assert!(proof.get("merkle_context").is_some());
-        assert!(proof.get("low_element").is_some());
-        assert!(proof.get("low_element_index").is_some());
-        assert!(proof.get("high_element").is_some());
-        assert!(proof.get("high_element_index").is_some());
-        assert!(proof.get("root_seq").is_some());
-        assert!(proof.get("root_index").is_some());
-        assert!(proof.get("merkleContext").is_none());
+        assert!(proof.get("merkleContext").is_some());
+        assert!(proof.get("lowElement").is_some());
+        assert!(proof.get("lowElementIndex").is_some());
+        assert!(proof.get("highElement").is_some());
+        assert!(proof.get("highElementIndex").is_some());
+        assert!(proof.get("rootSeq").is_some());
+        assert!(proof.get("rootIndex").is_some());
+        assert!(proof.get("merkle_context").is_none());
     }
 
     #[test]
@@ -212,7 +212,7 @@ mod tests {
         .unwrap();
 
         assert!(matches!(value, Value::Object(_)));
-        assert!(value.get("next_cursor").is_some());
-        assert!(value.get("nextCursor").is_none());
+        assert!(value.get("nextCursor").is_some());
+        assert!(value.get("next_cursor").is_none());
     }
 }

--- a/services/photon/src/api/rpc_server.rs
+++ b/services/photon/src/api/rpc_server.rs
@@ -184,12 +184,12 @@ mod tests {
         assert!(methods.contains(&"readiness"));
         assert!(methods.contains(&"getIndexerHealth"));
         assert!(methods.contains(&"getIndexerSlot"));
-        assert!(methods.contains(&"get_encrypted_utxos_by_tags"));
-        assert!(methods.contains(&"get_shielded_transactions_by_signature"));
-        assert!(methods.contains(&"get_shielded_transactions_by_tags"));
-        assert!(methods.contains(&"get_merkle_proofs"));
-        assert!(methods.contains(&"get_non_inclusion_proofs"));
-        assert!(methods.contains(&"get_nullifier_queue_elements"));
+        assert!(methods.contains(&"getEncryptedUtxosByTags"));
+        assert!(methods.contains(&"getShieldedTransactionsBySignature"));
+        assert!(methods.contains(&"getShieldedTransactionsByTags"));
+        assert!(methods.contains(&"getMerkleProofs"));
+        assert!(methods.contains(&"getNonInclusionProofs"));
+        assert!(methods.contains(&"getNullifierQueueElements"));
     }
 
     async fn test_api() -> PhotonApi {

--- a/services/photon/src/openapi/specs/rings.yaml
+++ b/services/photon/src/openapi/specs/rings.yaml
@@ -9,8 +9,8 @@ info:
 servers:
 - url: https://devnet.helius-rpc.com?api-key=<api_key>
 paths:
-  /get_encrypted_utxos_by_tags:
-    summary: get_encrypted_utxos_by_tags
+  /getEncryptedUtxosByTags:
+    summary: getEncryptedUtxosByTags
     post:
       requestBody:
         content:
@@ -37,7 +37,7 @@ paths:
                   type: string
                   description: The name of the method to invoke.
                   enum:
-                  - get_encrypted_utxos_by_tags
+                  - getEncryptedUtxosByTags
                 params:
                   type: object
                   required:
@@ -98,7 +98,7 @@ paths:
                         items:
                           $ref: '#/components/schemas/EncryptedUtxoMatch'
                         description: Output-level matches; every returned output slot has a view tag from the request.
-                      next_cursor:
+                      nextCursor:
                         oneOf:
                         - type: 'null'
                         - $ref: '#/components/schemas/Base64String'
@@ -139,8 +139,8 @@ paths:
                     type: string
                   jsonrpc:
                     type: string
-  /get_merkle_proofs:
-    summary: get_merkle_proofs
+  /getMerkleProofs:
+    summary: getMerkleProofs
     post:
       requestBody:
         content:
@@ -167,18 +167,18 @@ paths:
                   type: string
                   description: The name of the method to invoke.
                   enum:
-                  - get_merkle_proofs
+                  - getMerkleProofs
                 params:
                   type: object
                   required:
-                  - tree_account
+                  - treeAccount
                   - leaves
                   properties:
                     leaves:
                       type: array
                       items:
                         $ref: '#/components/schemas/Hash'
-                    tree_account:
+                    treeAccount:
                       $ref: '#/components/schemas/SerializablePubkey'
                   additionalProperties: false
         required: true
@@ -259,8 +259,8 @@ paths:
                     type: string
                   jsonrpc:
                     type: string
-  /get_non_inclusion_proofs:
-    summary: get_non_inclusion_proofs
+  /getNonInclusionProofs:
+    summary: getNonInclusionProofs
     post:
       requestBody:
         content:
@@ -287,18 +287,18 @@ paths:
                   type: string
                   description: The name of the method to invoke.
                   enum:
-                  - get_non_inclusion_proofs
+                  - getNonInclusionProofs
                 params:
                   type: object
                   required:
-                  - tree_account
+                  - treeAccount
                   - leaves
                   properties:
                     leaves:
                       type: array
                       items:
                         $ref: '#/components/schemas/Hash'
-                    tree_account:
+                    treeAccount:
                       $ref: '#/components/schemas/SerializablePubkey'
                   additionalProperties: false
         required: true
@@ -379,8 +379,8 @@ paths:
                     type: string
                   jsonrpc:
                     type: string
-  /get_nullifier_queue_elements:
-    summary: get_nullifier_queue_elements
+  /getNullifierQueueElements:
+    summary: getNullifierQueueElements
     post:
       requestBody:
         content:
@@ -407,22 +407,22 @@ paths:
                   type: string
                   description: The name of the method to invoke.
                   enum:
-                  - get_nullifier_queue_elements
+                  - getNullifierQueueElements
                 params:
                   type: object
                   required:
-                  - tree_account
+                  - treeAccount
                   - limit
                   properties:
                     limit:
                       $ref: '#/components/schemas/Limit'
                       description: Maximum number of elements to return.
-                    start_seq:
+                    startSeq:
                       type: integer
                       format: u-int64
-                      description: Return elements with `input_queue_seq >= start_seq` (default 0).
+                      description: Return elements with `input_queue_seq >= startSeq` (default 0).
                       minimum: 0
-                    tree_account:
+                    treeAccount:
                       $ref: '#/components/schemas/SerializablePubkey'
                   additionalProperties: false
         required: true
@@ -503,8 +503,8 @@ paths:
                     type: string
                   jsonrpc:
                     type: string
-  /get_shielded_transactions_by_nullifiers:
-    summary: get_shielded_transactions_by_nullifiers
+  /getShieldedTransactionsByNullifiers:
+    summary: getShieldedTransactionsByNullifiers
     post:
       requestBody:
         content:
@@ -531,7 +531,7 @@ paths:
                   type: string
                   description: The name of the method to invoke.
                   enum:
-                  - get_shielded_transactions_by_nullifiers
+                  - getShieldedTransactionsByNullifiers
                 params:
                   type: object
                   required:
@@ -587,7 +587,7 @@ paths:
                     properties:
                       context:
                         $ref: '#/components/schemas/Context'
-                      next_cursor:
+                      nextCursor:
                         oneOf:
                         - type: 'null'
                         - $ref: '#/components/schemas/Base64String'
@@ -635,8 +635,8 @@ paths:
                     type: string
                   jsonrpc:
                     type: string
-  /get_shielded_transactions_by_signature:
-    summary: get_shielded_transactions_by_signature
+  /getShieldedTransactionsBySignature:
+    summary: getShieldedTransactionsBySignature
     post:
       requestBody:
         content:
@@ -663,13 +663,13 @@ paths:
                   type: string
                   description: The name of the method to invoke.
                   enum:
-                  - get_shielded_transactions_by_signature
+                  - getShieldedTransactionsBySignature
                 params:
                   type: object
                   required:
-                  - tx_signature
+                  - txSignature
                   properties:
-                    tx_signature:
+                    txSignature:
                       $ref: '#/components/schemas/SerializableSignature'
                   additionalProperties: false
         required: true
@@ -750,8 +750,8 @@ paths:
                     type: string
                   jsonrpc:
                     type: string
-  /get_shielded_transactions_by_tags:
-    summary: get_shielded_transactions_by_tags
+  /getShieldedTransactionsByTags:
+    summary: getShieldedTransactionsByTags
     post:
       requestBody:
         content:
@@ -778,7 +778,7 @@ paths:
                   type: string
                   description: The name of the method to invoke.
                   enum:
-                  - get_shielded_transactions_by_tags
+                  - getShieldedTransactionsByTags
                 params:
                   type: object
                   required:
@@ -834,7 +834,7 @@ paths:
                     properties:
                       context:
                         $ref: '#/components/schemas/Context'
-                      next_cursor:
+                      nextCursor:
                         oneOf:
                         - type: 'null'
                         - $ref: '#/components/schemas/Base64String'
@@ -890,10 +890,10 @@ components:
     Context:
       type: object
       required:
-      - block_time
+      - blockTime
       - slot
       properties:
-        block_time:
+        blockTime:
           type: integer
           format: int64
         slot:
@@ -906,10 +906,10 @@ components:
       type: object
       required:
       - slot
-      - tx_signature
-      - output_slot
+      - txSignature
+      - outputSlot
       properties:
-        output_slot:
+        outputSlot:
           $ref: '#/components/schemas/RingsOutputSlot'
         salt:
           oneOf:
@@ -920,9 +920,9 @@ components:
           type: integer
           format: u-int64
           minimum: 0
-        tx_signature:
+        txSignature:
           $ref: '#/components/schemas/SerializableSignature'
-        tx_viewing_pk:
+        txViewingPk:
           oneOf:
           - type: 'null'
           - $ref: '#/components/schemas/Base64String'
@@ -933,10 +933,10 @@ components:
     IndexedShieldedTransaction:
       type: object
       required:
-      - event_index
+      - eventIndex
       - transaction
       properties:
-        event_index:
+        eventIndex:
           type: integer
           format: u-int16
           minimum: 0
@@ -951,12 +951,12 @@ components:
     MerkleContext:
       type: object
       required:
-      - tree_type
+      - treeType
       - tree
       properties:
         tree:
           $ref: '#/components/schemas/SerializablePubkey'
-        tree_type:
+        treeType:
           type: integer
           format: u-int16
           minimum: 0
@@ -965,20 +965,20 @@ components:
       type: object
       required:
       - leaf
-      - merkle_context
+      - merkleContext
       - path
-      - leaf_index
+      - leafIndex
       - root
-      - root_seq
-      - root_index
+      - rootSeq
+      - rootIndex
       properties:
         leaf:
           $ref: '#/components/schemas/Hash'
-        leaf_index:
+        leafIndex:
           type: integer
           format: u-int64
           minimum: 0
-        merkle_context:
+        merkleContext:
           $ref: '#/components/schemas/MerkleContext'
         path:
           type: array
@@ -986,11 +986,11 @@ components:
             $ref: '#/components/schemas/Hash'
         root:
           $ref: '#/components/schemas/Hash'
-        root_index:
+        rootIndex:
           type: integer
           format: u-int16
           minimum: 0
-        root_seq:
+        rootSeq:
           type: integer
           format: u-int64
           minimum: 0
@@ -999,31 +999,31 @@ components:
       type: object
       required:
       - leaf
-      - merkle_context
+      - merkleContext
       - path
-      - low_element
-      - low_element_index
-      - high_element
-      - high_element_index
+      - lowElement
+      - lowElementIndex
+      - highElement
+      - highElementIndex
       - root
-      - root_seq
-      - root_index
+      - rootSeq
+      - rootIndex
       properties:
-        high_element:
+        highElement:
           $ref: '#/components/schemas/Hash'
-        high_element_index:
+        highElementIndex:
           type: integer
           format: u-int64
           minimum: 0
         leaf:
           $ref: '#/components/schemas/Hash'
-        low_element:
+        lowElement:
           $ref: '#/components/schemas/Hash'
-        low_element_index:
+        lowElementIndex:
           type: integer
           format: u-int64
           minimum: 0
-        merkle_context:
+        merkleContext:
           $ref: '#/components/schemas/MerkleContext'
         path:
           type: array
@@ -1031,11 +1031,11 @@ components:
             $ref: '#/components/schemas/Hash'
         root:
           $ref: '#/components/schemas/Hash'
-        root_index:
+        rootIndex:
           type: integer
           format: u-int16
           minimum: 0
-        root_seq:
+        rootSeq:
           type: integer
           format: u-int64
           minimum: 0
@@ -1057,12 +1057,12 @@ components:
     RingsMessage:
       type: object
       required:
-      - view_tag
+      - viewTag
       - payload
       properties:
         payload:
           $ref: '#/components/schemas/Base64String'
-        view_tag:
+        viewTag:
           $ref: '#/components/schemas/Hash'
       additionalProperties: false
     RingsOutputContext:
@@ -1070,11 +1070,11 @@ components:
       required:
       - hash
       - tree
-      - leaf_index
+      - leafIndex
       properties:
         hash:
           $ref: '#/components/schemas/Hash'
-        leaf_index:
+        leafIndex:
           type: integer
           format: u-int64
           minimum: 0
@@ -1084,15 +1084,15 @@ components:
     RingsOutputSlot:
       type: object
       required:
-      - view_tag
-      - output_context
+      - viewTag
+      - outputContext
       - payload
       properties:
-        output_context:
+        outputContext:
           $ref: '#/components/schemas/RingsOutputContext'
         payload:
           $ref: '#/components/schemas/Base64String'
-        view_tag:
+        viewTag:
           $ref: '#/components/schemas/Hash'
       additionalProperties: false
     SerializablePubkey:
@@ -1105,8 +1105,8 @@ components:
       type: object
       required:
       - slot
-      - tx_signature
-      - output_slots
+      - txSignature
+      - outputSlots
       - messages
       - nullifiers
       - proofless
@@ -1120,7 +1120,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Hash'
-        output_slots:
+        outputSlots:
           type: array
           items:
             $ref: '#/components/schemas/RingsOutputSlot'
@@ -1136,9 +1136,9 @@ components:
           type: integer
           format: u-int64
           minimum: 0
-        tx_signature:
+        txSignature:
           $ref: '#/components/schemas/SerializableSignature'
-        tx_viewing_pk:
+        txViewingPk:
           oneOf:
           - type: 'null'
           - $ref: '#/components/schemas/Base64String'

--- a/services/photon/tests/integration_tests/open_api_tests.rs
+++ b/services/photon/tests/integration_tests/open_api_tests.rs
@@ -2,13 +2,13 @@ use photon_indexer::openapi::update_docs;
 use utoipa::openapi::{OpenApi, RefOr, Required};
 
 const METHODS: [&str; 7] = [
-    "get_encrypted_utxos_by_tags",
-    "get_merkle_proofs",
-    "get_non_inclusion_proofs",
-    "get_nullifier_queue_elements",
-    "get_shielded_transactions_by_nullifiers",
-    "get_shielded_transactions_by_signature",
-    "get_shielded_transactions_by_tags",
+    "getEncryptedUtxosByTags",
+    "getMerkleProofs",
+    "getNonInclusionProofs",
+    "getNullifierQueueElements",
+    "getShieldedTransactionsByNullifiers",
+    "getShieldedTransactionsBySignature",
+    "getShieldedTransactionsByTags",
 ];
 
 #[test]


### PR DESCRIPTION
The indexer JSON-RPC method names and every request/response field were
snake_case, while `getIndexerHealth`/`getIndexerSlot` and the whole TypeScript
SDK surface were already camelCase. One convention now covers both services.

## Indexer

The seven methods become `getEncryptedUtxosByTags`,
`getShieldedTransactionsByTags`/`BySignature`/`ByNullifiers`,
`getMerkleProofs`, `getNonInclusionProofs` and `getNullifierQueueElements`,
and every wire struct in `zolana-indexer-api` switches `rename_all` to
`camelCase`.

Rust field names stay snake_case, so photon and the Rust clients needed no
logic change -- only the hand-written JSON fixtures, the
`serde_path_to_error` paths, and the regenerated `rings.yaml`. The TypeScript
codec's wire keys now match the camelCase properties it was already mapping
onto, and `safeSchemaPath`'s field allowlist moved with them.

## Prover

Request payloads were already camelCase; the responses follow.
`proofCommitment`, `proofCommitmentPok`, `proofDurationMs`, and the queue
surface -- `jobId` as both query parameter and body field, `circuitType`,
`statusUrl`, `estimatedTime`, `failedAt`, `originalJob`, `totalPending`,
`queueLengths`, the `/queue/cleanup` result keys, and the `ProofJob` tags
`createdAt`/`treeId`/`batchIndex`.

## Breaking, with no compatibility shim

Photon and its SDK consumers must deploy together, as must the prover and its
clients. `deny_unknown_fields` makes a stale client fail loudly rather than
misread a response. Accepting both spellings during a transition would be a
separate, larger change and is not attempted here.

The Redis job-metadata keys move with the response fields they are copied
into, so a rolling prover deploy can omit `circuitType`/`submittedAt` from
status responses for jobs the previous binary queued. `status` and `result`
are unaffected.

## Deliberately unchanged

- Error-code and status string *values* (`job_not_found`, `already_queued`)
  keep their spelling: they are an enum taxonomy clients match on, not field
  names.
- `docs/spec.md` keeps the snake_case field names inside its Rust struct
  definitions; only the RPC endpoint headings and their cross-links were
  renamed. The Relayer's `submit_transaction` and the Ring RPC's
  `get_decrypted_*` endpoints are unimplemented and out of scope, so that
  chapter now mixes both spellings.
- `sdk-tests/*/prover` needed no work: `proof_commitment` there is a cgo C
  struct field, an in-process ABI with no JSON or HTTP.

## Verification

| Suite | Result |
| --- | --- |
| `cargo check --workspace --all-targets` | clean |
| `just clippy`, `just fmt-check` | clean |
| `zolana-indexer-api` / `zolana-api` | 5 / 4 passed |
| `photon-indexer` | 77 lib + 21 integration passed |
| `zolana-wallet` | 95 + 12 passed |
| `zolana-client --lib` | 52 passed |
| `zolana-client --test merge_proving` (real prover) | 2 passed |
| `just test-ring-validator` (validator + photon + prover) | 15 passed |
| Go prover: build, vet, gofmt, `go test ./server/...` | clean |
| TS SDK: 243 tests, typecheck, lint, format | clean |

`test-ring-validator` is the load-bearing one: both wires were renamed on
both sides, so a symmetric mistake would pass every unit test. Its
`p256_ring_lifecycle` cases put a real BSB22 commitment on the wire (covering
`proofCommitment`/`proofCommitmentPok`) while driving the indexer's camelCase
JSON-RPC through Photon.
