### PR TITLE
custom-ring: withdrawal rule per asset with approval

### DIFF
--- a/custom-rings/cli/src/config.rs
+++ b/custom-rings/cli/src/config.rs
@@ -36,8 +36,14 @@ pub struct RingConfig {
 pub struct PolicyConfig {
     /// Mints the ring accepts, `SOL` for native SOL. Absent: any asset.
     pub allowed_assets: Option<Vec<String>>,
-    /// `open` or `blocked`. Absent: open.
+    /// Withdrawal rule for assets without their own entry: `open`, `blocked`
+    /// or `approval`. Absent: open.
     pub withdrawals: Option<String>,
+    /// Per-asset withdrawal rule, mint to `open` / `blocked` / `approval`.
+    #[serde(default)]
+    pub asset_withdrawals: BTreeMap<String, String>,
+    /// The key that approves withdrawals under an `approval` rule.
+    pub approver: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -126,6 +132,10 @@ anonymous = false
 [policy]
 allowed_assets = ["SOL", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"]
 withdrawals = "blocked"
+approver = "2GNuM5ksdfNxGNbwf2hrnND9FHgQsdju7vz8CyGd7Zjy"
+
+[policy.asset_withdrawals]
+SOL = "approval"
 "#;
 
     #[test]
@@ -142,6 +152,14 @@ withdrawals = "blocked"
             Some(2)
         );
         assert_eq!(config.policy.withdrawals.as_deref(), Some("blocked"));
+        assert_eq!(
+            config
+                .policy
+                .asset_withdrawals
+                .get("SOL")
+                .map(String::as_str),
+            Some("approval")
+        );
     }
 
     #[test]

--- a/custom-rings/cli/src/config.rs
+++ b/custom-rings/cli/src/config.rs
@@ -22,11 +22,11 @@ pub struct RingConfig {
     /// Deploy upgrade authority and ring authority. `~` expands to `$HOME`.
     pub authority_keypair: PathBuf,
     pub urls: Urls,
-    /// Feature id to enabled. Ids come from the wizard's registry; the config
-    /// carries them as data so a new feature needs no code here.
+    /// Feature id to enabled. Ids come from the wizard's registry, and the
+    /// config carries them as data so a new feature needs no code here.
     #[serde(default)]
     pub features: BTreeMap<String, bool>,
-    /// What the enabled features enforce on chain; `init` writes it.
+    /// What the enabled features enforce on chain. `init` writes it.
     #[serde(default)]
     pub policy: PolicyConfig,
 }
@@ -34,10 +34,10 @@ pub struct RingConfig {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PolicyConfig {
-    /// Mints the ring accepts, `SOL` for native SOL. Absent: any asset.
+    /// Mints the ring accepts, `SOL` for native SOL. Absent means any asset.
     pub allowed_assets: Option<Vec<String>>,
-    /// Withdrawal rule for assets without their own entry: `open`, `blocked`
-    /// or `approval`. Absent: open.
+    /// Withdrawal rule for assets without their own entry, `open`, `blocked`
+    /// or `approval`. Absent means open.
     pub withdrawals: Option<String>,
     /// Per-asset withdrawal rule, mint to `open` / `blocked` / `approval`.
     #[serde(default)]
@@ -88,7 +88,7 @@ impl RingConfig {
     }
 }
 
-/// `Address` deserializes from bytes by default; the file carries base58.
+/// `Address` deserializes from bytes by default and the file carries base58.
 mod base58_address {
     use serde::{Deserialize, Deserializer};
     use solana_address::Address;

--- a/custom-rings/cli/src/deploy.rs
+++ b/custom-rings/cli/src/deploy.rs
@@ -14,7 +14,7 @@ pub struct Deploy<'a> {
     pub rpc_url: &'a str,
     pub authority_keypair: &'a Path,
     pub authority: Address,
-    /// Needed for the first deploy only; an upgrade names the program by id.
+    /// Needed for the first deploy only. An upgrade names the program by id.
     pub program_keypair: &'a Path,
     pub program_so: &'a Path,
 }
@@ -28,7 +28,7 @@ pub enum DeployOutcome {
     Upgraded,
 }
 
-/// The loader-v3 `ProgramData` of a deployed program: who may upgrade it and
+/// The loader-v3 `ProgramData` of a deployed program, who may upgrade it and
 /// how many bytecode bytes it can hold.
 pub struct ProgramDataInfo {
     pub upgrade_authority: Option<Address>,
@@ -103,7 +103,7 @@ impl Deploy<'_> {
         })
     }
 
-    /// Grows `ProgramData` so a larger binary fits; the loader refuses an
+    /// Grows `ProgramData` so a larger binary fits. The loader refuses an
     /// upgrade that does not.
     fn extend(&self, program_id: Address, additional_bytes: usize) -> Result<()> {
         println!("extending program data by {additional_bytes} bytes");

--- a/custom-rings/cli/src/init.rs
+++ b/custom-rings/cli/src/init.rs
@@ -17,7 +17,7 @@ pub struct InitOutcome {
     pub ring_registered: bool,
 }
 
-/// Idempotent: each step is skipped when its account already exists, so a rerun
+/// Idempotent. Each step is skipped when its account already exists, so a rerun
 /// after a partial failure finishes the job.
 pub fn init(
     rpc: &SolanaRpc,
@@ -72,7 +72,7 @@ fn read_pod<R: Rpc, T: bytemuck::Pod>(rpc: &R, address: Address, label: &str) ->
         .map_err(|_| anyhow!("{label} account has an unexpected layout"))
 }
 
-/// Name the two failures an operator can act on; everything else passes through.
+/// Name the two failures an operator can act on. Everything else passes through.
 fn explain(error: ClientError, step: &str) -> anyhow::Error {
     let hint = match custom_error_code(&error) {
         Some(code) if code == CustomRingError::UnauthorizedInitializer as u32 => {

--- a/custom-rings/cli/src/lib.rs
+++ b/custom-rings/cli/src/lib.rs
@@ -66,7 +66,7 @@ pub enum Command {
     Transact(TransactArgs),
     /// Confirm the ring RPC in `ring.toml` is up and holds this ring's auditor key.
     RpcCheck,
-    /// Approve one proven transact by its `private_tx_hash`.
+    /// Approve one proven transact by its `private_tx_hash`, or revoke it.
     Approve(ApproveArgs),
     /// Transfer or renounce the program's upgrade authority.
     #[command(subcommand)]
@@ -167,6 +167,9 @@ pub struct ApproveArgs {
     /// The approver, default the authority.
     #[arg(long, value_name = "KEYPAIR")]
     pub approver_keypair: Option<PathBuf>,
+    /// Take an unspent approval back instead; its rent returns to the approver.
+    #[arg(long)]
+    pub revoke: bool,
 }
 
 pub fn main() -> Result<()> {
@@ -284,7 +287,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 PolicyCommand::Set(args) => {
                     let mut wanted = policy::read_policy(&rpc)?;
                     if args.any_asset {
-                        wanted.allowlist = false;
+                        wanted.asset_policy = custom_ring_sdk::AssetPolicy::Any;
                     } else if !args.allow_assets.is_empty() {
                         let mints = args
                             .allow_assets
@@ -298,7 +301,7 @@ pub fn run(cli: Cli) -> Result<()> {
                                 mint,
                             })
                             .collect();
-                        wanted.allowlist = true;
+                        wanted.asset_policy = custom_ring_sdk::AssetPolicy::Allowlist;
                     }
                     if let Some(withdrawals) = args.withdrawals.as_deref() {
                         wanted.withdrawals = policy::parse_rule(withdrawals)?;
@@ -346,16 +349,26 @@ pub fn run(cli: Cli) -> Result<()> {
             let private_tx_hash: [u8; 32] = hex::decode(args.private_tx_hash.trim())?
                 .try_into()
                 .map_err(|_| anyhow!("private_tx_hash must be 32 bytes of hex"))?;
-            let ix = custom_ring_sdk::ApproveTransact {
-                approver: approver.pubkey(),
-                payer: approver.pubkey(),
-                private_tx_hash,
-            }
-            .instruction();
+            let ix = if args.revoke {
+                custom_ring_sdk::RevokeApproval {
+                    approver: approver.pubkey(),
+                    rent_recipient: approver.pubkey(),
+                    private_tx_hash,
+                }
+                .instruction()
+            } else {
+                custom_ring_sdk::ApproveTransact {
+                    approver: approver.pubkey(),
+                    payer: approver.pubkey(),
+                    private_tx_hash,
+                }
+                .instruction()
+            };
             let signature =
                 rpc.create_and_send_transaction(&[ix], approver.pubkey(), &[&approver])?;
             println!(
-                "approved    {} at {signature}",
+                "{}    {} at {signature}",
+                if args.revoke { "revoked " } else { "approved" },
                 custom_ring_sdk::approval_pda(&private_tx_hash)
             );
             Ok(())

--- a/custom-rings/cli/src/lib.rs
+++ b/custom-rings/cli/src/lib.rs
@@ -83,10 +83,10 @@ pub enum PolicyCommand {
     Set(PolicySetArgs),
 }
 
-/// Each flag changes one part of the on-chain policy; parts not named stay.
+/// Each flag changes one part of the on-chain policy. Parts not named stay.
 #[derive(Debug, Args)]
 pub struct PolicySetArgs {
-    /// Replace the allowlist with these mints, repeatable; `SOL` for native SOL.
+    /// Replace the allowlist with these mints, repeatable, `SOL` for native SOL.
     /// Listed mints keep their withdrawal rule when they had one.
     #[arg(
         long = "allow-asset",
@@ -97,7 +97,7 @@ pub struct PolicySetArgs {
     /// Drop the allowlist, every asset is accepted.
     #[arg(long)]
     pub any_asset: bool,
-    /// Default withdrawal rule: `open`, `blocked` or `approval`.
+    /// Default withdrawal rule, `open`, `blocked` or `approval`.
     #[arg(long, value_parser = ["open", "blocked", "approval"])]
     pub withdrawals: Option<String>,
     /// Withdrawal rule of one asset, `<mint>=<rule>`, repeatable.
@@ -167,7 +167,7 @@ pub struct ApproveArgs {
     /// The approver, default the authority.
     #[arg(long, value_name = "KEYPAIR")]
     pub approver_keypair: Option<PathBuf>,
-    /// Take an unspent approval back instead; its rent returns to the approver.
+    /// Take an unspent approval back instead. Its rent returns to the approver.
     #[arg(long)]
     pub revoke: bool,
 }
@@ -178,7 +178,7 @@ pub fn main() -> Result<()> {
 
 pub fn run(cli: Cli) -> Result<()> {
     let config = RingConfig::load(&cli.config)?;
-    // The builders carry the id this binary was compiled with; a mismatch means
+    // The builders carry the id this binary was compiled with. A mismatch means
     // every PDA and CPI would target the wrong program.
     if config.program_id != PROGRAM_ID {
         return Err(anyhow!(
@@ -408,8 +408,8 @@ pub fn run(cli: Cli) -> Result<()> {
             let authority = config.authority()?;
             fund_on_localnet(&config, &mut rpc, authority.pubkey())?;
             let auditor_pk = configured_auditor_pk(&rpc)?;
-            // Before proving: an RPC holding another ring's key would leave the
-            // readback below waiting for a transaction it can never open.
+            // Checked before proving. An RPC holding another ring's key would
+            // leave the readback below waiting for a transaction it can never open.
             let ring_rpc = RingRpc::new(&config.urls.ring_rpc);
             ring_rpc.check_serves(PROGRAM_ID, &auditor_pk)?;
             let indexer = ZolanaIndexer::new(&config.urls.indexer);
@@ -539,7 +539,7 @@ fn default_program_so(name: &str) -> PathBuf {
     ))
 }
 
-/// A local validator hands out SOL for free; devnet and beyond need a funded
+/// A local validator hands out SOL for free. Devnet and beyond need a funded
 /// authority.
 fn fund_on_localnet(config: &RingConfig, rpc: &mut SolanaRpc, authority: Address) -> Result<()> {
     if config.target != Target::Localnet {

--- a/custom-rings/cli/src/lib.rs
+++ b/custom-rings/cli/src/lib.rs
@@ -19,7 +19,7 @@ use clap::{Args, Parser, Subcommand};
 use custom_ring_sdk::PROGRAM_ID;
 use solana_address::Address;
 use solana_signer::Signer;
-use zolana_client::{ProverClient, SolanaRpc, ZolanaIndexer};
+use zolana_client::{ProverClient, Rpc, SolanaRpc, ZolanaIndexer};
 use zolana_interface::DEFAULT_TREE_ADDRESS;
 use zolana_keypair::P256Pubkey;
 use zolana_ring_rpc::{
@@ -66,6 +66,8 @@ pub enum Command {
     Transact(TransactArgs),
     /// Confirm the ring RPC in `ring.toml` is up and holds this ring's auditor key.
     RpcCheck,
+    /// Approve one proven transact by its `private_tx_hash`.
+    Approve(ApproveArgs),
     /// Transfer or renounce the program's upgrade authority.
     #[command(subcommand)]
     Authority(AuthorityCommand),
@@ -85,6 +87,7 @@ pub enum PolicyCommand {
 #[derive(Debug, Args)]
 pub struct PolicySetArgs {
     /// Replace the allowlist with these mints, repeatable; `SOL` for native SOL.
+    /// Listed mints keep their withdrawal rule when they had one.
     #[arg(
         long = "allow-asset",
         value_name = "MINT",
@@ -94,9 +97,15 @@ pub struct PolicySetArgs {
     /// Drop the allowlist, every asset is accepted.
     #[arg(long)]
     pub any_asset: bool,
-    /// `open` or `blocked`.
-    #[arg(long, value_parser = ["open", "blocked"])]
+    /// Default withdrawal rule: `open`, `blocked` or `approval`.
+    #[arg(long, value_parser = ["open", "blocked", "approval"])]
     pub withdrawals: Option<String>,
+    /// Withdrawal rule of one asset, `<mint>=<rule>`, repeatable.
+    #[arg(long = "asset-withdrawals", value_name = "MINT=RULE")]
+    pub asset_withdrawals: Vec<String>,
+    /// The key that approves withdrawals under an `approval` rule.
+    #[arg(long, value_name = "PUBKEY")]
+    pub approver: Option<Address>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -140,6 +149,24 @@ pub struct TransactArgs {
     /// Lamports the recipient receives.
     #[arg(long, default_value_t = 1_000_000_000)]
     pub amount: u64,
+    /// Withdraw this many lamports of the recipient's share publicly.
+    #[arg(long, value_name = "LAMPORTS")]
+    pub withdraw: Option<u64>,
+    /// Who receives the withdrawal, default the authority.
+    #[arg(long, value_name = "PUBKEY", requires = "withdraw")]
+    pub withdraw_to: Option<Address>,
+    /// Signs the approval when the policy asks for one, default the authority.
+    #[arg(long, value_name = "KEYPAIR")]
+    pub approver_keypair: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+pub struct ApproveArgs {
+    /// The `private_tx_hash` of the proven transact, hex.
+    pub private_tx_hash: String,
+    /// The approver, default the authority.
+    #[arg(long, value_name = "KEYPAIR")]
+    pub approver_keypair: Option<PathBuf>,
 }
 
 pub fn main() -> Result<()> {
@@ -257,17 +284,41 @@ pub fn run(cli: Cli) -> Result<()> {
                 PolicyCommand::Set(args) => {
                     let mut wanted = policy::read_policy(&rpc)?;
                     if args.any_asset {
-                        wanted.allowed_assets = None;
+                        wanted.allowlist = false;
                     } else if !args.allow_assets.is_empty() {
-                        wanted.allowed_assets = Some(
-                            args.allow_assets
-                                .iter()
-                                .map(|asset| policy::parse_asset(asset))
-                                .collect::<Result<_>>()?,
-                        );
+                        let mints = args
+                            .allow_assets
+                            .iter()
+                            .map(|asset| policy::parse_asset(asset))
+                            .collect::<Result<Vec<_>>>()?;
+                        wanted.assets = mints
+                            .into_iter()
+                            .map(|mint| custom_ring_sdk::AssetRule {
+                                withdrawals: wanted.withdrawal_rule(&mint),
+                                mint,
+                            })
+                            .collect();
+                        wanted.allowlist = true;
                     }
                     if let Some(withdrawals) = args.withdrawals.as_deref() {
-                        wanted.withdrawals_blocked = withdrawals == "blocked";
+                        wanted.withdrawals = policy::parse_rule(withdrawals)?;
+                    }
+                    for entry in &args.asset_withdrawals {
+                        let (mint, rule) = entry
+                            .split_once('=')
+                            .ok_or_else(|| anyhow!("expected <mint>=<rule>, got {entry}"))?;
+                        let mint = policy::parse_asset(mint)?;
+                        let rule = policy::parse_rule(rule)?;
+                        match wanted.assets.iter_mut().find(|asset| asset.mint == mint) {
+                            Some(asset) => asset.withdrawals = rule,
+                            None => wanted.assets.push(custom_ring_sdk::AssetRule {
+                                mint,
+                                withdrawals: rule,
+                            }),
+                        }
+                    }
+                    if let Some(approver) = args.approver {
+                        wanted.approver = Some(approver);
                     }
                     wanted
                 }
@@ -283,6 +334,30 @@ pub fn run(cli: Cli) -> Result<()> {
                 }
             );
             policy::print(&wanted);
+            Ok(())
+        }
+        Command::Approve(args) => {
+            let approver = match &args.approver_keypair {
+                Some(path) => solana_keypair::read_keypair_file(expand_tilde(path)?)
+                    .map_err(|e| anyhow!("reading approver keypair {}: {e}", path.display()))?,
+                None => config.authority()?,
+            };
+            fund_on_localnet(&config, &mut rpc, approver.pubkey())?;
+            let private_tx_hash: [u8; 32] = hex::decode(args.private_tx_hash.trim())?
+                .try_into()
+                .map_err(|_| anyhow!("private_tx_hash must be 32 bytes of hex"))?;
+            let ix = custom_ring_sdk::ApproveTransact {
+                approver: approver.pubkey(),
+                payer: approver.pubkey(),
+                private_tx_hash,
+            }
+            .instruction();
+            let signature =
+                rpc.create_and_send_transaction(&[ix], approver.pubkey(), &[&approver])?;
+            println!(
+                "approved    {} at {signature}",
+                custom_ring_sdk::approval_pda(&private_tx_hash)
+            );
             Ok(())
         }
         Command::Authority(command) => {
@@ -326,6 +401,12 @@ pub fn run(cli: Cli) -> Result<()> {
             ring_rpc.check_serves(PROGRAM_ID, &auditor_pk)?;
             let indexer = ZolanaIndexer::new(&config.urls.indexer);
             let prover = ProverClient::new(config.urls.prover.clone());
+            let ring_policy = policy::read_policy(&rpc)?;
+            let approver = match &args.approver_keypair {
+                Some(path) => solana_keypair::read_keypair_file(expand_tilde(path)?)
+                    .map_err(|e| anyhow!("reading approver keypair {}: {e}", path.display()))?,
+                None => config.authority()?,
+            };
             let receipt = DemoTransfer {
                 rpc: &rpc,
                 indexer: &indexer,
@@ -334,6 +415,11 @@ pub fn run(cli: Cli) -> Result<()> {
                 tree: Address::from_str_const(DEFAULT_TREE_ADDRESS),
                 auditor_pk,
                 amount: args.amount,
+                withdrawal: args
+                    .withdraw
+                    .map(|lamports| (args.withdraw_to.unwrap_or(authority.pubkey()), lamports)),
+                policy: &ring_policy,
+                approver: Some(&approver),
             }
             .run()?;
             println!(
@@ -348,6 +434,9 @@ pub fn run(cli: Cli) -> Result<()> {
             );
             for signature in &receipt.deposits {
                 println!("deposit     {signature}");
+            }
+            if let Some(signature) = &receipt.approval {
+                println!("approval    {signature}");
             }
             println!("transact    {}", receipt.transact);
             for line in program_logs(&rpc, &receipt.transact)? {

--- a/custom-rings/cli/src/policy.rs
+++ b/custom-rings/cli/src/policy.rs
@@ -1,7 +1,7 @@
 //! The ring's on-chain policy: read, applied from `ring.toml`, or changed.
 
 use anyhow::{anyhow, Result};
-use custom_ring_sdk::{AssetRule, RingPolicy, SetPolicy, WithdrawalRule, SOL};
+use custom_ring_sdk::{AssetPolicy, AssetRule, RingPolicy, SetPolicy, WithdrawalRule, SOL};
 use solana_address::Address;
 use solana_signer::Signer;
 use zolana_client::{Rpc, SolanaRpc};
@@ -26,8 +26,8 @@ pub fn format_asset(asset: &Address) -> String {
 }
 
 pub fn parse_rule(text: &str) -> Result<WithdrawalRule> {
-    WithdrawalRule::parse(text)
-        .ok_or_else(|| anyhow!("withdrawal rule must be open, blocked or approval, got {text}"))
+    text.parse()
+        .map_err(|_| anyhow!("withdrawal rule must be open, blocked or approval, got {text}"))
 }
 
 /// The policy `ring.toml` asks for. Absent keys leave that part open.
@@ -44,7 +44,7 @@ pub fn from_config(policy: &PolicyConfig) -> Result<RingPolicy> {
         .as_deref()
         .map(parse_rule)
         .transpose()?
-        .unwrap_or_default();
+        .unwrap_or(WithdrawalRule::Open);
     // Listed mints inherit the default rule until an entry names its own.
     for asset in &mut assets {
         asset.withdrawals = withdrawals;
@@ -67,7 +67,11 @@ pub fn from_config(policy: &PolicyConfig) -> Result<RingPolicy> {
         }
     }
     Ok(RingPolicy {
-        allowlist: policy.allowed_assets.is_some(),
+        asset_policy: if policy.allowed_assets.is_some() {
+            AssetPolicy::Allowlist
+        } else {
+            AssetPolicy::Any
+        },
         assets,
         withdrawals,
         approver: policy
@@ -105,7 +109,10 @@ pub fn apply(rpc: &SolanaRpc, authority: &dyn Signer, policy: &RingPolicy) -> Re
 pub fn print(policy: &RingPolicy) {
     println!(
         "assets      {}",
-        if policy.allowlist { "allowlist" } else { "any" }
+        match policy.asset_policy {
+            AssetPolicy::Any => "any",
+            AssetPolicy::Allowlist => "allowlist",
+        }
     );
     println!("withdrawals {} (default)", policy.withdrawals.as_str());
     for asset in &policy.assets {

--- a/custom-rings/cli/src/policy.rs
+++ b/custom-rings/cli/src/policy.rs
@@ -1,7 +1,7 @@
 //! The ring's on-chain policy: read, applied from `ring.toml`, or changed.
 
 use anyhow::{anyhow, Result};
-use custom_ring_sdk::{RingPolicy, SetPolicy, SOL};
+use custom_ring_sdk::{AssetRule, RingPolicy, SetPolicy, WithdrawalRule, SOL};
 use solana_address::Address;
 use solana_signer::Signer;
 use zolana_client::{Rpc, SolanaRpc};
@@ -25,19 +25,59 @@ pub fn format_asset(asset: &Address) -> String {
     }
 }
 
+pub fn parse_rule(text: &str) -> Result<WithdrawalRule> {
+    WithdrawalRule::parse(text)
+        .ok_or_else(|| anyhow!("withdrawal rule must be open, blocked or approval, got {text}"))
+}
+
 /// The policy `ring.toml` asks for. Absent keys leave that part open.
 pub fn from_config(policy: &PolicyConfig) -> Result<RingPolicy> {
+    let mut assets: Vec<AssetRule> = Vec::new();
+    for asset in policy.allowed_assets.iter().flatten() {
+        assets.push(AssetRule {
+            mint: parse_asset(asset)?,
+            withdrawals: WithdrawalRule::Open,
+        });
+    }
+    let withdrawals = policy
+        .withdrawals
+        .as_deref()
+        .map(parse_rule)
+        .transpose()?
+        .unwrap_or_default();
+    // Listed mints inherit the default rule until an entry names its own.
+    for asset in &mut assets {
+        asset.withdrawals = withdrawals;
+    }
+    for (mint, rule) in &policy.asset_withdrawals {
+        let mint = parse_asset(mint)?;
+        let rule = parse_rule(rule)?;
+        match assets.iter_mut().find(|asset| asset.mint == mint) {
+            Some(asset) => asset.withdrawals = rule,
+            None if policy.allowed_assets.is_some() => {
+                return Err(anyhow!(
+                    "asset_withdrawals names {} which is not in allowed_assets",
+                    format_asset(&mint)
+                ))
+            }
+            None => assets.push(AssetRule {
+                mint,
+                withdrawals: rule,
+            }),
+        }
+    }
     Ok(RingPolicy {
-        allowed_assets: policy
-            .allowed_assets
-            .as_ref()
-            .map(|assets| assets.iter().map(|asset| parse_asset(asset)).collect())
+        allowlist: policy.allowed_assets.is_some(),
+        assets,
+        withdrawals,
+        approver: policy
+            .approver
+            .as_deref()
+            .map(|key| {
+                key.parse()
+                    .map_err(|error| anyhow!("approver {key} is not a base58 pubkey: {error}"))
+            })
             .transpose()?,
-        withdrawals_blocked: match policy.withdrawals.as_deref() {
-            None | Some("open") => false,
-            Some("blocked") => true,
-            Some(other) => return Err(anyhow!("withdrawals must be open or blocked, got {other}")),
-        },
     })
 }
 
@@ -65,21 +105,17 @@ pub fn apply(rpc: &SolanaRpc, authority: &dyn Signer, policy: &RingPolicy) -> Re
 pub fn print(policy: &RingPolicy) {
     println!(
         "assets      {}",
-        match &policy.allowed_assets {
-            None => "any".to_owned(),
-            Some(assets) => assets
-                .iter()
-                .map(format_asset)
-                .collect::<Vec<_>>()
-                .join(", "),
-        }
+        if policy.allowlist { "allowlist" } else { "any" }
     );
-    println!(
-        "withdrawals {}",
-        if policy.withdrawals_blocked {
-            "blocked"
-        } else {
-            "open"
-        }
-    );
+    println!("withdrawals {} (default)", policy.withdrawals.as_str());
+    for asset in &policy.assets {
+        println!(
+            "  {:<44} withdrawals {}",
+            format_asset(&asset.mint),
+            asset.withdrawals.as_str()
+        );
+    }
+    if let Some(approver) = policy.approver {
+        println!("approver    {approver}");
+    }
 }

--- a/custom-rings/cli/src/ring_rpc.rs
+++ b/custom-rings/cli/src/ring_rpc.rs
@@ -98,7 +98,7 @@ impl RingRpc {
         })
     }
 
-    /// The RPC at this URL must hold the key behind `auditor_pk`; another
+    /// The RPC at this URL must hold the key behind `auditor_pk`. Another
     /// ring's RPC on the same port answers `health` but can open nothing here.
     pub fn check_serves(&self, ring: Address, auditor_pk: &P256Pubkey) -> Result<()> {
         let served = self.auditor_pubkey(ring)?.auditor_pk;

--- a/custom-rings/cli/src/transfer.rs
+++ b/custom-rings/cli/src/transfer.rs
@@ -27,9 +27,9 @@ pub struct DemoTransfer<'a> {
     pub indexer: &'a ZolanaIndexer,
     pub prover: &'a ProverClient,
     /// Pays the deposits and funds the sender for its own transaction. The
-    /// sender pays and signs the transact itself: with a separate fee payer
-    /// the second signature and static key push the audited transact past the
-    /// 1232-byte packet even behind a lookup table.
+    /// sender pays and signs the transact itself, because with a separate fee
+    /// payer the second signature and static key push the audited transact past
+    /// the 1232-byte packet even behind a lookup table.
     pub payer: &'a dyn Signer,
     pub tree: Address,
     pub auditor_pk: P256Pubkey,
@@ -95,7 +95,7 @@ impl DemoTransfer<'_> {
         }
         .prove()?;
 
-        // The policy decides whether this withdrawal needs an approval; the
+        // The policy decides whether this withdrawal needs an approval. The
         // approver signs off the proven transact by its private_tx_hash.
         let mut approval = None;
         let mut approval_account = None;

--- a/custom-rings/cli/src/transfer.rs
+++ b/custom-rings/cli/src/transfer.rs
@@ -1,11 +1,15 @@
 //! The demo the operator CLI runs: two ring deposits for a fresh sender, one
-//! audited confidential transfer to a fresh recipient, then the auditor's view
-//! of it read back from the ring RPC.
+//! audited confidential transfer to a fresh recipient (with an optional public
+//! SOL withdrawal, approved when the policy asks for it), then the auditor's
+//! view of it read back from the ring RPC.
 
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
-use custom_ring_sdk::{ring_deposit_sol, send_v0_with_lookup_table, AuditedTransfer};
+use custom_ring_sdk::{
+    approval_pda, ring_deposit_sol, send_v0_with_lookup_table, ApproveTransact, AuditedTransfer,
+    RingPolicy, WithdrawalRule, SOL,
+};
 use solana_address::Address;
 use solana_signature::Signature;
 use solana_signer::Signer;
@@ -32,12 +36,20 @@ pub struct DemoTransfer<'a> {
     /// Lamports the recipient receives. The sender is funded with twice that
     /// through two ring deposits, so the change output is the same amount.
     pub amount: u64,
+    /// A public SOL withdrawal out of the pool, `(recipient, lamports)`, taken
+    /// from the recipient's share.
+    pub withdrawal: Option<(Address, u64)>,
+    /// The ring's policy, to know whether the withdrawal needs an approval.
+    pub policy: &'a RingPolicy,
+    /// Signs the approval when the policy asks for one.
+    pub approver: Option<&'a dyn Signer>,
 }
 
 pub struct TransferReceipt {
     pub sender: ShieldedKeypair,
     pub recipient: ShieldedKeypair,
     pub deposits: Vec<Signature>,
+    pub approval: Option<Signature>,
     pub transact: Signature,
 }
 
@@ -62,6 +74,11 @@ impl DemoTransfer<'_> {
         self.rpc
             .create_and_send_transaction(&[fee], self.payer.pubkey(), &[self.payer])?;
 
+        let withdrawn = self.withdrawal.map_or(0, |(_, lamports)| lamports);
+        let to_recipient = self
+            .amount
+            .checked_sub(withdrawn)
+            .ok_or_else(|| anyhow!("the withdrawal exceeds the recipient's share"))?;
         let proven = AuditedTransfer {
             indexer: self.indexer,
             spp_prover: self.prover,
@@ -69,20 +86,46 @@ impl DemoTransfer<'_> {
             inputs,
             outputs: vec![
                 SppProofOutputUtxo::new(SOL_MINT, self.amount, sender.shielded_address()?)?,
-                SppProofOutputUtxo::new(SOL_MINT, self.amount, recipient.shielded_address()?)?,
+                SppProofOutputUtxo::new(SOL_MINT, to_recipient, recipient.shielded_address()?)?,
             ],
+            withdrawals: self.withdrawal.into_iter().collect(),
             tree: self.tree,
             auditor_pk: self.auditor_pk,
             assets: &AssetRegistry::default(),
         }
         .prove()?;
-        let ix = proven.instruction(sender.pubkey(), self.tree)?;
+
+        // The policy decides whether this withdrawal needs an approval; the
+        // approver signs off the proven transact by its private_tx_hash.
+        let mut approval = None;
+        let mut approval_account = None;
+        if self.withdrawal.is_some()
+            && self.policy.withdrawal_rule(&SOL) == WithdrawalRule::Approval
+        {
+            let approver = self.approver.ok_or_else(|| {
+                anyhow!("the policy requires an approval, no approver keypair given")
+            })?;
+            let ix = ApproveTransact {
+                approver: approver.pubkey(),
+                payer: self.payer.pubkey(),
+                private_tx_hash: proven.private_tx_hash(),
+            }
+            .instruction();
+            approval = Some(self.rpc.create_and_send_transaction(
+                &[ix],
+                self.payer.pubkey(),
+                &[self.payer, approver],
+            )?);
+            approval_account = Some(approval_pda(&proven.private_tx_hash()));
+        }
+        let ix = proven.instruction(sender.pubkey(), self.tree, approval_account)?;
         let transact = send_v0_with_lookup_table(self.rpc, &sender, &[], ix)?;
 
         Ok(TransferReceipt {
             sender,
             recipient,
             deposits,
+            approval,
             transact,
         })
     }

--- a/custom-rings/custom_ring.md
+++ b/custom-rings/custom_ring.md
@@ -97,7 +97,7 @@ the script takes the normal path and a failing `go build` is a hard error.
 
 ## Instructions
 
-Tags 1-5 are program-local. Ring deposits carry no proof and are forwarded to SPP
+Tags 1-6 are program-local. Ring deposits carry no proof and are forwarded to SPP
 byte for byte, so the dispatcher matches SPP's own
 `zolana_interface::instruction::tag::RING_DEPOSIT` (14) instead of allocating a
 local tag: the client builds the SPP-shaped instruction with the existing
@@ -131,28 +131,38 @@ program) flipped to a signer and `ring_authority_transact_is_enabled: false`.
 Accounts `[authority(s), config(w)]`; data `SetPolicyIxData { withdrawals: u8,
 asset_policy: u8, approver: [u8; 32], assets: Vec<AssetRule { mint, withdrawals
 }> }` (wincode, at most `MAX_ASSETS` = 8 entries, SOL is the all-zero mint).
-`withdrawals` is the default rule (`WITHDRAWALS_OPEN` 0, `WITHDRAWALS_BLOCKED`
-1, `WITHDRAWALS_APPROVAL` 2), each table entry carries its own; `asset_policy`
-`ASSETS_ALLOWLIST` limits deposits and settlement legs to the table's mints.
-Requires the stored authority to sign, rejects out-of-range values, oversized
-tables and an approval rule without an approver with `InvalidPolicy`, and
-replaces the policy fields of the config in place. A fresh config starts open.
+`withdrawals` is the default `WithdrawalRule` (`Open` 0, `Blocked` 1,
+`Approval` 2), each table entry carries its own; `asset_policy` is an
+`AssetPolicy` (`Any` 0, `Allowlist` 1), the allowlist limiting deposits and
+settlement legs to the table's mints. Both are `#[repr(u8)]` enums read back
+through `TryFrom<u8>`; a byte the program never wrote reads as `Blocked` /
+`Allowlist`, so corrupted state fails closed. Requires the stored authority to
+sign, rejects out-of-range values, oversized tables, a mint listed twice and an
+approval rule without an approver with `InvalidPolicy`, and replaces the policy
+fields of the config in place. A fresh config starts open.
 
 ### 5 `approve_transact`
 
 Accounts `[approver(s), payer(w,s), config, approval(w, PDA [b"approval",
 private_tx_hash]), system_program]`; data `ApproveTransactIxData {
 private_tx_hash: [u8; 32] }`. The config's approver signs off one proven
-transact by creating its approval account (one discriminator byte). The
-`private_tx_hash` commits to inputs, outputs and every settlement leg, so an
-approval fits exactly one transfer; `transact` spends it, so it cannot be
-replayed.
+transact by creating its approval account, `[discriminator, bump]`: the bump
+is stored so `transact` re-derives the address with one
+`create_program_address`. The `private_tx_hash` commits to inputs, outputs and
+every settlement leg, so an approval fits exactly one transfer; `transact`
+spends it, so it cannot be replayed.
+
+### 6 `revoke_approval`
+
+Accounts `[approver(s), rent_recipient(w), config, approval(w)]`; same data.
+The approver closes an unspent approval, its lamports go to `rent_recipient`.
 
 ### 14 `deposit` (forwarded)
 
 Proofless forwarder. Accounts `[config] ++ <SPP RING_DEPOSIT list>`. Checks the
 SPP program account, applies the asset allowlist to every deposited asset
-(reading the mint from the SPL settlement group SPP itself validates next),
+(reading only the leading `assets` field of the ring deposit data and the mint
+from the SPL settlement group SPP itself validates next),
 requires `ring_auth` to be present, flips it to a signer, and invokes SPP with the
 instruction data unchanged (tag byte included; SPP's dispatcher strips it).
 

--- a/custom-rings/custom_ring.md
+++ b/custom-rings/custom_ring.md
@@ -34,7 +34,7 @@ the recipients see. That is why the circuit needs no per-output witnesses and no
   ring, checked on ring deposits and on transact settlement legs) and a
   withdrawal rule per asset (open, blocked, or approval by a configured key,
   with a default for unlisted assets). All of it lives in the config and is set
-  by the authority (`set_policy`); nothing hidden inside confidential outputs is
+  by the authority (`set_policy`). Nothing hidden inside confidential outputs is
   inspected.
 - Config gating is the program's upgrade authority when the deployment names
   one, otherwise a plain authority signer. No key rotation yet.
@@ -128,14 +128,14 @@ program) flipped to a signer and `ring_authority_transact_is_enabled: false`.
 
 ### 4 `set_policy`
 
-Accounts `[authority(s), config(w)]`; data `SetPolicyIxData { withdrawals: u8,
+Accounts `[authority(s), config(w)]`. Data `SetPolicyIxData { withdrawals: u8,
 asset_policy: u8, approver: [u8; 32], assets: Vec<AssetRule { mint, withdrawals
 }> }` (wincode, at most `MAX_ASSETS` = 8 entries, SOL is the all-zero mint).
 `withdrawals` is the default `WithdrawalRule` (`Open` 0, `Blocked` 1,
-`Approval` 2), each table entry carries its own; `asset_policy` is an
+`Approval` 2) and each table entry carries its own. `asset_policy` is an
 `AssetPolicy` (`Any` 0, `Allowlist` 1), the allowlist limiting deposits and
 settlement legs to the table's mints. Both are `#[repr(u8)]` enums read back
-through `TryFrom<u8>`; a byte the program never wrote reads as `Blocked` /
+through `TryFrom<u8>`, and a byte the program never wrote reads as `Blocked` /
 `Allowlist`, so corrupted state fails closed. Requires the stored authority to
 sign, rejects out-of-range values, oversized tables, a mint listed twice and an
 approval rule without an approver with `InvalidPolicy`, and replaces the policy
@@ -144,17 +144,17 @@ fields of the config in place. A fresh config starts open.
 ### 5 `approve_transact`
 
 Accounts `[approver(s), payer(w,s), config, approval(w, PDA [b"approval",
-private_tx_hash]), system_program]`; data `ApproveTransactIxData {
+private_tx_hash]), system_program]`. Data `ApproveTransactIxData {
 private_tx_hash: [u8; 32] }`. The config's approver signs off one proven
-transact by creating its approval account, `[discriminator, bump]`: the bump
+transact by creating its approval account, `[discriminator, bump]`. The bump
 is stored so `transact` re-derives the address with one
 `create_program_address`. The `private_tx_hash` commits to inputs, outputs and
-every settlement leg, so an approval fits exactly one transfer; `transact`
+every settlement leg, so an approval fits exactly one transfer, and `transact`
 spends it, so it cannot be replayed.
 
 ### 6 `revoke_approval`
 
-Accounts `[approver(s), rent_recipient(w), config, approval(w)]`; same data.
+Accounts `[approver(s), rent_recipient(w), config, approval(w)]`, same data.
 The approver closes an unspent approval, its lamports go to `rent_recipient`.
 
 ### 14 `deposit` (forwarded)
@@ -175,8 +175,8 @@ list when a withdrawal falls under an approval rule (recognised by owner and
 discriminator). Flow: deserialize, load config, apply the policy to
 `interface_transfers` (`AssetNotAllowed` for a settlement leg outside the
 allowlist, then per withdrawal leg the asset's rule: `WithdrawalsBlocked`, or
-`ApprovalRequired` when the approval account is missing; before the pairing so
-a refused transfer costs no proof work), check the approval account is this
+`ApprovalRequired` when the approval account is missing, all before the pairing
+so a refused transfer costs no proof work), check the approval account is this
 transact's PDA (`InvalidApproval`), require `CircuitId::RingEddsa`, locate the
 auditor message, recompute the public-input hash, verify the Groth16 proof, CPI
 SPP `RING_TRANSACT` with `ring_auth` as signer, then spend the approval (its

--- a/custom-rings/custom_ring.md
+++ b/custom-rings/custom_ring.md
@@ -31,9 +31,11 @@ the recipients see. That is why the circuit needs no per-output witnesses and no
 - Verifiable encryption to the auditor. User-side encryption is not checked by
   the circuit.
 - Policy on public data only: an asset allowlist (what may enter or leave the
-  ring, checked on ring deposits and on transact settlement legs) and a public
-  withdrawal switch. Both live in the config and are set by the authority
-  (`set_policy`); nothing hidden inside confidential outputs is inspected.
+  ring, checked on ring deposits and on transact settlement legs) and a
+  withdrawal rule per asset (open, blocked, or approval by a configured key,
+  with a default for unlisted assets). All of it lives in the config and is set
+  by the authority (`set_policy`); nothing hidden inside confidential outputs is
+  inspected.
 - Config gating is the program's upgrade authority when the deployment names
   one, otherwise a plain authority signer. No key rotation yet.
 
@@ -95,7 +97,7 @@ the script takes the normal path and a failing `go build` is a hard error.
 
 ## Instructions
 
-Tags 1-4 are program-local. Ring deposits carry no proof and are forwarded to SPP
+Tags 1-5 are program-local. Ring deposits carry no proof and are forwarded to SPP
 byte for byte, so the dispatcher matches SPP's own
 `zolana_interface::instruction::tag::RING_DEPOSIT` (14) instead of allocating a
 local tag: the client builds the SPP-shaped instruction with the existing
@@ -127,11 +129,24 @@ program) flipped to a signer and `ring_authority_transact_is_enabled: false`.
 ### 4 `set_policy`
 
 Accounts `[authority(s), config(w)]`; data `SetPolicyIxData { withdrawals: u8,
-asset_policy: u8, allowed_assets: Vec<[u8; 32]> }` (wincode, at most
-`MAX_ALLOWED_ASSETS` = 8 mints, SOL is the all-zero mint). Requires the stored
-authority to sign, rejects values outside `{0, 1}` and oversized lists with
-`InvalidPolicy`, and replaces the policy fields of the config in place. A fresh
-config starts open (any asset, withdrawals allowed).
+asset_policy: u8, approver: [u8; 32], assets: Vec<AssetRule { mint, withdrawals
+}> }` (wincode, at most `MAX_ASSETS` = 8 entries, SOL is the all-zero mint).
+`withdrawals` is the default rule (`WITHDRAWALS_OPEN` 0, `WITHDRAWALS_BLOCKED`
+1, `WITHDRAWALS_APPROVAL` 2), each table entry carries its own; `asset_policy`
+`ASSETS_ALLOWLIST` limits deposits and settlement legs to the table's mints.
+Requires the stored authority to sign, rejects out-of-range values, oversized
+tables and an approval rule without an approver with `InvalidPolicy`, and
+replaces the policy fields of the config in place. A fresh config starts open.
+
+### 5 `approve_transact`
+
+Accounts `[approver(s), payer(w,s), config, approval(w, PDA [b"approval",
+private_tx_hash]), system_program]`; data `ApproveTransactIxData {
+private_tx_hash: [u8; 32] }`. The config's approver signs off one proven
+transact by creating its approval account (one discriminator byte). The
+`private_tx_hash` commits to inputs, outputs and every settlement leg, so an
+approval fits exactly one transfer; `transact` spends it, so it cannot be
+replayed.
 
 ### 14 `deposit` (forwarded)
 
@@ -145,13 +160,18 @@ instruction data unchanged (tag byte included; SPP's dispatcher strips it).
 
 Data `CustomRingTransactIxData { proof: AuditProof, transact: TransactIxData }`
 (wincode). Accounts `[payer(w,s), config] ++ <RING_TRANSACT list with ring_config
-unsigned>`. Flow: deserialize, load config, apply the policy to
-`interface_transfers` (`WithdrawalsBlocked` for a SOL or SPL withdrawal when
-blocked, `AssetNotAllowed` for a settlement leg outside the allowlist; before
-the pairing so a refused transfer costs no proof work), require
-`CircuitId::RingEddsa`, locate the auditor message, recompute the public-input
-hash, verify the Groth16 proof, then CPI SPP `RING_TRANSACT` with `ring_auth` as
-signer.
+unsigned>`, with the transact's approval account between the config and the SPP
+list when a withdrawal falls under an approval rule (recognised by owner and
+discriminator). Flow: deserialize, load config, apply the policy to
+`interface_transfers` (`AssetNotAllowed` for a settlement leg outside the
+allowlist, then per withdrawal leg the asset's rule: `WithdrawalsBlocked`, or
+`ApprovalRequired` when the approval account is missing; before the pairing so
+a refused transfer costs no proof work), check the approval account is this
+transact's PDA (`InvalidApproval`), require `CircuitId::RingEddsa`, locate the
+auditor message, recompute the public-input hash, verify the Groth16 proof, CPI
+SPP `RING_TRANSACT` with `ring_auth` as signer, then spend the approval (its
+rent goes to the payer). Lamports move only after the CPI, since the runtime
+syncs forwarded accounts before invoking and the rest only at the end.
 
 The auditor message is transported in SPP `transact` `messages`, which are folded
 into `external_data_hash` and republished verbatim in `GeneralEvent` - the
@@ -233,7 +253,7 @@ root `CLAUDE.md` rule that every program error belongs in
 `program-libs/interface` with a code in the 7000 space applies to SPP itself, not
 to the `sdk-tests`-style examples.
 
-This example uses the `8100..=8118` range, verified collision-free against SPP
+This example uses the `8100..=8121` range, verified collision-free against SPP
 (7000-7047), the swap example (8005-8016), and the remaining examples (9xxx).
 Every code is pinned in an `error_codes_are_stable` test.
 

--- a/custom-rings/program/src/error.rs
+++ b/custom-rings/program/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 /// Errors of the minimal custom ring program.
 ///
-/// The 8100..8118 range is reserved for this example and is collision-free
+/// The 8100..8121 range is reserved for this example and is collision-free
 /// against SPP (7000..7047) and the other example programs (zk-program-swap
 /// 8005..8016, the rest 9xxx). Every code is pinned by
 /// `tests/error_codes.rs::error_codes_are_stable`; clients observe them, so they
@@ -49,6 +49,12 @@ pub enum CustomRingError {
     WithdrawalsBlocked = 8117,
     #[error("policy values are out of range")]
     InvalidPolicy = 8118,
+    #[error("withdrawal needs an approval account created by the ring's approver")]
+    ApprovalRequired = 8119,
+    #[error("approval account is not this transact's approval")]
+    InvalidApproval = 8120,
+    #[error("signer is not the configured approver")]
+    UnauthorizedApprover = 8121,
 }
 
 impl From<CustomRingError> for ProgramError {

--- a/custom-rings/program/src/instructions/approve_transact.rs
+++ b/custom-rings/program/src/instructions/approve_transact.rs
@@ -75,9 +75,9 @@ pub fn process_approve_transact_ix(accounts: &mut [AccountView], data: &[u8]) ->
     Ok(())
 }
 
-/// The approver takes an approval back before it is spent; the account's
+/// The approver takes an approval back before it is spent and the account's
 /// lamports go to `rent_recipient`. Accounts `[approver(s), rent_recipient(w),
-/// config, approval(w)]`; data `ApproveTransactIxData`.
+/// config, approval(w)]`, data `ApproveTransactIxData`.
 #[inline(never)]
 pub fn process_revoke_approval_ix(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
     let ApproveTransactIxData { private_tx_hash } =
@@ -130,9 +130,9 @@ fn find_approval_bump(
     unimplemented!("approval PDA derivation requires Solana runtime syscalls")
 }
 
-/// `approval` must be the approval account of `private_tx_hash`: this
-/// program's, carrying the discriminator, at the address its stored bump
-/// derives. One `create_program_address` instead of a bump search.
+/// `approval` must be the approval account of `private_tx_hash`, owned by this
+/// program, carrying the discriminator, at the address its stored bump derives.
+/// One `create_program_address` instead of a bump search.
 #[cfg(any(target_os = "solana", target_arch = "bpf"))]
 pub fn check_approval(approval: &AccountView, private_tx_hash: &[u8; 32]) -> ProgramResult {
     let bump = {

--- a/custom-rings/program/src/instructions/approve_transact.rs
+++ b/custom-rings/program/src/instructions/approve_transact.rs
@@ -10,8 +10,9 @@ use zolana_account_checks::AccountIterator;
 use crate::{error::CustomRingError, instructions::loader::load_config, state::TRANSACT_APPROVAL};
 
 pub const APPROVAL_PDA_SEED: &[u8] = b"approval";
-/// One discriminator byte; the address already binds the transaction.
-pub const APPROVAL_SIZE: usize = 1;
+/// `[discriminator, bump]`. The bump is stored so `transact` re-derives the
+/// address with one `create_program_address` instead of a bump search.
+pub const APPROVAL_SIZE: usize = 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct ApproveTransactIxData {
@@ -41,11 +42,12 @@ pub fn process_approve_transact_ix(accounts: &mut [AccountView], data: &[u8]) ->
     }
     {
         let config = load_config(config_account)?;
-        if !config.has_approver() || !address_eq(&config.approver, approver.address()) {
-            return Err(CustomRingError::UnauthorizedApprover.into());
+        match config.approver() {
+            Some(configured) if address_eq(configured, approver.address()) => {}
+            _ => return Err(CustomRingError::UnauthorizedApprover.into()),
         }
     }
-    let bump = verify_approval_pda(approval.address(), &private_tx_hash)?;
+    let bump = find_approval_bump(approval.address(), &private_tx_hash)?;
     if approval.data_len() != 0 {
         return Err(CustomRingError::InvalidApproval.into());
     }
@@ -56,6 +58,8 @@ pub fn process_approve_transact_ix(accounts: &mut [AccountView], data: &[u8]) ->
         Seed::from(private_tx_hash.as_ref()),
         Seed::from(bump_seed.as_ref()),
     ];
+    // Handles the hot path (no lamports) and the cold path (lamports donated to
+    // the address to make a bare `CreateAccount` fail).
     pinocchio_system::create_account_with_minimum_balance_signed(
         approval,
         APPROVAL_SIZE,
@@ -67,17 +71,49 @@ pub fn process_approve_transact_ix(accounts: &mut [AccountView], data: &[u8]) ->
     let mut data = approval
         .try_borrow_mut()
         .map_err(|_| ProgramError::AccountBorrowFailed)?;
-    data[0] = TRANSACT_APPROVAL;
+    data.copy_from_slice(&[TRANSACT_APPROVAL, bump]);
     Ok(())
+}
+
+/// The approver takes an approval back before it is spent; the account's
+/// lamports go to `rent_recipient`. Accounts `[approver(s), rent_recipient(w),
+/// config, approval(w)]`; data `ApproveTransactIxData`.
+#[inline(never)]
+pub fn process_revoke_approval_ix(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
+    let ApproveTransactIxData { private_tx_hash } =
+        wincode::deserialize_exact(data).map_err(|_| CustomRingError::InvalidInstructionData)?;
+
+    let mut iter = AccountIterator::new(accounts);
+    let approver = iter.next_signer("approver")?;
+    let rent_recipient = iter.next_mut("rent_recipient")?;
+    let config_account = iter.next_account("config")?;
+    let approval = iter.next_mut("approval")?;
+
+    {
+        let config = load_config(config_account)?;
+        match config.approver() {
+            Some(configured) if address_eq(configured, approver.address()) => {}
+            _ => return Err(CustomRingError::UnauthorizedApprover.into()),
+        }
+    }
+    if !approval.owned_by(&crate::ID) {
+        return Err(CustomRingError::InvalidApproval.into());
+    }
+    check_approval(approval, &private_tx_hash)?;
+    rent_recipient.set_lamports(
+        rent_recipient
+            .lamports()
+            .checked_add(approval.lamports())
+            .ok_or(ProgramError::ArithmeticOverflow)?,
+    );
+    approval.set_lamports(0);
+    approval.close()
 }
 
 /// The approval account of `private_tx_hash` must be the canonical PDA. Fails
 /// closed on any other address.
 #[cfg(any(target_os = "solana", target_arch = "bpf"))]
-pub fn verify_approval_pda(
-    approval: &Address,
-    private_tx_hash: &[u8; 32],
-) -> Result<u8, ProgramError> {
+fn find_approval_bump(approval: &Address, private_tx_hash: &[u8; 32]) -> Result<u8, ProgramError> {
     let (derived, bump) =
         Address::find_program_address(&[APPROVAL_PDA_SEED, private_tx_hash], &crate::ID);
     if !address_eq(approval, &derived) {
@@ -87,9 +123,37 @@ pub fn verify_approval_pda(
 }
 
 #[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
-pub fn verify_approval_pda(
+fn find_approval_bump(
     _approval: &Address,
     _private_tx_hash: &[u8; 32],
 ) -> Result<u8, ProgramError> {
+    unimplemented!("approval PDA derivation requires Solana runtime syscalls")
+}
+
+/// `approval` must be the approval account of `private_tx_hash`: this
+/// program's, carrying the discriminator, at the address its stored bump
+/// derives. One `create_program_address` instead of a bump search.
+#[cfg(any(target_os = "solana", target_arch = "bpf"))]
+pub fn check_approval(approval: &AccountView, private_tx_hash: &[u8; 32]) -> ProgramResult {
+    let bump = {
+        let data = approval
+            .try_borrow()
+            .map_err(|_| ProgramError::AccountBorrowFailed)?;
+        match *data {
+            [TRANSACT_APPROVAL, bump] => bump,
+            _ => return Err(CustomRingError::InvalidApproval.into()),
+        }
+    };
+    let derived =
+        Address::create_program_address(&[APPROVAL_PDA_SEED, private_tx_hash, &[bump]], &crate::ID)
+            .map_err(|_| CustomRingError::InvalidApproval)?;
+    if !address_eq(approval.address(), &derived) {
+        return Err(CustomRingError::InvalidApproval.into());
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
+pub fn check_approval(_approval: &AccountView, _private_tx_hash: &[u8; 32]) -> ProgramResult {
     unimplemented!("approval PDA derivation requires Solana runtime syscalls")
 }

--- a/custom-rings/program/src/instructions/approve_transact.rs
+++ b/custom-rings/program/src/instructions/approve_transact.rs
@@ -1,0 +1,95 @@
+use pinocchio::{
+    address::address_eq,
+    cpi::{Seed, Signer},
+    error::ProgramError,
+    AccountView, Address, ProgramResult,
+};
+use wincode::{SchemaRead, SchemaWrite};
+use zolana_account_checks::AccountIterator;
+
+use crate::{error::CustomRingError, instructions::loader::load_config, state::TRANSACT_APPROVAL};
+
+pub const APPROVAL_PDA_SEED: &[u8] = b"approval";
+/// One discriminator byte; the address already binds the transaction.
+pub const APPROVAL_SIZE: usize = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
+pub struct ApproveTransactIxData {
+    /// The `private_tx_hash` of the transact being approved. It commits to the
+    /// inputs, outputs and every settlement leg, so an approval cannot be
+    /// re-used for a different transfer.
+    pub private_tx_hash: [u8; 32],
+}
+
+/// The approver signs off one transact by creating its approval account,
+/// `[b"approval", private_tx_hash]`. `transact` consumes it. Accounts
+/// `[approver(s), payer(w,s), config, approval(w), system_program]`.
+#[inline(never)]
+pub fn process_approve_transact_ix(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
+    let ApproveTransactIxData { private_tx_hash } =
+        wincode::deserialize_exact(data).map_err(|_| CustomRingError::InvalidInstructionData)?;
+
+    let mut iter = AccountIterator::new(accounts);
+    let approver = iter.next_signer("approver")?;
+    let payer = iter.next_signer_mut("payer")?;
+    let config_account = iter.next_account("config")?;
+    let approval = iter.next_mut("approval")?;
+    let system_program = iter.next_account("system_program")?;
+
+    if !pinocchio_system::check_id(system_program.address()) {
+        return Err(CustomRingError::InvalidSystemProgram.into());
+    }
+    {
+        let config = load_config(config_account)?;
+        if !config.has_approver() || !address_eq(&config.approver, approver.address()) {
+            return Err(CustomRingError::UnauthorizedApprover.into());
+        }
+    }
+    let bump = verify_approval_pda(approval.address(), &private_tx_hash)?;
+    if approval.data_len() != 0 {
+        return Err(CustomRingError::InvalidApproval.into());
+    }
+
+    let bump_seed = [bump];
+    let seeds = [
+        Seed::from(APPROVAL_PDA_SEED),
+        Seed::from(private_tx_hash.as_ref()),
+        Seed::from(bump_seed.as_ref()),
+    ];
+    pinocchio_system::create_account_with_minimum_balance_signed(
+        approval,
+        APPROVAL_SIZE,
+        &crate::ID,
+        payer,
+        None,
+        &[Signer::from(seeds.as_ref())],
+    )?;
+    let mut data = approval
+        .try_borrow_mut()
+        .map_err(|_| ProgramError::AccountBorrowFailed)?;
+    data[0] = TRANSACT_APPROVAL;
+    Ok(())
+}
+
+/// The approval account of `private_tx_hash` must be the canonical PDA. Fails
+/// closed on any other address.
+#[cfg(any(target_os = "solana", target_arch = "bpf"))]
+pub fn verify_approval_pda(
+    approval: &Address,
+    private_tx_hash: &[u8; 32],
+) -> Result<u8, ProgramError> {
+    let (derived, bump) =
+        Address::find_program_address(&[APPROVAL_PDA_SEED, private_tx_hash], &crate::ID);
+    if !address_eq(approval, &derived) {
+        return Err(CustomRingError::InvalidApproval.into());
+    }
+    Ok(bump)
+}
+
+#[cfg(not(any(target_os = "solana", target_arch = "bpf")))]
+pub fn verify_approval_pda(
+    _approval: &Address,
+    _private_tx_hash: &[u8; 32],
+) -> Result<u8, ProgramError> {
+    unimplemented!("approval PDA derivation requires Solana runtime syscalls")
+}

--- a/custom-rings/program/src/instructions/deposit.rs
+++ b/custom-rings/program/src/instructions/deposit.rs
@@ -10,12 +10,12 @@ use crate::instructions::{
 /// Proofless forwarder for SPP `RING_DEPOSIT`.
 ///
 /// Deposit amounts are public on-chain, so the ring has no statement to prove
-/// here; it checks the asset policy and lends its `ring_auth` signature.
+/// here. It checks the asset policy and lends its `ring_auth` signature.
 /// Accounts `[config, <SPP ring deposit accounts>]`. `data` still carries the
-/// leading tag byte: the client builds the instruction with the interface's
-/// `RingDeposit` builder, which already emits SPP's tag 14 and lays the accounts
-/// out exactly as SPP's deposit loader expects, so the forward is verbatim and
-/// nothing is re-tagged.
+/// leading tag byte because the client builds the instruction with the
+/// interface's `RingDeposit` builder, which already emits SPP's tag 14 and lays
+/// the accounts out exactly as SPP's deposit loader expects, so the forward is
+/// verbatim and nothing is re-tagged.
 #[inline(never)]
 pub fn process_deposit_ix(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
     let mut iter = AccountIterator::new(accounts);

--- a/custom-rings/program/src/instructions/loader.rs
+++ b/custom-rings/program/src/instructions/loader.rs
@@ -9,7 +9,7 @@ use zolana_interface::{BPF_LOADER_UPGRADEABLE_ID, SHIELDED_POOL_PROGRAM_ID};
 
 use crate::{error::CustomRingError, state::RingProgramConfig};
 
-/// Load the ring config read-only: owned by this program, exact length, and
+/// Load the ring config read-only. Owned by this program, exact length, and
 /// carrying the config discriminator.
 ///
 /// The canonical PDA derivation is checked once, at creation; access control

--- a/custom-rings/program/src/instructions/mod.rs
+++ b/custom-rings/program/src/instructions/mod.rs
@@ -1,3 +1,4 @@
+pub mod approve_transact;
 pub mod create_config;
 pub mod deposit;
 pub mod init_spp_ring_config;
@@ -8,6 +9,7 @@ pub mod shared;
 pub mod transact;
 pub mod verifier;
 
+pub use approve_transact::process_approve_transact_ix;
 pub use create_config::process_create_config_ix;
 pub use deposit::process_deposit_ix;
 pub use init_spp_ring_config::process_init_spp_ring_config_ix;

--- a/custom-rings/program/src/instructions/mod.rs
+++ b/custom-rings/program/src/instructions/mod.rs
@@ -9,7 +9,7 @@ pub mod shared;
 pub mod transact;
 pub mod verifier;
 
-pub use approve_transact::process_approve_transact_ix;
+pub use approve_transact::{process_approve_transact_ix, process_revoke_approval_ix};
 pub use create_config::process_create_config_ix;
 pub use deposit::process_deposit_ix;
 pub use init_spp_ring_config::process_init_spp_ring_config_ix;

--- a/custom-rings/program/src/instructions/policy.rs
+++ b/custom-rings/program/src/instructions/policy.rs
@@ -3,12 +3,12 @@
 //! so a rejection here is a named error where SPP would still have accepted the
 //! transfer.
 
-use pinocchio::{AccountView, ProgramResult};
+use pinocchio::{error::ProgramError, AccountView, ProgramResult};
 use zolana_interface::instruction::{DepositAssetKind, InterfaceTransfer, RingDepositIxDataRef};
 
 use crate::{
     error::CustomRingError,
-    state::{RingProgramConfig, SOL_MINT},
+    state::{RingProgramConfig, SOL_MINT, WITHDRAWALS_APPROVAL, WITHDRAWALS_BLOCKED},
 };
 
 /// Accounts of SPP's `RING_DEPOSIT` before the per-asset settlement groups:
@@ -61,26 +61,17 @@ pub fn check_deposit(
     Ok(())
 }
 
-/// `spp_accounts` is the forwarded ring transact list. Public withdrawals are
-/// refused when blocked, and every settlement leg's mint must pass the
-/// allowlist.
+/// `spp_accounts` is the forwarded ring transact list. Every settlement leg's
+/// mint must pass the allowlist, and its withdrawal rule decides whether a
+/// withdrawal is forwarded, refused, or needs an approval account. Returns
+/// whether the transact must carry an approval.
 pub fn check_transact(
     config: &RingProgramConfig,
     spp_accounts: &[AccountView],
     interface_transfers: &[InterfaceTransfer],
-) -> ProgramResult {
-    if config.withdrawals_blocked()
-        && interface_transfers.iter().any(|transfer| {
-            matches!(
-                transfer,
-                InterfaceTransfer::SolWithdrawal { .. } | InterfaceTransfer::SplWithdrawal { .. }
-            )
-        })
-    {
-        return Err(CustomRingError::WithdrawalsBlocked.into());
-    }
-    if config.allows_every_asset() || interface_transfers.is_empty() {
-        return Ok(());
+) -> Result<bool, ProgramError> {
+    if interface_transfers.is_empty() {
+        return Ok(false);
     }
     // Owner signers follow the fixed prefix; the settlement groups start at
     // the first non-signer, in `interface_transfers` order.
@@ -92,26 +83,33 @@ pub fn check_transact(
         .position(|account| !account.is_signer())
         .unwrap_or(after_prefix.len());
     let mut groups = &after_prefix[signer_count..];
+    let mut needs_approval = false;
     for transfer in interface_transfers {
         // Group shapes follow SPP's transact loader: SPL deposit `[mint,
         // spl_interface, token_authority, user_token, token_program]`, SPL
         // withdrawal `[mint, spl_interface, user_token, token_program]`, SOL
         // `[sol_interface, recipient]`.
-        let (mint, width) = match transfer {
-            InterfaceTransfer::SplDeposit { .. } => (spl_mint(groups)?, 5),
-            InterfaceTransfer::SplWithdrawal { .. } => (spl_mint(groups)?, 4),
-            InterfaceTransfer::SolDeposit { .. } | InterfaceTransfer::SolWithdrawal { .. } => {
-                (SOL_MINT, 2)
-            }
+        let (mint, width, is_withdrawal) = match transfer {
+            InterfaceTransfer::SplDeposit { .. } => (spl_mint(groups)?, 5, false),
+            InterfaceTransfer::SplWithdrawal { .. } => (spl_mint(groups)?, 4, true),
+            InterfaceTransfer::SolDeposit { .. } => (SOL_MINT, 2, false),
+            InterfaceTransfer::SolWithdrawal { .. } => (SOL_MINT, 2, true),
         };
         if !config.allows_asset(&mint) {
             return Err(CustomRingError::AssetNotAllowed.into());
+        }
+        if is_withdrawal {
+            match config.withdrawal_rule(&mint) {
+                WITHDRAWALS_BLOCKED => return Err(CustomRingError::WithdrawalsBlocked.into()),
+                WITHDRAWALS_APPROVAL => needs_approval = true,
+                _ => {}
+            }
         }
         groups = groups
             .get(width..)
             .ok_or(CustomRingError::InvalidInstructionData)?;
     }
-    Ok(())
+    Ok(needs_approval)
 }
 
 fn spl_mint(group: &[AccountView]) -> Result<[u8; 32], CustomRingError> {

--- a/custom-rings/program/src/instructions/policy.rs
+++ b/custom-rings/program/src/instructions/policy.rs
@@ -4,11 +4,17 @@
 //! transfer.
 
 use pinocchio::{error::ProgramError, AccountView, ProgramResult};
-use zolana_interface::instruction::{DepositAssetKind, InterfaceTransfer, RingDepositIxDataRef};
+use wincode::{
+    config::{Configuration, DEFAULT_PREALLOCATION_SIZE_LIMIT},
+    containers,
+    len::FixIntLen,
+    SchemaRead,
+};
+use zolana_interface::instruction::{DepositAssetKind, InterfaceTransfer};
 
 use crate::{
     error::CustomRingError,
-    state::{RingProgramConfig, SOL_MINT, WITHDRAWALS_APPROVAL, WITHDRAWALS_BLOCKED},
+    state::{AssetPolicy, RingProgramConfig, WithdrawalRule, SOL_MINT},
 };
 
 /// Accounts of SPP's `RING_DEPOSIT` before the per-asset settlement groups:
@@ -18,6 +24,31 @@ const DEPOSIT_PREFIX: usize = 4;
 /// `[payer, input_tree, output_tree, spp_program, system_program, ring_config]`.
 const TRANSACT_PREFIX: usize = 6;
 
+/// The wincode configuration SPP's `RingDepositIxData` is encoded with.
+type DepositConfig = Configuration<true, DEFAULT_PREALLOCATION_SIZE_LIMIT, FixIntLen<u16>>;
+
+/// The leading field of `RingDepositIxData`. Reading only this leaves the
+/// entries with their ciphertexts unparsed.
+#[derive(SchemaRead)]
+struct DepositAssets {
+    #[wincode(with = "containers::Vec<DepositAssetKind, FixIntLen<u8>>")]
+    assets: Vec<DepositAssetKind>,
+}
+
+/// A settlement leg as the policy sees it: which mint, which way, and how many
+/// accounts its group takes in SPP's layout.
+struct Leg {
+    mint: [u8; 32],
+    direction: Direction,
+    width: usize,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Direction {
+    Into,
+    OutOf,
+}
+
 /// `spp_accounts` and `data` are the forwarded ring deposit; `data` still
 /// carries SPP's tag byte. Every deposited mint must pass the allowlist.
 pub fn check_deposit(
@@ -25,31 +56,24 @@ pub fn check_deposit(
     spp_accounts: &[AccountView],
     data: &[u8],
 ) -> ProgramResult {
-    if config.allows_every_asset() {
+    if config.asset_policy() == AssetPolicy::Any {
         return Ok(());
     }
     let body = data
         .get(1..)
         .ok_or(CustomRingError::InvalidInstructionData)?;
-    let deposit = RingDepositIxDataRef::from_bytes(body)
+    let DepositAssets { assets } = wincode::config::deserialize(body, DepositConfig::new())
         .map_err(|_| CustomRingError::InvalidInstructionData)?;
     let mut groups = spp_accounts
         .get(DEPOSIT_PREFIX..)
         .ok_or(CustomRingError::InvalidInstructionData)?;
-    for kind in &deposit.assets {
+    for kind in &assets {
         // Group shapes follow SPP's deposit loader: SOL reads `[system_program,
         // sol_interface]`, SPL reads `[token_program, mint, user_token,
         // spl_interface]`.
         let (mint, width) = match kind {
             DepositAssetKind::Sol => (SOL_MINT, 2),
-            DepositAssetKind::Spl { .. } => (
-                *groups
-                    .get(1)
-                    .ok_or(CustomRingError::InvalidInstructionData)?
-                    .address()
-                    .as_array(),
-                4,
-            ),
+            DepositAssetKind::Spl { .. } => (mint_at(groups, 1)?, 4),
         };
         if !config.allows_asset(&mint) {
             return Err(CustomRingError::AssetNotAllowed.into());
@@ -74,7 +98,8 @@ pub fn check_transact(
         return Ok(false);
     }
     // Owner signers follow the fixed prefix; the settlement groups start at
-    // the first non-signer, in `interface_transfers` order.
+    // the first non-signer, in `interface_transfers` order. Every group opens
+    // with a non-signer (`mint` or `sol_interface`), so the boundary is exact.
     let after_prefix = spp_accounts
         .get(TRANSACT_PREFIX..)
         .ok_or(CustomRingError::InvalidInstructionData)?;
@@ -85,36 +110,56 @@ pub fn check_transact(
     let mut groups = &after_prefix[signer_count..];
     let mut needs_approval = false;
     for transfer in interface_transfers {
-        // Group shapes follow SPP's transact loader: SPL deposit `[mint,
-        // spl_interface, token_authority, user_token, token_program]`, SPL
-        // withdrawal `[mint, spl_interface, user_token, token_program]`, SOL
-        // `[sol_interface, recipient]`.
-        let (mint, width, is_withdrawal) = match transfer {
-            InterfaceTransfer::SplDeposit { .. } => (spl_mint(groups)?, 5, false),
-            InterfaceTransfer::SplWithdrawal { .. } => (spl_mint(groups)?, 4, true),
-            InterfaceTransfer::SolDeposit { .. } => (SOL_MINT, 2, false),
-            InterfaceTransfer::SolWithdrawal { .. } => (SOL_MINT, 2, true),
-        };
-        if !config.allows_asset(&mint) {
+        let leg = leg(transfer, groups)?;
+        if !config.allows_asset(&leg.mint) {
             return Err(CustomRingError::AssetNotAllowed.into());
         }
-        if is_withdrawal {
-            match config.withdrawal_rule(&mint) {
-                WITHDRAWALS_BLOCKED => return Err(CustomRingError::WithdrawalsBlocked.into()),
-                WITHDRAWALS_APPROVAL => needs_approval = true,
-                _ => {}
+        if leg.direction == Direction::OutOf {
+            match config.withdrawal_rule(&leg.mint) {
+                WithdrawalRule::Open => {}
+                WithdrawalRule::Blocked => return Err(CustomRingError::WithdrawalsBlocked.into()),
+                WithdrawalRule::Approval => needs_approval = true,
             }
         }
         groups = groups
-            .get(width..)
+            .get(leg.width..)
             .ok_or(CustomRingError::InvalidInstructionData)?;
     }
     Ok(needs_approval)
 }
 
-fn spl_mint(group: &[AccountView]) -> Result<[u8; 32], CustomRingError> {
+/// Group shapes follow SPP's transact loader: SPL deposit `[mint,
+/// spl_interface, token_authority, user_token, token_program]`, SPL withdrawal
+/// `[mint, spl_interface, user_token, token_program]`, SOL `[sol_interface,
+/// recipient]`.
+fn leg(transfer: &InterfaceTransfer, group: &[AccountView]) -> Result<Leg, CustomRingError> {
+    Ok(match transfer {
+        InterfaceTransfer::SplDeposit { .. } => Leg {
+            mint: mint_at(group, 0)?,
+            direction: Direction::Into,
+            width: 5,
+        },
+        InterfaceTransfer::SplWithdrawal { .. } => Leg {
+            mint: mint_at(group, 0)?,
+            direction: Direction::OutOf,
+            width: 4,
+        },
+        InterfaceTransfer::SolDeposit { .. } => Leg {
+            mint: SOL_MINT,
+            direction: Direction::Into,
+            width: 2,
+        },
+        InterfaceTransfer::SolWithdrawal { .. } => Leg {
+            mint: SOL_MINT,
+            direction: Direction::OutOf,
+            width: 2,
+        },
+    })
+}
+
+fn mint_at(group: &[AccountView], index: usize) -> Result<[u8; 32], CustomRingError> {
     group
-        .first()
+        .get(index)
         .map(|mint| *mint.address().as_array())
         .ok_or(CustomRingError::InvalidInstructionData)
 }

--- a/custom-rings/program/src/instructions/policy.rs
+++ b/custom-rings/program/src/instructions/policy.rs
@@ -35,7 +35,7 @@ struct DepositAssets {
     assets: Vec<DepositAssetKind>,
 }
 
-/// A settlement leg as the policy sees it: which mint, which way, and how many
+/// A settlement leg as the policy sees it. Which mint, which way, and how many
 /// accounts its group takes in SPP's layout.
 struct Leg {
     mint: [u8; 32],
@@ -49,8 +49,8 @@ enum Direction {
     OutOf,
 }
 
-/// `spp_accounts` and `data` are the forwarded ring deposit; `data` still
-/// carries SPP's tag byte. Every deposited mint must pass the allowlist.
+/// `spp_accounts` and `data` are the forwarded ring deposit, `data` still
+/// carrying SPP's tag byte. Every deposited mint must pass the allowlist.
 pub fn check_deposit(
     config: &RingProgramConfig,
     spp_accounts: &[AccountView],
@@ -68,7 +68,7 @@ pub fn check_deposit(
         .get(DEPOSIT_PREFIX..)
         .ok_or(CustomRingError::InvalidInstructionData)?;
     for kind in &assets {
-        // Group shapes follow SPP's deposit loader: SOL reads `[system_program,
+        // Group shapes follow SPP's deposit loader. SOL reads `[system_program,
         // sol_interface]`, SPL reads `[token_program, mint, user_token,
         // spl_interface]`.
         let (mint, width) = match kind {
@@ -97,7 +97,7 @@ pub fn check_transact(
     if interface_transfers.is_empty() {
         return Ok(false);
     }
-    // Owner signers follow the fixed prefix; the settlement groups start at
+    // Owner signers follow the fixed prefix and the settlement groups start at
     // the first non-signer, in `interface_transfers` order. Every group opens
     // with a non-signer (`mint` or `sol_interface`), so the boundary is exact.
     let after_prefix = spp_accounts
@@ -128,7 +128,7 @@ pub fn check_transact(
     Ok(needs_approval)
 }
 
-/// Group shapes follow SPP's transact loader: SPL deposit `[mint,
+/// Group shapes follow SPP's transact loader. SPL deposit `[mint,
 /// spl_interface, token_authority, user_token, token_program]`, SPL withdrawal
 /// `[mint, spl_interface, user_token, token_program]`, SOL `[sol_interface,
 /// recipient]`.

--- a/custom-rings/program/src/instructions/set_policy.rs
+++ b/custom-rings/program/src/instructions/set_policy.rs
@@ -8,7 +8,7 @@ use crate::{
     state::{AssetPolicy, AssetRule, WithdrawalRule, MAX_ASSETS},
 };
 
-/// One asset table entry on the wire; `withdrawals` is a `WithdrawalRule`.
+/// One asset table entry on the wire, `withdrawals` a `WithdrawalRule`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct AssetRuleData {
     pub mint: [u8; 32],
@@ -28,8 +28,8 @@ pub struct SetPolicyIxData {
     pub assets: Vec<AssetRuleData>,
 }
 
-/// Replaces the ring's policy. Accounts `[authority(s), config(w)]`; the
-/// authority is the one `create_config` recorded.
+/// Replaces the ring's policy. Accounts `[authority(s), config(w)]`, the
+/// authority being the one `create_config` recorded.
 #[inline(never)]
 pub fn process_set_policy_ix(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
     let SetPolicyIxData {

--- a/custom-rings/program/src/instructions/set_policy.rs
+++ b/custom-rings/program/src/instructions/set_policy.rs
@@ -5,37 +5,27 @@ use zolana_account_checks::AccountIterator;
 use crate::{
     error::CustomRingError,
     instructions::loader::load_config_mut,
-    state::{
-        ASSETS_ALLOWLIST, ASSETS_ANY, MAX_ASSETS, WITHDRAWALS_APPROVAL, WITHDRAWALS_BLOCKED,
-        WITHDRAWALS_OPEN,
-    },
+    state::{AssetPolicy, AssetRule, WithdrawalRule, MAX_ASSETS},
 };
 
-/// One asset table entry: a mint and its withdrawal rule.
+/// One asset table entry on the wire; `withdrawals` is a `WithdrawalRule`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
-pub struct AssetRule {
+pub struct AssetRuleData {
     pub mint: [u8; 32],
     pub withdrawals: u8,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct SetPolicyIxData {
-    /// Withdrawal rule for assets without a table entry.
+    /// `WithdrawalRule` for assets without a table entry.
     pub withdrawals: u8,
-    /// `ASSETS_ANY` or `ASSETS_ALLOWLIST`.
+    /// `AssetPolicy`.
     pub asset_policy: u8,
-    /// All zero when no rule is `WITHDRAWALS_APPROVAL`.
+    /// All zero when no rule is `WithdrawalRule::Approval`.
     pub approver: [u8; 32],
-    /// At most `MAX_ASSETS` entries.
-    #[wincode(with = "containers::Vec<AssetRule, FixIntLen<u8>>")]
-    pub assets: Vec<AssetRule>,
-}
-
-fn is_rule(value: u8) -> bool {
-    matches!(
-        value,
-        WITHDRAWALS_OPEN | WITHDRAWALS_BLOCKED | WITHDRAWALS_APPROVAL
-    )
+    /// At most `MAX_ASSETS` entries, distinct mints.
+    #[wincode(with = "containers::Vec<AssetRuleData, FixIntLen<u8>>")]
+    pub assets: Vec<AssetRuleData>,
 }
 
 /// Replaces the ring's policy. Accounts `[authority(s), config(w)]`; the
@@ -48,16 +38,36 @@ pub fn process_set_policy_ix(accounts: &mut [AccountView], data: &[u8]) -> Progr
         approver,
         assets,
     } = wincode::deserialize_exact(data).map_err(|_| CustomRingError::InvalidInstructionData)?;
-    let needs_approver = withdrawals == WITHDRAWALS_APPROVAL
-        || assets
+    let withdrawals = WithdrawalRule::try_from(withdrawals)?;
+    let asset_policy = AssetPolicy::try_from(asset_policy)?;
+    if assets.len() > MAX_ASSETS {
+        return Err(CustomRingError::InvalidPolicy.into());
+    }
+    let mut table = [AssetRule {
+        mint: [0u8; 32],
+        withdrawals: WithdrawalRule::Open,
+    }; MAX_ASSETS];
+    for (index, asset) in assets.iter().enumerate() {
+        // A mint listed twice would let the first entry's rule shadow the
+        // second silently.
+        if assets[..index]
             .iter()
-            .any(|asset| asset.withdrawals == WITHDRAWALS_APPROVAL);
-    if !is_rule(withdrawals)
-        || !matches!(asset_policy, ASSETS_ANY | ASSETS_ALLOWLIST)
-        || assets.len() > MAX_ASSETS
-        || assets.iter().any(|asset| !is_rule(asset.withdrawals))
-        || (needs_approver && approver == [0u8; 32])
-    {
+            .any(|earlier| earlier.mint == asset.mint)
+        {
+            return Err(CustomRingError::InvalidPolicy.into());
+        }
+        table[index] = AssetRule {
+            mint: asset.mint,
+            withdrawals: WithdrawalRule::try_from(asset.withdrawals)?,
+        };
+    }
+    let table = &table[..assets.len()];
+    let needs_approver = withdrawals == WithdrawalRule::Approval
+        || table
+            .iter()
+            .any(|asset| asset.withdrawals == WithdrawalRule::Approval);
+    let approver = Address::new_from_array(approver);
+    if needs_approver && approver == Address::default() {
         return Err(CustomRingError::InvalidPolicy.into());
     }
 
@@ -69,15 +79,6 @@ pub fn process_set_policy_ix(accounts: &mut [AccountView], data: &[u8]) -> Progr
     if !address_eq(&config.authority, authority.address()) {
         return Err(CustomRingError::UnauthorizedAuthority.into());
     }
-    config.withdrawals = withdrawals;
-    config.asset_policy = asset_policy;
-    config.approver = Address::new_from_array(approver);
-    config.assets = [[0u8; 32]; MAX_ASSETS];
-    config.asset_withdrawals = [0u8; MAX_ASSETS];
-    for (index, asset) in assets.iter().enumerate() {
-        config.assets[index] = asset.mint;
-        config.asset_withdrawals[index] = asset.withdrawals;
-    }
-    config.assets_len = assets.len() as u8;
+    config.set_policy(asset_policy, withdrawals, approver, table);
     Ok(())
 }

--- a/custom-rings/program/src/instructions/set_policy.rs
+++ b/custom-rings/program/src/instructions/set_policy.rs
@@ -1,4 +1,4 @@
-use pinocchio::{address::address_eq, AccountView, ProgramResult};
+use pinocchio::{address::address_eq, AccountView, Address, ProgramResult};
 use wincode::{containers, len::FixIntLen, SchemaRead, SchemaWrite};
 use zolana_account_checks::AccountIterator;
 
@@ -6,19 +6,36 @@ use crate::{
     error::CustomRingError,
     instructions::loader::load_config_mut,
     state::{
-        ASSETS_ALLOWLIST, ASSETS_ANY, MAX_ALLOWED_ASSETS, WITHDRAWALS_BLOCKED, WITHDRAWALS_OPEN,
+        ASSETS_ALLOWLIST, ASSETS_ANY, MAX_ASSETS, WITHDRAWALS_APPROVAL, WITHDRAWALS_BLOCKED,
+        WITHDRAWALS_OPEN,
     },
 };
 
+/// One asset table entry: a mint and its withdrawal rule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
+pub struct AssetRule {
+    pub mint: [u8; 32],
+    pub withdrawals: u8,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct SetPolicyIxData {
-    /// `WITHDRAWALS_OPEN` or `WITHDRAWALS_BLOCKED`.
+    /// Withdrawal rule for assets without a table entry.
     pub withdrawals: u8,
     /// `ASSETS_ANY` or `ASSETS_ALLOWLIST`.
     pub asset_policy: u8,
-    /// Mints accepted under the allowlist, at most `MAX_ALLOWED_ASSETS`.
-    #[wincode(with = "containers::Vec<[u8; 32], FixIntLen<u8>>")]
-    pub allowed_assets: Vec<[u8; 32]>,
+    /// All zero when no rule is `WITHDRAWALS_APPROVAL`.
+    pub approver: [u8; 32],
+    /// At most `MAX_ASSETS` entries.
+    #[wincode(with = "containers::Vec<AssetRule, FixIntLen<u8>>")]
+    pub assets: Vec<AssetRule>,
+}
+
+fn is_rule(value: u8) -> bool {
+    matches!(
+        value,
+        WITHDRAWALS_OPEN | WITHDRAWALS_BLOCKED | WITHDRAWALS_APPROVAL
+    )
 }
 
 /// Replaces the ring's policy. Accounts `[authority(s), config(w)]`; the
@@ -28,11 +45,18 @@ pub fn process_set_policy_ix(accounts: &mut [AccountView], data: &[u8]) -> Progr
     let SetPolicyIxData {
         withdrawals,
         asset_policy,
-        allowed_assets,
+        approver,
+        assets,
     } = wincode::deserialize_exact(data).map_err(|_| CustomRingError::InvalidInstructionData)?;
-    if !matches!(withdrawals, WITHDRAWALS_OPEN | WITHDRAWALS_BLOCKED)
+    let needs_approver = withdrawals == WITHDRAWALS_APPROVAL
+        || assets
+            .iter()
+            .any(|asset| asset.withdrawals == WITHDRAWALS_APPROVAL);
+    if !is_rule(withdrawals)
         || !matches!(asset_policy, ASSETS_ANY | ASSETS_ALLOWLIST)
-        || allowed_assets.len() > MAX_ALLOWED_ASSETS
+        || assets.len() > MAX_ASSETS
+        || assets.iter().any(|asset| !is_rule(asset.withdrawals))
+        || (needs_approver && approver == [0u8; 32])
     {
         return Err(CustomRingError::InvalidPolicy.into());
     }
@@ -47,10 +71,13 @@ pub fn process_set_policy_ix(accounts: &mut [AccountView], data: &[u8]) -> Progr
     }
     config.withdrawals = withdrawals;
     config.asset_policy = asset_policy;
-    config.allowed_assets = [[0u8; 32]; MAX_ALLOWED_ASSETS];
-    for (slot, mint) in config.allowed_assets.iter_mut().zip(&allowed_assets) {
-        *slot = *mint;
+    config.approver = Address::new_from_array(approver);
+    config.assets = [[0u8; 32]; MAX_ASSETS];
+    config.asset_withdrawals = [0u8; MAX_ASSETS];
+    for (index, asset) in assets.iter().enumerate() {
+        config.assets[index] = asset.mint;
+        config.asset_withdrawals[index] = asset.withdrawals;
     }
-    config.allowed_assets_len = allowed_assets.len() as u8;
+    config.assets_len = assets.len() as u8;
     Ok(())
 }

--- a/custom-rings/program/src/instructions/transact.rs
+++ b/custom-rings/program/src/instructions/transact.rs
@@ -10,7 +10,7 @@ use zolana_interface::{
 use crate::{
     error::CustomRingError,
     instructions::{
-        approve_transact::{verify_approval_pda, APPROVAL_SIZE},
+        approve_transact::{check_approval, APPROVAL_SIZE},
         loader::{load_config, validate_spp_program},
         policy::check_transact,
         shared::{cpi_spp_signed, pack33_to_2fe},
@@ -27,8 +27,7 @@ fn is_approval_account(account: &AccountView) -> bool {
         && account.data_len() == APPROVAL_SIZE
         && account
             .try_borrow()
-            .map(|data| data.first() == Some(&TRANSACT_APPROVAL))
-            .unwrap_or(false)
+            .is_ok_and(|data| data.first() == Some(&TRANSACT_APPROVAL))
 }
 /// AES-256-CTR ciphertext of the 32-byte transaction viewing secret key.
 const CIPHERTEXT_LEN: usize = 32;
@@ -193,7 +192,7 @@ pub fn process_transact_ix(accounts: &mut [AccountView], data: &[u8]) -> Program
     // The approval is bound to this transact through `private_tx_hash`; it is
     // spent after the CPI so it cannot approve a second submission.
     if let Some(approval) = &approval {
-        verify_approval_pda(approval.address(), &transact.private_tx_hash)?;
+        check_approval(approval, &transact.private_tx_hash)?;
     }
 
     // This ring has one rail: Solana eddsa signers. `RingP256` (and any future

--- a/custom-rings/program/src/instructions/transact.rs
+++ b/custom-rings/program/src/instructions/transact.rs
@@ -10,15 +10,26 @@ use zolana_interface::{
 use crate::{
     error::CustomRingError,
     instructions::{
+        approve_transact::{verify_approval_pda, APPROVAL_SIZE},
         loader::{load_config, validate_spp_program},
         policy::check_transact,
         shared::{cpi_spp_signed, pack33_to_2fe},
         verifier::{verify_groth16, CompressedGroth16Proof},
     },
+    state::TRANSACT_APPROVAL,
 };
 
 /// SEC1-compressed public key length.
 const COMPRESSED_PUBKEY_LEN: usize = 33;
+
+fn is_approval_account(account: &AccountView) -> bool {
+    account.owned_by(&crate::ID)
+        && account.data_len() == APPROVAL_SIZE
+        && account
+            .try_borrow()
+            .map(|data| data.first() == Some(&TRANSACT_APPROVAL))
+            .unwrap_or(false)
+}
 /// AES-256-CTR ciphertext of the 32-byte transaction viewing secret key.
 const CIPHERTEXT_LEN: usize = 32;
 /// `eph_pk_compressed(33) || ciphertext(32)`.
@@ -147,15 +158,23 @@ fn select_auditor_message<'a>(
 #[inline(never)]
 pub fn process_transact_ix(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
     let mut iter = AccountIterator::new(accounts);
-    iter.next_signer_mut("payer")?;
+    let payer = iter.next_signer_mut("payer")?;
     let config_account = iter.next_account("config")?;
 
     let CustomRingTransactIxData { proof, transact } =
         wincode::deserialize_exact(data).map_err(|_| CustomRingError::InvalidInstructionData)?;
 
+    // An approval account, when the caller passes one, sits between the config
+    // and the forwarded list. Only this program writes accounts with that
+    // discriminator, so ownership plus the first byte identify it; SPP's list
+    // starts with a system-owned signer and can never be mistaken for one.
+    let rest = iter.remaining_mut()?;
+    let (approval, spp_accounts) = match rest.split_first_mut() {
+        Some((first, spp_accounts)) if is_approval_account(first) => (Some(first), spp_accounts),
+        _ => (None, rest),
+    };
     // The forwarded list is taken before the expensive work so a malformed
     // account list costs no pairing.
-    let spp_accounts = iter.remaining()?;
     validate_spp_program(spp_accounts)?;
 
     // Only this program can own an account it wrote, and `create_config` writes
@@ -165,9 +184,17 @@ pub fn process_transact_ix(accounts: &mut [AccountView], data: &[u8]) -> Program
     let auditor_pubkey = {
         let config = load_config(config_account)?;
         // Policy before the pairing: a refused transfer costs no proof work.
-        check_transact(&config, spp_accounts, &transact.interface_transfers)?;
+        let needs_approval = check_transact(&config, spp_accounts, &transact.interface_transfers)?;
+        if needs_approval && approval.is_none() {
+            return Err(CustomRingError::ApprovalRequired.into());
+        }
         config.auditor_pubkey
     };
+    // The approval is bound to this transact through `private_tx_hash`; it is
+    // spent after the CPI so it cannot approve a second submission.
+    if let Some(approval) = &approval {
+        verify_approval_pda(approval.address(), &transact.private_tx_hash)?;
+    }
 
     // This ring has one rail: Solana eddsa signers. `RingP256` (and any future
     // selector) would put SPP on a proof shape whose ownership semantics this
@@ -211,7 +238,23 @@ pub fn process_transact_ix(accounts: &mut [AccountView], data: &[u8]) -> Program
     let mut instruction_data = Vec::with_capacity(1 + transact_bytes.len());
     instruction_data.push(tag::RING_TRANSACT);
     instruction_data.extend_from_slice(&transact_bytes);
-    cpi_spp_signed(spp_accounts, &instruction_data)
+    cpi_spp_signed(spp_accounts, &instruction_data)?;
+
+    // Lamports move only after the CPI: the runtime syncs the caller's changes
+    // to the accounts it forwards (the payer) before invoking, and an account
+    // outside the CPI list (the approval) only at the end, so moving them
+    // earlier reads as an unbalanced instruction.
+    if let Some(approval) = approval {
+        payer.set_lamports(
+            payer
+                .lamports()
+                .checked_add(approval.lamports())
+                .ok_or(ProgramError::ArithmeticOverflow)?,
+        );
+        approval.set_lamports(0);
+        approval.close()?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/custom-rings/program/src/instructions/transact.rs
+++ b/custom-rings/program/src/instructions/transact.rs
@@ -165,8 +165,8 @@ pub fn process_transact_ix(accounts: &mut [AccountView], data: &[u8]) -> Program
 
     // An approval account, when the caller passes one, sits between the config
     // and the forwarded list. Only this program writes accounts with that
-    // discriminator, so ownership plus the first byte identify it; SPP's list
-    // starts with a system-owned signer and can never be mistaken for one.
+    // discriminator, so ownership plus the first byte identify it, and SPP's
+    // list starts with a system-owned signer that can never be mistaken for one.
     let rest = iter.remaining_mut()?;
     let (approval, spp_accounts) = match rest.split_first_mut() {
         Some((first, spp_accounts)) if is_approval_account(first) => (Some(first), spp_accounts),
@@ -182,15 +182,15 @@ pub fn process_transact_ix(accounts: &mut [AccountView], data: &[u8]) -> Program
     // account is not still borrowed across the CPI.
     let auditor_pubkey = {
         let config = load_config(config_account)?;
-        // Policy before the pairing: a refused transfer costs no proof work.
+        // Policy before the pairing, so a refused transfer costs no proof work.
         let needs_approval = check_transact(&config, spp_accounts, &transact.interface_transfers)?;
         if needs_approval && approval.is_none() {
             return Err(CustomRingError::ApprovalRequired.into());
         }
         config.auditor_pubkey
     };
-    // The approval is bound to this transact through `private_tx_hash`; it is
-    // spent after the CPI so it cannot approve a second submission.
+    // The approval is bound to this transact through `private_tx_hash` and is
+    // spent after the CPI, so it cannot approve a second submission.
     if let Some(approval) = &approval {
         check_approval(approval, &transact.private_tx_hash)?;
     }
@@ -239,7 +239,7 @@ pub fn process_transact_ix(accounts: &mut [AccountView], data: &[u8]) -> Program
     instruction_data.extend_from_slice(&transact_bytes);
     cpi_spp_signed(spp_accounts, &instruction_data)?;
 
-    // Lamports move only after the CPI: the runtime syncs the caller's changes
+    // Lamports move only after the CPI. The runtime syncs the caller's changes
     // to the accounts it forwards (the payer) before invoking, and an account
     // outside the CPI list (the approval) only at the end, so moving them
     // earlier reads as an unbalanced instruction.

--- a/custom-rings/program/src/lib.rs
+++ b/custom-rings/program/src/lib.rs
@@ -16,7 +16,8 @@ use pinocchio::{address::address_eq, error::ProgramError, AccountView, Address, 
 
 use crate::instructions::{
     process_approve_transact_ix, process_create_config_ix, process_deposit_ix,
-    process_init_spp_ring_config_ix, process_set_policy_ix, process_transact_ix,
+    process_init_spp_ring_config_ix, process_revoke_approval_ix, process_set_policy_ix,
+    process_transact_ix,
 };
 
 pub mod tag {
@@ -25,6 +26,7 @@ pub mod tag {
     pub const TRANSACT: u8 = 3;
     pub const SET_POLICY: u8 = 4;
     pub const APPROVE_TRANSACT: u8 = 5;
+    pub const REVOKE_APPROVAL: u8 = 6;
     /// Ring deposits carry no proof and are forwarded to SPP byte for byte, so
     /// the dispatcher matches SPP's own deposit tag instead of a program-local
     /// one: the client builds the SPP-shaped instruction and only re-targets the
@@ -60,6 +62,7 @@ pub fn process_instruction(
         tag::TRANSACT => process_transact_ix(accounts, ix_data),
         tag::SET_POLICY => process_set_policy_ix(accounts, ix_data),
         tag::APPROVE_TRANSACT => process_approve_transact_ix(accounts, ix_data),
+        tag::REVOKE_APPROVAL => process_revoke_approval_ix(accounts, ix_data),
         // The forwarder passes the tag byte on as well: SPP's dispatcher strips it.
         tag::DEPOSIT => process_deposit_ix(accounts, instruction_data),
         _ => Err(ProgramError::InvalidInstructionData),

--- a/custom-rings/program/src/lib.rs
+++ b/custom-rings/program/src/lib.rs
@@ -4,8 +4,8 @@
 //!
 //! Scope is deliberately minimal: confidential transfers only, Solana eddsa
 //! signers only (`CircuitId::RingEddsa`), no smart accounts, no user accounts.
-//! Policy is an asset allowlist and a public-withdrawal switch, both set by the
-//! ring authority. See `custom-rings/custom_ring.md`.
+//! Policy is an asset allowlist and a withdrawal rule per asset (open, blocked,
+//! or approved by a configured key), set by the ring authority. See `custom-rings/custom_ring.md`.
 
 pub mod error;
 pub mod instructions;
@@ -15,8 +15,8 @@ pub mod verifying_keys;
 use pinocchio::{address::address_eq, error::ProgramError, AccountView, Address, ProgramResult};
 
 use crate::instructions::{
-    process_create_config_ix, process_deposit_ix, process_init_spp_ring_config_ix,
-    process_set_policy_ix, process_transact_ix,
+    process_approve_transact_ix, process_create_config_ix, process_deposit_ix,
+    process_init_spp_ring_config_ix, process_set_policy_ix, process_transact_ix,
 };
 
 pub mod tag {
@@ -24,6 +24,7 @@ pub mod tag {
     pub const INIT_SPP_RING_CONFIG: u8 = 2;
     pub const TRANSACT: u8 = 3;
     pub const SET_POLICY: u8 = 4;
+    pub const APPROVE_TRANSACT: u8 = 5;
     /// Ring deposits carry no proof and are forwarded to SPP byte for byte, so
     /// the dispatcher matches SPP's own deposit tag instead of a program-local
     /// one: the client builds the SPP-shaped instruction and only re-targets the
@@ -58,6 +59,7 @@ pub fn process_instruction(
         tag::INIT_SPP_RING_CONFIG => process_init_spp_ring_config_ix(accounts, ix_data),
         tag::TRANSACT => process_transact_ix(accounts, ix_data),
         tag::SET_POLICY => process_set_policy_ix(accounts, ix_data),
+        tag::APPROVE_TRANSACT => process_approve_transact_ix(accounts, ix_data),
         // The forwarder passes the tag byte on as well: SPP's dispatcher strips it.
         tag::DEPOSIT => process_deposit_ix(accounts, instruction_data),
         _ => Err(ProgramError::InvalidInstructionData),

--- a/custom-rings/program/src/state.rs
+++ b/custom-rings/program/src/state.rs
@@ -15,8 +15,8 @@ pub const MAX_ASSETS: usize = 8;
 /// The mint that stands for native SOL in the asset table and in SPP's registry.
 pub const SOL_MINT: [u8; 32] = [0u8; 32];
 
-/// What happens to a public settlement leg out of the pool. Stored as its `u8`
-/// in the config; every byte the program writes came through `try_from`.
+/// What happens to a public settlement leg out of the pool. The config stores
+/// the `u8` and every byte the program writes came through `try_from`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum WithdrawalRule {
@@ -108,10 +108,10 @@ pub struct RingProgramConfig {
     pub asset_policy: u8,
     /// Live entries of `assets` and `asset_withdrawals`, at most [`MAX_ASSETS`].
     pub assets_len: u8,
-    /// The key that may create approval accounts; all zero when no rule needs
+    /// The key that may create approval accounts, all zero when no rule needs
     /// approval.
     pub approver: Address,
-    /// Mints of the asset table; SOL is [`SOL_MINT`].
+    /// Mints of the asset table, SOL is [`SOL_MINT`].
     pub assets: [[u8; 32]; MAX_ASSETS],
     /// [`WithdrawalRule`] per table entry.
     pub asset_withdrawals: [u8; MAX_ASSETS],
@@ -150,7 +150,7 @@ impl RingProgramConfig {
         }
     }
 
-    /// The withdrawal rule for `mint`: its table entry, else the default.
+    /// The withdrawal rule for `mint`, its table entry or else the default.
     pub fn withdrawal_rule(&self, mint: &[u8; 32]) -> WithdrawalRule {
         self.assets().find(|asset| asset.mint == *mint).map_or_else(
             || rule_or_blocked(self.withdrawals),
@@ -162,7 +162,7 @@ impl RingProgramConfig {
         (self.approver != Address::default()).then_some(&self.approver)
     }
 
-    /// Replaces the policy fields; the caller has validated `assets.len()`.
+    /// Replaces the policy fields. The caller has validated `assets.len()`.
     pub fn set_policy(
         &mut self,
         asset_policy: AssetPolicy,

--- a/custom-rings/program/src/state.rs
+++ b/custom-rings/program/src/state.rs
@@ -3,23 +3,27 @@ use pinocchio::{AccountView, Address, ProgramResult};
 
 use crate::error::CustomRingError;
 
-/// Discriminator of [`RingProgramConfig`]. The program owns a single account
-/// type, so one byte suffices; value 0 stays reserved for "uninitialized".
+/// Discriminator of [`RingProgramConfig`]. Value 0 stays reserved for
+/// "uninitialized".
 pub const RING_PROGRAM_CONFIG: u8 = 1;
+/// Discriminator of an approval account, see `approve_transact`.
+pub const TRANSACT_APPROVAL: u8 = 2;
 
-/// Capacity of the asset allowlist. Fixed so the config stays a `Pod` account.
-pub const MAX_ALLOWED_ASSETS: usize = 8;
+/// Capacity of the asset table. Fixed so the config stays a `Pod` account.
+pub const MAX_ASSETS: usize = 8;
 
-/// `RingProgramConfig::withdrawals`: public withdrawals (SOL or SPL settlement
-/// legs out of the pool) are forwarded or refused.
+/// A withdrawal rule: what happens to a public settlement leg out of the pool.
 pub const WITHDRAWALS_OPEN: u8 = 0;
 pub const WITHDRAWALS_BLOCKED: u8 = 1;
+/// The transact must carry an approval account the configured approver created
+/// for its `private_tx_hash`.
+pub const WITHDRAWALS_APPROVAL: u8 = 2;
 
 /// `RingProgramConfig::asset_policy`: any asset, or only the listed mints.
 pub const ASSETS_ANY: u8 = 0;
 pub const ASSETS_ALLOWLIST: u8 = 1;
 
-/// The mint that stands for native SOL in the allowlist and in SPP's registry.
+/// The mint that stands for native SOL in the asset table and in SPP's registry.
 pub const SOL_MINT: [u8; 32] = [0u8; 32];
 
 /// The ring's singleton config: who may register the ring with SPP, the auditor
@@ -33,15 +37,20 @@ pub struct RingProgramConfig {
     /// Auditor P256 public key in SEC1 compressed form (`0x02`/`0x03 || x`).
     pub auditor_pubkey: [u8; 33],
     pub bump: u8,
-    /// [`WITHDRAWALS_OPEN`] or [`WITHDRAWALS_BLOCKED`].
+    /// Withdrawal rule for assets without an entry in the table.
     pub withdrawals: u8,
-    /// [`ASSETS_ANY`] or [`ASSETS_ALLOWLIST`].
+    /// [`ASSETS_ANY`] or [`ASSETS_ALLOWLIST`]. Under the allowlist only the
+    /// table's mints may enter or leave the ring.
     pub asset_policy: u8,
-    /// Live entries of `allowed_assets`, at most [`MAX_ALLOWED_ASSETS`].
-    pub allowed_assets_len: u8,
-    /// Mints the ring accepts when `asset_policy` is the allowlist; SOL is
-    /// [`SOL_MINT`].
-    pub allowed_assets: [[u8; 32]; MAX_ALLOWED_ASSETS],
+    /// Live entries of `assets` and `asset_withdrawals`, at most [`MAX_ASSETS`].
+    pub assets_len: u8,
+    /// The key that may create approval accounts; all zero when no rule needs
+    /// approval.
+    pub approver: Address,
+    /// Mints of the asset table; SOL is [`SOL_MINT`].
+    pub assets: [[u8; 32]; MAX_ASSETS],
+    /// Withdrawal rule per table entry.
+    pub asset_withdrawals: [u8; MAX_ASSETS],
 }
 
 impl RingProgramConfig {
@@ -52,9 +61,12 @@ impl RingProgramConfig {
         self.discriminator == RING_PROGRAM_CONFIG
     }
 
-    pub fn allowed_assets(&self) -> &[[u8; 32]] {
-        let len = usize::from(self.allowed_assets_len).min(MAX_ALLOWED_ASSETS);
-        &self.allowed_assets[..len]
+    /// The asset table as `(mint, withdrawal rule)` pairs.
+    pub fn assets(&self) -> impl Iterator<Item = (&[u8; 32], u8)> {
+        let len = usize::from(self.assets_len).min(MAX_ASSETS);
+        self.assets[..len]
+            .iter()
+            .zip(self.asset_withdrawals[..len].iter().copied())
     }
 
     pub fn allows_every_asset(&self) -> bool {
@@ -63,18 +75,25 @@ impl RingProgramConfig {
 
     /// Whether `mint` may enter or leave the ring under the asset policy.
     pub fn allows_asset(&self, mint: &[u8; 32]) -> bool {
-        self.allows_every_asset() || self.allowed_assets().contains(mint)
+        self.allows_every_asset() || self.assets().any(|(listed, _)| listed == mint)
     }
 
-    pub fn withdrawals_blocked(&self) -> bool {
-        self.withdrawals == WITHDRAWALS_BLOCKED
+    /// The withdrawal rule for `mint`: its table entry, else the default.
+    pub fn withdrawal_rule(&self, mint: &[u8; 32]) -> u8 {
+        self.assets()
+            .find(|(listed, _)| *listed == mint)
+            .map_or(self.withdrawals, |(_, rule)| rule)
+    }
+
+    pub fn has_approver(&self) -> bool {
+        self.approver != Address::default()
     }
 }
 
 // Every field is byte-typed (`Address` is a 32-byte, align-1 newtype), so the
 // struct carries no padding: its `Pod` image is exactly its field bytes and
 // `SIZE` is the on-chain account length.
-const _: () = assert!(RingProgramConfig::SIZE == 70 + 32 * MAX_ALLOWED_ASSETS);
+const _: () = assert!(RingProgramConfig::SIZE == 102 + 33 * MAX_ASSETS);
 const _: () = assert!(core::mem::align_of::<RingProgramConfig>() == 1);
 
 /// Values written into a freshly created config account. The policy starts
@@ -110,8 +129,10 @@ impl RingProgramConfigInitParams {
             bump: self.bump,
             withdrawals: WITHDRAWALS_OPEN,
             asset_policy: ASSETS_ANY,
-            allowed_assets_len: 0,
-            allowed_assets: [[0u8; 32]; MAX_ALLOWED_ASSETS],
+            assets_len: 0,
+            approver: Address::default(),
+            assets: [[0u8; 32]; MAX_ASSETS],
+            asset_withdrawals: [0u8; MAX_ASSETS],
         };
         Ok(())
     }

--- a/custom-rings/program/src/state.rs
+++ b/custom-rings/program/src/state.rs
@@ -12,19 +12,84 @@ pub const TRANSACT_APPROVAL: u8 = 2;
 /// Capacity of the asset table. Fixed so the config stays a `Pod` account.
 pub const MAX_ASSETS: usize = 8;
 
-/// A withdrawal rule: what happens to a public settlement leg out of the pool.
-pub const WITHDRAWALS_OPEN: u8 = 0;
-pub const WITHDRAWALS_BLOCKED: u8 = 1;
-/// The transact must carry an approval account the configured approver created
-/// for its `private_tx_hash`.
-pub const WITHDRAWALS_APPROVAL: u8 = 2;
-
-/// `RingProgramConfig::asset_policy`: any asset, or only the listed mints.
-pub const ASSETS_ANY: u8 = 0;
-pub const ASSETS_ALLOWLIST: u8 = 1;
-
 /// The mint that stands for native SOL in the asset table and in SPP's registry.
 pub const SOL_MINT: [u8; 32] = [0u8; 32];
+
+/// What happens to a public settlement leg out of the pool. Stored as its `u8`
+/// in the config; every byte the program writes came through `try_from`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum WithdrawalRule {
+    Open = 0,
+    Blocked = 1,
+    /// The transact must carry an approval account the configured approver
+    /// created for its `private_tx_hash`.
+    Approval = 2,
+}
+
+impl WithdrawalRule {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Blocked => "blocked",
+            Self::Approval => "approval",
+        }
+    }
+}
+
+impl TryFrom<u8> for WithdrawalRule {
+    type Error = CustomRingError;
+
+    fn try_from(value: u8) -> Result<Self, CustomRingError> {
+        match value {
+            0 => Ok(Self::Open),
+            1 => Ok(Self::Blocked),
+            2 => Ok(Self::Approval),
+            _ => Err(CustomRingError::InvalidPolicy),
+        }
+    }
+}
+
+impl core::str::FromStr for WithdrawalRule {
+    type Err = CustomRingError;
+
+    fn from_str(text: &str) -> Result<Self, CustomRingError> {
+        match text {
+            "open" => Ok(Self::Open),
+            "blocked" => Ok(Self::Blocked),
+            "approval" => Ok(Self::Approval),
+            _ => Err(CustomRingError::InvalidPolicy),
+        }
+    }
+}
+
+/// Which mints may enter or leave the ring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum AssetPolicy {
+    Any = 0,
+    /// Only the mints in the asset table.
+    Allowlist = 1,
+}
+
+impl TryFrom<u8> for AssetPolicy {
+    type Error = CustomRingError;
+
+    fn try_from(value: u8) -> Result<Self, CustomRingError> {
+        match value {
+            0 => Ok(Self::Any),
+            1 => Ok(Self::Allowlist),
+            _ => Err(CustomRingError::InvalidPolicy),
+        }
+    }
+}
+
+/// One asset table entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AssetRule {
+    pub mint: [u8; 32],
+    pub withdrawals: WithdrawalRule,
+}
 
 /// The ring's singleton config: who may register the ring with SPP, the auditor
 /// key every `transact` must verifiably encrypt the transaction viewing secret
@@ -37,10 +102,9 @@ pub struct RingProgramConfig {
     /// Auditor P256 public key in SEC1 compressed form (`0x02`/`0x03 || x`).
     pub auditor_pubkey: [u8; 33],
     pub bump: u8,
-    /// Withdrawal rule for assets without an entry in the table.
+    /// [`WithdrawalRule`] for assets without an entry in the table.
     pub withdrawals: u8,
-    /// [`ASSETS_ANY`] or [`ASSETS_ALLOWLIST`]. Under the allowlist only the
-    /// table's mints may enter or leave the ring.
+    /// [`AssetPolicy`].
     pub asset_policy: u8,
     /// Live entries of `assets` and `asset_withdrawals`, at most [`MAX_ASSETS`].
     pub assets_len: u8,
@@ -49,7 +113,7 @@ pub struct RingProgramConfig {
     pub approver: Address,
     /// Mints of the asset table; SOL is [`SOL_MINT`].
     pub assets: [[u8; 32]; MAX_ASSETS],
-    /// Withdrawal rule per table entry.
+    /// [`WithdrawalRule`] per table entry.
     pub asset_withdrawals: [u8; MAX_ASSETS],
 }
 
@@ -61,33 +125,66 @@ impl RingProgramConfig {
         self.discriminator == RING_PROGRAM_CONFIG
     }
 
-    /// The asset table as `(mint, withdrawal rule)` pairs.
-    pub fn assets(&self) -> impl Iterator<Item = (&[u8; 32], u8)> {
+    /// The asset table. A rule byte the program never wrote reads as
+    /// `Blocked`, so corrupted state fails closed.
+    pub fn assets(&self) -> impl Iterator<Item = AssetRule> + '_ {
         let len = usize::from(self.assets_len).min(MAX_ASSETS);
         self.assets[..len]
             .iter()
-            .zip(self.asset_withdrawals[..len].iter().copied())
+            .zip(&self.asset_withdrawals[..len])
+            .map(|(mint, rule)| AssetRule {
+                mint: *mint,
+                withdrawals: rule_or_blocked(*rule),
+            })
     }
 
-    pub fn allows_every_asset(&self) -> bool {
-        self.asset_policy != ASSETS_ALLOWLIST
+    pub fn asset_policy(&self) -> AssetPolicy {
+        AssetPolicy::try_from(self.asset_policy).unwrap_or(AssetPolicy::Allowlist)
     }
 
     /// Whether `mint` may enter or leave the ring under the asset policy.
     pub fn allows_asset(&self, mint: &[u8; 32]) -> bool {
-        self.allows_every_asset() || self.assets().any(|(listed, _)| listed == mint)
+        match self.asset_policy() {
+            AssetPolicy::Any => true,
+            AssetPolicy::Allowlist => self.assets().any(|asset| asset.mint == *mint),
+        }
     }
 
     /// The withdrawal rule for `mint`: its table entry, else the default.
-    pub fn withdrawal_rule(&self, mint: &[u8; 32]) -> u8 {
-        self.assets()
-            .find(|(listed, _)| *listed == mint)
-            .map_or(self.withdrawals, |(_, rule)| rule)
+    pub fn withdrawal_rule(&self, mint: &[u8; 32]) -> WithdrawalRule {
+        self.assets().find(|asset| asset.mint == *mint).map_or_else(
+            || rule_or_blocked(self.withdrawals),
+            |asset| asset.withdrawals,
+        )
     }
 
-    pub fn has_approver(&self) -> bool {
-        self.approver != Address::default()
+    pub fn approver(&self) -> Option<&Address> {
+        (self.approver != Address::default()).then_some(&self.approver)
     }
+
+    /// Replaces the policy fields; the caller has validated `assets.len()`.
+    pub fn set_policy(
+        &mut self,
+        asset_policy: AssetPolicy,
+        withdrawals: WithdrawalRule,
+        approver: Address,
+        assets: &[AssetRule],
+    ) {
+        self.asset_policy = asset_policy as u8;
+        self.withdrawals = withdrawals as u8;
+        self.approver = approver;
+        self.assets = [[0u8; 32]; MAX_ASSETS];
+        self.asset_withdrawals = [0u8; MAX_ASSETS];
+        for (index, asset) in assets.iter().enumerate().take(MAX_ASSETS) {
+            self.assets[index] = asset.mint;
+            self.asset_withdrawals[index] = asset.withdrawals as u8;
+        }
+        self.assets_len = assets.len().min(MAX_ASSETS) as u8;
+    }
+}
+
+fn rule_or_blocked(value: u8) -> WithdrawalRule {
+    WithdrawalRule::try_from(value).unwrap_or(WithdrawalRule::Blocked)
 }
 
 // Every field is byte-typed (`Address` is a 32-byte, align-1 newtype), so the
@@ -127,8 +224,8 @@ impl RingProgramConfigInitParams {
             authority: self.authority,
             auditor_pubkey: self.auditor_pubkey,
             bump: self.bump,
-            withdrawals: WITHDRAWALS_OPEN,
-            asset_policy: ASSETS_ANY,
+            withdrawals: WithdrawalRule::Open as u8,
+            asset_policy: AssetPolicy::Any as u8,
             assets_len: 0,
             approver: Address::default(),
             assets: [[0u8; 32]; MAX_ASSETS],

--- a/custom-rings/program/tests/common/mod.rs
+++ b/custom-rings/program/tests/common/mod.rs
@@ -197,7 +197,7 @@ pub fn approval_account(private_tx_hash: &[u8; 32]) -> (Pubkey, Account) {
     )
 }
 
-/// `approve_transact` fixture: `[approver(s), payer(w,s), config, approval(w),
+/// `approve_transact` fixture, `[approver(s), payer(w,s), config, approval(w),
 /// system_program]` over `config`.
 pub fn approve_transact_fixture(
     config: Account,
@@ -240,7 +240,7 @@ pub fn set_policy_data(policy: &SetPolicyIxData) -> Vec<u8> {
     data
 }
 
-/// `set_policy` fixture: `[authority(s), config(w)]` over `config`.
+/// `set_policy` fixture, `[authority(s), config(w)]` over `config`.
 pub fn set_policy_fixture(
     config: Account,
     policy: &SetPolicyIxData,
@@ -350,11 +350,11 @@ pub fn init_spp_ring_config_fixture(config: Account) -> (Instruction, Vec<(Pubke
     )
 }
 
-/// SOL-only ring-deposit fixture: the ring config first, then SPP's list laid
-/// out exactly as its deposit loader wants it: `[tree(w), depositor(w,s),
+/// SOL-only ring-deposit fixture, the ring config first, then SPP's list laid
+/// out exactly as its deposit loader wants it, `[tree(w), depositor(w,s),
 /// ring_config, spp_program, system_program, sol_interface]`. The instruction
 /// data starts with SPP's own `RING_DEPOSIT` tag, which the ring forwards
-/// verbatim; `data` is the body after the tag.
+/// verbatim, and `data` is the body after the tag.
 pub fn deposit_fixture_with(
     config: Account,
     data: Vec<u8>,

--- a/custom-rings/program/tests/common/mod.rs
+++ b/custom-rings/program/tests/common/mod.rs
@@ -1,8 +1,12 @@
 use custom_ring_program::{
-    instructions::{create_config::CreateConfigIxData, set_policy::SetPolicyIxData},
+    instructions::{
+        approve_transact::{ApproveTransactIxData, APPROVAL_PDA_SEED, APPROVAL_SIZE},
+        create_config::CreateConfigIxData,
+        set_policy::{AssetRule, SetPolicyIxData},
+    },
     state::{
-        RingProgramConfig, ASSETS_ALLOWLIST, ASSETS_ANY, MAX_ALLOWED_ASSETS, RING_PROGRAM_CONFIG,
-        WITHDRAWALS_BLOCKED, WITHDRAWALS_OPEN,
+        RingProgramConfig, ASSETS_ALLOWLIST, ASSETS_ANY, MAX_ASSETS, RING_PROGRAM_CONFIG,
+        TRANSACT_APPROVAL, WITHDRAWALS_OPEN,
     },
     tag, CONFIG_PDA_SEED,
 };
@@ -107,37 +111,59 @@ pub fn auditor_pubkey(prefix: u8) -> [u8; 33] {
 /// An initialized config account as this program would have written it, with
 /// the open policy `create_config` starts from.
 pub fn initialized_config_account(authority: Pubkey, auditor_pubkey: [u8; 33]) -> Account {
-    config_account_with_policy(authority, auditor_pubkey, None, false)
+    config_account_with_policy(authority, auditor_pubkey, PolicyFixture::default())
 }
 
 /// A config account carrying a policy as `set_policy` would have written it:
-/// `allowed_assets` `Some(mints)` turns the allowlist on.
+/// `allowlist` turns the asset allowlist on over `assets`, `withdrawals` is the
+/// default withdrawal rule, `approver` the approval signer.
+pub struct PolicyFixture<'a> {
+    pub allowlist: bool,
+    pub assets: &'a [AssetRule],
+    pub withdrawals: u8,
+    pub approver: Option<Pubkey>,
+}
+
+impl Default for PolicyFixture<'_> {
+    fn default() -> Self {
+        Self {
+            allowlist: false,
+            assets: &[],
+            withdrawals: WITHDRAWALS_OPEN,
+            approver: None,
+        }
+    }
+}
+
 pub fn config_account_with_policy(
     authority: Pubkey,
     auditor_pubkey: [u8; 33],
-    allowed_assets: Option<&[[u8; 32]]>,
-    withdrawals_blocked: bool,
+    policy: PolicyFixture<'_>,
 ) -> Account {
-    let mut assets = [[0u8; 32]; MAX_ALLOWED_ASSETS];
-    let listed = allowed_assets.unwrap_or_default();
-    assets[..listed.len()].copy_from_slice(listed);
+    let mut assets = [[0u8; 32]; MAX_ASSETS];
+    let mut asset_withdrawals = [0u8; MAX_ASSETS];
+    for (index, asset) in policy.assets.iter().enumerate() {
+        assets[index] = asset.mint;
+        asset_withdrawals[index] = asset.withdrawals;
+    }
     let state = RingProgramConfig {
         discriminator: RING_PROGRAM_CONFIG,
         authority: Address::new_from_array(authority.to_bytes()),
         auditor_pubkey,
         bump: config_pda().1,
-        withdrawals: if withdrawals_blocked {
-            WITHDRAWALS_BLOCKED
-        } else {
-            WITHDRAWALS_OPEN
-        },
-        asset_policy: if allowed_assets.is_some() {
+        withdrawals: policy.withdrawals,
+        asset_policy: if policy.allowlist {
             ASSETS_ALLOWLIST
         } else {
             ASSETS_ANY
         },
-        allowed_assets_len: listed.len() as u8,
-        allowed_assets: assets,
+        assets_len: policy.assets.len() as u8,
+        approver: policy
+            .approver
+            .map(|key| Address::new_from_array(key.to_bytes()))
+            .unwrap_or_default(),
+        assets,
+        asset_withdrawals,
     };
     Account {
         lamports: 1_000_000_000,
@@ -146,6 +172,62 @@ pub fn config_account_with_policy(
         executable: false,
         rent_epoch: 0,
     }
+}
+
+pub fn approver() -> Pubkey {
+    Pubkey::new_from_array([23; 32])
+}
+
+pub fn approval_pda(private_tx_hash: &[u8; 32]) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[APPROVAL_PDA_SEED, private_tx_hash], &program_id())
+}
+
+/// An approval account as `approve_transact` writes it.
+pub fn approval_account() -> Account {
+    Account {
+        lamports: 1_000_000,
+        data: vec![TRANSACT_APPROVAL; APPROVAL_SIZE],
+        owner: program_id(),
+        executable: false,
+        rent_epoch: 0,
+    }
+}
+
+/// `approve_transact` fixture: `[approver(s), payer(w,s), config, approval(w),
+/// system_program]` over `config`.
+pub fn approve_transact_fixture(
+    config: Account,
+    private_tx_hash: [u8; 32],
+) -> (Instruction, Vec<(Pubkey, Account)>) {
+    let (config_key, _) = config_pda();
+    let (approval, _) = approval_pda(&private_tx_hash);
+    let (system_program, system_program_account) =
+        mollusk_svm::program::keyed_account_for_system_program();
+    let mut data = vec![tag::APPROVE_TRANSACT];
+    data.extend_from_slice(
+        &wincode::serialize(&ApproveTransactIxData { private_tx_hash })
+            .expect("serialize approve_transact data"),
+    );
+    (
+        Instruction {
+            program_id: program_id(),
+            accounts: vec![
+                AccountMeta::new_readonly(approver(), true),
+                AccountMeta::new(payer(), true),
+                AccountMeta::new_readonly(config_key, false),
+                AccountMeta::new(approval, false),
+                AccountMeta::new_readonly(system_program, false),
+            ],
+            data,
+        },
+        vec![
+            (approver(), account(1_000_000_000)),
+            (payer(), account(1_000_000_000)),
+            (config_key, config),
+            (approval, account(0)),
+            (system_program, system_program_account),
+        ],
+    )
 }
 
 pub fn set_policy_data(policy: &SetPolicyIxData) -> Vec<u8> {

--- a/custom-rings/program/tests/common/mod.rs
+++ b/custom-rings/program/tests/common/mod.rs
@@ -1,12 +1,12 @@
 use custom_ring_program::{
     instructions::{
-        approve_transact::{ApproveTransactIxData, APPROVAL_PDA_SEED, APPROVAL_SIZE},
+        approve_transact::{ApproveTransactIxData, APPROVAL_PDA_SEED},
         create_config::CreateConfigIxData,
-        set_policy::{AssetRule, SetPolicyIxData},
+        set_policy::SetPolicyIxData,
     },
     state::{
-        RingProgramConfig, ASSETS_ALLOWLIST, ASSETS_ANY, MAX_ASSETS, RING_PROGRAM_CONFIG,
-        TRANSACT_APPROVAL, WITHDRAWALS_OPEN,
+        AssetPolicy, AssetRule, RingProgramConfig, WithdrawalRule, MAX_ASSETS, RING_PROGRAM_CONFIG,
+        TRANSACT_APPROVAL,
     },
     tag, CONFIG_PDA_SEED,
 };
@@ -120,7 +120,7 @@ pub fn initialized_config_account(authority: Pubkey, auditor_pubkey: [u8; 33]) -
 pub struct PolicyFixture<'a> {
     pub allowlist: bool,
     pub assets: &'a [AssetRule],
-    pub withdrawals: u8,
+    pub withdrawals: WithdrawalRule,
     pub approver: Option<Pubkey>,
 }
 
@@ -129,7 +129,7 @@ impl Default for PolicyFixture<'_> {
         Self {
             allowlist: false,
             assets: &[],
-            withdrawals: WITHDRAWALS_OPEN,
+            withdrawals: WithdrawalRule::Open,
             approver: None,
         }
     }
@@ -140,31 +140,31 @@ pub fn config_account_with_policy(
     auditor_pubkey: [u8; 33],
     policy: PolicyFixture<'_>,
 ) -> Account {
-    let mut assets = [[0u8; 32]; MAX_ASSETS];
-    let mut asset_withdrawals = [0u8; MAX_ASSETS];
-    for (index, asset) in policy.assets.iter().enumerate() {
-        assets[index] = asset.mint;
-        asset_withdrawals[index] = asset.withdrawals;
-    }
-    let state = RingProgramConfig {
+    let mut state = RingProgramConfig {
         discriminator: RING_PROGRAM_CONFIG,
         authority: Address::new_from_array(authority.to_bytes()),
         auditor_pubkey,
         bump: config_pda().1,
-        withdrawals: policy.withdrawals,
-        asset_policy: if policy.allowlist {
-            ASSETS_ALLOWLIST
+        withdrawals: 0,
+        asset_policy: 0,
+        assets_len: 0,
+        approver: Address::default(),
+        assets: [[0u8; 32]; MAX_ASSETS],
+        asset_withdrawals: [0u8; MAX_ASSETS],
+    };
+    state.set_policy(
+        if policy.allowlist {
+            AssetPolicy::Allowlist
         } else {
-            ASSETS_ANY
+            AssetPolicy::Any
         },
-        assets_len: policy.assets.len() as u8,
-        approver: policy
+        policy.withdrawals,
+        policy
             .approver
             .map(|key| Address::new_from_array(key.to_bytes()))
             .unwrap_or_default(),
-        assets,
-        asset_withdrawals,
-    };
+        policy.assets,
+    );
     Account {
         lamports: 1_000_000_000,
         data: bytemuck::bytes_of(&state).to_vec(),
@@ -182,15 +182,19 @@ pub fn approval_pda(private_tx_hash: &[u8; 32]) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[APPROVAL_PDA_SEED, private_tx_hash], &program_id())
 }
 
-/// An approval account as `approve_transact` writes it.
-pub fn approval_account() -> Account {
-    Account {
-        lamports: 1_000_000,
-        data: vec![TRANSACT_APPROVAL; APPROVAL_SIZE],
-        owner: program_id(),
-        executable: false,
-        rent_epoch: 0,
-    }
+/// The approval account of `private_tx_hash` as `approve_transact` writes it.
+pub fn approval_account(private_tx_hash: &[u8; 32]) -> (Pubkey, Account) {
+    let (address, bump) = approval_pda(private_tx_hash);
+    (
+        address,
+        Account {
+            lamports: 1_000_000,
+            data: vec![TRANSACT_APPROVAL, bump],
+            owner: program_id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
 }
 
 /// `approve_transact` fixture: `[approver(s), payer(w,s), config, approval(w),

--- a/custom-rings/program/tests/error_codes.rs
+++ b/custom-rings/program/tests/error_codes.rs
@@ -22,6 +22,9 @@ fn error_codes_are_stable() {
         (AssetNotAllowed as u32, 8116),
         (WithdrawalsBlocked as u32, 8117),
         (InvalidPolicy as u32, 8118),
+        (ApprovalRequired as u32, 8119),
+        (InvalidApproval as u32, 8120),
+        (UnauthorizedApprover as u32, 8121),
     ];
     for (got, want) in table {
         assert_eq!(got, want, "error code drifted");

--- a/custom-rings/program/tests/failing.rs
+++ b/custom-rings/program/tests/failing.rs
@@ -1,5 +1,7 @@
 mod common;
 
+#[path = "failing/approve_transact.rs"]
+mod approve_transact;
 #[path = "failing/create_config.rs"]
 mod create_config;
 #[path = "failing/deposit.rs"]

--- a/custom-rings/program/tests/failing/approve_transact.rs
+++ b/custom-rings/program/tests/failing/approve_transact.rs
@@ -3,16 +3,18 @@
 
 use custom_ring_program::{
     error::CustomRingError,
-    instructions::approve_transact::APPROVAL_SIZE,
-    state::{TRANSACT_APPROVAL, WITHDRAWALS_APPROVAL},
+    state::{WithdrawalRule, TRANSACT_APPROVAL},
+    tag,
 };
+use solana_instruction::AccountMeta;
 use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use zolana_test_utils::mollusk::expect_err_exact;
 
 use crate::common::{
-    account, approval_pda, approve_transact_fixture, approver, auditor_pubkey, authority,
-    config_account_with_policy, initialized_config_account, setup_mollusk, PolicyFixture,
+    account, approval_account, approval_pda, approve_transact_fixture, approver, auditor_pubkey,
+    authority, config_account_with_policy, initialized_config_account, setup_mollusk,
+    PolicyFixture,
 };
 
 fn custom(error: CustomRingError) -> ProgramError {
@@ -24,7 +26,7 @@ fn config_with_approver() -> solana_account::Account {
         authority(),
         auditor_pubkey(2),
         PolicyFixture {
-            withdrawals: WITHDRAWALS_APPROVAL,
+            withdrawals: WithdrawalRule::Approval,
             approver: Some(approver()),
             ..PolicyFixture::default()
         },
@@ -38,11 +40,59 @@ fn approver_creates_the_approval_of_one_transact() {
     let (instruction, accounts) = approve_transact_fixture(config_with_approver(), private_tx_hash);
     let result = mollusk.process_and_validate_instruction(&instruction, &accounts, &[]);
     assert!(result.program_result.is_ok(), "{:?}", result.program_result);
-    let approval = result
-        .get_account(&approval_pda(&private_tx_hash).0)
-        .expect("approval account");
+    let (address, bump) = approval_pda(&private_tx_hash);
+    let approval = result.get_account(&address).expect("approval account");
     assert_eq!(approval.owner, crate::common::program_id());
-    assert_eq!(approval.data, vec![TRANSACT_APPROVAL; APPROVAL_SIZE]);
+    assert_eq!(approval.data, vec![TRANSACT_APPROVAL, bump]);
+}
+
+/// `revoke_approval` over the account `approve_transact` wrote: the account
+/// closes and its lamports land with the rent recipient.
+#[test]
+fn approver_revokes_an_unspent_approval() {
+    let (mollusk, _) = setup_mollusk();
+    let private_tx_hash = [4u8; 32];
+    let (address, approval) = approval_account(&private_tx_hash);
+    let rent_recipient = Pubkey::new_from_array([80; 32]);
+    let (config_key, _) = crate::common::config_pda();
+    let mut data = vec![tag::REVOKE_APPROVAL];
+    data.extend_from_slice(&private_tx_hash);
+    let instruction = solana_instruction::Instruction {
+        program_id: crate::common::program_id(),
+        accounts: vec![
+            AccountMeta::new_readonly(approver(), true),
+            AccountMeta::new(rent_recipient, false),
+            AccountMeta::new_readonly(config_key, false),
+            AccountMeta::new(address, false),
+        ],
+        data,
+    };
+    let accounts = vec![
+        (approver(), account(1_000_000_000)),
+        (rent_recipient, account(1_000_000_000)),
+        (config_key, config_with_approver()),
+        (address, approval),
+    ];
+    let result = mollusk.process_and_validate_instruction(&instruction, &accounts, &[]);
+    assert!(result.program_result.is_ok(), "{:?}", result.program_result);
+    assert_eq!(
+        result.get_account(&rent_recipient).map(|a| a.lamports),
+        Some(1_001_000_000)
+    );
+    assert_eq!(result.get_account(&address).map(|a| a.lamports), Some(0));
+
+    // Not the approver.
+    let mut wrong = instruction.clone();
+    let impostor = Pubkey::new_from_array([81; 32]);
+    wrong.accounts[0].pubkey = impostor;
+    let mut wrong_accounts = accounts.clone();
+    wrong_accounts.push((impostor, account(1_000_000_000)));
+    expect_err_exact(
+        &mollusk,
+        &wrong,
+        &wrong_accounts,
+        custom(CustomRingError::UnauthorizedApprover),
+    );
 }
 
 #[test]

--- a/custom-rings/program/tests/failing/approve_transact.rs
+++ b/custom-rings/program/tests/failing/approve_transact.rs
@@ -1,0 +1,93 @@
+//! `approve_transact` negatives and its positive, which mollusk runs in full
+//! (system program create is native).
+
+use custom_ring_program::{
+    error::CustomRingError,
+    instructions::approve_transact::APPROVAL_SIZE,
+    state::{TRANSACT_APPROVAL, WITHDRAWALS_APPROVAL},
+};
+use solana_program_error::ProgramError;
+use solana_pubkey::Pubkey;
+use zolana_test_utils::mollusk::expect_err_exact;
+
+use crate::common::{
+    account, approval_pda, approve_transact_fixture, approver, auditor_pubkey, authority,
+    config_account_with_policy, initialized_config_account, setup_mollusk, PolicyFixture,
+};
+
+fn custom(error: CustomRingError) -> ProgramError {
+    ProgramError::Custom(error as u32)
+}
+
+fn config_with_approver() -> solana_account::Account {
+    config_account_with_policy(
+        authority(),
+        auditor_pubkey(2),
+        PolicyFixture {
+            withdrawals: WITHDRAWALS_APPROVAL,
+            approver: Some(approver()),
+            ..PolicyFixture::default()
+        },
+    )
+}
+
+#[test]
+fn approver_creates_the_approval_of_one_transact() {
+    let (mollusk, _) = setup_mollusk();
+    let private_tx_hash = [4u8; 32];
+    let (instruction, accounts) = approve_transact_fixture(config_with_approver(), private_tx_hash);
+    let result = mollusk.process_and_validate_instruction(&instruction, &accounts, &[]);
+    assert!(result.program_result.is_ok(), "{:?}", result.program_result);
+    let approval = result
+        .get_account(&approval_pda(&private_tx_hash).0)
+        .expect("approval account");
+    assert_eq!(approval.owner, crate::common::program_id());
+    assert_eq!(approval.data, vec![TRANSACT_APPROVAL; APPROVAL_SIZE]);
+}
+
+#[test]
+fn a_config_without_approver_rejects_exactly() {
+    let (mollusk, _) = setup_mollusk();
+    let (instruction, accounts) = approve_transact_fixture(
+        initialized_config_account(authority(), auditor_pubkey(2)),
+        [4u8; 32],
+    );
+    expect_err_exact(
+        &mollusk,
+        &instruction,
+        &accounts,
+        custom(CustomRingError::UnauthorizedApprover),
+    );
+}
+
+#[test]
+fn a_signer_other_than_the_approver_is_rejected_exactly() {
+    let (mollusk, _) = setup_mollusk();
+    let (mut instruction, mut accounts) =
+        approve_transact_fixture(config_with_approver(), [4u8; 32]);
+    let impostor = Pubkey::new_from_array([78; 32]);
+    instruction.accounts[0].pubkey = impostor;
+    accounts.push((impostor, account(1_000_000_000)));
+    expect_err_exact(
+        &mollusk,
+        &instruction,
+        &accounts,
+        custom(CustomRingError::UnauthorizedApprover),
+    );
+}
+
+#[test]
+fn an_approval_at_the_wrong_address_is_rejected_exactly() {
+    let (mollusk, _) = setup_mollusk();
+    let (mut instruction, mut accounts) =
+        approve_transact_fixture(config_with_approver(), [4u8; 32]);
+    let elsewhere = Pubkey::new_from_array([79; 32]);
+    instruction.accounts[3].pubkey = elsewhere;
+    accounts.push((elsewhere, account(0)));
+    expect_err_exact(
+        &mollusk,
+        &instruction,
+        &accounts,
+        custom(CustomRingError::InvalidApproval),
+    );
+}

--- a/custom-rings/program/tests/failing/approve_transact.rs
+++ b/custom-rings/program/tests/failing/approve_transact.rs
@@ -46,7 +46,7 @@ fn approver_creates_the_approval_of_one_transact() {
     assert_eq!(approval.data, vec![TRANSACT_APPROVAL, bump]);
 }
 
-/// `revoke_approval` over the account `approve_transact` wrote: the account
+/// `revoke_approval` over the account `approve_transact` wrote. The account
 /// closes and its lamports land with the rent recipient.
 #[test]
 fn approver_revokes_an_unspent_approval() {

--- a/custom-rings/program/tests/failing/create_config.rs
+++ b/custom-rings/program/tests/failing/create_config.rs
@@ -1,6 +1,6 @@
 use custom_ring_program::{
     error::CustomRingError,
-    state::{RingProgramConfig, ASSETS_ANY, MAX_ASSETS, RING_PROGRAM_CONFIG, WITHDRAWALS_OPEN},
+    state::{AssetPolicy, RingProgramConfig, WithdrawalRule, MAX_ASSETS, RING_PROGRAM_CONFIG},
     tag,
 };
 use mollusk_svm::result::ProgramResult;
@@ -52,8 +52,8 @@ fn create_config_writes_the_config_account() {
             authority: pinocchio::Address::new_from_array(authority),
             auditor_pubkey: auditor_pubkey(2),
             bump,
-            withdrawals: WITHDRAWALS_OPEN,
-            asset_policy: ASSETS_ANY,
+            withdrawals: WithdrawalRule::Open as u8,
+            asset_policy: AssetPolicy::Any as u8,
             assets_len: 0,
             approver: pinocchio::Address::default(),
             assets: [[0u8; 32]; MAX_ASSETS],

--- a/custom-rings/program/tests/failing/create_config.rs
+++ b/custom-rings/program/tests/failing/create_config.rs
@@ -1,8 +1,6 @@
 use custom_ring_program::{
     error::CustomRingError,
-    state::{
-        RingProgramConfig, ASSETS_ANY, MAX_ALLOWED_ASSETS, RING_PROGRAM_CONFIG, WITHDRAWALS_OPEN,
-    },
+    state::{RingProgramConfig, ASSETS_ANY, MAX_ASSETS, RING_PROGRAM_CONFIG, WITHDRAWALS_OPEN},
     tag,
 };
 use mollusk_svm::result::ProgramResult;
@@ -56,8 +54,10 @@ fn create_config_writes_the_config_account() {
             bump,
             withdrawals: WITHDRAWALS_OPEN,
             asset_policy: ASSETS_ANY,
-            allowed_assets_len: 0,
-            allowed_assets: [[0u8; 32]; MAX_ALLOWED_ASSETS],
+            assets_len: 0,
+            approver: pinocchio::Address::default(),
+            assets: [[0u8; 32]; MAX_ASSETS],
+            asset_withdrawals: [0u8; MAX_ASSETS],
         },
         "a fresh config starts with the open policy"
     );

--- a/custom-rings/program/tests/failing/deposit.rs
+++ b/custom-rings/program/tests/failing/deposit.rs
@@ -5,13 +5,16 @@
 //! pre-CPI. The successful forward is covered by the localnet end-to-end test.
 
 use custom_ring_program::{
-    error::CustomRingError, instructions::set_policy::AssetRule, state::SOL_MINT,
+    error::CustomRingError,
+    state::{AssetRule, WithdrawalRule, SOL_MINT},
 };
 use pinocchio::cpi::MAX_CPI_ACCOUNTS;
 use solana_instruction::AccountMeta;
 use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
-use zolana_interface::instruction::{DepositAssetKind, RingDepositIxData};
+use zolana_interface::instruction::{
+    DepositAssetKind, EncryptedRingDepositData, RingDepositEntry, RingDepositIxData,
+};
 use zolana_test_utils::mollusk::expect_err_exact;
 
 use crate::common::{
@@ -27,7 +30,7 @@ fn allowlist(mint: [u8; 32]) -> solana_account::Account {
             allowlist: true,
             assets: &[AssetRule {
                 mint,
-                withdrawals: 0,
+                withdrawals: WithdrawalRule::Open,
             }],
             ..PolicyFixture::default()
         },
@@ -100,12 +103,25 @@ fn oversized_account_list_is_rejected_exactly() {
     );
 }
 
-/// A SOL deposit body as SPP's `RING_DEPOSIT` carries it, entries left out
-/// because only the asset kinds matter to the policy.
+/// A SOL deposit body as SPP's `RING_DEPOSIT` carries it, with one full entry
+/// after the asset kinds: the policy reads only the prefix and must leave the
+/// entry alone.
 fn sol_deposit_body() -> Vec<u8> {
     RingDepositIxData {
         assets: vec![DepositAssetKind::Sol],
-        deposits: Vec::new(),
+        deposits: vec![RingDepositEntry {
+            asset_index: 0,
+            view_tag: [1u8; 32],
+            owner_utxo_hash: [2u8; 32],
+            amount: 7,
+            data_hash: Some([3u8; 32]),
+            ring_data_hash: [4u8; 32],
+            encrypted: EncryptedRingDepositData {
+                tx_viewing_pk: [2u8; 33],
+                salt: [5u8; 16],
+                ciphertext: vec![6u8; 300],
+            },
+        }],
     }
     .serialize()
     .expect("serialize ring deposit")

--- a/custom-rings/program/tests/failing/deposit.rs
+++ b/custom-rings/program/tests/failing/deposit.rs
@@ -4,7 +4,9 @@
 //! cannot execute (SPP is not loaded here), so every assertable failure is
 //! pre-CPI. The successful forward is covered by the localnet end-to-end test.
 
-use custom_ring_program::{error::CustomRingError, state::SOL_MINT};
+use custom_ring_program::{
+    error::CustomRingError, instructions::set_policy::AssetRule, state::SOL_MINT,
+};
 use pinocchio::cpi::MAX_CPI_ACCOUNTS;
 use solana_instruction::AccountMeta;
 use solana_program_error::ProgramError;
@@ -14,8 +16,23 @@ use zolana_test_utils::mollusk::expect_err_exact;
 
 use crate::common::{
     account, auditor_pubkey, authority, config_account_with_policy, deposit_fixture,
-    deposit_fixture_with, setup_mollusk, substitute_account,
+    deposit_fixture_with, setup_mollusk, substitute_account, PolicyFixture,
 };
+
+fn allowlist(mint: [u8; 32]) -> solana_account::Account {
+    config_account_with_policy(
+        authority(),
+        auditor_pubkey(2),
+        PolicyFixture {
+            allowlist: true,
+            assets: &[AssetRule {
+                mint,
+                withdrawals: 0,
+            }],
+            ..PolicyFixture::default()
+        },
+    )
+}
 
 fn custom(error: CustomRingError) -> ProgramError {
     ProgramError::Custom(error as u32)
@@ -99,9 +116,7 @@ fn sol_deposit_body() -> Vec<u8> {
 #[test]
 fn deposit_of_an_asset_outside_the_allowlist_is_rejected_exactly() {
     let (mollusk, _) = setup_mollusk();
-    let usdc = [9u8; 32];
-    let config = config_account_with_policy(authority(), auditor_pubkey(2), Some(&[usdc]), false);
-    let (instruction, accounts) = deposit_fixture_with(config, sol_deposit_body());
+    let (instruction, accounts) = deposit_fixture_with(allowlist([9u8; 32]), sol_deposit_body());
     expect_err_exact(
         &mollusk,
         &instruction,
@@ -115,9 +130,7 @@ fn deposit_of_an_asset_outside_the_allowlist_is_rejected_exactly() {
 #[test]
 fn deposit_of_an_allowlisted_asset_reaches_the_forward() {
     let (mollusk, _) = setup_mollusk();
-    let config =
-        config_account_with_policy(authority(), auditor_pubkey(2), Some(&[SOL_MINT]), false);
-    let (instruction, accounts) = deposit_fixture_with(config, sol_deposit_body());
+    let (instruction, accounts) = deposit_fixture_with(allowlist(SOL_MINT), sol_deposit_body());
     let result = mollusk.process_instruction(&instruction, &accounts);
     assert_ne!(
         result.program_result,

--- a/custom-rings/program/tests/failing/deposit.rs
+++ b/custom-rings/program/tests/failing/deposit.rs
@@ -104,7 +104,7 @@ fn oversized_account_list_is_rejected_exactly() {
 }
 
 /// A SOL deposit body as SPP's `RING_DEPOSIT` carries it, with one full entry
-/// after the asset kinds: the policy reads only the prefix and must leave the
+/// after the asset kinds. The policy reads only the prefix and must leave the
 /// entry alone.
 fn sol_deposit_body() -> Vec<u8> {
     RingDepositIxData {

--- a/custom-rings/program/tests/failing/set_policy.rs
+++ b/custom-rings/program/tests/failing/set_policy.rs
@@ -2,11 +2,8 @@
 
 use custom_ring_program::{
     error::CustomRingError,
-    instructions::set_policy::{AssetRule, SetPolicyIxData},
-    state::{
-        RingProgramConfig, ASSETS_ALLOWLIST, ASSETS_ANY, MAX_ASSETS, WITHDRAWALS_APPROVAL,
-        WITHDRAWALS_BLOCKED, WITHDRAWALS_OPEN,
-    },
+    instructions::set_policy::{AssetRuleData, SetPolicyIxData},
+    state::{AssetPolicy, AssetRule, RingProgramConfig, WithdrawalRule, MAX_ASSETS},
 };
 use pinocchio::Address;
 use solana_program_error::ProgramError;
@@ -22,10 +19,10 @@ fn custom(error: CustomRingError) -> ProgramError {
     ProgramError::Custom(error as u32)
 }
 
-fn allowlist(assets: Vec<AssetRule>) -> SetPolicyIxData {
+fn allowlist(assets: Vec<AssetRuleData>) -> SetPolicyIxData {
     SetPolicyIxData {
-        withdrawals: WITHDRAWALS_BLOCKED,
-        asset_policy: ASSETS_ALLOWLIST,
+        withdrawals: WithdrawalRule::Blocked as u8,
+        asset_policy: AssetPolicy::Allowlist as u8,
         approver: [0u8; 32],
         assets,
     }
@@ -34,13 +31,13 @@ fn allowlist(assets: Vec<AssetRule>) -> SetPolicyIxData {
 #[test]
 fn policy_is_written_as_sent() {
     let (mollusk, _) = setup_mollusk();
-    let usdc = AssetRule {
+    let usdc = AssetRuleData {
         mint: [9u8; 32],
-        withdrawals: WITHDRAWALS_APPROVAL,
+        withdrawals: WithdrawalRule::Approval as u8,
     };
-    let sol = AssetRule {
+    let sol = AssetRuleData {
         mint: [0u8; 32],
-        withdrawals: WITHDRAWALS_OPEN,
+        withdrawals: WithdrawalRule::Open as u8,
     };
     let mut policy = allowlist(vec![usdc, sol]);
     policy.approver = approver().to_bytes();
@@ -53,21 +50,29 @@ fn policy_is_written_as_sent() {
     let (config_key, _) = config_pda();
     let config = result.get_account(&config_key).expect("config account");
     let state: &RingProgramConfig = bytemuck::from_bytes(&config.data);
-    assert_eq!(state.withdrawals, WITHDRAWALS_BLOCKED);
-    assert_eq!(state.asset_policy, ASSETS_ALLOWLIST);
+    assert_eq!(state.asset_policy(), AssetPolicy::Allowlist);
     assert_eq!(
-        state.approver,
-        Address::new_from_array(approver().to_bytes())
+        state.approver(),
+        Some(&Address::new_from_array(approver().to_bytes()))
     );
     assert_eq!(
         state.assets().collect::<Vec<_>>(),
-        vec![(&usdc.mint, usdc.withdrawals), (&sol.mint, sol.withdrawals)]
+        vec![
+            AssetRule {
+                mint: usdc.mint,
+                withdrawals: WithdrawalRule::Approval
+            },
+            AssetRule {
+                mint: sol.mint,
+                withdrawals: WithdrawalRule::Open
+            },
+        ]
     );
-    assert_eq!(state.withdrawal_rule(&usdc.mint), WITHDRAWALS_APPROVAL);
-    assert_eq!(state.withdrawal_rule(&sol.mint), WITHDRAWALS_OPEN);
+    assert_eq!(state.withdrawal_rule(&usdc.mint), WithdrawalRule::Approval);
+    assert_eq!(state.withdrawal_rule(&sol.mint), WithdrawalRule::Open);
     assert_eq!(
         state.withdrawal_rule(&[5u8; 32]),
-        WITHDRAWALS_BLOCKED,
+        WithdrawalRule::Blocked,
         "unlisted assets take the default rule"
     );
     assert_eq!(
@@ -111,30 +116,41 @@ fn an_uninitialized_config_is_rejected_exactly() {
 fn out_of_range_policy_values_are_rejected_exactly() {
     let (mollusk, _) = setup_mollusk();
     let config = || initialized_config_account(authority(), auditor_pubkey(2));
-    let rule = |withdrawals| AssetRule {
+    let rule = |withdrawals| AssetRuleData {
         mint: [1u8; 32],
         withdrawals,
     };
+    let distinct: Vec<AssetRuleData> = (0..=MAX_ASSETS as u8)
+        .map(|index| AssetRuleData {
+            mint: [index; 32],
+            withdrawals: WithdrawalRule::Open as u8,
+        })
+        .collect();
     for policy in [
         SetPolicyIxData {
             withdrawals: 3,
-            asset_policy: ASSETS_ANY,
+            asset_policy: AssetPolicy::Any as u8,
             approver: [0u8; 32],
             assets: vec![],
         },
         SetPolicyIxData {
-            withdrawals: WITHDRAWALS_OPEN,
+            withdrawals: WithdrawalRule::Open as u8,
             asset_policy: 2,
             approver: [0u8; 32],
             assets: vec![],
         },
-        allowlist(vec![rule(WITHDRAWALS_OPEN); MAX_ASSETS + 1]),
+        allowlist(distinct),
         allowlist(vec![rule(3)]),
+        // The same mint twice would let one rule shadow the other.
+        allowlist(vec![
+            rule(WithdrawalRule::Open as u8),
+            rule(WithdrawalRule::Blocked as u8),
+        ]),
         // Approval anywhere needs an approver.
-        allowlist(vec![rule(WITHDRAWALS_APPROVAL)]),
+        allowlist(vec![rule(WithdrawalRule::Approval as u8)]),
         SetPolicyIxData {
-            withdrawals: WITHDRAWALS_APPROVAL,
-            asset_policy: ASSETS_ANY,
+            withdrawals: WithdrawalRule::Approval as u8,
+            asset_policy: AssetPolicy::Any as u8,
             approver: [0u8; 32],
             assets: vec![],
         },

--- a/custom-rings/program/tests/failing/set_policy.rs
+++ b/custom-rings/program/tests/failing/set_policy.rs
@@ -2,40 +2,51 @@
 
 use custom_ring_program::{
     error::CustomRingError,
-    instructions::set_policy::SetPolicyIxData,
+    instructions::set_policy::{AssetRule, SetPolicyIxData},
     state::{
-        RingProgramConfig, ASSETS_ALLOWLIST, ASSETS_ANY, MAX_ALLOWED_ASSETS, WITHDRAWALS_BLOCKED,
-        WITHDRAWALS_OPEN,
+        RingProgramConfig, ASSETS_ALLOWLIST, ASSETS_ANY, MAX_ASSETS, WITHDRAWALS_APPROVAL,
+        WITHDRAWALS_BLOCKED, WITHDRAWALS_OPEN,
     },
 };
+use pinocchio::Address;
 use solana_program_error::ProgramError;
 use solana_pubkey::Pubkey;
 use zolana_test_utils::mollusk::expect_err_exact;
 
 use crate::common::{
-    account, auditor_pubkey, authority, config_pda, initialized_config_account, set_policy_fixture,
-    setup_mollusk,
+    account, approver, auditor_pubkey, authority, config_pda, initialized_config_account,
+    set_policy_fixture, setup_mollusk,
 };
 
 fn custom(error: CustomRingError) -> ProgramError {
     ProgramError::Custom(error as u32)
 }
 
-fn allowlist(mints: Vec<[u8; 32]>) -> SetPolicyIxData {
+fn allowlist(assets: Vec<AssetRule>) -> SetPolicyIxData {
     SetPolicyIxData {
         withdrawals: WITHDRAWALS_BLOCKED,
         asset_policy: ASSETS_ALLOWLIST,
-        allowed_assets: mints,
+        approver: [0u8; 32],
+        assets,
     }
 }
 
 #[test]
 fn policy_is_written_as_sent() {
     let (mollusk, _) = setup_mollusk();
-    let usdc = [9u8; 32];
+    let usdc = AssetRule {
+        mint: [9u8; 32],
+        withdrawals: WITHDRAWALS_APPROVAL,
+    };
+    let sol = AssetRule {
+        mint: [0u8; 32],
+        withdrawals: WITHDRAWALS_OPEN,
+    };
+    let mut policy = allowlist(vec![usdc, sol]);
+    policy.approver = approver().to_bytes();
     let (instruction, accounts) = set_policy_fixture(
         initialized_config_account(authority(), auditor_pubkey(2)),
-        &allowlist(vec![usdc, [0u8; 32]]),
+        &policy,
     );
     let result = mollusk.process_and_validate_instruction(&instruction, &accounts, &[]);
     assert!(result.program_result.is_ok(), "{:?}", result.program_result);
@@ -44,7 +55,21 @@ fn policy_is_written_as_sent() {
     let state: &RingProgramConfig = bytemuck::from_bytes(&config.data);
     assert_eq!(state.withdrawals, WITHDRAWALS_BLOCKED);
     assert_eq!(state.asset_policy, ASSETS_ALLOWLIST);
-    assert_eq!(state.allowed_assets(), &[usdc, [0u8; 32]]);
+    assert_eq!(
+        state.approver,
+        Address::new_from_array(approver().to_bytes())
+    );
+    assert_eq!(
+        state.assets().collect::<Vec<_>>(),
+        vec![(&usdc.mint, usdc.withdrawals), (&sol.mint, sol.withdrawals)]
+    );
+    assert_eq!(state.withdrawal_rule(&usdc.mint), WITHDRAWALS_APPROVAL);
+    assert_eq!(state.withdrawal_rule(&sol.mint), WITHDRAWALS_OPEN);
+    assert_eq!(
+        state.withdrawal_rule(&[5u8; 32]),
+        WITHDRAWALS_BLOCKED,
+        "unlisted assets take the default rule"
+    );
     assert_eq!(
         state.auditor_pubkey,
         auditor_pubkey(2),
@@ -86,18 +111,33 @@ fn an_uninitialized_config_is_rejected_exactly() {
 fn out_of_range_policy_values_are_rejected_exactly() {
     let (mollusk, _) = setup_mollusk();
     let config = || initialized_config_account(authority(), auditor_pubkey(2));
+    let rule = |withdrawals| AssetRule {
+        mint: [1u8; 32],
+        withdrawals,
+    };
     for policy in [
         SetPolicyIxData {
-            withdrawals: 2,
+            withdrawals: 3,
             asset_policy: ASSETS_ANY,
-            allowed_assets: vec![],
+            approver: [0u8; 32],
+            assets: vec![],
         },
         SetPolicyIxData {
             withdrawals: WITHDRAWALS_OPEN,
             asset_policy: 2,
-            allowed_assets: vec![],
+            approver: [0u8; 32],
+            assets: vec![],
         },
-        allowlist(vec![[1u8; 32]; MAX_ALLOWED_ASSETS + 1]),
+        allowlist(vec![rule(WITHDRAWALS_OPEN); MAX_ASSETS + 1]),
+        allowlist(vec![rule(3)]),
+        // Approval anywhere needs an approver.
+        allowlist(vec![rule(WITHDRAWALS_APPROVAL)]),
+        SetPolicyIxData {
+            withdrawals: WITHDRAWALS_APPROVAL,
+            asset_policy: ASSETS_ANY,
+            approver: [0u8; 32],
+            assets: vec![],
+        },
     ] {
         let (instruction, accounts) = set_policy_fixture(config(), &policy);
         expect_err_exact(

--- a/custom-rings/program/tests/failing/transact.rs
+++ b/custom-rings/program/tests/failing/transact.rs
@@ -8,7 +8,11 @@
 
 use custom_ring_program::{
     error::CustomRingError,
-    instructions::transact::{AuditProof, CustomRingTransactIxData, AUDITOR_MESSAGE_LEN},
+    instructions::{
+        set_policy::AssetRule,
+        transact::{AuditProof, CustomRingTransactIxData, AUDITOR_MESSAGE_LEN},
+    },
+    state::{WITHDRAWALS_APPROVAL, WITHDRAWALS_BLOCKED, WITHDRAWALS_OPEN},
     tag,
 };
 use solana_account::Account;
@@ -23,9 +27,9 @@ use zolana_interface::{
 use zolana_test_utils::mollusk::expect_err_exact;
 
 use crate::common::{
-    account, auditor_pubkey, authority, config_account_with_policy, config_pda,
-    initialized_config_account, payer, program_id, ring_auth_pda, setup_mollusk,
-    spp_program_account, substitute_account,
+    account, approval_account, approval_pda, approver, auditor_pubkey, authority,
+    config_account_with_policy, config_pda, initialized_config_account, payer, program_id,
+    ring_auth_pda, setup_mollusk, spp_program_account, substitute_account, PolicyFixture,
 };
 
 fn custom(error: CustomRingError) -> ProgramError {
@@ -381,28 +385,126 @@ fn zeroed_proof_is_rejected_exactly() {
     );
 }
 
-/// Policy runs before the proof: the fixture's proof is bogus and the
-/// withdrawal is still what gets named.
-#[test]
-fn public_withdrawal_is_rejected_exactly_when_blocked() {
-    let (mollusk, _) = setup_mollusk();
+/// A transact carrying one SOL withdrawal leg over `config`, with the SOL
+/// settlement group `[sol_interface, recipient]` after the (empty) signer run
+/// and, when given, the approval account between the config and SPP's list.
+fn withdrawal_fixture(
+    config: Account,
+    approval: Option<(Pubkey, Account)>,
+) -> (Instruction, Vec<(Pubkey, Account)>) {
     let mut transact = transact(vec![auditor_message(AUDITOR_MESSAGE_LEN)]);
     transact.interface_transfers = vec![InterfaceTransfer::SolWithdrawal { amount: 5 }];
-    let config = config_account_with_policy(authority(), config_auditor_pubkey(), None, true);
     let (mut instruction, mut accounts) =
         transact_fixture(config, instruction_data(bogus_proof(), transact));
-    // SOL settlement group `[sol_interface, recipient]` after the (empty)
-    // signer run.
+    if let Some((key, account)) = approval {
+        instruction.accounts.insert(2, AccountMeta::new(key, false));
+        accounts.push((key, account));
+    }
     for key in [[61u8; 32], [62u8; 32]] {
         let key = Pubkey::new_from_array(key);
         instruction.accounts.push(AccountMeta::new(key, false));
         accounts.push((key, account(1_000_000_000)));
     }
+    (instruction, accounts)
+}
+
+fn policy(withdrawals: u8) -> Account {
+    config_account_with_policy(
+        authority(),
+        config_auditor_pubkey(),
+        PolicyFixture {
+            withdrawals,
+            approver: Some(approver()),
+            ..PolicyFixture::default()
+        },
+    )
+}
+
+/// Policy runs before the proof: the fixture's proof is bogus and the
+/// withdrawal is still what gets named.
+#[test]
+fn public_withdrawal_is_rejected_exactly_when_blocked() {
+    let (mollusk, _) = setup_mollusk();
+    let (instruction, accounts) = withdrawal_fixture(policy(WITHDRAWALS_BLOCKED), None);
     expect_err_exact(
         &mollusk,
         &instruction,
         &accounts,
         custom(CustomRingError::WithdrawalsBlocked),
+    );
+}
+
+#[test]
+fn public_withdrawal_under_approval_needs_the_approval_account() {
+    let (mollusk, _) = setup_mollusk();
+    let (instruction, accounts) = withdrawal_fixture(policy(WITHDRAWALS_APPROVAL), None);
+    expect_err_exact(
+        &mollusk,
+        &instruction,
+        &accounts,
+        custom(CustomRingError::ApprovalRequired),
+    );
+}
+
+/// The approval account is bound to `private_tx_hash`; another transact's
+/// approval does not open this one.
+#[test]
+fn an_approval_for_another_transact_is_rejected_exactly() {
+    let (mollusk, _) = setup_mollusk();
+    let other = approval_pda(&[8u8; 32]).0;
+    let (instruction, accounts) = withdrawal_fixture(
+        policy(WITHDRAWALS_APPROVAL),
+        Some((other, approval_account())),
+    );
+    expect_err_exact(
+        &mollusk,
+        &instruction,
+        &accounts,
+        custom(CustomRingError::InvalidApproval),
+    );
+}
+
+/// With the right approval the policy passes and the proof is what fails,
+/// which is as far as mollusk can take a transact.
+#[test]
+fn a_matching_approval_lets_the_withdrawal_reach_the_proof() {
+    let (mollusk, _) = setup_mollusk();
+    let private_tx_hash = transact(vec![]).private_tx_hash;
+    let approval = approval_pda(&private_tx_hash).0;
+    let (instruction, accounts) = withdrawal_fixture(
+        policy(WITHDRAWALS_APPROVAL),
+        Some((approval, approval_account())),
+    );
+    expect_err_exact(
+        &mollusk,
+        &instruction,
+        &accounts,
+        custom(CustomRingError::ProofVerificationFailed),
+    );
+}
+
+/// The per-asset rule wins over the default: SOL open while the default blocks.
+#[test]
+fn per_asset_rule_overrides_the_default() {
+    let (mollusk, _) = setup_mollusk();
+    let config = config_account_with_policy(
+        authority(),
+        config_auditor_pubkey(),
+        PolicyFixture {
+            withdrawals: WITHDRAWALS_BLOCKED,
+            assets: &[AssetRule {
+                mint: [0u8; 32],
+                withdrawals: WITHDRAWALS_OPEN,
+            }],
+            ..PolicyFixture::default()
+        },
+    );
+    let (instruction, accounts) = withdrawal_fixture(config, None);
+    expect_err_exact(
+        &mollusk,
+        &instruction,
+        &accounts,
+        custom(CustomRingError::ProofVerificationFailed),
     );
 }
 
@@ -413,9 +515,18 @@ fn settlement_of_an_asset_outside_the_allowlist_is_rejected_exactly() {
     let (mollusk, _) = setup_mollusk();
     let mut transact = transact(vec![auditor_message(AUDITOR_MESSAGE_LEN)]);
     transact.interface_transfers = vec![InterfaceTransfer::SolDeposit { amount: 5 }];
-    let usdc = [9u8; 32];
-    let config =
-        config_account_with_policy(authority(), config_auditor_pubkey(), Some(&[usdc]), false);
+    let config = config_account_with_policy(
+        authority(),
+        config_auditor_pubkey(),
+        PolicyFixture {
+            allowlist: true,
+            assets: &[AssetRule {
+                mint: [9u8; 32],
+                withdrawals: WITHDRAWALS_OPEN,
+            }],
+            ..PolicyFixture::default()
+        },
+    );
     let (mut instruction, mut accounts) =
         transact_fixture(config, instruction_data(bogus_proof(), transact));
     for key in [[61u8; 32], [62u8; 32]] {

--- a/custom-rings/program/tests/failing/transact.rs
+++ b/custom-rings/program/tests/failing/transact.rs
@@ -8,11 +8,8 @@
 
 use custom_ring_program::{
     error::CustomRingError,
-    instructions::{
-        set_policy::AssetRule,
-        transact::{AuditProof, CustomRingTransactIxData, AUDITOR_MESSAGE_LEN},
-    },
-    state::{WITHDRAWALS_APPROVAL, WITHDRAWALS_BLOCKED, WITHDRAWALS_OPEN},
+    instructions::transact::{AuditProof, CustomRingTransactIxData, AUDITOR_MESSAGE_LEN},
+    state::{AssetRule, WithdrawalRule},
     tag,
 };
 use solana_account::Account;
@@ -27,9 +24,9 @@ use zolana_interface::{
 use zolana_test_utils::mollusk::expect_err_exact;
 
 use crate::common::{
-    account, approval_account, approval_pda, approver, auditor_pubkey, authority,
-    config_account_with_policy, config_pda, initialized_config_account, payer, program_id,
-    ring_auth_pda, setup_mollusk, spp_program_account, substitute_account, PolicyFixture,
+    account, approval_account, approver, auditor_pubkey, authority, config_account_with_policy,
+    config_pda, initialized_config_account, payer, program_id, ring_auth_pda, setup_mollusk,
+    spp_program_account, substitute_account, PolicyFixture,
 };
 
 fn custom(error: CustomRingError) -> ProgramError {
@@ -408,7 +405,7 @@ fn withdrawal_fixture(
     (instruction, accounts)
 }
 
-fn policy(withdrawals: u8) -> Account {
+fn policy(withdrawals: WithdrawalRule) -> Account {
     config_account_with_policy(
         authority(),
         config_auditor_pubkey(),
@@ -425,7 +422,7 @@ fn policy(withdrawals: u8) -> Account {
 #[test]
 fn public_withdrawal_is_rejected_exactly_when_blocked() {
     let (mollusk, _) = setup_mollusk();
-    let (instruction, accounts) = withdrawal_fixture(policy(WITHDRAWALS_BLOCKED), None);
+    let (instruction, accounts) = withdrawal_fixture(policy(WithdrawalRule::Blocked), None);
     expect_err_exact(
         &mollusk,
         &instruction,
@@ -437,7 +434,7 @@ fn public_withdrawal_is_rejected_exactly_when_blocked() {
 #[test]
 fn public_withdrawal_under_approval_needs_the_approval_account() {
     let (mollusk, _) = setup_mollusk();
-    let (instruction, accounts) = withdrawal_fixture(policy(WITHDRAWALS_APPROVAL), None);
+    let (instruction, accounts) = withdrawal_fixture(policy(WithdrawalRule::Approval), None);
     expect_err_exact(
         &mollusk,
         &instruction,
@@ -451,10 +448,9 @@ fn public_withdrawal_under_approval_needs_the_approval_account() {
 #[test]
 fn an_approval_for_another_transact_is_rejected_exactly() {
     let (mollusk, _) = setup_mollusk();
-    let other = approval_pda(&[8u8; 32]).0;
     let (instruction, accounts) = withdrawal_fixture(
-        policy(WITHDRAWALS_APPROVAL),
-        Some((other, approval_account())),
+        policy(WithdrawalRule::Approval),
+        Some(approval_account(&[8u8; 32])),
     );
     expect_err_exact(
         &mollusk,
@@ -470,10 +466,9 @@ fn an_approval_for_another_transact_is_rejected_exactly() {
 fn a_matching_approval_lets_the_withdrawal_reach_the_proof() {
     let (mollusk, _) = setup_mollusk();
     let private_tx_hash = transact(vec![]).private_tx_hash;
-    let approval = approval_pda(&private_tx_hash).0;
     let (instruction, accounts) = withdrawal_fixture(
-        policy(WITHDRAWALS_APPROVAL),
-        Some((approval, approval_account())),
+        policy(WithdrawalRule::Approval),
+        Some(approval_account(&private_tx_hash)),
     );
     expect_err_exact(
         &mollusk,
@@ -491,10 +486,10 @@ fn per_asset_rule_overrides_the_default() {
         authority(),
         config_auditor_pubkey(),
         PolicyFixture {
-            withdrawals: WITHDRAWALS_BLOCKED,
+            withdrawals: WithdrawalRule::Blocked,
             assets: &[AssetRule {
                 mint: [0u8; 32],
-                withdrawals: WITHDRAWALS_OPEN,
+                withdrawals: WithdrawalRule::Open,
             }],
             ..PolicyFixture::default()
         },
@@ -522,7 +517,7 @@ fn settlement_of_an_asset_outside_the_allowlist_is_rejected_exactly() {
             allowlist: true,
             assets: &[AssetRule {
                 mint: [9u8; 32],
-                withdrawals: WITHDRAWALS_OPEN,
+                withdrawals: WithdrawalRule::Open,
             }],
             ..PolicyFixture::default()
         },

--- a/custom-rings/program/tests/failing/transact.rs
+++ b/custom-rings/program/tests/failing/transact.rs
@@ -417,7 +417,7 @@ fn policy(withdrawals: WithdrawalRule) -> Account {
     )
 }
 
-/// Policy runs before the proof: the fixture's proof is bogus and the
+/// Policy runs before the proof. The fixture's proof is bogus and the
 /// withdrawal is still what gets named.
 #[test]
 fn public_withdrawal_is_rejected_exactly_when_blocked() {
@@ -443,7 +443,7 @@ fn public_withdrawal_under_approval_needs_the_approval_account() {
     );
 }
 
-/// The approval account is bound to `private_tx_hash`; another transact's
+/// The approval account is bound to `private_tx_hash`. Another transact's
 /// approval does not open this one.
 #[test]
 fn an_approval_for_another_transact_is_rejected_exactly() {
@@ -478,7 +478,7 @@ fn a_matching_approval_lets_the_withdrawal_reach_the_proof() {
     );
 }
 
-/// The per-asset rule wins over the default: SOL open while the default blocks.
+/// The per-asset rule wins over the default, SOL open while the default blocks.
 #[test]
 fn per_asset_rule_overrides_the_default() {
     let (mollusk, _) = setup_mollusk();

--- a/custom-rings/sdk/src/instructions/approve_transact/instruction.rs
+++ b/custom-rings/sdk/src/instructions/approve_transact/instruction.rs
@@ -1,0 +1,44 @@
+use custom_ring_program::instructions::approve_transact::{
+    ApproveTransactIxData, APPROVAL_PDA_SEED,
+};
+use solana_address::Address;
+use solana_instruction::{AccountMeta, Instruction};
+
+use crate::{config_pda, tag, PROGRAM_ID};
+
+/// The approval account of the transact with `private_tx_hash`.
+pub fn approval_pda(private_tx_hash: &[u8; 32]) -> Address {
+    Address::find_program_address(&[APPROVAL_PDA_SEED, private_tx_hash], &PROGRAM_ID).0
+}
+
+/// The approver signs off one transact; `transact` spends the approval.
+pub struct ApproveTransact {
+    /// The config's approver.
+    pub approver: Address,
+    /// Pays the approval account's rent, refunded to the transact's payer.
+    pub payer: Address,
+    pub private_tx_hash: [u8; 32],
+}
+
+impl ApproveTransact {
+    pub fn instruction(self) -> Instruction {
+        let mut data = vec![tag::APPROVE_TRANSACT];
+        data.extend_from_slice(
+            &wincode::serialize(&ApproveTransactIxData {
+                private_tx_hash: self.private_tx_hash,
+            })
+            .expect("approve_transact instruction data is fixed size"),
+        );
+        Instruction {
+            program_id: PROGRAM_ID,
+            accounts: vec![
+                AccountMeta::new_readonly(self.approver, true),
+                AccountMeta::new(self.payer, true),
+                AccountMeta::new_readonly(config_pda(), false),
+                AccountMeta::new(approval_pda(&self.private_tx_hash), false),
+                AccountMeta::new_readonly(Address::default(), false),
+            ],
+            data,
+        }
+    }
+}

--- a/custom-rings/sdk/src/instructions/approve_transact/instruction.rs
+++ b/custom-rings/sdk/src/instructions/approve_transact/instruction.rs
@@ -11,7 +11,7 @@ pub fn approval_pda(private_tx_hash: &[u8; 32]) -> Address {
     Address::find_program_address(&[APPROVAL_PDA_SEED, private_tx_hash], &PROGRAM_ID).0
 }
 
-/// The approver signs off one transact; `transact` spends the approval.
+/// The approver signs off one transact and `transact` spends the approval.
 pub struct ApproveTransact {
     /// The config's approver.
     pub approver: Address,
@@ -43,7 +43,7 @@ impl ApproveTransact {
     }
 }
 
-/// The approver takes an unspent approval back; its lamports go to
+/// The approver takes an unspent approval back and its lamports go to
 /// `rent_recipient`.
 pub struct RevokeApproval {
     pub approver: Address,

--- a/custom-rings/sdk/src/instructions/approve_transact/instruction.rs
+++ b/custom-rings/sdk/src/instructions/approve_transact/instruction.rs
@@ -42,3 +42,33 @@ impl ApproveTransact {
         }
     }
 }
+
+/// The approver takes an unspent approval back; its lamports go to
+/// `rent_recipient`.
+pub struct RevokeApproval {
+    pub approver: Address,
+    pub rent_recipient: Address,
+    pub private_tx_hash: [u8; 32],
+}
+
+impl RevokeApproval {
+    pub fn instruction(self) -> Instruction {
+        let mut data = vec![tag::REVOKE_APPROVAL];
+        data.extend_from_slice(
+            &wincode::serialize(&ApproveTransactIxData {
+                private_tx_hash: self.private_tx_hash,
+            })
+            .expect("revoke_approval instruction data is fixed size"),
+        );
+        Instruction {
+            program_id: PROGRAM_ID,
+            accounts: vec![
+                AccountMeta::new_readonly(self.approver, true),
+                AccountMeta::new(self.rent_recipient, false),
+                AccountMeta::new_readonly(config_pda(), false),
+                AccountMeta::new(approval_pda(&self.private_tx_hash), false),
+            ],
+            data,
+        }
+    }
+}

--- a/custom-rings/sdk/src/instructions/approve_transact/mod.rs
+++ b/custom-rings/sdk/src/instructions/approve_transact/mod.rs
@@ -1,0 +1,3 @@
+mod instruction;
+
+pub use instruction::{approval_pda, ApproveTransact};

--- a/custom-rings/sdk/src/instructions/approve_transact/mod.rs
+++ b/custom-rings/sdk/src/instructions/approve_transact/mod.rs
@@ -1,3 +1,3 @@
 mod instruction;
 
-pub use instruction::{approval_pda, ApproveTransact};
+pub use instruction::{approval_pda, ApproveTransact, RevokeApproval};

--- a/custom-rings/sdk/src/instructions/create_config/instruction.rs
+++ b/custom-rings/sdk/src/instructions/create_config/instruction.rs
@@ -14,7 +14,7 @@ pub struct CreateConfig {
     /// authority is always a key that consented to the role. When the program
     /// was deployed with an upgrade authority, this must be that key.
     pub authority: Address,
-    /// Auditor P256 public key. The type guarantees a point on the curve; the
+    /// Auditor P256 public key. The type guarantees a point on the curve. The
     /// program only checks the SEC1 prefix, and an off-curve key would leave the
     /// ring without a provable transaction.
     pub auditor_pubkey: P256Pubkey,

--- a/custom-rings/sdk/src/instructions/deposit/instruction.rs
+++ b/custom-rings/sdk/src/instructions/deposit/instruction.rs
@@ -6,11 +6,11 @@ use crate::{config_pda, PROGRAM_ID};
 
 /// Ring deposit: SPP's `RING_DEPOSIT` instruction re-targeted at this program.
 ///
-/// The ring proves nothing for a deposit -- amounts are public on-chain -- so it
+/// The ring proves nothing for a deposit, amounts are public on-chain, so it
 /// checks its asset policy, lends its `ring_auth` signature and forwards the
 /// instruction data byte for byte, tag included. Encoding and SPP's account
-/// layout stay in the interface builder; the ring config is prepended for the
-/// policy read. This wrapper pins `ring_program_id`, which selects both the
+/// layout stay in the interface builder, and the ring config is prepended for
+/// the policy read. This wrapper pins `ring_program_id`, which selects both the
 /// instruction target and the `ring_auth` PDA that has to sign inside the
 /// forwarded CPI. Those two must never disagree, and here they cannot.
 pub struct Deposit {

--- a/custom-rings/sdk/src/instructions/mod.rs
+++ b/custom-rings/sdk/src/instructions/mod.rs
@@ -1,3 +1,4 @@
+pub mod approve_transact;
 pub mod create_config;
 pub mod deposit;
 pub mod init_spp_ring_config;

--- a/custom-rings/sdk/src/instructions/set_policy/instruction.rs
+++ b/custom-rings/sdk/src/instructions/set_policy/instruction.rs
@@ -1,9 +1,6 @@
 use custom_ring_program::{
-    instructions::set_policy::{AssetRule as AssetRuleData, SetPolicyIxData},
-    state::{
-        RingProgramConfig, ASSETS_ALLOWLIST, ASSETS_ANY, MAX_ASSETS, SOL_MINT,
-        WITHDRAWALS_APPROVAL, WITHDRAWALS_BLOCKED, WITHDRAWALS_OPEN,
-    },
+    instructions::set_policy::{AssetRuleData, SetPolicyIxData},
+    state::{AssetPolicy, RingProgramConfig, WithdrawalRule, MAX_ASSETS, SOL_MINT},
 };
 use solana_address::Address;
 use solana_instruction::{AccountMeta, Instruction};
@@ -13,51 +10,6 @@ use crate::{config_pda, tag, PROGRAM_ID};
 /// The address SOL takes in the asset table.
 pub const SOL: Address = Address::new_from_array(SOL_MINT);
 
-/// What happens to a public settlement leg out of the pool.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum WithdrawalRule {
-    #[default]
-    Open,
-    Blocked,
-    /// The transact must carry an approval the ring's approver created for it.
-    Approval,
-}
-
-impl WithdrawalRule {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Open => "open",
-            Self::Blocked => "blocked",
-            Self::Approval => "approval",
-        }
-    }
-
-    pub fn parse(text: &str) -> Option<Self> {
-        match text {
-            "open" => Some(Self::Open),
-            "blocked" => Some(Self::Blocked),
-            "approval" => Some(Self::Approval),
-            _ => None,
-        }
-    }
-
-    fn from_wire(value: u8) -> Self {
-        match value {
-            WITHDRAWALS_BLOCKED => Self::Blocked,
-            WITHDRAWALS_APPROVAL => Self::Approval,
-            _ => Self::Open,
-        }
-    }
-
-    fn to_wire(self) -> u8 {
-        match self {
-            Self::Open => WITHDRAWALS_OPEN,
-            Self::Blocked => WITHDRAWALS_BLOCKED,
-            Self::Approval => WITHDRAWALS_APPROVAL,
-        }
-    }
-}
-
 /// One asset table entry.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AssetRule {
@@ -66,12 +18,11 @@ pub struct AssetRule {
 }
 
 /// What the ring enforces on the transfers it forwards.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RingPolicy {
-    /// Only the table's mints may enter or leave the ring.
-    pub allowlist: bool,
-    /// The asset table: a withdrawal rule per mint, and under `allowlist` the
-    /// mints allowed at all.
+    pub asset_policy: AssetPolicy,
+    /// The asset table: a withdrawal rule per mint, and under the allowlist
+    /// the mints allowed at all.
     pub assets: Vec<AssetRule>,
     /// Withdrawal rule for mints outside the table.
     pub withdrawals: WithdrawalRule,
@@ -79,20 +30,32 @@ pub struct RingPolicy {
     pub approver: Option<Address>,
 }
 
+impl Default for RingPolicy {
+    fn default() -> Self {
+        Self {
+            asset_policy: AssetPolicy::Any,
+            assets: Vec::new(),
+            withdrawals: WithdrawalRule::Open,
+            approver: None,
+        }
+    }
+}
+
 impl RingPolicy {
     /// The policy a config account carries.
     pub fn from_config(config: &RingProgramConfig) -> Self {
         Self {
-            allowlist: config.asset_policy == ASSETS_ALLOWLIST,
+            asset_policy: config.asset_policy(),
             assets: config
                 .assets()
-                .map(|(mint, rule)| AssetRule {
-                    mint: Address::new_from_array(*mint),
-                    withdrawals: WithdrawalRule::from_wire(rule),
+                .map(|asset| AssetRule {
+                    mint: Address::new_from_array(asset.mint),
+                    withdrawals: asset.withdrawals,
                 })
                 .collect(),
-            withdrawals: WithdrawalRule::from_wire(config.withdrawals),
-            approver: config.has_approver().then_some(config.approver),
+            withdrawals: WithdrawalRule::try_from(config.withdrawals)
+                .unwrap_or(WithdrawalRule::Blocked),
+            approver: config.approver().copied(),
         }
     }
 
@@ -115,23 +78,26 @@ impl RingPolicy {
         if self.assets.len() > MAX_ASSETS {
             return Err(PolicyError::TooManyAssets(self.assets.len()));
         }
+        if let Some(duplicate) = self.assets.iter().enumerate().find(|(index, asset)| {
+            self.assets[..*index]
+                .iter()
+                .any(|earlier| earlier.mint == asset.mint)
+        }) {
+            return Err(PolicyError::DuplicateAsset(duplicate.1.mint));
+        }
         if self.needs_approver() && self.approver.is_none() {
             return Err(PolicyError::ApproverRequired);
         }
         Ok(SetPolicyIxData {
-            withdrawals: self.withdrawals.to_wire(),
-            asset_policy: if self.allowlist {
-                ASSETS_ALLOWLIST
-            } else {
-                ASSETS_ANY
-            },
+            withdrawals: self.withdrawals as u8,
+            asset_policy: self.asset_policy as u8,
             approver: self.approver.map(|key| key.to_bytes()).unwrap_or_default(),
             assets: self
                 .assets
                 .iter()
                 .map(|asset| AssetRuleData {
                     mint: asset.mint.to_bytes(),
-                    withdrawals: asset.withdrawals.to_wire(),
+                    withdrawals: asset.withdrawals as u8,
                 })
                 .collect(),
         })
@@ -142,6 +108,8 @@ impl RingPolicy {
 pub enum PolicyError {
     #[error("asset table holds {0} entries, the ring stores at most {MAX_ASSETS}")]
     TooManyAssets(usize),
+    #[error("asset {0} is listed twice")]
+    DuplicateAsset(Address),
     #[error("a withdrawal rule requires approval but no approver is set")]
     ApproverRequired,
 }

--- a/custom-rings/sdk/src/instructions/set_policy/instruction.rs
+++ b/custom-rings/sdk/src/instructions/set_policy/instruction.rs
@@ -1,8 +1,8 @@
 use custom_ring_program::{
-    instructions::set_policy::SetPolicyIxData,
+    instructions::set_policy::{AssetRule as AssetRuleData, SetPolicyIxData},
     state::{
-        RingProgramConfig, ASSETS_ALLOWLIST, ASSETS_ANY, MAX_ALLOWED_ASSETS, SOL_MINT,
-        WITHDRAWALS_BLOCKED, WITHDRAWALS_OPEN,
+        RingProgramConfig, ASSETS_ALLOWLIST, ASSETS_ANY, MAX_ASSETS, SOL_MINT,
+        WITHDRAWALS_APPROVAL, WITHDRAWALS_BLOCKED, WITHDRAWALS_OPEN,
     },
 };
 use solana_address::Address;
@@ -10,58 +10,140 @@ use solana_instruction::{AccountMeta, Instruction};
 
 use crate::{config_pda, tag, PROGRAM_ID};
 
+/// The address SOL takes in the asset table.
+pub const SOL: Address = Address::new_from_array(SOL_MINT);
+
+/// What happens to a public settlement leg out of the pool.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum WithdrawalRule {
+    #[default]
+    Open,
+    Blocked,
+    /// The transact must carry an approval the ring's approver created for it.
+    Approval,
+}
+
+impl WithdrawalRule {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Blocked => "blocked",
+            Self::Approval => "approval",
+        }
+    }
+
+    pub fn parse(text: &str) -> Option<Self> {
+        match text {
+            "open" => Some(Self::Open),
+            "blocked" => Some(Self::Blocked),
+            "approval" => Some(Self::Approval),
+            _ => None,
+        }
+    }
+
+    fn from_wire(value: u8) -> Self {
+        match value {
+            WITHDRAWALS_BLOCKED => Self::Blocked,
+            WITHDRAWALS_APPROVAL => Self::Approval,
+            _ => Self::Open,
+        }
+    }
+
+    fn to_wire(self) -> u8 {
+        match self {
+            Self::Open => WITHDRAWALS_OPEN,
+            Self::Blocked => WITHDRAWALS_BLOCKED,
+            Self::Approval => WITHDRAWALS_APPROVAL,
+        }
+    }
+}
+
+/// One asset table entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AssetRule {
+    pub mint: Address,
+    pub withdrawals: WithdrawalRule,
+}
+
 /// What the ring enforces on the transfers it forwards.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RingPolicy {
-    /// `Some(mints)`: only these assets may enter or leave the ring (SOL is
-    /// [`SOL_MINT`]). `None`: any asset.
-    pub allowed_assets: Option<Vec<Address>>,
-    pub withdrawals_blocked: bool,
+    /// Only the table's mints may enter or leave the ring.
+    pub allowlist: bool,
+    /// The asset table: a withdrawal rule per mint, and under `allowlist` the
+    /// mints allowed at all.
+    pub assets: Vec<AssetRule>,
+    /// Withdrawal rule for mints outside the table.
+    pub withdrawals: WithdrawalRule,
+    /// Required when any rule is `Approval`.
+    pub approver: Option<Address>,
 }
 
 impl RingPolicy {
     /// The policy a config account carries.
     pub fn from_config(config: &RingProgramConfig) -> Self {
         Self {
-            allowed_assets: (config.asset_policy == ASSETS_ALLOWLIST).then(|| {
-                config
-                    .allowed_assets()
-                    .iter()
-                    .map(|mint| Address::new_from_array(*mint))
-                    .collect()
-            }),
-            withdrawals_blocked: config.withdrawals_blocked(),
+            allowlist: config.asset_policy == ASSETS_ALLOWLIST,
+            assets: config
+                .assets()
+                .map(|(mint, rule)| AssetRule {
+                    mint: Address::new_from_array(*mint),
+                    withdrawals: WithdrawalRule::from_wire(rule),
+                })
+                .collect(),
+            withdrawals: WithdrawalRule::from_wire(config.withdrawals),
+            approver: config.has_approver().then_some(config.approver),
         }
     }
 
+    pub fn withdrawal_rule(&self, mint: &Address) -> WithdrawalRule {
+        self.assets
+            .iter()
+            .find(|asset| asset.mint == *mint)
+            .map_or(self.withdrawals, |asset| asset.withdrawals)
+    }
+
+    pub fn needs_approver(&self) -> bool {
+        self.withdrawals == WithdrawalRule::Approval
+            || self
+                .assets
+                .iter()
+                .any(|asset| asset.withdrawals == WithdrawalRule::Approval)
+    }
+
     pub fn ix_data(&self) -> Result<SetPolicyIxData, PolicyError> {
-        let allowed_assets = self.allowed_assets.clone().unwrap_or_default();
-        if allowed_assets.len() > MAX_ALLOWED_ASSETS {
-            return Err(PolicyError::TooManyAssets(allowed_assets.len()));
+        if self.assets.len() > MAX_ASSETS {
+            return Err(PolicyError::TooManyAssets(self.assets.len()));
+        }
+        if self.needs_approver() && self.approver.is_none() {
+            return Err(PolicyError::ApproverRequired);
         }
         Ok(SetPolicyIxData {
-            withdrawals: if self.withdrawals_blocked {
-                WITHDRAWALS_BLOCKED
-            } else {
-                WITHDRAWALS_OPEN
-            },
-            asset_policy: if self.allowed_assets.is_some() {
+            withdrawals: self.withdrawals.to_wire(),
+            asset_policy: if self.allowlist {
                 ASSETS_ALLOWLIST
             } else {
                 ASSETS_ANY
             },
-            allowed_assets: allowed_assets.iter().map(Address::to_bytes).collect(),
+            approver: self.approver.map(|key| key.to_bytes()).unwrap_or_default(),
+            assets: self
+                .assets
+                .iter()
+                .map(|asset| AssetRuleData {
+                    mint: asset.mint.to_bytes(),
+                    withdrawals: asset.withdrawals.to_wire(),
+                })
+                .collect(),
         })
     }
 }
 
-/// The address SOL takes in an allowlist.
-pub const SOL: Address = Address::new_from_array(SOL_MINT);
-
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum PolicyError {
-    #[error("allowlist holds {0} assets, the ring stores at most {MAX_ALLOWED_ASSETS}")]
+    #[error("asset table holds {0} entries, the ring stores at most {MAX_ASSETS}")]
     TooManyAssets(usize),
+    #[error("a withdrawal rule requires approval but no approver is set")]
+    ApproverRequired,
 }
 
 /// Replaces the ring's policy; `authority` is the config's authority.

--- a/custom-rings/sdk/src/instructions/set_policy/instruction.rs
+++ b/custom-rings/sdk/src/instructions/set_policy/instruction.rs
@@ -21,7 +21,7 @@ pub struct AssetRule {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RingPolicy {
     pub asset_policy: AssetPolicy,
-    /// The asset table: a withdrawal rule per mint, and under the allowlist
+    /// The asset table, a withdrawal rule per mint and, under the allowlist,
     /// the mints allowed at all.
     pub assets: Vec<AssetRule>,
     /// Withdrawal rule for mints outside the table.
@@ -114,7 +114,7 @@ pub enum PolicyError {
     ApproverRequired,
 }
 
-/// Replaces the ring's policy; `authority` is the config's authority.
+/// Replaces the ring's policy. `authority` is the config's authority.
 pub struct SetPolicy {
     pub authority: Address,
     pub policy: RingPolicy,

--- a/custom-rings/sdk/src/instructions/set_policy/mod.rs
+++ b/custom-rings/sdk/src/instructions/set_policy/mod.rs
@@ -1,3 +1,4 @@
 mod instruction;
 
-pub use instruction::{AssetRule, PolicyError, RingPolicy, SetPolicy, WithdrawalRule, SOL};
+pub use custom_ring_program::state::{AssetPolicy, WithdrawalRule};
+pub use instruction::{AssetRule, PolicyError, RingPolicy, SetPolicy, SOL};

--- a/custom-rings/sdk/src/instructions/set_policy/mod.rs
+++ b/custom-rings/sdk/src/instructions/set_policy/mod.rs
@@ -1,3 +1,3 @@
 mod instruction;
 
-pub use instruction::{PolicyError, RingPolicy, SetPolicy, SOL};
+pub use instruction::{AssetRule, PolicyError, RingPolicy, SetPolicy, WithdrawalRule, SOL};

--- a/custom-rings/sdk/src/instructions/transact/instruction.rs
+++ b/custom-rings/sdk/src/instructions/transact/instruction.rs
@@ -10,11 +10,12 @@ use crate::{config_pda, tag, PROGRAM_ID};
 /// Audited ring transact: the ring's auditor key-encryption proof followed by the
 /// SPP payload it forwards.
 ///
-/// The account list is `[payer, config]` prepended to SPP's own `RING_TRANSACT`
-/// list. Those two extra accounts are all this program reads for itself: the payer
-/// it requires as a signer, and the config account holding the auditor key the
-/// public-input hash is recomputed against. Everything after them is forwarded to
-/// SPP position for position, so it is taken straight from
+/// The account list is `[payer, config, approval?]` prepended to SPP's own
+/// `RING_TRANSACT` list. Those extra accounts are all this program reads for
+/// itself: the payer it requires as a signer, the config account holding the
+/// auditor key the public-input hash is recomputed against and the policy, and
+/// the approval account a withdrawal under an approval rule spends. Everything
+/// after them is forwarded to SPP position for position, so it is taken straight from
 /// [`RingTransact::instruction`] rather than re-listed here -- a hand-written copy
 /// would be a second definition of SPP's loader order, free to drift from it.
 ///
@@ -27,6 +28,9 @@ pub struct RingTransactWithAudit {
     pub output_tree: Address,
     /// The eddsa owners of the spent UTXOs; SPP requires each as a signer.
     pub owner_signers: Vec<Address>,
+    /// The approval account of this transact (`approval_pda(private_tx_hash)`)
+    /// when a withdrawal leg falls under an approval rule.
+    pub approval: Option<Address>,
     /// Settlement accounts for the payload's `interface_transfers`, in the same
     /// order.
     pub interface_transfer_accounts: Vec<TransactInterfaceTransferAccounts>,
@@ -46,6 +50,7 @@ impl RingTransactWithAudit {
             input_tree,
             output_tree,
             owner_signers,
+            approval,
             interface_transfer_accounts,
             audit_proof,
             transact,
@@ -65,9 +70,12 @@ impl RingTransactWithAudit {
         let spp_accounts = ring.instruction().accounts;
         let transact = ring.data;
 
-        let mut accounts = Vec::with_capacity(2 + spp_accounts.len());
+        let mut accounts = Vec::with_capacity(3 + spp_accounts.len());
         accounts.push(AccountMeta::new(payer, true));
         accounts.push(AccountMeta::new_readonly(config_pda(), false));
+        if let Some(approval) = approval {
+            accounts.push(AccountMeta::new(approval, false));
+        }
         accounts.extend(spp_accounts);
 
         let body = wincode::serialize(&CustomRingTransactIxData {

--- a/custom-rings/sdk/src/instructions/transact/instruction.rs
+++ b/custom-rings/sdk/src/instructions/transact/instruction.rs
@@ -12,7 +12,7 @@ use crate::{config_pda, tag, PROGRAM_ID};
 ///
 /// The account list is `[payer, config, approval?]` prepended to SPP's own
 /// `RING_TRANSACT` list. Those extra accounts are all this program reads for
-/// itself: the payer it requires as a signer, the config account holding the
+/// itself, the payer it requires as a signer, the config account holding the
 /// auditor key the public-input hash is recomputed against and the policy, and
 /// the approval account a withdrawal under an approval rule spends. Everything
 /// after them is forwarded to SPP position for position, so it is taken straight from

--- a/custom-rings/sdk/src/lib.rs
+++ b/custom-rings/sdk/src/lib.rs
@@ -23,11 +23,13 @@ pub use zolana_ring_client::{
 
 pub use crate::{
     instructions::{
-        approve_transact::{approval_pda, ApproveTransact},
+        approve_transact::{approval_pda, ApproveTransact, RevokeApproval},
         create_config::CreateConfig,
         deposit::Deposit,
         init_spp_ring_config::InitSppRingConfig,
-        set_policy::{AssetRule, PolicyError, RingPolicy, SetPolicy, WithdrawalRule, SOL},
+        set_policy::{
+            AssetPolicy, AssetRule, PolicyError, RingPolicy, SetPolicy, WithdrawalRule, SOL,
+        },
         transact::{
             to_instruction_proof, AuditProofInputError, AuditProofParams, PendingAuditProof,
             RingTransactWithAudit,

--- a/custom-rings/sdk/src/lib.rs
+++ b/custom-rings/sdk/src/lib.rs
@@ -23,10 +23,11 @@ pub use zolana_ring_client::{
 
 pub use crate::{
     instructions::{
+        approve_transact::{approval_pda, ApproveTransact},
         create_config::CreateConfig,
         deposit::Deposit,
         init_spp_ring_config::InitSppRingConfig,
-        set_policy::{PolicyError, RingPolicy, SetPolicy, SOL},
+        set_policy::{AssetRule, PolicyError, RingPolicy, SetPolicy, WithdrawalRule, SOL},
         transact::{
             to_instruction_proof, AuditProofInputError, AuditProofParams, PendingAuditProof,
             RingTransactWithAudit,

--- a/custom-rings/sdk/src/lookup_table.rs
+++ b/custom-rings/sdk/src/lookup_table.rs
@@ -20,7 +20,7 @@ use zolana_client::SolanaRpc;
 pub const TRANSACT_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
 
 /// Send `ix` as a v0 transaction behind a fresh lookup table. `payer` pays for
-/// the table and the transaction; `signers` are the other required signers.
+/// the table and the transaction, `signers` are the other required signers.
 pub fn send_v0_with_lookup_table(
     rpc: &SolanaRpc,
     payer: &dyn Signer,
@@ -88,9 +88,10 @@ pub fn build_v0_with_lookup_table(
 }
 
 /// Every key the transaction needs except the signers, which stay static. The
-/// compute budget program is included too: a key left out of the table costs 32
-/// message bytes instead of a 1-byte index, and the audited ring transact has no
-/// such bytes to spare. Duplicates are dropped so one key never claims two slots.
+/// compute budget program is included too, because a key left out of the table
+/// costs 32 message bytes instead of a 1-byte index and the audited ring
+/// transact has no such bytes to spare. Duplicates are dropped so one key never
+/// claims two slots.
 pub fn lookup_table_addresses(ix: &Instruction, compute_program: Address) -> Vec<Address> {
     let mut addresses: Vec<Address> = Vec::new();
     for address in ix

--- a/custom-rings/sdk/src/shared.rs
+++ b/custom-rings/sdk/src/shared.rs
@@ -22,7 +22,7 @@ pub fn ring_auth_pda() -> Address {
     pda
 }
 
-/// The program's `ProgramData` account under the upgradeable BPF loader;
+/// The program's `ProgramData` account under the upgradeable BPF loader,
 /// `create_config` reads the deploy upgrade authority from it.
 pub fn program_data_pda() -> Address {
     let (pda, _bump) = Address::find_program_address(

--- a/custom-rings/sdk/src/transfer.rs
+++ b/custom-rings/sdk/src/transfer.rs
@@ -21,15 +21,17 @@ use zolana_client::{
 };
 use zolana_interface::{
     instruction::{
-        tag::RING_TRANSACT, CircuitId, DepositAsset, InputUtxo, RingAssetDeposit, TransactIxData,
-        TransactProof,
+        tag::RING_TRANSACT, CircuitId, DepositAsset, InputUtxo, RingAssetDeposit,
+        TransactInterfaceTransferAccounts, TransactIxData, TransactProof,
+        TransactSolTransferAccounts,
     },
     N_PUBLIC_SLOTS,
 };
 use zolana_keypair::{random_blinding, P256Pubkey, ShieldedKeypair, ViewingKey};
 use zolana_transaction::{
     instructions::transact::{
-        encrypt_transaction_data, get_transaction_viewing_key, ExternalData, SppProofOutputUtxo,
+        encrypt_transaction_data, get_transaction_viewing_key, ExternalData, SettlementTransfer,
+        SppProofOutputUtxo,
     },
     owner_utxo_hash, AssetRegistry, Data, RingDepositPlaintext, Utxo, SOL_MINT,
 };
@@ -43,14 +45,16 @@ use crate::{
 const ZERO: [u8; 32] = [0u8; 32];
 
 /// One audited transfer: `sender` spends `inputs` (ring-owned UTXOs) into
-/// `outputs`, and the transaction viewing key is verifiably encrypted to
-/// `auditor_pk`.
+/// `outputs` and `withdrawals`, and the transaction viewing key is verifiably
+/// encrypted to `auditor_pk`.
 pub struct AuditedTransfer<'a, I: Rpc> {
     pub indexer: &'a I,
     pub spp_prover: &'a ProverClient,
     pub sender: &'a ShieldedKeypair,
     pub inputs: Vec<Utxo>,
     pub outputs: Vec<SppProofOutputUtxo>,
+    /// Public SOL withdrawals out of the pool, `(recipient, lamports)`.
+    pub withdrawals: Vec<(Address, u64)>,
     pub tree: Address,
     pub auditor_pk: P256Pubkey,
     pub assets: &'a AssetRegistry,
@@ -63,6 +67,8 @@ pub struct ProvenTransfer {
     pub data: TransactIxData,
     pub audit_proof: AuditProof,
     pub owner_signers: Vec<Address>,
+    /// Settlement accounts of `data.interface_transfers`, in order.
+    pub interface_transfer_accounts: Vec<TransactInterfaceTransferAccounts>,
 }
 
 impl<I: Rpc> AuditedTransfer<'_, I> {
@@ -86,7 +92,17 @@ impl<I: Rpc> AuditedTransfer<'_, I> {
             encoded.outputs,
             encoded.resolved_owner_tags,
             vec![auditor_message.to_message_data(&self.auditor_pk)],
-        );
+        )
+        .with_interface_transfers(
+            self.withdrawals
+                .iter()
+                .map(|(recipient, amount)| SettlementTransfer::Sol {
+                    is_deposit: false,
+                    amount: *amount,
+                    user_sol_account: *recipient,
+                })
+                .collect(),
+        )?;
         // Folded into external_data_hash and from there into private_tx_hash,
         // so it is bound before anything hashes external data.
         external_data.instruction_discriminator = RING_TRANSACT;
@@ -123,22 +139,47 @@ impl<I: Rpc> AuditedTransfer<'_, I> {
             data: assemble_ring_eddsa_ix_data(&proof_inputs, &ring_result, spp_proof)?,
             audit_proof,
             owner_signers: proof_inputs.owner_signer_pubkeys()?,
+            interface_transfer_accounts: self
+                .withdrawals
+                .iter()
+                .map(|(recipient, _)| {
+                    TransactInterfaceTransferAccounts::Sol(TransactSolTransferAccounts {
+                        recipient: *recipient,
+                    })
+                })
+                .collect(),
         })
     }
 }
 
 impl ProvenTransfer {
-    /// The audited ring transact instruction, `payer` paying. `ring_config`
-    /// (the ring's `ring_auth` PDA) stays unsigned here; the program flips it to
-    /// a signer inside its CPI.
-    pub fn instruction(&self, payer: Address, tree: Address) -> Result<Instruction> {
-        ring_transact_ix(
+    /// What an approver signs off, and the seed of the approval account.
+    pub fn private_tx_hash(&self) -> [u8; 32] {
+        self.data.private_tx_hash
+    }
+
+    /// The audited ring transact instruction, `payer` paying. `approval` is
+    /// this transact's approval account when a withdrawal falls under an
+    /// approval rule. `ring_config` (the ring's `ring_auth` PDA) stays unsigned
+    /// here; the program flips it to a signer inside its CPI.
+    pub fn instruction(
+        &self,
+        payer: Address,
+        tree: Address,
+        approval: Option<Address>,
+    ) -> Result<Instruction> {
+        RingTransactWithAudit {
             payer,
-            tree,
-            self.owner_signers.clone(),
-            self.audit_proof,
-            self.data.clone(),
-        )
+            input_tree: tree,
+            output_tree: tree,
+            owner_signers: self.owner_signers.clone(),
+            approval,
+            interface_transfer_accounts: self.interface_transfer_accounts.clone(),
+            audit_proof: self.audit_proof,
+            transact: self.data.clone(),
+        }
+        .instruction()
+        .map_err(|e| anyhow!("ring transact instruction: {e}"))
     }
 }
 
@@ -307,6 +348,7 @@ pub fn ring_transact_ix(
         input_tree: tree,
         output_tree: tree,
         owner_signers,
+        approval: None,
         interface_transfer_accounts: Vec::new(),
         audit_proof,
         transact,

--- a/custom-rings/sdk/src/transfer.rs
+++ b/custom-rings/sdk/src/transfer.rs
@@ -44,7 +44,7 @@ use crate::{
 /// A UTXO's `data_hash` / `ring_data_hash` when it carries neither.
 const ZERO: [u8; 32] = [0u8; 32];
 
-/// One audited transfer: `sender` spends `inputs` (ring-owned UTXOs) into
+/// One audited transfer. `sender` spends `inputs` (ring-owned UTXOs) into
 /// `outputs` and `withdrawals`, and the transaction viewing key is verifiably
 /// encrypted to `auditor_pk`.
 pub struct AuditedTransfer<'a, I: Rpc> {
@@ -62,7 +62,7 @@ pub struct AuditedTransfer<'a, I: Rpc> {
 
 /// Both proofs and the instruction data they verify, ready to send.
 pub struct ProvenTransfer {
-    /// The key the auditor recovers; every output ciphertext is under it.
+    /// The key the auditor recovers, every output ciphertext is under it.
     pub tx_viewing_key: ViewingKey,
     pub data: TransactIxData,
     pub audit_proof: AuditProof,
@@ -161,7 +161,7 @@ impl ProvenTransfer {
     /// The audited ring transact instruction, `payer` paying. `approval` is
     /// this transact's approval account when a withdrawal falls under an
     /// approval rule. `ring_config` (the ring's `ring_auth` PDA) stays unsigned
-    /// here; the program flips it to a signer inside its CPI.
+    /// here, the program flips it to a signer inside its CPI.
     pub fn instruction(
         &self,
         payer: Address,
@@ -186,7 +186,7 @@ impl ProvenTransfer {
 /// Ring-deposit `amount` lamports to `recipient`'s shielded address, paid by
 /// `payer`, returning the ring-owned UTXO the deposit created. The public face
 /// of a ring deposit carries only the `owner_utxo_hash` commitment and the
-/// recipient bootstrap view tag; the blinding travels encrypted to the
+/// recipient bootstrap view tag, while the blinding travels encrypted to the
 /// recipient's viewing key.
 pub fn ring_deposit_sol<R: Rpc>(
     rpc: &R,
@@ -335,7 +335,7 @@ pub fn assemble_ring_eddsa_ix_data(
 }
 
 /// The audited ring transact instruction. `ring_config` (the ring's `ring_auth`
-/// PDA) stays unsigned here; the program flips it to a signer inside its CPI.
+/// PDA) stays unsigned here, the program flips it to a signer inside its CPI.
 pub fn ring_transact_ix(
     payer: Address,
     tree: Address,

--- a/custom-rings/sdk/tests/instruction_builders.rs
+++ b/custom-rings/sdk/tests/instruction_builders.rs
@@ -364,6 +364,7 @@ fn ring_transact_with_audit_prepends_payer_and_config_to_the_spp_list() {
         input_tree: input_tree(),
         output_tree: output_tree(),
         owner_signers: vec![owner_signer()],
+        approval: None,
         interface_transfer_accounts: Vec::new(),
         audit_proof: proof,
         transact: transact.clone(),
@@ -405,6 +406,7 @@ fn ring_transact_with_audit_leaves_ring_config_unsigned() {
         input_tree: input_tree(),
         output_tree: output_tree(),
         owner_signers: Vec::new(),
+        approval: None,
         interface_transfer_accounts: Vec::new(),
         audit_proof: audit_proof(),
         transact: transact_data(Vec::new()),
@@ -428,6 +430,7 @@ fn ring_transact_with_audit_forwards_settlement_accounts() {
         input_tree: input_tree(),
         output_tree: output_tree(),
         owner_signers: vec![owner_signer()],
+        approval: None,
         interface_transfer_accounts: vec![TransactInterfaceTransferAccounts::Sol(
             TransactSolTransferAccounts { recipient },
         )],

--- a/custom-rings/test/tests/ring.rs
+++ b/custom-rings/test/tests/ring.rs
@@ -22,7 +22,7 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use custom_ring_program::{
     error::CustomRingError,
-    state::{RingProgramConfig, ASSETS_ANY, MAX_ASSETS, RING_PROGRAM_CONFIG, WITHDRAWALS_OPEN},
+    state::{AssetPolicy, RingProgramConfig, WithdrawalRule, MAX_ASSETS, RING_PROGRAM_CONFIG},
 };
 use custom_ring_sdk::{
     auditor_view_tag, config_pda, ring_auth_pda, ring_deposit_sol, send_v0_with_lookup_table,
@@ -297,8 +297,8 @@ fn auditor_sees_every_ring_transfer() -> Result<()> {
             authority,
             auditor_pubkey,
             bump: config_bump,
-            withdrawals: WITHDRAWALS_OPEN,
-            asset_policy: ASSETS_ANY,
+            withdrawals: WithdrawalRule::Open as u8,
+            asset_policy: AssetPolicy::Any as u8,
             assets_len: 0,
             approver: Address::default(),
             assets: [[0u8; 32]; MAX_ASSETS],

--- a/custom-rings/test/tests/ring.rs
+++ b/custom-rings/test/tests/ring.rs
@@ -352,7 +352,7 @@ fn auditor_sees_every_ring_transfer() -> Result<()> {
         spendable.push(utxo);
     }
 
-    // 5a. Two explicit outputs -- the sender's change and the recipient -- which
+    // 5a. Two explicit outputs, the sender's change and the recipient, which
     //     is the (2, 2) shape. This is the `SppProofInputs` layer the transaction
     //     crate documents for ring flows, not the high-level
     //     `ConfidentialTransfer`: that builder always emits three outputs (a
@@ -377,8 +377,8 @@ fn auditor_sees_every_ring_transfer() -> Result<()> {
     //     every output ciphertext is HPKE'd under it, so recovering this one
     //     scalar opens the transaction. `AuditedTransfer::prove` encrypts it to
     //     the auditor before the SPP proof runs, so the message is inside the
-    //     `private_tx_hash` the audit circuit binds; the program recomputes that
-    //     same public-input chain from the payload and the config account.
+    //     `private_tx_hash` the audit circuit binds, and the program recomputes
+    //     that same public-input chain from the payload and the config account.
     let proven = AuditedTransfer {
         indexer,
         spp_prover: &ProverClient::local(),

--- a/custom-rings/test/tests/ring.rs
+++ b/custom-rings/test/tests/ring.rs
@@ -22,9 +22,7 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use custom_ring_program::{
     error::CustomRingError,
-    state::{
-        RingProgramConfig, ASSETS_ANY, MAX_ALLOWED_ASSETS, RING_PROGRAM_CONFIG, WITHDRAWALS_OPEN,
-    },
+    state::{RingProgramConfig, ASSETS_ANY, MAX_ASSETS, RING_PROGRAM_CONFIG, WITHDRAWALS_OPEN},
 };
 use custom_ring_sdk::{
     auditor_view_tag, config_pda, ring_auth_pda, ring_deposit_sol, send_v0_with_lookup_table,
@@ -301,8 +299,10 @@ fn auditor_sees_every_ring_transfer() -> Result<()> {
             bump: config_bump,
             withdrawals: WITHDRAWALS_OPEN,
             asset_policy: ASSETS_ANY,
-            allowed_assets_len: 0,
-            allowed_assets: [[0u8; 32]; MAX_ALLOWED_ASSETS],
+            assets_len: 0,
+            approver: Address::default(),
+            assets: [[0u8; 32]; MAX_ASSETS],
+            asset_withdrawals: [0u8; MAX_ASSETS],
         },
         "custom-ring config account"
     );
@@ -385,6 +385,7 @@ fn auditor_sees_every_ring_transfer() -> Result<()> {
         sender: &env.sender.keypair,
         inputs: spendable,
         outputs: vec![change_output.clone(), recipient_output.clone()],
+        withdrawals: Vec::new(),
         tree: env.tree,
         auditor_pk,
         assets: &env.assets,
@@ -395,6 +396,7 @@ fn auditor_sees_every_ring_transfer() -> Result<()> {
         data,
         audit_proof,
         owner_signers,
+        ..
     } = proven;
 
     // 6. Negative, before the real spend so the tree snapshot is meaningful: flip

--- a/justfile
+++ b/justfile
@@ -116,7 +116,7 @@ test-custom-ring: ensure-custom-ring-keys build-programs test-ring-rpc
 ring-new dest="" *args:
     tools/ring-wizard.sh {{dest}} {{args}}
 
-# Local validator for a generated ring: SPP, user registry, photon and the prover
+# Local validator for a generated ring. SPP, user registry, photon and the prover
 # on the per-clone ports, protocol accounts from snapshots (ring creation
 # permissionless). Stays up until `just ring-localnet-stop`.
 ring-localnet: build-programs build-prover-server build-cli ensure-photon ensure-custom-ring-keys
@@ -141,7 +141,7 @@ ring-localnet: build-programs build-prover-server build-cli ensure-photon ensure
     cargo run -q -p xtask -- generate-account-snapshots \
       --deploy-dir target/deploy --accounts-dir "$accounts_dir"
     # The test validator activates SIMD-0500 (no new SBPF v0 deployments) by
-    # default; the ring deploys through `solana program deploy` like on devnet
+    # default. The ring deploys through `solana program deploy` like on devnet
     # and mainnet, where v0 deployments are still accepted, so it is turned off.
     # The ledger keeps enough shreds for a session, so the ring RPC can still
     # read a transaction's signers minutes after it landed.
@@ -159,7 +159,7 @@ ring-localnet: build-programs build-prover-server build-cli ensure-photon ensure
     echo "  prover    {{localnet-prover-url}}"
     echo "  ring rpc  http://127.0.0.1:{{localnet-ring-rpc-port}}  (started per ring by 'just rpc' or 'just pipeline')"
 
-# A ring RPC in derived mode for the localnet: one root secret, a key per
+# A ring RPC in derived mode for the localnet, one root secret and a key per
 # ring, the shape the hosted devnet instance has. Foreground.
 ring-rpc-derived:
     #!/usr/bin/env bash
@@ -181,7 +181,7 @@ ring-localnet-stop:
     lsof -ti "tcp:{{localnet-prover-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
     lsof -ti "tcp:{{localnet-ring-rpc-port}}" 2>/dev/null | xargs kill 2>/dev/null || true
 
-# Template smoke test: generate a ring without prompts and build its workspace.
+# Template smoke test. Generates a ring without prompts and builds its workspace.
 test-ring-template:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/sdk-libs/keypair/src/viewing_key.rs
+++ b/sdk-libs/keypair/src/viewing_key.rs
@@ -71,7 +71,7 @@ impl ViewingKey {
     }
 
     /// HKDF-SHA256 over `ikm` with `info`, then the hash-to-scalar of the
-    /// 48-byte output. Deterministic: the same inputs give the same key.
+    /// 48-byte output. Deterministic, the same inputs give the same key.
     pub fn from_hkdf(ikm: &[u8], info: &[&[u8]]) -> Result<Self, KeypairError> {
         let mut okm = Zeroizing::new([0u8; 48]);
         derivation::hkdf_expand(None, ikm, info, okm.as_mut_slice())?;

--- a/sdk-libs/ring-client/src/types.rs
+++ b/sdk-libs/ring-client/src/types.rs
@@ -16,7 +16,7 @@ pub struct AuditedOutput {
     pub slot_index: u32,
     /// The recipient's viewing key, published in clear at the head of every
     /// confidential slot so the recipient can find it. It is the auditor's
-    /// "to": the sender's own change carries the sender's viewing key.
+    /// "to". The sender's own change carries the sender's viewing key.
     pub recipient_viewing_pk: P256Pubkey,
     pub asset: Address,
     pub amount: u64,

--- a/services/ring-rpc/src/api.rs
+++ b/services/ring-rpc/src/api.rs
@@ -236,9 +236,9 @@ pub struct GetDecryptedTransactionsResponse {
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct DecryptedTransactionsPage {
     pub items: Vec<DecryptedTransaction>,
-    /// Transactions tagged for this auditor that did not audit: a message
-    /// encrypted to another key, a malformed message, or an asset the service
-    /// cannot resolve. Reported so a gap is visible instead of silent.
+    /// Transactions tagged for this auditor that did not audit, because of a
+    /// message encrypted to another key, a malformed message, or an asset the
+    /// service cannot resolve. Reported so a gap is visible instead of silent.
     pub skipped: Vec<SkippedTransaction>,
     pub cursor: Option<Base64String>,
 }
@@ -249,12 +249,12 @@ pub struct DecryptedTransaction {
     pub slot: u64,
     pub tx_signature: SerializableSignature,
     /// Solana signers of the transaction. On the eddsa rail the spent inputs'
-    /// owners sign, so this is the sender side; the fee payer is among them.
+    /// owners sign, so this is the sender side, and the fee payer is among them.
     pub signers: Vec<SerializablePubkey>,
     /// SEC1 compressed transaction viewing pubkey the recovered key matched.
     pub tx_viewing_pk: Base64String,
     pub outputs: Vec<DecryptedOutput>,
-    /// Slot positions the recovered key did not open: dummies, other schemes,
+    /// Slot positions the recovered key did not open, dummies, other schemes,
     /// or ciphertexts under another transaction key.
     pub undecryptable_slots: Vec<u32>,
     pub nullifiers: Vec<Hash>,

--- a/services/ring-rpc/src/audit.rs
+++ b/services/ring-rpc/src/audit.rs
@@ -35,7 +35,7 @@ use crate::api::{
 };
 
 /// Where the service reads from. Photon serves the tagged transactions and the
-/// Solana RPC the signers; tests provide both in memory.
+/// Solana RPC the signers. Tests provide both in memory.
 pub trait TransactionSource: Send + Sync {
     fn transactions_by_tag(
         &self,
@@ -58,7 +58,7 @@ pub trait TransactionSource: Send + Sync {
     ) -> impl Future<Output = Result<Option<Address>, ClientError>> + Send;
 }
 
-/// The production source: a Photon indexer plus the Solana RPC it follows.
+/// The production source, a Photon indexer plus the Solana RPC it follows.
 pub struct ChainSource {
     indexer: AsyncZolanaIndexer,
     rpc: AsyncSolanaRpc,
@@ -101,8 +101,8 @@ impl TransactionSource for ChainSource {
             .get_shielded_transactions_by_tags(vec![tag], cursor, limit, None)
     }
 
-    // One read of the confirmed transaction: the JSON encoding lists the static
-    // keys with the signers first. The audit itself comes from the indexer;
+    // One read of the confirmed transaction. The JSON encoding lists the static
+    // keys with the signers first. The audit itself comes from the indexer and
     // signers are enrichment, so an RPC that no longer holds the transaction
     // (a pruned ledger) leaves them empty instead of failing the page.
     async fn signers(&self, signature: Signature) -> Result<Vec<Address>, ClientError> {
@@ -295,7 +295,7 @@ impl<S: TransactionSource> AuditService<S> {
     /// recovered transaction viewing keys.
     ///
     /// The indexer matches the tag against output tags and message tags, so a
-    /// transaction can arrive without an auditor message; those are dropped. A
+    /// transaction can arrive without an auditor message. Those are dropped. A
     /// tagged transaction that fails to audit is reported under `skipped`.
     pub async fn decrypted_transactions(
         &self,
@@ -434,7 +434,7 @@ fn decrypted_transaction(
     }
 }
 
-/// The SPL asset registry as SPP publishes it: every `SplAssetRegistry` account
+/// The SPL asset registry as SPP publishes it, every `SplAssetRegistry` account
 /// under the shielded-pool program. SOL is implicit in the registry.
 pub async fn asset_registry_from_chain<R: AsyncRpc>(rpc: &R) -> Result<AssetRegistry, ClientError> {
     let accounts = rpc

--- a/services/ring-rpc/src/config.rs
+++ b/services/ring-rpc/src/config.rs
@@ -34,7 +34,7 @@ pub enum Command {
 
 #[derive(Debug, Args)]
 pub struct ServeArgs {
-    /// Interface to listen on. Loopback by default; the auditor key opens every
+    /// Interface to listen on, loopback by default. The auditor key opens every
     /// transaction of the ring, so exposing the port is a deliberate step.
     #[arg(long, env = "RING_RPC_BIND", default_value = "127.0.0.1")]
     pub bind: IpAddr,
@@ -134,7 +134,7 @@ pub enum KeyFileError {
     Key(#[from] KeypairError),
 }
 
-/// Writes a fresh auditor key: the secret to `out` (mode 0600 on unix) and the
+/// Writes a fresh auditor key, the secret to `out` (mode 0600 on unix) and the
 /// SEC1 compressed public key as hex to `<out>.pub`. Refuses to overwrite.
 pub fn write_auditor_key(out: &Path) -> Result<ViewingKey, KeyFileError> {
     let key = ViewingKey::new();

--- a/services/ring-rpc/src/server.rs
+++ b/services/ring-rpc/src/server.rs
@@ -192,7 +192,7 @@ where
 }
 
 async fn readiness<S: TransactionSource>(hub: &Hub<S>) -> HttpResponse {
-    // Any ring probes the same indexer; the local key or an arbitrary ring.
+    // Any ring probes the same indexer, the local key or an arbitrary ring.
     let service = match hub.local_service() {
         Some(service) => Ok(service),
         None => hub.ring(Some(Address::default())),

--- a/services/ring-rpc/tests/audit_service.rs
+++ b/services/ring-rpc/tests/audit_service.rs
@@ -225,7 +225,7 @@ fn fixture() -> Fixture {
     );
 
     // Returned by the indexer because an output tag collided with the auditor
-    // tag; it carries no auditor message and must be dropped.
+    // tag. It carries no auditor message and must be dropped.
     let tx3 = ViewingKey::new();
     let mut slot = confidential_slot(&tx3, &recipient, 11, 0);
     slot.view_tag = auditor_view_tag(&auditor_pk);

--- a/templates/README.md
+++ b/templates/README.md
@@ -42,8 +42,10 @@ answer is `<id>_enabled` (a bool), which is what liquid files and
 `[conditional]` blocks read. Features that need on-chain values add them to
 `policy_toml`, rendered as `ring.toml`'s `[policy]` table: `allowed_assets`
 asks for the mints (`-d allowed_assets=SOL,<mint>` without prompts, `SOL` is
-native SOL) and `withdrawal_rules` blocks public withdrawals. `just init`
-writes the policy on chain and the CLI's `policy` command shows or changes it.
+native SOL) and `withdrawal_rules` asks for the default withdrawal rule
+(`-d withdrawals=blocked|approval|open`; `approval` needs an approver,
+default the authority, `-d approver=<pubkey>`). `just init` writes the policy
+on chain and the CLI's `policy` command shows or changes it, per asset too.
 
 ### Variables
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -17,8 +17,8 @@ just ring-new              # ring lands next to this checkout
 just ring-new ~/rings      # or in a chosen parent directory
 ```
 
-Non-interactive runs pass every answer with `-d`; `--silent` turns remaining
-questions into their defaults:
+Non-interactive runs pass every answer with `-d`, and `--silent` turns the
+remaining questions into their defaults.
 
 ```bash
 RING_NAME=demo tools/ring-wizard.sh /tmp --silent -d target=localnet \
@@ -29,7 +29,7 @@ RING_NAME=demo tools/ring-wizard.sh /tmp --silent -d target=localnet \
 
 `custom-ring/hooks/wizard.rhai` runs as a cargo-generate `pre` hook, the first
 stage that sees `-d` values. It prints the pipeline, asks for the target
-(`localnet`, `devnet`; `mainnet` is listed and refused), the authority keypair
+(`localnet` or `devnet`, `mainnet` is listed and refused), the authority keypair
 (default the Solana CLI keypair), the service URLs (localnet defaults from the
 driver, devnet asks, plus the ring RPC's service pubkey that `init` pins), and
 the features.
@@ -37,13 +37,13 @@ the features.
 `FEATURES` in that file is the registry. Each entry has an `id`, a display
 `name`, an `example` and a `state`: `always` (on for every ring), `ready`
 (offered as a yes/no question) or `coming_soon` (listed, disabled). Adding a
-feature is one entry; `ring.toml` and the README table follow. The resolved
+feature is one entry, and `ring.toml` and the README table follow. The resolved
 answer is `<id>_enabled` (a bool), which is what liquid files and
 `[conditional]` blocks read. Features that need on-chain values add them to
 `policy_toml`, rendered as `ring.toml`'s `[policy]` table: `allowed_assets`
 asks for the mints (`-d allowed_assets=SOL,<mint>` without prompts, `SOL` is
 native SOL) and `withdrawal_rules` asks for the default withdrawal rule
-(`-d withdrawals=blocked|approval|open`; `approval` needs an approver,
+(`-d withdrawals=blocked|approval|open`, where `approval` needs an approver,
 default the authority, `-d approver=<pubkey>`). `just init` writes the policy
 on chain and the CLI's `policy` command shows or changes it, per asset too.
 
@@ -61,4 +61,4 @@ on chain and the CLI's `policy` command shows or changes it, per asset too.
 | `<id>_enabled`, `features_toml`, `features_markdown`, `policy_toml` | computed by the wizard |
 
 `just test-ring-template` generates a ring without prompts and builds its
-workspace; CI runs it in the custom-ring job.
+workspace. CI runs it in the custom-ring job.

--- a/templates/custom-ring/README.md
+++ b/templates/custom-ring/README.md
@@ -3,7 +3,7 @@
 A custom ring on the Solana Privacy Program: confidential transfers whose
 per-transaction viewing key is verifiably encrypted to this ring's auditor. The
 program logic is `custom-ring-program` from the zolana checkout at
-`{{zolana_path}}`; this repository pins the deploy address
+`{{zolana_path}}`. This repository pins the deploy address
 `{{program_id}}`, records the wizard's answers in `ring.toml`, and drives the
 pipeline with `just`.
 
@@ -35,9 +35,9 @@ zolana checkout, and `just localnet-stop` tears it down.
 | Feature | Status | Example |
 | --- | --- | --- |
 {{features_markdown}}
-Features are declared in the template's `hooks/wizard.rhai`; a ring regenerated
-with the template picks up new ones. Enabled features that carry on-chain
-values live in `ring.toml`'s `[policy]` table: `allowed_assets` (mints the ring
+Features are declared in the template's `hooks/wizard.rhai`, and a ring
+regenerated with the template picks up new ones. Enabled features that carry
+on-chain values live in `ring.toml`'s `[policy]` table. `allowed_assets` (mints the ring
 accepts, `SOL` for native SOL), `withdrawals` (the default rule for public
 withdrawals out of the ring: `open`, `blocked`, or `approval`),
 `[policy.asset_withdrawals]` (a rule per mint) and `approver` (the key whose
@@ -47,7 +47,7 @@ sign-off an `approval` rule needs). `just init` writes the policy on chain, and
 --approver <pubkey>`, `policy set --asset-withdrawals SOL=open`, `policy set
 --allow-asset <mint>`, `policy set --any-asset`). Under an approval rule the
 approver runs `approve <private_tx_hash>` for a proven transact, and the
-transact then carries the approval account; `transact --withdraw <lamports>`
+transact then carries the approval account, and `transact --withdraw <lamports>`
 demonstrates it with the authority as approver.
 
 ## Layout

--- a/templates/custom-ring/README.md
+++ b/templates/custom-ring/README.md
@@ -38,10 +38,17 @@ zolana checkout, and `just localnet-stop` tears it down.
 Features are declared in the template's `hooks/wizard.rhai`; a ring regenerated
 with the template picks up new ones. Enabled features that carry on-chain
 values live in `ring.toml`'s `[policy]` table: `allowed_assets` (mints the ring
-accepts, `SOL` for native SOL) and `withdrawals = "blocked"` (no public
-withdrawals out of the ring). `just init` writes the policy on chain, and
+accepts, `SOL` for native SOL), `withdrawals` (the default rule for public
+withdrawals out of the ring: `open`, `blocked`, or `approval`),
+`[policy.asset_withdrawals]` (a rule per mint) and `approver` (the key whose
+sign-off an `approval` rule needs). `just init` writes the policy on chain, and
 `cargo run -p {{project-name}} -- policy show|apply|set` reads it back, re-applies
-`ring.toml`, or changes one part at a time (`policy set --withdrawals open`, `policy set --allow-asset <mint>`, `policy set --any-asset`).
+`ring.toml`, or changes one part at a time (`policy set --withdrawals approval
+--approver <pubkey>`, `policy set --asset-withdrawals SOL=open`, `policy set
+--allow-asset <mint>`, `policy set --any-asset`). Under an approval rule the
+approver runs `approve <private_tx_hash>` for a proven transact, and the
+transact then carries the approval account; `transact --withdraw <lamports>`
+demonstrates it with the authority as approver.
 
 ## Layout
 

--- a/templates/custom-ring/cargo-generate.toml
+++ b/templates/custom-ring/cargo-generate.toml
@@ -1,12 +1,12 @@
 # Custom ring template. The wizard in hooks/wizard.rhai asks for everything a
-# generated ring needs and records the answers in ring.toml; every variable can
+# generated ring needs and records the answers in ring.toml. Every variable can
 # also be passed with `-d name=value`, which is how the driver and CI run it.
-# It runs as a `pre` hook: `-d` values are visible only from that stage on.
+# It runs as a `pre` hook because `-d` values are visible only from that stage on.
 [template]
 cargo_generate_version = ">=0.20.0"
 # The wizard script is not part of a generated ring.
 ignore = ["hooks"]
-# Not liquid: a keypair placeholder the driver fills after generation.
+# Not liquid, a keypair placeholder the driver fills after generation.
 exclude = ["keys/.gitkeep"]
 
 [hooks]

--- a/templates/custom-ring/hooks/wizard.rhai
+++ b/templates/custom-ring/hooks/wizard.rhai
@@ -3,9 +3,8 @@
 // Every answer becomes a template variable. A variable that arrives on the
 // command line (`-d name=value`) is kept, so the driver and CI can run this
 // without prompts. The feature registry below is the one place a feature is
-// declared: add an entry, and the prompt, ring.toml, README and cargo feature
-// list follow. A `ready` feature id is a cargo feature of both
-// `custom-ring-program` and `custom-ring-cli`.
+// declared. Add an entry, and the prompt, ring.toml and README follow. A
+// feature that needs on-chain values adds them to `policy_toml`.
 
 const PIPELINE = [
     "cargo generate template (this wizard)",
@@ -17,8 +16,8 @@ const PIPELINE = [
     "transact in the ring (`just transact`)",
 ];
 
-// state: "always" is on for every ring, "ready" is offered as a choice,
-// "coming_soon" is listed and disabled.
+// The `state` field. "always" is on for every ring, "ready" is offered as a
+// choice, "coming_soon" is listed and disabled.
 const FEATURES = [
     #{ id: "confidential", name: "Confidential", example: "Amounts and recipients are hidden on chain", state: "always" },
     #{ id: "auditor_visibility", name: "Auditor visibility", example: "Let compliance, accounting, or regulators view ring activity", state: "always" },
@@ -38,7 +37,7 @@ const FEATURES = [
 
 const TARGETS = ["localnet", "devnet", "mainnet"];
 
-// Public clusters go through Helius RPC; the API key is the only per-user part.
+// Public clusters go through Helius RPC. The API key is the only per-user part.
 const HELIUS_RPC = #{
     devnet: "https://devnet.helius-rpc.com/?api-key=",
     mainnet: "https://mainnet.helius-rpc.com/?api-key=",
@@ -53,7 +52,7 @@ fn setting(name, fallback) {
 }
 
 // `-d silent=true` (what the driver passes for `--silent`) turns every question
-// into its fallback; a missing required answer aborts instead of prompting.
+// into its fallback. A missing required answer aborts instead of prompting.
 fn silent() {
     let value = setting("silent", false);
     value == true || value == "true"
@@ -102,7 +101,7 @@ variable::set("target", target);
 // keypair, so an existing setup is picked up without typing.
 ask("authority_keypair", "Deployer and ring authority keypair", "~/.config/solana/id.json");
 
-// Service URLs. localnet defaults come from the driver (per-clone port offset);
+// Service URLs. localnet defaults come from the driver (per-clone port offset),
 // devnet has to name its indexer, prover and ring RPC.
 let ring_rpc_port = setting("default_ring_rpc_port", "8785");
 if target == "localnet" {
@@ -136,7 +135,7 @@ if target == "localnet" {
 }
 
 // The program id is the address the ring deploys to. The driver generates the
-// keypair and hands the pubkey in; typing one by hand needs the matching keypair
+// keypair and hands the pubkey in. Typing one by hand needs the matching keypair
 // in keys/program-keypair.json before `just deploy`.
 ask("program_id", "Program id (base58 pubkey of keys/program-keypair.json)", "");
 if variable::get("program_id") == "" {
@@ -211,7 +210,7 @@ if variable::get("allowed_assets_enabled") {
     policy_toml += "allowed_assets = [" + list + "]\n";
 }
 if variable::get("withdrawal_rules_enabled") {
-    // The default rule for every asset; `policy set --asset-withdrawals` and
+    // The default rule for every asset. `policy set --asset-withdrawals` and
     // ring.toml's `[policy.asset_withdrawals]` refine it per mint.
     let rule = if variable::is_set("withdrawals") {
         variable::get("withdrawals")
@@ -225,7 +224,7 @@ if variable::get("withdrawal_rules_enabled") {
     }
     policy_toml += "withdrawals = \"" + rule + "\"\n";
     if rule == "approval" {
-        // The authority approves by default; the driver passes its pubkey.
+        // The authority approves by default. The driver passes its pubkey.
         let approver = if variable::is_set("approver") {
             variable::get("approver")
         } else if silent() {

--- a/templates/custom-ring/hooks/wizard.rhai
+++ b/templates/custom-ring/hooks/wizard.rhai
@@ -23,7 +23,7 @@ const FEATURES = [
     #{ id: "confidential", name: "Confidential", example: "Amounts and recipients are hidden on chain", state: "always" },
     #{ id: "auditor_visibility", name: "Auditor visibility", example: "Let compliance, accounting, or regulators view ring activity", state: "always" },
     #{ id: "allowed_assets", name: "Allowed assets", example: "Only USDC or a specific issued stablecoin", state: "ready" },
-    #{ id: "withdrawal_rules", name: "Withdrawal rules", example: "Block public withdrawals out of the ring", state: "ready" },
+    #{ id: "withdrawal_rules", name: "Withdrawal rules", example: "Block public withdrawals, or require an approver's sign-off, per asset", state: "ready" },
     #{ id: "anonymous", name: "Anonymous", example: "Hide senders and recipients from the ring itself", state: "coming_soon" },
     #{ id: "freeze_thaw", name: "Freeze/thaw", example: "Freeze a balance while an investigation is pending", state: "coming_soon" },
     #{ id: "transfer_limits", name: "Transfer limits", example: "Require extra approval above a threshold", state: "coming_soon" },
@@ -211,6 +211,32 @@ if variable::get("allowed_assets_enabled") {
     policy_toml += "allowed_assets = [" + list + "]\n";
 }
 if variable::get("withdrawal_rules_enabled") {
-    policy_toml += "withdrawals = \"blocked\"\n";
+    // The default rule for every asset; `policy set --asset-withdrawals` and
+    // ring.toml's `[policy.asset_withdrawals]` refine it per mint.
+    let rule = if variable::is_set("withdrawals") {
+        variable::get("withdrawals")
+    } else if silent() {
+        "blocked"
+    } else {
+        variable::prompt("Public withdrawals", "blocked", ["blocked", "approval", "open"])
+    };
+    if rule != "blocked" && rule != "approval" && rule != "open" {
+        abort("withdrawals must be blocked, approval or open");
+    }
+    policy_toml += "withdrawals = \"" + rule + "\"\n";
+    if rule == "approval" {
+        // The authority approves by default; the driver passes its pubkey.
+        let approver = if variable::is_set("approver") {
+            variable::get("approver")
+        } else if silent() {
+            setting("authority_pubkey", "")
+        } else {
+            variable::prompt("Approver pubkey", setting("authority_pubkey", ""))
+        };
+        if approver == "" {
+            abort("an approval rule needs an approver, pass -d approver=<pubkey>");
+        }
+        policy_toml += "approver = \"" + approver + "\"\n";
+    }
 }
 variable::set("policy_toml", policy_toml);

--- a/templates/custom-ring/justfile
+++ b/templates/custom-ring/justfile
@@ -1,5 +1,5 @@
-# {{project-name}} pipeline. Each recipe is one step; `just pipeline` runs them
-# in order against the target recorded in ring.toml.
+# {{project-name}} pipeline. Each recipe is one step and `just pipeline` runs
+# them in order against the target recorded in ring.toml.
 
 zolana := "{{zolana_path}}"
 # Same platform tools as the zolana checkout, so the binary matches what its
@@ -12,7 +12,7 @@ default:
     @just --list
 
 # Local test validator with SPP, photon and the prover (localnet target only).
-# The ring RPC is not part of it: `just rpc` starts it once the ring is
+# The ring RPC is not part of it. `just rpc` starts it once the ring is
 # initialized, `just pipeline` does so on its own.
 localnet:
     just -f {{ "{{zolana}}" }}/justfile ring-localnet
@@ -41,7 +41,7 @@ deploy: build
     cargo run -q -p {{project-name}} -- deploy --program-so {{ "{{program-so}}" }}
 
 {%- if target == "localnet" %}
-# Localnet: the auditor key is a local file the ring RPC below serves.
+# On localnet the auditor key is a local file the ring RPC below serves.
 auditor-key:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -67,7 +67,7 @@ rpc:
 init:
     cargo run -q -p {{project-name}} -- init
 
-# The ring RPC is hosted; nothing to start here.
+# The ring RPC is hosted, nothing to start here.
 rpc:
     @echo "ring rpc is hosted at {{ring_rpc_url}}"
 {%- endif %}
@@ -81,12 +81,12 @@ status:
 
 # Steps 3 to 7 in one go. The ring RPC is started in the background if none
 # answers at its URL, and stays up afterwards for the auditor (`just
-# rpc-stop` ends it; its log is .localnet/ring-rpc.log).
+# rpc-stop` ends it, its log is .localnet/ring-rpc.log).
 pipeline: build deploy init
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p .localnet
-    # An RPC already answering must be this ring's: rings generated on the same
+    # An RPC already answering must be this ring's. Rings generated on the same
     # machine share the default port, and a foreign RPC can open nothing here.
     # A foreign one left behind by another local ring's pipeline is replaced.
     start_rpc=true

--- a/templates/custom-ring/ring.toml
+++ b/templates/custom-ring/ring.toml
@@ -1,5 +1,5 @@
 # Answers recorded by the custom ring wizard. `just` and the `{{project-name}}`
-# CLI read this file; edit it to retarget the ring.
+# CLI read this file. Edit it to retarget the ring.
 name = "{{project-name}}"
 target = "{{target}}"
 program_id = "{{program_id}}"

--- a/tools/ring-wizard.sh
+++ b/tools/ring-wizard.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Custom ring wizard driver: prepares what cargo-generate cannot (the program
+# Custom ring wizard driver. Prepares what cargo-generate cannot (the program
 # keypair, the per-clone service URLs), runs the template interactively, and
 # places the keypair in the generated ring.
 #
@@ -49,11 +49,11 @@ mkdir -p "$keys"
 trap 'rm -rf "$keys"' EXIT
 solana-keygen new --no-bip39-passphrase --silent --force -o "$keys/program-keypair.json"
 program_id="$(solana-keygen pubkey "$keys/program-keypair.json")"
-# The default approver of an approval rule; the wizard offers it as the default.
+# The default approver of an approval rule, offered by the wizard as its default.
 authority_pubkey="$(solana-keygen pubkey "${AUTHORITY_KEYPAIR:-$HOME/.config/solana/id.json}" 2>/dev/null || true)"
 
 # Service URLs come from the justfile (`just ring-new`), which resolves the
-# per-clone port offset and every explicit override; a direct call falls back to
+# per-clone port offset and every explicit override. A direct call falls back to
 # the offset alone.
 offset="${ZOLANA_PORT_OFFSET:-0}"
 rpc_url="${ZOLANA_LOCALNET_URL:-http://127.0.0.1:$((8899 + offset))}"
@@ -62,7 +62,7 @@ prover_url="${ZOLANA_PROVER_URL:-http://127.0.0.1:$((3001 + offset))}"
 ring_rpc_port="${ZOLANA_LOCALNET_RING_RPC_PORT:-$((8785 + offset))}"
 
 # Non-interactive runs (`--silent`, or no terminal) answer every question with
-# its default; the hook learns that through `silent`.
+# its default. The hook learns that through `silent`.
 silent=()
 wants_silent=false
 for arg in "$@"; do

--- a/tools/ring-wizard.sh
+++ b/tools/ring-wizard.sh
@@ -49,6 +49,8 @@ mkdir -p "$keys"
 trap 'rm -rf "$keys"' EXIT
 solana-keygen new --no-bip39-passphrase --silent --force -o "$keys/program-keypair.json"
 program_id="$(solana-keygen pubkey "$keys/program-keypair.json")"
+# The default approver of an approval rule; the wizard offers it as the default.
+authority_pubkey="$(solana-keygen pubkey "${AUTHORITY_KEYPAIR:-$HOME/.config/solana/id.json}" 2>/dev/null || true)"
 
 # Service URLs come from the justfile (`just ring-new`), which resolves the
 # per-clone port offset and every explicit override; a direct call falls back to
@@ -75,6 +77,7 @@ fi
 cargo generate --path "$root/templates/custom-ring" --destination "$dest" --name "$name" \
     ${silent[@]+"${silent[@]}"} \
     -d program_id="$program_id" \
+    -d authority_pubkey="$authority_pubkey" \
     -d zolana_path="$root" \
     -d default_rpc_url="$rpc_url" \
     -d default_indexer_url="$indexer_url" \


### PR DESCRIPTION
Stacked on #242.

Per-asset withdrawal rules (open, blocked, approval) with a default for unlisted assets, and an approver key. Under an approval rule the approver creates an approval account for one proven transact (`approve_transact`, seed `private_tx_hash`), the transact carries and spends it. `set_policy` gains the asset table and the approver. CLI: `policy set --withdrawals <rule> --asset-withdrawals <mint>=<rule> --approver <pubkey>`, `approve <private_tx_hash>`, `transact --withdraw <lamports>` demonstrating an approved withdrawal. Wizard asks for the default rule when withdrawal rules are on.

Verified on localnet.