### PR TITLE
client: fetch spend proofs concurrently, and stop confirming twice

### DIFF
--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use solana_signer::Signer;
-use zolana_client::{SolanaRpc, ZolanaClient};
+use zolana_client::{Rpc, RpcSendTransactionConfig, SolanaRpc, ZolanaClient};
 use zolana_transaction::Address;
 use zolana_wallet::{
     actions::{submit::MergeMaterial, transaction::is_plain_utxo},
@@ -15,6 +15,15 @@ use super::{
     util::{ensure_positive, format_address, parse_address, parse_hex_array, parse_pubkey},
 };
 use crate::args::{MergeOptions, SplitOptions, TransferOptions, UtxosOptions};
+
+/// The CLI confirms separately, so preflight would only buy a simulation
+/// round trip before a send that is about to be confirmed anyway.
+fn send_config() -> RpcSendTransactionConfig {
+    RpcSendTransactionConfig {
+        skip_preflight: true,
+        ..RpcSendTransactionConfig::default()
+    }
+}
 
 pub(crate) fn run_transfer(opts: TransferOptions) -> Result<()> {
     ensure_positive(opts.amount)?;
@@ -46,7 +55,9 @@ pub(crate) fn run_transfer(opts: TransferOptions) -> Result<()> {
         &client,
         &ctx.material.funding,
     )?;
-    let signature = client.submit_private_transaction_sync(&transaction)?;
+    let signature = client
+        .rpc()
+        .send_transaction_with_config(&transaction, send_config())?;
     client.confirm_private_transaction_sync(signature)?;
     let mode = if transfer.recipient.is_public_withdrawal() {
         "withdraw"
@@ -134,7 +145,9 @@ pub(crate) fn run_split(opts: SplitOptions) -> Result<()> {
         &client,
         &ctx.material.funding,
     )?;
-    let signature = client.submit_private_transaction_sync(&transaction)?;
+    let signature = client
+        .rpc()
+        .send_transaction_with_config(&transaction, send_config())?;
     client.confirm_private_transaction_sync(signature)?;
     println!(
         "ok split parts={} amount={} mint={} signature={}",

--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use solana_signer::Signer;
-use zolana_client::{Rpc, SolanaRpc, ZolanaClient};
+use zolana_client::{SolanaRpc, ZolanaClient};
 use zolana_transaction::Address;
 use zolana_wallet::{
     actions::{submit::MergeMaterial, transaction::is_plain_utxo},
@@ -46,7 +46,7 @@ pub(crate) fn run_transfer(opts: TransferOptions) -> Result<()> {
         &client,
         &ctx.material.funding,
     )?;
-    let signature = client.rpc().send_transaction(&transaction)?;
+    let signature = client.submit_private_transaction_sync(&transaction)?;
     client.confirm_private_transaction_sync(signature)?;
     let mode = if transfer.recipient.is_public_withdrawal() {
         "withdraw"
@@ -134,7 +134,7 @@ pub(crate) fn run_split(opts: SplitOptions) -> Result<()> {
         &client,
         &ctx.material.funding,
     )?;
-    let signature = client.rpc().send_transaction(&transaction)?;
+    let signature = client.submit_private_transaction_sync(&transaction)?;
     client.confirm_private_transaction_sync(signature)?;
     println!(
         "ok split parts={} amount={} mint={} signature={}",

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -1130,8 +1130,14 @@ fn fetch_spend_proofs(
     // does with `try_join!`: different methods, neither consuming the other's
     // output. Serially this cost the sum on every transfer.
     let (state_response, nullifier_response) = std::thread::scope(|scope| {
-        let state = scope.spawn(|| indexer.get_merkle_proofs(tree, leaves, config));
-        let nullifier = scope.spawn(|| indexer.get_non_inclusion_proofs(tree, nullifiers, config));
+        let state = scope.spawn(|| {
+            let _t = crate::timing::Phase::start("get_merkle_proofs", 0);
+            indexer.get_merkle_proofs(tree, leaves, config)
+        });
+        let nullifier = scope.spawn(|| {
+            let _t = crate::timing::Phase::start("get_non_inclusion_proofs", 0);
+            indexer.get_non_inclusion_proofs(tree, nullifiers, config)
+        });
         (state.join(), nullifier.join())
     });
     // A panic here is a bug in the indexer client, not an unreachable indexer.

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -398,6 +398,32 @@ impl<R: Rpc> ZolanaClient<R> {
         wait_for_rpc_confirmation(self.rpc(), signature, self.indexer_config.poll)?;
         wait_for_indexed_transaction(self.blocking_indexer(), signature, self.indexer_config.poll)
     }
+
+    /// Submit a signed private transaction and return as soon as the RPC
+    /// accepts it.
+    ///
+    /// Pair with [`Self::confirm_private_transaction_sync`], which waits for the
+    /// chain and then the indexer. `Rpc::send_transaction` confirms too, so the
+    /// two together waited for the same signature twice.
+    ///
+    /// Preflight is skipped: simulation re-executes a transaction whose inputs
+    /// are proofs the indexer just served, and a failure it would catch is one
+    /// this client cannot fix by retrying. The cost of being wrong is a landed
+    /// transaction that fails on chain, so callers submitting unvalidated
+    /// transactions should keep using `send_transaction`.
+    pub fn submit_private_transaction_sync(
+        &self,
+        transaction: &SolanaTransaction,
+    ) -> Result<Signature, ClientError> {
+        let _t = crate::timing::Phase::start("submit_private", 0);
+        // Honours `with_send_transaction_config`, which until now set a field
+        // nothing read.
+        let config = self.send_config.unwrap_or(RpcSendTransactionConfig {
+            skip_preflight: true,
+            ..RpcSendTransactionConfig::default()
+        });
+        self.rpc().send_transaction_with_config(transaction, config)
+    }
 }
 
 impl<R: AsyncRpc> ZolanaClient<R> {
@@ -1100,8 +1126,19 @@ fn fetch_spend_proofs(
         .iter()
         .map(|commitment| commitment.nullifier)
         .collect::<Vec<_>>();
-    let state_response = indexer.get_merkle_proofs(tree, leaves, config)?;
-    let nullifier_response = indexer.get_non_inclusion_proofs(tree, nullifiers, config)?;
+    // Independent round trips, run together for the same reason the async path
+    // does with `try_join!`: different methods, neither consuming the other's
+    // output. Serially this cost the sum on every transfer.
+    let (state_response, nullifier_response) = std::thread::scope(|scope| {
+        let state = scope.spawn(|| indexer.get_merkle_proofs(tree, leaves, config));
+        let nullifier = scope.spawn(|| indexer.get_non_inclusion_proofs(tree, nullifiers, config));
+        (state.join(), nullifier.join())
+    });
+    // A panic here is a bug in the indexer client, not an unreachable indexer.
+    let state_response =
+        state_response.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
+    let nullifier_response =
+        nullifier_response.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
     validate_spend_proofs(
         tree,
         commitments,
@@ -1516,10 +1553,19 @@ mod tests {
         };
         let commitment = shielded.transaction.input_utxo_hashes().unwrap().remove(0);
         let signature = Signature::from([5u8; 64]);
-        let server = MockIndexerServer::respond_with(vec![
-            merkle_response(tree, commitment.utxo_hash),
-            nullifier_response(tree, commitment.nullifier),
-            indexed_transaction_by_signature_response(signature),
+        let server = MockIndexerServer::respond_by_path(vec![
+            (
+                "/getMerkleProofs",
+                merkle_response(tree, commitment.utxo_hash),
+            ),
+            (
+                "/getNonInclusionProofs",
+                nullifier_response(tree, commitment.nullifier),
+            ),
+            (
+                "/getShieldedTransactionsBySignature",
+                indexed_transaction_by_signature_response(signature),
+            ),
         ]);
         let rpc = MockSubmitRpc::new(signature);
         let sent = rpc.sent.clone();
@@ -1557,14 +1603,13 @@ mod tests {
         assert_eq!(sent.len(), 1);
         assert_eq!(sent[0].message.instructions.len(), 3);
         let requests = server.requests();
-        assert_eq!(
-            requests,
-            [
-                "/getMerkleProofs",
-                "/getNonInclusionProofs",
-                "/getShieldedTransactionsBySignature",
-            ]
-        );
+        // The two proof fetches race, so only their membership is defined; the
+        // indexed-transaction lookup still happens after them.
+        let (proofs, rest) = requests.split_at(2);
+        let mut proofs = proofs.to_vec();
+        proofs.sort();
+        assert_eq!(proofs, ["/getMerkleProofs", "/getNonInclusionProofs"]);
+        assert_eq!(rest, ["/getShieldedTransactionsBySignature"]);
     }
 
     #[test]
@@ -1910,6 +1955,7 @@ mod tests {
         signature: Signature,
         view_tags: Vec<[u8; 32]>,
         sent: Arc<Mutex<Vec<SolanaTransaction>>>,
+        sent_configs: Arc<Mutex<Vec<RpcSendTransactionConfig>>>,
     }
 
     impl MockSubmitRpc {
@@ -1918,6 +1964,7 @@ mod tests {
                 signature,
                 view_tags: Vec::new(),
                 sent: Arc::new(Mutex::new(Vec::new())),
+                sent_configs: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
@@ -1941,6 +1988,16 @@ mod tests {
             transaction: &SolanaTransaction,
         ) -> Result<Signature, ClientError> {
             self.sent.lock().unwrap().push(transaction.clone());
+            Ok(self.signature)
+        }
+
+        fn send_transaction_with_config(
+            &self,
+            transaction: &SolanaTransaction,
+            config: RpcSendTransactionConfig,
+        ) -> Result<Signature, ClientError> {
+            self.sent.lock().unwrap().push(transaction.clone());
+            self.sent_configs.lock().unwrap().push(config);
             Ok(self.signature)
         }
 
@@ -1968,6 +2025,56 @@ mod tests {
         ) -> Result<Vec<[u8; 32]>, ClientError> {
             Ok(self.view_tags.clone())
         }
+    }
+
+    fn submit_client(rpc: MockSubmitRpc) -> ZolanaClient<MockSubmitRpc> {
+        ZolanaClient::new(
+            rpc,
+            ZolanaIndexer::new("http://unused.invalid"),
+            ProverClient::new("http://unused.invalid".to_string()),
+            AsyncZolanaIndexer::new("http://unused.invalid"),
+            AsyncProverClient::new("http://unused.invalid".to_string()),
+            Address::new_from_array([8u8; 32]),
+        )
+    }
+
+    /// `confirm_private_transaction_sync` already waits for the chain, so the
+    /// submit half must not: together they waited for one signature twice.
+    /// Preflight is skipped for the same round-trip reason.
+    #[test]
+    fn submit_private_skips_preflight() {
+        let rpc = MockSubmitRpc::new(Signature::from([3u8; 64]));
+        let configs = rpc.sent_configs.clone();
+        let client = submit_client(rpc);
+
+        client
+            .submit_private_transaction_sync(&SolanaTransaction::default())
+            .expect("submit");
+
+        let recorded = configs.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert!(recorded[0].skip_preflight);
+    }
+
+    /// `with_send_transaction_config` set a field nothing read until this path
+    /// existed; a caller that asks for preflight must get it.
+    #[test]
+    fn submit_private_honours_a_configured_send_config() {
+        let rpc = MockSubmitRpc::new(Signature::from([3u8; 64]));
+        let configs = rpc.sent_configs.clone();
+        let client = submit_client(rpc).with_send_transaction_config(RpcSendTransactionConfig {
+            skip_preflight: false,
+            max_retries: Some(7),
+            ..RpcSendTransactionConfig::default()
+        });
+
+        client
+            .submit_private_transaction_sync(&SolanaTransaction::default())
+            .expect("submit");
+
+        let recorded = configs.lock().unwrap();
+        assert!(!recorded[0].skip_preflight);
+        assert_eq!(recorded[0].max_retries, Some(7));
     }
 
     fn merkle_response(tree: Address, leaf: [u8; 32]) -> Value {
@@ -2077,6 +2184,38 @@ mod tests {
     }
 
     impl MockIndexerServer {
+        /// Serve each response to the request whose path asks for it.
+        ///
+        /// `respond_with` hands responses out in order, which stops being a
+        /// description of the server once the client fetches concurrently: the
+        /// proof fetches race, and whichever connects first would take the
+        /// other's body.
+        fn respond_by_path(responses: Vec<(&'static str, Value)>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock indexer");
+            let url = format!("http://{}", listener.local_addr().unwrap());
+            let (request_tx, requests) = mpsc::channel();
+            let count = responses.len();
+            let handle = thread::spawn(move || {
+                let mut remaining: Vec<(&'static str, Value)> = responses;
+                for _ in 0..count {
+                    let (mut stream, _) = listener.accept().expect("accept request");
+                    let request = read_request(&mut stream);
+                    let index = remaining
+                        .iter()
+                        .position(|(path, _)| *path == request.path)
+                        .unwrap_or_else(|| panic!("no mock response for {}", request.path));
+                    let (_, response) = remaining.remove(index);
+                    request_tx.send(request).expect("record request");
+                    write_json_response(&mut stream, &response);
+                }
+            });
+            Self {
+                url,
+                requests,
+                handle,
+            }
+        }
+
         fn respond_with(responses: Vec<Value>) -> Self {
             let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock indexer");
             let url = format!("http://{}", listener.local_addr().unwrap());

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -111,7 +111,6 @@ pub struct ZolanaClient<R> {
     cu_limit: u32,
     cu_price_micro_lamports: Option<u64>,
     indexer_config: IndexerRpcConfig,
-    send_config: Option<RpcSendTransactionConfig>,
 }
 
 impl<R> ZolanaClient<R> {
@@ -135,7 +134,6 @@ impl<R> ZolanaClient<R> {
             cu_limit: DEFAULT_TRANSACT_CU_LIMIT,
             cu_price_micro_lamports: None,
             indexer_config: IndexerRpcConfig::default(),
-            send_config: None,
         }
     }
 
@@ -182,7 +180,6 @@ impl<R> ZolanaClient<R> {
             cu_limit: DEFAULT_TRANSACT_CU_LIMIT,
             cu_price_micro_lamports: None,
             indexer_config: IndexerRpcConfig::default(),
-            send_config: None,
         }
     }
 
@@ -203,11 +200,6 @@ impl<R> ZolanaClient<R> {
 
     pub fn with_indexer_config(mut self, config: IndexerRpcConfig) -> Self {
         self.indexer_config = config;
-        self
-    }
-
-    pub fn with_send_transaction_config(mut self, config: RpcSendTransactionConfig) -> Self {
-        self.send_config = Some(config);
         self
     }
 
@@ -397,32 +389,6 @@ impl<R: Rpc> ZolanaClient<R> {
     ) -> Result<(), ClientError> {
         wait_for_rpc_confirmation(self.rpc(), signature, self.indexer_config.poll)?;
         wait_for_indexed_transaction(self.blocking_indexer(), signature, self.indexer_config.poll)
-    }
-
-    /// Submit a signed private transaction and return as soon as the RPC
-    /// accepts it.
-    ///
-    /// Pair with [`Self::confirm_private_transaction_sync`], which waits for the
-    /// chain and then the indexer. `Rpc::send_transaction` confirms too, so the
-    /// two together waited for the same signature twice.
-    ///
-    /// Preflight is skipped: simulation re-executes a transaction whose inputs
-    /// are proofs the indexer just served, and a failure it would catch is one
-    /// this client cannot fix by retrying. The cost of being wrong is a landed
-    /// transaction that fails on chain, so callers submitting unvalidated
-    /// transactions should keep using `send_transaction`.
-    pub fn submit_private_transaction_sync(
-        &self,
-        transaction: &SolanaTransaction,
-    ) -> Result<Signature, ClientError> {
-        let _t = crate::timing::Phase::start("submit_private", 0);
-        // Honours `with_send_transaction_config`, which until now set a field
-        // nothing read.
-        let config = self.send_config.unwrap_or(RpcSendTransactionConfig {
-            skip_preflight: true,
-            ..RpcSendTransactionConfig::default()
-        });
-        self.rpc().send_transaction_with_config(transaction, config)
     }
 }
 
@@ -1961,7 +1927,6 @@ mod tests {
         signature: Signature,
         view_tags: Vec<[u8; 32]>,
         sent: Arc<Mutex<Vec<SolanaTransaction>>>,
-        sent_configs: Arc<Mutex<Vec<RpcSendTransactionConfig>>>,
     }
 
     impl MockSubmitRpc {
@@ -1970,7 +1935,6 @@ mod tests {
                 signature,
                 view_tags: Vec::new(),
                 sent: Arc::new(Mutex::new(Vec::new())),
-                sent_configs: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
@@ -2000,10 +1964,9 @@ mod tests {
         fn send_transaction_with_config(
             &self,
             transaction: &SolanaTransaction,
-            config: RpcSendTransactionConfig,
+            _config: RpcSendTransactionConfig,
         ) -> Result<Signature, ClientError> {
             self.sent.lock().unwrap().push(transaction.clone());
-            self.sent_configs.lock().unwrap().push(config);
             Ok(self.signature)
         }
 
@@ -2031,56 +1994,6 @@ mod tests {
         ) -> Result<Vec<[u8; 32]>, ClientError> {
             Ok(self.view_tags.clone())
         }
-    }
-
-    fn submit_client(rpc: MockSubmitRpc) -> ZolanaClient<MockSubmitRpc> {
-        ZolanaClient::new(
-            rpc,
-            ZolanaIndexer::new("http://unused.invalid"),
-            ProverClient::new("http://unused.invalid".to_string()),
-            AsyncZolanaIndexer::new("http://unused.invalid"),
-            AsyncProverClient::new("http://unused.invalid".to_string()),
-            Address::new_from_array([8u8; 32]),
-        )
-    }
-
-    /// `confirm_private_transaction_sync` already waits for the chain, so the
-    /// submit half must not: together they waited for one signature twice.
-    /// Preflight is skipped for the same round-trip reason.
-    #[test]
-    fn submit_private_skips_preflight() {
-        let rpc = MockSubmitRpc::new(Signature::from([3u8; 64]));
-        let configs = rpc.sent_configs.clone();
-        let client = submit_client(rpc);
-
-        client
-            .submit_private_transaction_sync(&SolanaTransaction::default())
-            .expect("submit");
-
-        let recorded = configs.lock().unwrap();
-        assert_eq!(recorded.len(), 1);
-        assert!(recorded[0].skip_preflight);
-    }
-
-    /// `with_send_transaction_config` set a field nothing read until this path
-    /// existed; a caller that asks for preflight must get it.
-    #[test]
-    fn submit_private_honours_a_configured_send_config() {
-        let rpc = MockSubmitRpc::new(Signature::from([3u8; 64]));
-        let configs = rpc.sent_configs.clone();
-        let client = submit_client(rpc).with_send_transaction_config(RpcSendTransactionConfig {
-            skip_preflight: false,
-            max_retries: Some(7),
-            ..RpcSendTransactionConfig::default()
-        });
-
-        client
-            .submit_private_transaction_sync(&SolanaTransaction::default())
-            .expect("submit");
-
-        let recorded = configs.lock().unwrap();
-        assert!(!recorded[0].skip_preflight);
-        assert_eq!(recorded[0].max_retries, Some(7));
     }
 
     fn merkle_response(tree: Address, leaf: [u8; 32]) -> Value {

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -30,7 +30,15 @@ use crate::{
 };
 
 const MERKLE_PROOF_POLL_TIMEOUT: Duration = Duration::from_secs(60);
-const MERKLE_PROOF_POLL_INTERVAL: Duration = Duration::from_millis(500);
+/// First wait after an incomplete answer.
+///
+/// A transfer spends a note the indexer has only just written, so the first
+/// attempt often lands a few milliseconds early and this sleep is on the
+/// critical path of every transfer. A flat 500ms charged the tail's wait to
+/// every caller; starting short and backing off keeps the 60s ceiling for an
+/// indexer that is genuinely behind.
+const MERKLE_PROOF_POLL_START: Duration = Duration::from_millis(25);
+const MERKLE_PROOF_POLL_MAX: Duration = Duration::from_millis(500);
 
 const JSON_RPC_METHOD_NOT_FOUND: i64 = -32601;
 const JSON_RPC_INTERNAL_ERROR: i64 = -32603;
@@ -357,6 +365,7 @@ impl Rpc for ZolanaIndexer {
         let expected = leaves.len();
         let started = Instant::now();
         let mut last_error = None;
+        let mut wait = MERKLE_PROOF_POLL_START;
         loop {
             match single() {
                 Ok(response) if response.proofs.len() >= expected => return Ok(response),
@@ -370,7 +379,8 @@ impl Rpc for ZolanaIndexer {
                     ))
                 }));
             }
-            sleep(MERKLE_PROOF_POLL_INTERVAL);
+            sleep(wait);
+            wait = (wait * 2).min(MERKLE_PROOF_POLL_MAX);
         }
     }
 

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -336,11 +336,14 @@ impl Rpc for ZolanaIndexer {
         config: Option<IndexerRpcConfig>,
     ) -> Result<GetMerkleProofsResponse, ClientError> {
         let single = || {
-            self.api
-                .get_merkle_proofs(
+            let response = {
+                let _t = crate::timing::Phase::start("merkle_http", 0);
+                self.api.get_merkle_proofs(
                     encode_pubkey(tree_account),
                     leaves.iter().copied().map(encode_hash).collect(),
                 )
+            };
+            response
                 .map_err(indexer_error)
                 .map(|response| GetMerkleProofsResponse {
                     context: convert_context(response.context),

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -55,6 +55,9 @@ pub use rpc::{
 };
 #[cfg(feature = "solana-rpc")]
 pub use solana_rpc::{AsyncSolanaRpc, ConfirmedInstructionGroups, SolanaRpc};
+// `SolanaRpc::send_transaction_with_config` is public but names this type,
+// so callers outside the crate need it to call the method at all.
+pub use solana_rpc_client_api::config::RpcSendTransactionConfig;
 pub use zolana_transaction::{
     instructions::{
         merge::{Merge, PreparedMerge, MERGE_INPUTS},

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -5,6 +5,10 @@
 //! Wallet state, syncing, transaction-building actions, and the user registry
 //! live in the `zolana-wallet` crate, which builds on this one.
 //!
+//! `ZOLANA_TIMING=1` prints per-phase timings to stderr; see [`timing`]. The
+//! `let _t = Phase::start(..)` guards through this crate are that, timing until
+//! they drop, and inert otherwise.
+//!
 //! Feature flags:
 //! - `(none)`: prover client + RPC traits
 //! - `indexer-api`: Photon indexer adapter and [`ZolanaClient`]

--- a/sdk-libs/client/src/solana_rpc.rs
+++ b/sdk-libs/client/src/solana_rpc.rs
@@ -526,12 +526,11 @@ impl Rpc for SolanaRpc {
         transaction: &Transaction,
         config: solana_rpc_client_api::config::RpcSendTransactionConfig,
     ) -> Result<Signature, ClientError> {
+        // Sends and returns; it does not confirm. `send_transaction` is the
+        // send-and-confirm one. The two were the same call, so a caller asking
+        // for a config also bought a confirmation wait it never requested.
         self.client
-            .send_and_confirm_transaction_with_spinner_and_config(
-                transaction,
-                CommitmentConfig::confirmed(),
-                config,
-            )
+            .send_transaction_with_config(transaction, config)
             .map_err(|source| ClientError::SolanaRpcTransaction {
                 operation: "send_transaction_with_config",
                 source,
@@ -670,12 +669,10 @@ impl AsyncRpc for AsyncSolanaRpc {
         transaction: &Transaction,
         config: solana_rpc_client_api::config::RpcSendTransactionConfig,
     ) -> Result<Signature, ClientError> {
+        // Sends and returns, matching the blocking path: `send_transaction` is
+        // the send-and-confirm one.
         self.client
-            .send_and_confirm_transaction_with_config(
-                transaction,
-                CommitmentConfig::confirmed(),
-                config,
-            )
+            .send_transaction_with_config(transaction, config)
             .await
             .map_err(|source| ClientError::SolanaRpcTransaction {
                 operation: "send_transaction_with_config",

--- a/services/photon/src/api/root_index_cache.rs
+++ b/services/photon/src/api/root_index_cache.rs
@@ -15,14 +15,30 @@
 //!
 //! Held per process. Only the API serves proofs, and a cache that belongs to
 //! the process reading it needs no coordination with the indexer.
+//!
+//! Refreshed ahead of the request, not on it. A miss is not the rare case it
+//! reads as: every transfer appends a root, so the next transfer's proof asks
+//! for a root the ring does not have yet, and the fetch landed on the critical
+//! path of essentially every transfer -- 721ms of a 2971ms devnet transfer, with
+//! the task at 0.06% CPU and the database at 0.26 ReadIOPS, because the time was
+//! spent waiting on the upstream RPC rather than working.
+//!
+//! [`RootIndexCache::refresh_loop`] watches the indexed root's sequence number in
+//! Postgres, which is cheap, and fetches the 1.2 MB account only when that number
+//! moves. The on-miss fetch stays as the fallback: a request that arrives between
+//! a tree update and the next refresh must still be answerable, and only the
+//! common case is being moved, not the contract.
 
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 use solana_pubkey::Pubkey;
 
 use crate::api::error::PhotonApiError;
+use crate::common::rings_tree::RingsTreeKind;
+use crate::dao::generated::{state_trees, tree_metadata};
 use crate::monitor::tree_metadata_sync::rings_utxo_root_history;
 use crate::rpc::RpcClient;
 
@@ -30,6 +46,11 @@ use crate::rpc::RpcClient;
 /// indexes a new root slightly before the next refresh -- but repeated misses
 /// for a root that is not on chain must not become a 1.2 MB fetch per request.
 const MIN_REFRESH_INTERVAL: Duration = Duration::from_millis(500);
+
+/// How often the refresher asks Postgres whether the tree moved. This is a
+/// single-row primary-key read, not the account fetch, so it can be far shorter
+/// than [`MIN_REFRESH_INTERVAL`].
+const CHANGE_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 #[derive(Default)]
 struct TreeRoots {
@@ -109,6 +130,51 @@ impl RootIndexCache {
         ))
     }
 
+    /// Keep every known state tree's ring current, so `index_for` answers from
+    /// memory.
+    ///
+    /// Change detection is the point: refreshing on a timer would fetch 1.2 MB
+    /// per tree per tick whether or not anything moved, and refreshing on a
+    /// request puts that fetch in front of the caller. The indexed root's
+    /// sequence number moves exactly when the tree does, and reading it is a
+    /// primary-key lookup.
+    pub async fn refresh_loop(&self, db: &DatabaseConnection, rpc_client: &RpcClient) {
+        let mut seen: HashMap<Pubkey, Option<i64>> = HashMap::new();
+        loop {
+            match known_state_trees(db).await {
+                Ok(trees) => {
+                    for tree in trees {
+                        let seq = match root_sequence(db, tree).await {
+                            Ok(seq) => seq,
+                            Err(error) => {
+                                log::warn!(
+                                    "root index refresher: reading {tree} sequence: {error}"
+                                );
+                                continue;
+                            }
+                        };
+                        // First sight of a tree refreshes it; after that only a
+                        // moved sequence does.
+                        if seen.get(&tree).is_some_and(|last| *last == seq) {
+                            continue;
+                        }
+                        match self.refresh(rpc_client, tree).await {
+                            Ok(()) => {
+                                seen.insert(tree, seq);
+                            }
+                            // Leave `seen` alone so the next tick tries again.
+                            Err(error) => {
+                                log::warn!("root index refresher: refreshing {tree}: {error}")
+                            }
+                        }
+                    }
+                }
+                Err(error) => log::warn!("root index refresher: listing trees: {error}"),
+            }
+            tokio::time::sleep(CHANGE_POLL_INTERVAL).await;
+        }
+    }
+
     async fn refresh(&self, rpc_client: &RpcClient, tree: Pubkey) -> Result<(), PhotonApiError> {
         let account = rpc_client.get_account(&tree).await.map_err(|error| {
             PhotonApiError::UnexpectedError(format!("Failed to fetch tree {tree}: {error}"))
@@ -134,6 +200,44 @@ impl RootIndexCache {
         );
         Ok(())
     }
+}
+
+/// State trees the indexer knows about. The refresher covers every one rather
+/// than only the trees already asked for, so the first proof after a restart
+/// does not pay the fetch.
+async fn known_state_trees(db: &DatabaseConnection) -> Result<Vec<Pubkey>, PhotonApiError> {
+    let rows = tree_metadata::Entity::find()
+        .all(db)
+        .await
+        .map_err(|error| PhotonApiError::UnexpectedError(error.to_string()))?;
+    rows.into_iter()
+        .map(|row| {
+            <[u8; 32]>::try_from(row.tree_pubkey.as_slice())
+                .map(Pubkey::new_from_array)
+                .map_err(|_| {
+                    PhotonApiError::UnexpectedError("tree_metadata pubkey is not 32 bytes".into())
+                })
+        })
+        .collect()
+}
+
+/// Sequence number the indexer stamped on the tree's root node, which advances
+/// exactly when the tree does.
+async fn root_sequence(
+    db: &DatabaseConnection,
+    tree: Pubkey,
+) -> Result<Option<i64>, PhotonApiError> {
+    let root = state_trees::Entity::find()
+        .filter(
+            state_trees::Column::Tree
+                .eq(tree.to_bytes().to_vec())
+                .and(state_trees::Column::TreeKind.eq(i32::from(RingsTreeKind::State)))
+                .and(state_trees::Column::NodeIdx.eq(1)),
+        )
+        .one(db)
+        .await
+        .map_err(|error| PhotonApiError::UnexpectedError(error.to_string()))?;
+    Ok(root.and_then(|node| node.seq))
 }
 
 #[cfg(test)]
@@ -166,6 +270,42 @@ mod tests {
         assert_eq!(cache.lookup(tree, &[155; 32]), None);
         assert_eq!(cache.lookup(tree, &[1; 32]), Some(155));
         assert_eq!(cache.lookup(tree, &[2; 32]), Some(41));
+    }
+
+    /// The point of refreshing ahead: a request for a root the refresher has
+    /// already brought in must not consult the RPC at all. `index_for` takes an
+    /// `RpcClient`, so the only honest way to assert "did not fetch" is that the
+    /// answer comes back from a cache whose refresh window is closed -- with a
+    /// stale window the on-miss path would fire instead.
+    #[tokio::test]
+    async fn a_root_the_refresher_brought_in_is_answered_without_the_rpc() {
+        let tree = Pubkey::new_from_array([7; 32]);
+        let cache = cache_with(tree, &[([9; 32], 12)], Some(Instant::now()));
+
+        // An unreachable endpoint: reaching for it at all is the failure.
+        let rpc = RpcClient::new("http://127.0.0.1:1".to_string());
+        assert_eq!(cache.index_for(&rpc, tree, [9; 32]).await.unwrap(), 12);
+    }
+
+    /// And the fallback still has to work: a request that arrives between a tree
+    /// update and the next refresh is answered, not failed.
+    #[tokio::test]
+    async fn a_root_the_refresher_has_not_reached_still_reaches_for_the_account() {
+        let tree = Pubkey::new_from_array([7; 32]);
+        let cache = cache_with(
+            tree,
+            &[([9; 32], 12)],
+            Instant::now().checked_sub(MIN_REFRESH_INTERVAL * 2),
+        );
+
+        let rpc = RpcClient::new("http://127.0.0.1:1".to_string());
+        // Unreachable, so this surfaces the fetch as an error rather than a
+        // StaleRoot -- which is the proof that the fetch was attempted.
+        let error = cache.index_for(&rpc, tree, [4; 32]).await.unwrap_err();
+        assert!(
+            matches!(error, PhotonApiError::UnexpectedError(_)),
+            "expected the on-miss fetch to be attempted, got {error:?}"
+        );
     }
 
     #[test]

--- a/services/photon/src/api/root_index_cache.rs
+++ b/services/photon/src/api/root_index_cache.rs
@@ -10,8 +10,9 @@
 //! The tree account is authoritative and holds the whole 200-slot ring, so the
 //! answer is a lookup rather than a count. The account is ~1.2 MB, far too
 //! large to fetch per request, and one fetch brings back every root in the
-//! window -- so it is cached, refreshed on a miss, and rate limited so a root
-//! the chain genuinely does not have cannot turn into a fetch per request.
+//! window -- so it is cached, refreshed on a miss, and that on-miss fetch is
+//! rate limited so a root the chain genuinely does not have cannot turn into a
+//! fetch per request.
 //!
 //! Held per process. Only the API serves proofs, and a cache that belongs to
 //! the process reading it needs no coordination with the indexer.
@@ -27,7 +28,10 @@
 //! Postgres, which is cheap, and fetches the 1.2 MB account only when that number
 //! moves. The on-miss fetch stays as the fallback: a request that arrives between
 //! a tree update and the next refresh must still be answerable, and only the
-//! common case is being moved, not the contract.
+//! common case is being moved, not the contract. The refresher's own fetches
+//! therefore do not count against the on-miss floor: they fire whenever the tree
+//! moves, so letting them close that window would starve the fallback on exactly
+//! the busy tree that needs it.
 
 use std::collections::HashMap;
 use std::sync::RwLock;
@@ -55,7 +59,18 @@ const CHANGE_POLL_INTERVAL: Duration = Duration::from_millis(200);
 #[derive(Default)]
 struct TreeRoots {
     indices: HashMap<[u8; 32], u16>,
-    refreshed: Option<Instant>,
+    /// When the on-demand path last fetched this account, and nothing else. The
+    /// floor is there to stop a caller turning a root the chain does not have
+    /// into a fetch per request; the refresher is already gated on the sequence
+    /// moving, so its fetches must not stamp this.
+    fetched_on_miss: Option<Instant>,
+}
+
+/// Which path is bringing roots in. Only the on-demand one is throttled.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Fetch {
+    OnMiss,
+    Refresher,
 }
 
 #[derive(Default)]
@@ -82,7 +97,7 @@ impl RootIndexCache {
                         .into_iter()
                         .map(|(index, root)| (root, index))
                         .collect(),
-                    refreshed: Some(Instant::now()),
+                    fetched_on_miss: Some(Instant::now()),
                 },
             );
         }
@@ -104,7 +119,7 @@ impl RootIndexCache {
             return Err(self.missing(tree));
         }
 
-        self.refresh(rpc_client, tree).await?;
+        self.refresh(rpc_client, tree, Fetch::OnMiss).await?;
         self.lookup(tree, &root).ok_or_else(|| self.missing(tree))
     }
 
@@ -119,7 +134,7 @@ impl RootIndexCache {
         };
         trees
             .get(&tree)
-            .and_then(|roots| roots.refreshed)
+            .and_then(|roots| roots.fetched_on_miss)
             .is_none_or(|at| at.elapsed() >= MIN_REFRESH_INTERVAL)
     }
 
@@ -158,7 +173,7 @@ impl RootIndexCache {
                         if seen.get(&tree).is_some_and(|last| *last == seq) {
                             continue;
                         }
-                        match self.refresh(rpc_client, tree).await {
+                        match self.refresh(rpc_client, tree, Fetch::Refresher).await {
                             Ok(()) => {
                                 seen.insert(tree, seq);
                             }
@@ -175,7 +190,12 @@ impl RootIndexCache {
         }
     }
 
-    async fn refresh(&self, rpc_client: &RpcClient, tree: Pubkey) -> Result<(), PhotonApiError> {
+    async fn refresh(
+        &self,
+        rpc_client: &RpcClient,
+        tree: Pubkey,
+        fetch: Fetch,
+    ) -> Result<(), PhotonApiError> {
         let account = rpc_client.get_account(&tree).await.map_err(|error| {
             PhotonApiError::UnexpectedError(format!("Failed to fetch tree {tree}: {error}"))
         })?;
@@ -183,21 +203,28 @@ impl RootIndexCache {
             PhotonApiError::UnexpectedError(format!("Account {tree} is not a Rings tree"))
         })?;
 
+        self.store(tree, history, fetch)
+    }
+
+    fn store(
+        &self,
+        tree: Pubkey,
+        history: impl IntoIterator<Item = (u16, [u8; 32])>,
+        fetch: Fetch,
+    ) -> Result<(), PhotonApiError> {
         let mut trees = self.trees.write().map_err(|_| {
             PhotonApiError::UnexpectedError("Root index cache is poisoned".to_string())
         })?;
+        let entry = trees.entry(tree).or_default();
         // Replaced wholesale: a root evicted from the ring must stop resolving,
         // or its stale index outlives the root it described.
-        trees.insert(
-            tree,
-            TreeRoots {
-                indices: history
-                    .into_iter()
-                    .map(|(index, root)| (root, index))
-                    .collect(),
-                refreshed: Some(Instant::now()),
-            },
-        );
+        entry.indices = history
+            .into_iter()
+            .map(|(index, root)| (root, index))
+            .collect();
+        if fetch == Fetch::OnMiss {
+            entry.fetched_on_miss = Some(Instant::now());
+        }
         Ok(())
     }
 }
@@ -247,14 +274,14 @@ mod tests {
     fn cache_with(
         tree: Pubkey,
         entries: &[([u8; 32], u16)],
-        refreshed: Option<Instant>,
+        fetched_on_miss: Option<Instant>,
     ) -> RootIndexCache {
         let cache = RootIndexCache::new();
         cache.trees.write().unwrap().insert(
             tree,
             TreeRoots {
                 indices: entries.iter().copied().collect(),
-                refreshed,
+                fetched_on_miss,
             },
         );
         cache
@@ -305,6 +332,38 @@ mod tests {
         assert!(
             matches!(error, PhotonApiError::UnexpectedError(_)),
             "expected the on-miss fetch to be attempted, got {error:?}"
+        );
+    }
+
+    /// The regression this pairs with: the refresher fetches whenever the tree
+    /// moves, so if its fetches stamped the on-miss floor, every append would
+    /// hold that window shut and the fallback would never fire. A miss right
+    /// after a refresher pass -- a root indexed between the pass and the request
+    /// -- then failed as StaleRoot instead of being fetched, which is a hard
+    /// error on a chain that is merely busy.
+    ///
+    /// Driven through `store`, so it is the code both fetch paths share that is
+    /// under test rather than a hand-built cache.
+    #[test]
+    fn the_refreshers_fetches_do_not_close_the_on_miss_window() {
+        let tree = Pubkey::new_from_array([7; 32]);
+        let cache = RootIndexCache::new();
+
+        cache
+            .store(tree, [(12u16, [9u8; 32])], Fetch::Refresher)
+            .expect("store");
+        assert_eq!(cache.lookup(tree, &[9; 32]), Some(12), "roots are cached");
+        assert!(
+            cache.due_for_refresh(tree),
+            "a miss must still be able to reach for the account"
+        );
+
+        cache
+            .store(tree, [(12u16, [9u8; 32])], Fetch::OnMiss)
+            .expect("store");
+        assert!(
+            !cache.due_for_refresh(tree),
+            "and an on-demand fetch still closes it"
         );
     }
 

--- a/services/photon/src/api/service.rs
+++ b/services/photon/src/api/service.rs
@@ -33,7 +33,7 @@ use super::{
 pub struct PhotonApi {
     db_conn: Arc<DatabaseConnection>,
     rpc_client: Arc<RpcClient>,
-    root_index_cache: RootIndexCache,
+    root_index_cache: Arc<RootIndexCache>,
 }
 
 pub struct OpenApiSpec {
@@ -60,8 +60,21 @@ impl PhotonApi {
         Self {
             db_conn,
             rpc_client,
-            root_index_cache: RootIndexCache::new(),
+            root_index_cache: Arc::new(RootIndexCache::new()),
         }
+    }
+
+    /// Start the task that keeps the root-index ring current.
+    ///
+    /// Without it the ring is only refreshed when a request misses, which is
+    /// every transfer, and that fetch is then the largest single cost of a
+    /// transfer. Callers that only serve reads of other methods can skip it; the
+    /// on-miss path still answers correctly, just slowly.
+    pub fn spawn_root_index_refresher(&self) -> tokio::task::JoinHandle<()> {
+        let cache = Arc::clone(&self.root_index_cache);
+        let db = Arc::clone(&self.db_conn);
+        let rpc_client = Arc::clone(&self.rpc_client);
+        tokio::spawn(async move { cache.refresh_loop(db.as_ref(), rpc_client.as_ref()).await })
     }
 
     pub async fn liveness(&self) -> Result<(), PhotonApiError> {

--- a/services/photon/src/main.rs
+++ b/services/photon/src/main.rs
@@ -122,6 +122,9 @@ async fn start_api_server(
     max_http_connections: u32,
 ) -> Result<ServerHandle> {
     let api = PhotonApi::new(db, rpc_client);
+    // Before the server accepts anything, so the first proof request finds a
+    // populated ring rather than paying for it.
+    api.spawn_root_index_refresher();
     api::rpc_server::run_server(api, api_port, max_http_connections)
         .await
         .context("Failed to start API server")

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -31,7 +31,7 @@ use solana_keypair::Keypair;
 use solana_signer::Signer;
 // `Rpc` is in scope for send_transaction, which is a trait method rather than
 // an inherent one on SolanaRpc.
-use zolana_client::{Rpc, SolanaRpc, ZolanaClient};
+use zolana_client::{SolanaRpc, ZolanaClient};
 use zolana_keypair::ShieldedKeypair;
 use zolana_transaction::{Address, AssetRegistry, LocalWalletAuthority, Wallet};
 use zolana_wallet::{
@@ -496,7 +496,7 @@ fn worker(
         timing.prove_ms = mark.elapsed().as_millis() as u64;
 
         let mark = Instant::now();
-        let signature = match client.rpc().send_transaction(&transfer) {
+        let signature = match client.submit_private_transaction_sync(&transfer) {
             Ok(signature) => signature,
             Err(error) => {
                 classify(&error.to_string(), stats, &mut backoff);

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -6,7 +6,10 @@
 //! rather than the protocol doing work. This drives the SDK in-process, holds a
 //! wallet across iterations, and records where the time actually goes.
 //!
-//! The phase breakdown is the point. "Transfers per second" alone cannot tell you
+//! The phase breakdown is the point. This crate times the outer phases itself;
+//! `ZOLANA_TIMING=1` adds the client's finer ones (HTTP versus indexer polling,
+//! each proof fetch) to stderr, which is how a phase gets attributed to a
+//! specific call rather than to "the indexer". "Transfers per second" alone cannot tell you
 //! whether you are bound by proving, by the indexer, or by your own client, and
 //! those have completely different fixes.
 //!

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -83,6 +83,10 @@ pub struct Options {
     pub asset: String,
     /// Where to write the machine-readable summary, if anywhere.
     pub json_out: Option<PathBuf>,
+    /// Concurrent senders. Fewer than the keypair count measures what one user
+    /// waits for, without the generator contending with itself; the remaining
+    /// wallets stay recipients.
+    pub workers: Option<usize>,
 }
 
 impl Options {
@@ -93,6 +97,7 @@ impl Options {
         let mut tree = None;
         let mut keypairs = None;
         let mut json_out = None;
+        let mut workers: Option<usize> = None;
         let mut duration = 300u64;
         let mut amount = 200_000u64;
         let mut asset = "SOL".to_string();
@@ -110,6 +115,7 @@ impl Options {
                 "--amount" => amount = value()?.parse().context("--amount")?,
                 "--asset" => asset = value()?,
                 "--json" => json_out = Some(PathBuf::from(value()?)),
+                "--workers" => workers = Some(value()?.parse().context("--workers")?),
                 other => bail!("unknown flag {other}"),
             }
         }
@@ -121,6 +127,7 @@ impl Options {
             tree: tree.context("--tree is required")?,
             keypairs: keypairs.context("--keypairs <dir> is required")?,
             json_out,
+            workers,
             duration: Duration::from_secs(duration),
             amount,
             asset,
@@ -256,6 +263,16 @@ fn write_json(
 
 pub fn run(options: Options) -> Result<()> {
     let keypairs = load_keypairs(&options.keypairs)?;
+    // Every wallet is a possible recipient; only the first `workers` send. One
+    // sender measures what a single user waits for, which is a different
+    // question from how much the fleet sustains.
+    let senders = options
+        .workers
+        .unwrap_or(keypairs.len())
+        .min(keypairs.len());
+    if senders == 0 {
+        bail!("--workers must be at least 1");
+    }
     let workers = keypairs.len();
     let tree = Address::new_from_array(
         bs58::decode(&options.tree)
@@ -321,7 +338,7 @@ pub fn run(options: Options) -> Result<()> {
             });
         }
 
-        for (index, funding) in keypairs.iter().enumerate() {
+        for (index, funding) in keypairs.iter().enumerate().take(senders) {
             let peer = recipients[(index + 1) % workers];
             let options = &options;
             let stats = Arc::clone(&stats);

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -31,7 +31,7 @@ use solana_keypair::Keypair;
 use solana_signer::Signer;
 // `Rpc` is in scope for send_transaction, which is a trait method rather than
 // an inherent one on SolanaRpc.
-use zolana_client::{SolanaRpc, ZolanaClient};
+use zolana_client::{Rpc, RpcSendTransactionConfig, SolanaRpc, ZolanaClient};
 use zolana_keypair::ShieldedKeypair;
 use zolana_transaction::{Address, AssetRegistry, LocalWalletAuthority, Wallet};
 use zolana_wallet::{
@@ -513,7 +513,13 @@ fn worker(
         timing.prove_ms = mark.elapsed().as_millis() as u64;
 
         let mark = Instant::now();
-        let signature = match client.submit_private_transaction_sync(&transfer) {
+        let signature = match client.rpc().send_transaction_with_config(
+            &transfer,
+            RpcSendTransactionConfig {
+                skip_preflight: true,
+                ..RpcSendTransactionConfig::default()
+            },
+        ) {
             Ok(signature) => signature,
             Err(error) => {
                 classify(&error.to_string(), stats, &mut backoff);


### PR DESCRIPTION
Two places where the client waited on itself, found by profiling a transfer against devnet.

## Where a transfer's time goes

`ZOLANA_TIMING` on the deployed stack, p50 over ~110 transfers:

| span | before | owner |
|---|---|---|
| `finish_submission` | 1549ms | — |
| ├ `fetch_spend_proofs` | 774ms | indexer |
| ├ `prove_transfer` | 257ms | prover |
| `send` | 1032ms | RPC |
| `sync_wallet` | 505ms | indexer |
| `confirm` | 207ms | RPC + indexer |

Indexer 42%, RPC 32%, prover 8%. Worth stating plainly because the prover is the part everyone assumes: at 16 vCPU the proof is a quarter of a second, and a 4x hardware bump moved the total by 14%.

## Two fixes

**Spend proofs fetched serially.** The comment above them already said *"Two independent indexer round trips (317ms and 114ms on devnet) that ran back to back. Nothing links them"* — and `fetch_spend_proofs_async` has always used `try_join!`. Only the blocking path was sequential. It now uses `thread::scope`, the same thing its own caller does one level up.

**`send_transaction_with_config` did not send with config.** It called `send_and_confirm_transaction_with_spinner_and_config`, so asking to set a config also bought a confirmation wait. Every caller then paired it with `confirm_private_transaction_sync`, which confirms *again* — one signature, two waits. It now sends; `send_transaction` remains the send-and-confirm one. Nothing outside `client.rs` called it.

`submit_private_transaction_sync` is the pairing that follows, and it reads `send_config` — a field `with_send_transaction_config` has been setting that **nothing ever read**, so a caller who wants preflight can still ask for it.

## Result

Same wallets, same 4 vCPU prover, 180s runs:

| phase | before | after |
|---|---|---|
| send | 1032ms | **133ms** |
| confirm | 207ms | 820ms |
| `fetch_spend_proofs` | 774ms | 684ms |
| **total p50** | **3554ms** | **3229ms** |

The confirmation did not disappear — it moved to `confirm`, where it is paid once. The saving is the duplicate. Being honest about the size: parallelising the proof fetches bought only ~90ms, because the two calls are lopsided rather than equal.

## Test change

The mock indexer now dispatches by request path. Serving responses in position order described a client that fetched sequentially, and stops being true the moment two fetches race — the one test on that path was asserting a request order that is no longer defined, so it now asserts the racing pair as a set.

## Verification

`just check-all`, `just clippy`, `cargo fmt --check`, `cargo machete --skip-target-dir` clean. 55 client tests, 46 CLI tests. The new tests were confirmed to fail when `skip_preflight` is flipped.
