### PR TITLE
test(client): camelCase the slow-status mock's prover names

### DIFF
--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -979,7 +979,7 @@ mod tests {
     #[test]
     fn a_slow_status_endpoint_cannot_extend_the_deadline() {
         let server = MockServer::respond_then_hold(vec![
-            MockResponse::json(202, json!({ "job_id": "job-slow-status" })),
+            MockResponse::json(202, json!({ "jobId": "job-slow-status" })),
             MockResponse::slow_json(
                 200,
                 json!({ "status": "processing" }),
@@ -1007,7 +1007,7 @@ mod tests {
         // time it spent waiting had not been charged against the deadline.
         assert_paths(
             &server.requests(),
-            ["/prove", "/prove/status?job_id=job-slow-status"],
+            ["/prove", "/prove/status?jobId=job-slow-status"],
         );
     }
 


### PR DESCRIPTION
## Summary

Main's `tests / sdk-libs` job is red: `prover::client::tests::a_slow_status_endpoint_cannot_extend_the_deadline` fails on every run with `expected a timeout, got proof parse error: could not parse proof: {"job_id":"job-slow-status"}`.

The test landed in #227 concurrently with the camelCase API rename in #229 (merged 38 seconds apart, each green on its own), so its mock kept the snake_case names: the 202 body says `job_id` and the expected poll path says `job_id=`. The client no longer recognizes that body as a queued job and treats it as an unparseable direct proof, so the queued-poll path under test never runs.

This renames both to `jobId`, matching every other test in the module.

## Test plan

- `cargo test -p zolana-client` (36 tests, all green; the fixed test exercises the 1.5s slow poll and times out as intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)