### PR TITLE
chore(ts-sdk): rename package to @heliuslabs/zolana

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -33,14 +33,14 @@ jobs:
         run: |
           tmp="$(mktemp -d)"
           trap 'rm -rf "$tmp"' EXIT
-          npm pack --workspace @zolana/sdk --pack-destination "$tmp"
+          npm pack --workspace @heliuslabs/zolana --pack-destination "$tmp"
           set -- "$tmp"/*.tgz
           test "$#" -eq 1
           tarball="$1"
           printf '{"private":true,"type":"module"}\n' > "$tmp/package.json"
           npm --prefix "$tmp" install "$tarball" "@solana/kit@^7" --ignore-scripts
           cat > "$tmp/smoke.mts" <<'TS'
-          import { createZolanaClient, type ZolanaClientConfig } from "@zolana/sdk";
+          import { createZolanaClient, type ZolanaClientConfig } from "@heliuslabs/zolana";
           const config: ZolanaClientConfig = {
             solanaRpcUrl: new URL("http://127.0.0.1:8899"),
             indexerUrl: undefined,
@@ -55,11 +55,11 @@ jobs:
           (
             cd "$tmp"
             node --input-type=module <<'NODE'
-          const sdk = await import("@zolana/sdk");
-          const instructions = await import("@zolana/sdk/instructions");
+          const sdk = await import("@heliuslabs/zolana");
+          const instructions = await import("@heliuslabs/zolana/instructions");
           await Promise.all(
             ["addresses", "client", "interface", "keypair", "transaction", "wallet"].map(
-              (subpath) => import(`@zolana/sdk/${subpath}`),
+              (subpath) => import(`@heliuslabs/zolana/${subpath}`),
             ),
           );
           if (!sdk.buildTransferTransaction || !instructions.getDepositInstructionAsync) process.exit(1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,10 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@heliuslabs/zolana": {
+      "resolved": "sdk-libs/ts",
+      "link": true
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -2634,10 +2638,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@zolana/sdk": {
-      "resolved": "sdk-libs/ts",
-      "link": true
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3598,7 +3598,7 @@
       }
     },
     "sdk-libs/ts": {
-      "name": "@zolana/sdk",
+      "name": "@heliuslabs/zolana",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "sdk-libs/ts"
   ],
   "scripts": {
-    "build:ts": "npm run build --workspace @zolana/sdk",
-    "check:ts": "npm run check --workspace @zolana/sdk && npm run check:ts:example",
+    "build:ts": "npm run build --workspace @heliuslabs/zolana",
+    "check:ts": "npm run check --workspace @heliuslabs/zolana && npm run check:ts:example",
     "check:ts:example": "oxfmt --check sdk-tests/client/typescript && oxlint --deny-warnings sdk-tests/client/typescript && npm run typecheck:ts:example",
     "typecheck:ts:example": "tsc --noEmit --project sdk-tests/client/typescript/tsconfig.json",
-    "test:ts": "npm run test --workspace @zolana/sdk",
-    "test:ts:e2e:sdk": "npm run test:e2e --workspace @zolana/sdk",
+    "test:ts": "npm run test --workspace @heliuslabs/zolana",
+    "test:ts:e2e:sdk": "npm run test:e2e --workspace @heliuslabs/zolana",
     "test:ts:example": "npm run build:ts && vitest run --config sdk-tests/client/typescript/vitest.config.ts",
     "test:ts:e2e": "npm run test:ts:e2e:sdk && npm run test:ts:example"
   }

--- a/sdk-libs/ts/README.md
+++ b/sdk-libs/ts/README.md
@@ -1,6 +1,6 @@
-# @zolana/sdk
+# @heliuslabs/zolana
 
-`@zolana/sdk` is the TypeScript SDK for Zolana shielded assets on Solana. Use it
+`@heliuslabs/zolana` is the TypeScript SDK for Zolana shielded assets on Solana. Use it
 to:
 
 - shield SOL, SPL Token, and Token-2022 assets;
@@ -12,7 +12,7 @@ to:
 ## Install
 
 ```sh
-npm install @zolana/sdk @solana/kit
+npm install @heliuslabs/zolana @solana/kit
 ```
 
 Requirements:
@@ -47,7 +47,7 @@ import {
   getPrivateTransactions,
   syncWallet,
   type Bytes32,
-} from "@zolana/sdk";
+} from "@heliuslabs/zolana";
 
 // One url serves the RPC, the indexer, and the prover.
 // localnet: const client = await createZolanaClient({});
@@ -175,7 +175,7 @@ address. Passing a `ShieldedAddress` directly bypasses the lookup.
 A transfer normally targets the recipient's registered Solana public key.
 
 ```ts
-import { buildTransferTransaction } from "@zolana/sdk";
+import { buildTransferTransaction } from "@heliuslabs/zolana";
 
 declare const recipientSolanaAddress: Address;
 
@@ -198,7 +198,7 @@ Pass `asset: mint` for an SPL or Token-2022 balance.
 Withdraw to a public Solana address:
 
 ```ts
-import { buildWithdrawalTransaction } from "@zolana/sdk";
+import { buildWithdrawalTransaction } from "@heliuslabs/zolana";
 
 const withdrawal = await buildWithdrawalTransaction({
   client,
@@ -234,7 +234,7 @@ contains private note data and must be encrypted at rest.
 
 ## Public API
 
-Common exports from `@zolana/sdk` include:
+Common exports from `@heliuslabs/zolana` include:
 
 - setup: `createZolanaClient`, `ShieldedKeypair`, `Wallet`,
   `LocalWalletAuthority`;
@@ -246,9 +246,9 @@ Common exports from `@zolana/sdk` include:
 - registration: `buildRegistrationTransaction`.
 
 Advanced protocol users can import low-level instruction builders from
-`@zolana/sdk/instructions`. PDA helpers are available from
-`@zolana/sdk/addresses`; additional typed surfaces are exposed under
-`@zolana/sdk/client`, `/interface`, `/keypair`, `/transaction`, and `/wallet`.
+`@heliuslabs/zolana/instructions`. PDA helpers are available from
+`@heliuslabs/zolana/addresses`; additional typed surfaces are exposed under
+`@heliuslabs/zolana/client`, `/interface`, `/keypair`, `/transaction`, and `/wallet`.
 
 ## Important notes
 

--- a/sdk-libs/ts/package.json
+++ b/sdk-libs/ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zolana/sdk",
+  "name": "@heliuslabs/zolana",
   "version": "0.1.0",
   "description": "TypeScript SDK for the Zolana shielded protocol.",
   "license": "Apache-2.0",

--- a/sdk-tests/client/typescript/README.md
+++ b/sdk-tests/client/typescript/README.md
@@ -1,7 +1,7 @@
 # TypeScript client example
 
 [`deposit-transfer-withdraw.test.ts`](deposit-transfer-withdraw.test.ts) shows
-the instruction-level `@zolana/sdk` flow to deposit SOL into a private balance,
+the instruction-level `@heliuslabs/zolana` flow to deposit SOL into a private balance,
 transfer between private balances, and withdraw from a private balance to a
 public balance.
 

--- a/sdk-tests/client/typescript/deposit-transfer-withdraw.test.ts
+++ b/sdk-tests/client/typescript/deposit-transfer-withdraw.test.ts
@@ -1,21 +1,21 @@
 /// <reference types="node" />
 
-import { SOL_MINT, createZolanaClient } from "@zolana/sdk";
-import { atSlot } from "@zolana/sdk/client";
+import { SOL_MINT, createZolanaClient } from "@heliuslabs/zolana";
+import { atSlot } from "@heliuslabs/zolana/client";
 import {
   depositInstruction,
   transactInstruction,
   DepositAsset,
   TransactWithdrawal,
-} from "@zolana/sdk/interface";
-import { randomBlinding } from "@zolana/sdk/keypair";
+} from "@heliuslabs/zolana/interface";
+import { randomBlinding } from "@heliuslabs/zolana/keypair";
 import {
   AssetRegistry,
   ConfidentialTransfer,
   ProofInputUtxo,
   decryptToBalances,
   WithdrawalTarget,
-} from "@zolana/sdk/transaction";
+} from "@heliuslabs/zolana/transaction";
 import { describe, expect, it } from "vitest";
 
 import { sendAndConfirmFactory, setup } from "./setup.js";

--- a/sdk-tests/client/typescript/setup.ts
+++ b/sdk-tests/client/typescript/setup.ts
@@ -30,7 +30,7 @@ import {
   initializePoseidon,
   type Bytes32,
   type ZolanaClientConfig,
-} from "@zolana/sdk";
+} from "@heliuslabs/zolana";
 
 // The SDK's localnet default; the airdrop is a localnet-only operation and
 // targets the same validator the client connects to.


### PR DESCRIPTION
## Summary
- Rename the TypeScript SDK from `@zolana/sdk` to `@heliuslabs/zolana`.

## Test plan
- [x] `npm run check:ts`