### PR TITLE
indexer: split the paging cursor from the sync watermark

### DIFF
--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use solana_signer::Signer;
-use zolana_client::{SolanaRpc, ZolanaClient};
+use zolana_client::{Rpc, RpcSendTransactionConfig, SolanaRpc, ZolanaClient};
 use zolana_transaction::Address;
 use zolana_wallet::{
     actions::{submit::MergeMaterial, transaction::is_plain_utxo},
@@ -15,6 +15,15 @@ use super::{
     util::{ensure_positive, format_address, parse_address, parse_hex_array, parse_pubkey},
 };
 use crate::args::{MergeOptions, SplitOptions, TransferOptions, UtxosOptions};
+
+/// The CLI confirms separately, so preflight would only buy a simulation
+/// round trip before a send that is about to be confirmed anyway.
+fn send_config() -> RpcSendTransactionConfig {
+    RpcSendTransactionConfig {
+        skip_preflight: true,
+        ..RpcSendTransactionConfig::default()
+    }
+}
 
 pub(crate) fn run_transfer(opts: TransferOptions) -> Result<()> {
     ensure_positive(opts.amount)?;
@@ -46,7 +55,9 @@ pub(crate) fn run_transfer(opts: TransferOptions) -> Result<()> {
         &client,
         &ctx.material.funding,
     )?;
-    let signature = client.submit_private_transaction_sync(&transaction)?;
+    let signature = client
+        .rpc()
+        .send_transaction_with_config(&transaction, send_config())?;
     client.confirm_private_transaction_sync(signature)?;
     let mode = if transfer.recipient.is_public_withdrawal() {
         "withdraw"
@@ -134,7 +145,9 @@ pub(crate) fn run_split(opts: SplitOptions) -> Result<()> {
         &client,
         &ctx.material.funding,
     )?;
-    let signature = client.submit_private_transaction_sync(&transaction)?;
+    let signature = client
+        .rpc()
+        .send_transaction_with_config(&transaction, send_config())?;
     client.confirm_private_transaction_sync(signature)?;
     println!(
         "ok split parts={} amount={} mint={} signature={}",

--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use solana_signer::Signer;
-use zolana_client::{Rpc, SolanaRpc, ZolanaClient};
+use zolana_client::{SolanaRpc, ZolanaClient};
 use zolana_transaction::Address;
 use zolana_wallet::{
     actions::{submit::MergeMaterial, transaction::is_plain_utxo},
@@ -46,7 +46,7 @@ pub(crate) fn run_transfer(opts: TransferOptions) -> Result<()> {
         &client,
         &ctx.material.funding,
     )?;
-    let signature = client.rpc().send_transaction(&transaction)?;
+    let signature = client.submit_private_transaction_sync(&transaction)?;
     client.confirm_private_transaction_sync(signature)?;
     let mode = if transfer.recipient.is_public_withdrawal() {
         "withdraw"
@@ -134,7 +134,7 @@ pub(crate) fn run_split(opts: SplitOptions) -> Result<()> {
         &client,
         &ctx.material.funding,
     )?;
-    let signature = client.rpc().send_transaction(&transaction)?;
+    let signature = client.submit_private_transaction_sync(&transaction)?;
     client.confirm_private_transaction_sync(signature)?;
     println!(
         "ok split parts={} amount={} mint={} signature={}",

--- a/custom-ring-tests/client/tests/audit.rs
+++ b/custom-ring-tests/client/tests/audit.rs
@@ -544,6 +544,11 @@ impl Rpc for PagedIndexer {
                 slot: 1,
             },
             transactions,
+            // A last page reports where the scan reached instead of a paging
+            // cursor; this double pages by index, so the tip is the final page.
+            scanned_through: next_cursor
+                .is_none()
+                .then(|| vec![u8::try_from(self.pages.len()).expect("page count")]),
             next_cursor,
         })
     }

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -1130,8 +1130,14 @@ fn fetch_spend_proofs(
     // does with `try_join!`: different methods, neither consuming the other's
     // output. Serially this cost the sum on every transfer.
     let (state_response, nullifier_response) = std::thread::scope(|scope| {
-        let state = scope.spawn(|| indexer.get_merkle_proofs(tree, leaves, config));
-        let nullifier = scope.spawn(|| indexer.get_non_inclusion_proofs(tree, nullifiers, config));
+        let state = scope.spawn(|| {
+            let _t = crate::timing::Phase::start("get_merkle_proofs", 0);
+            indexer.get_merkle_proofs(tree, leaves, config)
+        });
+        let nullifier = scope.spawn(|| {
+            let _t = crate::timing::Phase::start("get_non_inclusion_proofs", 0);
+            indexer.get_non_inclusion_proofs(tree, nullifiers, config)
+        });
         (state.join(), nullifier.join())
     });
     // A panic here is a bug in the indexer client, not an unreachable indexer.

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -398,6 +398,32 @@ impl<R: Rpc> ZolanaClient<R> {
         wait_for_rpc_confirmation(self.rpc(), signature, self.indexer_config.poll)?;
         wait_for_indexed_transaction(self.blocking_indexer(), signature, self.indexer_config.poll)
     }
+
+    /// Submit a signed private transaction and return as soon as the RPC
+    /// accepts it.
+    ///
+    /// Pair with [`Self::confirm_private_transaction_sync`], which waits for the
+    /// chain and then the indexer. `Rpc::send_transaction` confirms too, so the
+    /// two together waited for the same signature twice.
+    ///
+    /// Preflight is skipped: simulation re-executes a transaction whose inputs
+    /// are proofs the indexer just served, and a failure it would catch is one
+    /// this client cannot fix by retrying. The cost of being wrong is a landed
+    /// transaction that fails on chain, so callers submitting unvalidated
+    /// transactions should keep using `send_transaction`.
+    pub fn submit_private_transaction_sync(
+        &self,
+        transaction: &SolanaTransaction,
+    ) -> Result<Signature, ClientError> {
+        let _t = crate::timing::Phase::start("submit_private", 0);
+        // Honours `with_send_transaction_config`, which until now set a field
+        // nothing read.
+        let config = self.send_config.unwrap_or(RpcSendTransactionConfig {
+            skip_preflight: true,
+            ..RpcSendTransactionConfig::default()
+        });
+        self.rpc().send_transaction_with_config(transaction, config)
+    }
 }
 
 impl<R: AsyncRpc> ZolanaClient<R> {
@@ -1100,8 +1126,19 @@ fn fetch_spend_proofs(
         .iter()
         .map(|commitment| commitment.nullifier)
         .collect::<Vec<_>>();
-    let state_response = indexer.get_merkle_proofs(tree, leaves, config)?;
-    let nullifier_response = indexer.get_non_inclusion_proofs(tree, nullifiers, config)?;
+    // Independent round trips, run together for the same reason the async path
+    // does with `try_join!`: different methods, neither consuming the other's
+    // output. Serially this cost the sum on every transfer.
+    let (state_response, nullifier_response) = std::thread::scope(|scope| {
+        let state = scope.spawn(|| indexer.get_merkle_proofs(tree, leaves, config));
+        let nullifier = scope.spawn(|| indexer.get_non_inclusion_proofs(tree, nullifiers, config));
+        (state.join(), nullifier.join())
+    });
+    // A panic here is a bug in the indexer client, not an unreachable indexer.
+    let state_response =
+        state_response.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
+    let nullifier_response =
+        nullifier_response.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
     validate_spend_proofs(
         tree,
         commitments,
@@ -1516,10 +1553,19 @@ mod tests {
         };
         let commitment = shielded.transaction.input_utxo_hashes().unwrap().remove(0);
         let signature = Signature::from([5u8; 64]);
-        let server = MockIndexerServer::respond_with(vec![
-            merkle_response(tree, commitment.utxo_hash),
-            nullifier_response(tree, commitment.nullifier),
-            indexed_transaction_by_signature_response(signature),
+        let server = MockIndexerServer::respond_by_path(vec![
+            (
+                "/getMerkleProofs",
+                merkle_response(tree, commitment.utxo_hash),
+            ),
+            (
+                "/getNonInclusionProofs",
+                nullifier_response(tree, commitment.nullifier),
+            ),
+            (
+                "/getShieldedTransactionsBySignature",
+                indexed_transaction_by_signature_response(signature),
+            ),
         ]);
         let rpc = MockSubmitRpc::new(signature);
         let sent = rpc.sent.clone();
@@ -1557,14 +1603,13 @@ mod tests {
         assert_eq!(sent.len(), 1);
         assert_eq!(sent[0].message.instructions.len(), 3);
         let requests = server.requests();
-        assert_eq!(
-            requests,
-            [
-                "/getMerkleProofs",
-                "/getNonInclusionProofs",
-                "/getShieldedTransactionsBySignature",
-            ]
-        );
+        // The two proof fetches race, so only their membership is defined; the
+        // indexed-transaction lookup still happens after them.
+        let (proofs, rest) = requests.split_at(2);
+        let mut proofs = proofs.to_vec();
+        proofs.sort();
+        assert_eq!(proofs, ["/getMerkleProofs", "/getNonInclusionProofs"]);
+        assert_eq!(rest, ["/getShieldedTransactionsBySignature"]);
     }
 
     #[test]
@@ -1910,6 +1955,7 @@ mod tests {
         signature: Signature,
         view_tags: Vec<[u8; 32]>,
         sent: Arc<Mutex<Vec<SolanaTransaction>>>,
+        sent_configs: Arc<Mutex<Vec<RpcSendTransactionConfig>>>,
     }
 
     impl MockSubmitRpc {
@@ -1918,6 +1964,7 @@ mod tests {
                 signature,
                 view_tags: Vec::new(),
                 sent: Arc::new(Mutex::new(Vec::new())),
+                sent_configs: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
@@ -1941,6 +1988,16 @@ mod tests {
             transaction: &SolanaTransaction,
         ) -> Result<Signature, ClientError> {
             self.sent.lock().unwrap().push(transaction.clone());
+            Ok(self.signature)
+        }
+
+        fn send_transaction_with_config(
+            &self,
+            transaction: &SolanaTransaction,
+            config: RpcSendTransactionConfig,
+        ) -> Result<Signature, ClientError> {
+            self.sent.lock().unwrap().push(transaction.clone());
+            self.sent_configs.lock().unwrap().push(config);
             Ok(self.signature)
         }
 
@@ -1968,6 +2025,56 @@ mod tests {
         ) -> Result<Vec<[u8; 32]>, ClientError> {
             Ok(self.view_tags.clone())
         }
+    }
+
+    fn submit_client(rpc: MockSubmitRpc) -> ZolanaClient<MockSubmitRpc> {
+        ZolanaClient::new(
+            rpc,
+            ZolanaIndexer::new("http://unused.invalid"),
+            ProverClient::new("http://unused.invalid".to_string()),
+            AsyncZolanaIndexer::new("http://unused.invalid"),
+            AsyncProverClient::new("http://unused.invalid".to_string()),
+            Address::new_from_array([8u8; 32]),
+        )
+    }
+
+    /// `confirm_private_transaction_sync` already waits for the chain, so the
+    /// submit half must not: together they waited for one signature twice.
+    /// Preflight is skipped for the same round-trip reason.
+    #[test]
+    fn submit_private_skips_preflight() {
+        let rpc = MockSubmitRpc::new(Signature::from([3u8; 64]));
+        let configs = rpc.sent_configs.clone();
+        let client = submit_client(rpc);
+
+        client
+            .submit_private_transaction_sync(&SolanaTransaction::default())
+            .expect("submit");
+
+        let recorded = configs.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert!(recorded[0].skip_preflight);
+    }
+
+    /// `with_send_transaction_config` set a field nothing read until this path
+    /// existed; a caller that asks for preflight must get it.
+    #[test]
+    fn submit_private_honours_a_configured_send_config() {
+        let rpc = MockSubmitRpc::new(Signature::from([3u8; 64]));
+        let configs = rpc.sent_configs.clone();
+        let client = submit_client(rpc).with_send_transaction_config(RpcSendTransactionConfig {
+            skip_preflight: false,
+            max_retries: Some(7),
+            ..RpcSendTransactionConfig::default()
+        });
+
+        client
+            .submit_private_transaction_sync(&SolanaTransaction::default())
+            .expect("submit");
+
+        let recorded = configs.lock().unwrap();
+        assert!(!recorded[0].skip_preflight);
+        assert_eq!(recorded[0].max_retries, Some(7));
     }
 
     fn merkle_response(tree: Address, leaf: [u8; 32]) -> Value {
@@ -2077,6 +2184,38 @@ mod tests {
     }
 
     impl MockIndexerServer {
+        /// Serve each response to the request whose path asks for it.
+        ///
+        /// `respond_with` hands responses out in order, which stops being a
+        /// description of the server once the client fetches concurrently: the
+        /// proof fetches race, and whichever connects first would take the
+        /// other's body.
+        fn respond_by_path(responses: Vec<(&'static str, Value)>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock indexer");
+            let url = format!("http://{}", listener.local_addr().unwrap());
+            let (request_tx, requests) = mpsc::channel();
+            let count = responses.len();
+            let handle = thread::spawn(move || {
+                let mut remaining: Vec<(&'static str, Value)> = responses;
+                for _ in 0..count {
+                    let (mut stream, _) = listener.accept().expect("accept request");
+                    let request = read_request(&mut stream);
+                    let index = remaining
+                        .iter()
+                        .position(|(path, _)| *path == request.path)
+                        .unwrap_or_else(|| panic!("no mock response for {}", request.path));
+                    let (_, response) = remaining.remove(index);
+                    request_tx.send(request).expect("record request");
+                    write_json_response(&mut stream, &response);
+                }
+            });
+            Self {
+                url,
+                requests,
+                handle,
+            }
+        }
+
         fn respond_with(responses: Vec<Value>) -> Self {
             let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock indexer");
             let url = format!("http://{}", listener.local_addr().unwrap());

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -111,7 +111,6 @@ pub struct ZolanaClient<R> {
     cu_limit: u32,
     cu_price_micro_lamports: Option<u64>,
     indexer_config: IndexerRpcConfig,
-    send_config: Option<RpcSendTransactionConfig>,
 }
 
 impl<R> ZolanaClient<R> {
@@ -135,7 +134,6 @@ impl<R> ZolanaClient<R> {
             cu_limit: DEFAULT_TRANSACT_CU_LIMIT,
             cu_price_micro_lamports: None,
             indexer_config: IndexerRpcConfig::default(),
-            send_config: None,
         }
     }
 
@@ -182,7 +180,6 @@ impl<R> ZolanaClient<R> {
             cu_limit: DEFAULT_TRANSACT_CU_LIMIT,
             cu_price_micro_lamports: None,
             indexer_config: IndexerRpcConfig::default(),
-            send_config: None,
         }
     }
 
@@ -203,11 +200,6 @@ impl<R> ZolanaClient<R> {
 
     pub fn with_indexer_config(mut self, config: IndexerRpcConfig) -> Self {
         self.indexer_config = config;
-        self
-    }
-
-    pub fn with_send_transaction_config(mut self, config: RpcSendTransactionConfig) -> Self {
-        self.send_config = Some(config);
         self
     }
 
@@ -397,32 +389,6 @@ impl<R: Rpc> ZolanaClient<R> {
     ) -> Result<(), ClientError> {
         wait_for_rpc_confirmation(self.rpc(), signature, self.indexer_config.poll)?;
         wait_for_indexed_transaction(self.blocking_indexer(), signature, self.indexer_config.poll)
-    }
-
-    /// Submit a signed private transaction and return as soon as the RPC
-    /// accepts it.
-    ///
-    /// Pair with [`Self::confirm_private_transaction_sync`], which waits for the
-    /// chain and then the indexer. `Rpc::send_transaction` confirms too, so the
-    /// two together waited for the same signature twice.
-    ///
-    /// Preflight is skipped: simulation re-executes a transaction whose inputs
-    /// are proofs the indexer just served, and a failure it would catch is one
-    /// this client cannot fix by retrying. The cost of being wrong is a landed
-    /// transaction that fails on chain, so callers submitting unvalidated
-    /// transactions should keep using `send_transaction`.
-    pub fn submit_private_transaction_sync(
-        &self,
-        transaction: &SolanaTransaction,
-    ) -> Result<Signature, ClientError> {
-        let _t = crate::timing::Phase::start("submit_private", 0);
-        // Honours `with_send_transaction_config`, which until now set a field
-        // nothing read.
-        let config = self.send_config.unwrap_or(RpcSendTransactionConfig {
-            skip_preflight: true,
-            ..RpcSendTransactionConfig::default()
-        });
-        self.rpc().send_transaction_with_config(transaction, config)
     }
 }
 
@@ -1961,7 +1927,6 @@ mod tests {
         signature: Signature,
         view_tags: Vec<[u8; 32]>,
         sent: Arc<Mutex<Vec<SolanaTransaction>>>,
-        sent_configs: Arc<Mutex<Vec<RpcSendTransactionConfig>>>,
     }
 
     impl MockSubmitRpc {
@@ -1970,7 +1935,6 @@ mod tests {
                 signature,
                 view_tags: Vec::new(),
                 sent: Arc::new(Mutex::new(Vec::new())),
-                sent_configs: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
@@ -2000,10 +1964,9 @@ mod tests {
         fn send_transaction_with_config(
             &self,
             transaction: &SolanaTransaction,
-            config: RpcSendTransactionConfig,
+            _config: RpcSendTransactionConfig,
         ) -> Result<Signature, ClientError> {
             self.sent.lock().unwrap().push(transaction.clone());
-            self.sent_configs.lock().unwrap().push(config);
             Ok(self.signature)
         }
 
@@ -2031,56 +1994,6 @@ mod tests {
         ) -> Result<Vec<[u8; 32]>, ClientError> {
             Ok(self.view_tags.clone())
         }
-    }
-
-    fn submit_client(rpc: MockSubmitRpc) -> ZolanaClient<MockSubmitRpc> {
-        ZolanaClient::new(
-            rpc,
-            ZolanaIndexer::new("http://unused.invalid"),
-            ProverClient::new("http://unused.invalid".to_string()),
-            AsyncZolanaIndexer::new("http://unused.invalid"),
-            AsyncProverClient::new("http://unused.invalid".to_string()),
-            Address::new_from_array([8u8; 32]),
-        )
-    }
-
-    /// `confirm_private_transaction_sync` already waits for the chain, so the
-    /// submit half must not: together they waited for one signature twice.
-    /// Preflight is skipped for the same round-trip reason.
-    #[test]
-    fn submit_private_skips_preflight() {
-        let rpc = MockSubmitRpc::new(Signature::from([3u8; 64]));
-        let configs = rpc.sent_configs.clone();
-        let client = submit_client(rpc);
-
-        client
-            .submit_private_transaction_sync(&SolanaTransaction::default())
-            .expect("submit");
-
-        let recorded = configs.lock().unwrap();
-        assert_eq!(recorded.len(), 1);
-        assert!(recorded[0].skip_preflight);
-    }
-
-    /// `with_send_transaction_config` set a field nothing read until this path
-    /// existed; a caller that asks for preflight must get it.
-    #[test]
-    fn submit_private_honours_a_configured_send_config() {
-        let rpc = MockSubmitRpc::new(Signature::from([3u8; 64]));
-        let configs = rpc.sent_configs.clone();
-        let client = submit_client(rpc).with_send_transaction_config(RpcSendTransactionConfig {
-            skip_preflight: false,
-            max_retries: Some(7),
-            ..RpcSendTransactionConfig::default()
-        });
-
-        client
-            .submit_private_transaction_sync(&SolanaTransaction::default())
-            .expect("submit");
-
-        let recorded = configs.lock().unwrap();
-        assert!(!recorded[0].skip_preflight);
-        assert_eq!(recorded[0].max_retries, Some(7));
     }
 
     fn merkle_response(tree: Address, leaf: [u8; 32]) -> Value {

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -30,7 +30,15 @@ use crate::{
 };
 
 const MERKLE_PROOF_POLL_TIMEOUT: Duration = Duration::from_secs(60);
-const MERKLE_PROOF_POLL_INTERVAL: Duration = Duration::from_millis(500);
+/// First wait after an incomplete answer.
+///
+/// A transfer spends a note the indexer has only just written, so the first
+/// attempt often lands a few milliseconds early and this sleep is on the
+/// critical path of every transfer. A flat 500ms charged the tail's wait to
+/// every caller; starting short and backing off keeps the 60s ceiling for an
+/// indexer that is genuinely behind.
+const MERKLE_PROOF_POLL_START: Duration = Duration::from_millis(25);
+const MERKLE_PROOF_POLL_MAX: Duration = Duration::from_millis(500);
 
 const JSON_RPC_METHOD_NOT_FOUND: i64 = -32601;
 const JSON_RPC_INTERNAL_ERROR: i64 = -32603;
@@ -357,6 +365,7 @@ impl Rpc for ZolanaIndexer {
         let expected = leaves.len();
         let started = Instant::now();
         let mut last_error = None;
+        let mut wait = MERKLE_PROOF_POLL_START;
         loop {
             match single() {
                 Ok(response) if response.proofs.len() >= expected => return Ok(response),
@@ -370,7 +379,8 @@ impl Rpc for ZolanaIndexer {
                     ))
                 }));
             }
-            sleep(MERKLE_PROOF_POLL_INTERVAL);
+            sleep(wait);
+            wait = (wait * 2).min(MERKLE_PROOF_POLL_MAX);
         }
     }
 

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -243,6 +243,7 @@ impl Rpc for ZolanaIndexer {
                         .map(|(index, item)| convert_encrypted_utxo_match(index, item))
                         .collect::<Result<Vec<_>, _>>()?,
                     next_cursor: response.next_cursor.map(Into::into),
+                    scanned_through: response.scanned_through.map(Into::into),
                 })
             },
         )
@@ -454,6 +455,7 @@ impl AsyncRpc for AsyncZolanaIndexer {
                         .map(|(index, item)| convert_encrypted_utxo_match(index, item))
                         .collect::<Result<Vec<_>, _>>()?,
                     next_cursor: response.next_cursor.map(Into::into),
+                    scanned_through: response.scanned_through.map(Into::into),
                 })
             },
         )
@@ -678,6 +680,7 @@ fn convert_shielded_transactions_response(
             })
             .collect::<Result<Vec<_>, _>>()?,
         next_cursor: response.next_cursor.map(Into::into),
+        scanned_through: response.scanned_through.map(Into::into),
     })
 }
 
@@ -926,6 +929,7 @@ mod tests {
                     salt: None,
                 }],
                 next_cursor: Some(vec![5, 6]),
+                scanned_through: None,
             }
         );
     }
@@ -1001,6 +1005,7 @@ mod tests {
                     messages: vec![],
                 }],
                 next_cursor: Some(vec![23]),
+                scanned_through: None,
             }
         );
     }

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -336,11 +336,14 @@ impl Rpc for ZolanaIndexer {
         config: Option<IndexerRpcConfig>,
     ) -> Result<GetMerkleProofsResponse, ClientError> {
         let single = || {
-            self.api
-                .get_merkle_proofs(
+            let response = {
+                let _t = crate::timing::Phase::start("merkle_http", 0);
+                self.api.get_merkle_proofs(
                     encode_pubkey(tree_account),
                     leaves.iter().copied().map(encode_hash).collect(),
                 )
+            };
+            response
                 .map_err(indexer_error)
                 .map(|response| GetMerkleProofsResponse {
                     context: convert_context(response.context),

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -55,6 +55,9 @@ pub use rpc::{
 };
 #[cfg(feature = "solana-rpc")]
 pub use solana_rpc::{AsyncSolanaRpc, ConfirmedInstructionGroups, SolanaRpc};
+// `SolanaRpc::send_transaction_with_config` is public but names this type,
+// so callers outside the crate need it to call the method at all.
+pub use solana_rpc_client_api::config::RpcSendTransactionConfig;
 pub use zolana_transaction::{
     instructions::{
         merge::{Merge, PreparedMerge, MERGE_INPUTS},

--- a/sdk-libs/client/src/lib.rs
+++ b/sdk-libs/client/src/lib.rs
@@ -5,6 +5,10 @@
 //! Wallet state, syncing, transaction-building actions, and the user registry
 //! live in the `zolana-wallet` crate, which builds on this one.
 //!
+//! `ZOLANA_TIMING=1` prints per-phase timings to stderr; see [`timing`]. The
+//! `let _t = Phase::start(..)` guards through this crate are that, timing until
+//! they drop, and inert otherwise.
+//!
 //! Feature flags:
 //! - `(none)`: prover client + RPC traits
 //! - `indexer-api`: Photon indexer adapter and [`ZolanaClient`]

--- a/sdk-libs/client/src/rpc.rs
+++ b/sdk-libs/client/src/rpc.rs
@@ -59,6 +59,9 @@ pub struct GetEncryptedUtxosByTagsResponse {
     pub context: Context,
     pub matches: Vec<EncryptedUtxoMatch>,
     pub next_cursor: Option<Vec<u8>>,
+    /// Where the indexer's scan reached. The watermark to resume from, which
+    /// `next_cursor` no longer carries on a last page.
+    pub scanned_through: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -66,6 +69,9 @@ pub struct GetShieldedTransactionsByTagsResponse {
     pub context: Context,
     pub transactions: Vec<ShieldedTransaction>,
     pub next_cursor: Option<Vec<u8>>,
+    /// Where the indexer's scan reached. The watermark to resume from, which
+    /// `next_cursor` no longer carries on a last page.
+    pub scanned_through: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/sdk-libs/client/src/rpc.rs
+++ b/sdk-libs/client/src/rpc.rs
@@ -59,8 +59,14 @@ pub struct GetEncryptedUtxosByTagsResponse {
     pub context: Context,
     pub matches: Vec<EncryptedUtxoMatch>,
     pub next_cursor: Option<Vec<u8>>,
-    /// Where the indexer's scan reached. The watermark to resume from, which
-    /// `next_cursor` no longer carries on a last page.
+    /// Where the indexer's scan reached: the position to resume from next sync.
+    ///
+    /// Not a duplicate of `next_cursor`, which is a liveness signal -- its
+    /// presence means "read on", so the page that ends a read is by definition
+    /// the one without it, and it cannot also carry that page's position.
+    /// Ending on page size instead would collapse the two, and is rejected by
+    /// `only_a_missing_cursor_ends_the_read`: it stakes not skipping a spend on
+    /// every endpoint returning a short page only when out of rows.
     pub scanned_through: Option<Vec<u8>>,
 }
 
@@ -69,8 +75,14 @@ pub struct GetShieldedTransactionsByTagsResponse {
     pub context: Context,
     pub transactions: Vec<ShieldedTransaction>,
     pub next_cursor: Option<Vec<u8>>,
-    /// Where the indexer's scan reached. The watermark to resume from, which
-    /// `next_cursor` no longer carries on a last page.
+    /// Where the indexer's scan reached: the position to resume from next sync.
+    ///
+    /// Not a duplicate of `next_cursor`, which is a liveness signal -- its
+    /// presence means "read on", so the page that ends a read is by definition
+    /// the one without it, and it cannot also carry that page's position.
+    /// Ending on page size instead would collapse the two, and is rejected by
+    /// `only_a_missing_cursor_ends_the_read`: it stakes not skipping a spend on
+    /// every endpoint returning a short page only when out of rows.
     pub scanned_through: Option<Vec<u8>>,
 }
 

--- a/sdk-libs/client/src/solana_rpc.rs
+++ b/sdk-libs/client/src/solana_rpc.rs
@@ -526,12 +526,11 @@ impl Rpc for SolanaRpc {
         transaction: &Transaction,
         config: solana_rpc_client_api::config::RpcSendTransactionConfig,
     ) -> Result<Signature, ClientError> {
+        // Sends and returns; it does not confirm. `send_transaction` is the
+        // send-and-confirm one. The two were the same call, so a caller asking
+        // for a config also bought a confirmation wait it never requested.
         self.client
-            .send_and_confirm_transaction_with_spinner_and_config(
-                transaction,
-                CommitmentConfig::confirmed(),
-                config,
-            )
+            .send_transaction_with_config(transaction, config)
             .map_err(|source| ClientError::SolanaRpcTransaction {
                 operation: "send_transaction_with_config",
                 source,
@@ -670,12 +669,10 @@ impl AsyncRpc for AsyncSolanaRpc {
         transaction: &Transaction,
         config: solana_rpc_client_api::config::RpcSendTransactionConfig,
     ) -> Result<Signature, ClientError> {
+        // Sends and returns, matching the blocking path: `send_transaction` is
+        // the send-and-confirm one.
         self.client
-            .send_and_confirm_transaction_with_config(
-                transaction,
-                CommitmentConfig::confirmed(),
-                config,
-            )
+            .send_transaction_with_config(transaction, config)
             .await
             .map_err(|source| ClientError::SolanaRpcTransaction {
                 operation: "send_transaction_with_config",

--- a/sdk-libs/indexer-api/src/lib.rs
+++ b/sdk-libs/indexer-api/src/lib.rs
@@ -542,6 +542,18 @@ pub struct GetEncryptedUtxosByTagsResponse {
     /// Output-level matches; every returned output slot has a view tag from the request.
     pub matches: Vec<EncryptedUtxoMatch>,
     pub next_cursor: Option<Base64String>,
+    /// Where the scan reached, when it ran out of rows rather than filling a
+    /// page.
+    ///
+    /// Separates the two jobs `next_cursor` used to do at once. A cursor on
+    /// every non-empty page made "is there more?" cost an extra request, and
+    /// dropping it there instead would leave a caller with no watermark to
+    /// resume from -- so the watermark moved here, and `next_cursor` now means
+    /// only that another page exists. Present only on a page the limit did not
+    /// truncate, which is when "nothing further exists at or before this
+    /// position" holds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scanned_through: Option<Base64String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -607,6 +619,18 @@ pub struct GetShieldedTransactionsByTagsResponse {
     /// output view tag and includes all of its output slots.
     pub transactions: Vec<ShieldedTransaction>,
     pub next_cursor: Option<Base64String>,
+    /// Where the scan reached, when it ran out of rows rather than filling a
+    /// page.
+    ///
+    /// Separates the two jobs `next_cursor` used to do at once. A cursor on
+    /// every non-empty page made "is there more?" cost an extra request, and
+    /// dropping it there instead would leave a caller with no watermark to
+    /// resume from -- so the watermark moved here, and `next_cursor` now means
+    /// only that another page exists. Present only on a page the limit did not
+    /// truncate, which is when "nothing further exists at or before this
+    /// position" holds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scanned_through: Option<Base64String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -800,10 +824,13 @@ mod tests {
             },
             matches: Vec::new(),
             next_cursor: Some(Base64String(vec![1])),
+            scanned_through: Some(Base64String(vec![2])),
         })
         .unwrap();
         assert!(value.get("nextCursor").is_some());
         assert!(value.get("next_cursor").is_none());
+        assert!(value.get("scannedThrough").is_some());
+        assert!(value.get("scanned_through").is_none());
         assert!(value["context"].get("blockTime").is_some());
         assert!(value["context"].get("block_time").is_none());
     }

--- a/sdk-libs/ts/src/indexer/codec.ts
+++ b/sdk-libs/ts/src/indexer/codec.ts
@@ -416,24 +416,28 @@ export function encodeShieldedTransactionsBySignatureRequest(
 }
 
 export function decodeEncryptedUtxosResponse(value: unknown): GetEncryptedUtxosByTagsResponse {
-  const record = object(value, "$", ["context", "matches", "nextCursor"]);
+  const record = object(value, "$", ["context", "matches", "nextCursor", "scannedThrough"]);
   const nextCursor = optional(record["nextCursor"], "$.nextCursor", checkedBase64);
+  const scannedThrough = optional(record["scannedThrough"], "$.scannedThrough", checkedBase64);
   return {
     context: context(record["context"], "$.context"),
     matches: array(record["matches"], "$.matches", encryptedUtxoMatch),
     ...(nextCursor === undefined ? {} : { nextCursor }),
+    ...(scannedThrough === undefined ? {} : { scannedThrough }),
   };
 }
 
 export function decodeShieldedTransactionsResponse(
   value: unknown,
 ): GetShieldedTransactionsByTagsResponse {
-  const record = object(value, "$", ["context", "transactions", "nextCursor"]);
+  const record = object(value, "$", ["context", "transactions", "nextCursor", "scannedThrough"]);
   const nextCursor = optional(record["nextCursor"], "$.nextCursor", checkedBase64);
+  const scannedThrough = optional(record["scannedThrough"], "$.scannedThrough", checkedBase64);
   return {
     context: context(record["context"], "$.context"),
     transactions: array(record["transactions"], "$.transactions", indexedTransaction),
     ...(nextCursor === undefined ? {} : { nextCursor }),
+    ...(scannedThrough === undefined ? {} : { scannedThrough }),
   };
 }
 

--- a/sdk-libs/ts/src/indexer/types.ts
+++ b/sdk-libs/ts/src/indexer/types.ts
@@ -56,6 +56,15 @@ export interface GetEncryptedUtxosByTagsResponse {
   readonly context: IndexerContext;
   readonly matches: readonly EncryptedUtxoMatch[];
   readonly nextCursor?: Base64String;
+  /**
+   * Where the indexer's scan reached, on a page the limit did not truncate.
+   *
+   * The watermark to resume from. `nextCursor` reports only whether another page
+   * exists, so a last page carries this instead — without it a caller either
+   * spends a request discovering the page was the last, or has nothing to resume
+   * from and rescans.
+   */
+  readonly scannedThrough?: Base64String;
 }
 
 export interface IndexedShieldedTransaction {
@@ -85,6 +94,15 @@ export interface GetShieldedTransactionsByTagsResponse {
   readonly context: IndexerContext;
   readonly transactions: readonly IndexedShieldedTransaction[];
   readonly nextCursor?: Base64String;
+  /**
+   * Where the indexer's scan reached, on a page the limit did not truncate.
+   *
+   * The watermark to resume from. `nextCursor` reports only whether another page
+   * exists, so a last page carries this instead — without it a caller either
+   * spends a request discovering the page was the last, or has nothing to resume
+   * from and rescans.
+   */
+  readonly scannedThrough?: Base64String;
 }
 
 export interface GetShieldedTransactionsByNullifiersResponse {

--- a/sdk-libs/wallet/src/wallet_sync.rs
+++ b/sdk-libs/wallet/src/wallet_sync.rs
@@ -569,8 +569,12 @@ fn group_by_resume_point<K: Copy + Eq + std::hash::Hash>(
 /// One page of a cursor-ordered stream, reduced to what paging needs.
 struct Page {
     next_cursor: Option<Vec<u8>>,
-    /// Where the server's scan reached. Reported only by the nullifier stream,
-    /// whose pages are normally empty and so carry no last row.
+    /// Where the server's scan reached, on a page the limit did not truncate.
+    ///
+    /// The watermark, separate from `next_cursor`, which reports only whether
+    /// another page exists. Every stream reports it: without it a last page
+    /// would either cost an extra request to recognise or leave nothing to
+    /// resume from.
     scanned_through: Option<Vec<u8>>,
 }
 
@@ -700,7 +704,7 @@ fn fetch_shielded_transactions_incremental<I: Rpc>(
                 }
                 Ok(Page {
                     next_cursor: response.next_cursor,
-                    scanned_through: None,
+                    scanned_through: response.scanned_through,
                 })
             })?;
 
@@ -743,7 +747,7 @@ async fn fetch_shielded_transactions_incremental_async<I: AsyncRpc>(
                 }
                 let page = Page {
                     next_cursor: response.next_cursor,
-                    scanned_through: None,
+                    scanned_through: response.scanned_through,
                 };
                 let Some(next) = advance(&mut furthest, page) else {
                     break;
@@ -884,7 +888,7 @@ where
                 }
                 Ok(Page {
                     next_cursor: response.next_cursor,
-                    scanned_through: None,
+                    scanned_through: response.scanned_through,
                 })
             })?;
 
@@ -935,7 +939,7 @@ async fn fetch_proofless_deposits_async<I: AsyncRpc>(
                 }
                 let page = Page {
                     next_cursor: response.next_cursor,
-                    scanned_through: None,
+                    scanned_through: response.scanned_through,
                 };
                 let Some(next) = advance(&mut furthest, page) else {
                     break;
@@ -1075,7 +1079,7 @@ mod tests {
             tags: &[ViewTag],
             cursor: Option<Vec<u8>>,
             limit: usize,
-        ) -> (Vec<ShieldedTransaction>, Option<Vec<u8>>) {
+        ) -> (Vec<ShieldedTransaction>, Option<Vec<u8>>, Option<Vec<u8>>) {
             let after = cursor.as_ref().map(|bytes| {
                 u64::from_be_bytes(bytes.as_slice().try_into().expect("8-byte cursor"))
             });
@@ -1091,12 +1095,20 @@ mod tests {
                 .collect();
             rows.sort_by_key(|(slot, _)| *slot);
 
-            // Photon's rule (`next_cursor_from_rows`): the position of the last
-            // row returned, or None when there were none. A short page still
-            // carries a cursor, so the client can resume from the tip next sync
-            // instead of rescanning; the loop ends on the following empty page.
+            // Photon's rule (`page_cursor`): one row past the limit decides
+            // whether another page exists, and only then is a cursor returned.
+            // The watermark is `scanned_through`, which a last page carries
+            // instead -- so the client resumes from the tip next sync without
+            // spending a request to discover the page was the last.
+            let more = rows.len() > limit;
             rows.truncate(limit);
-            let next = rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec());
+            let next = more
+                .then(|| rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec()))
+                .flatten();
+            let scanned_through = (!more)
+                .then(|| self.entries.iter().map(|(slot, _)| *slot).max())
+                .flatten()
+                .map(|slot| slot.to_be_bytes().to_vec());
             let transactions = rows
                 .into_iter()
                 .map(|(slot, tag)| ShieldedTransaction {
@@ -1118,7 +1130,7 @@ mod tests {
                     proofless: false,
                 })
                 .collect();
-            (transactions, next)
+            (transactions, next, scanned_through)
         }
 
         /// The nullifier stream, same ordering and cursor rule.
@@ -1211,6 +1223,7 @@ mod tests {
                 },
                 matches: self.matches.clone(),
                 next_cursor: None,
+                scanned_through: None,
             })
         }
 
@@ -1228,6 +1241,7 @@ mod tests {
                 },
                 transactions: self.transactions.clone(),
                 next_cursor: None,
+                scanned_through: None,
             })
         }
 
@@ -1291,9 +1305,17 @@ mod tests {
                 .filter(|(slot, tag)| tags.contains(tag) && after.is_none_or(|after| *slot > after))
                 .collect();
             rows.sort_by_key(|(slot, _)| *slot);
+            // Same rule as the transaction stream: a cursor only when a row was
+            // left behind, a watermark otherwise.
+            let more = rows.len() > limit;
             rows.truncate(limit);
-
-            let next_cursor = rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec());
+            let next_cursor = more
+                .then(|| rows.last().map(|(slot, _)| slot.to_be_bytes().to_vec()))
+                .flatten();
+            let scanned_through = (!more)
+                .then(|| self.utxo_entries.iter().map(|(slot, _)| *slot).max())
+                .flatten()
+                .map(|slot| slot.to_be_bytes().to_vec());
             let matches = rows
                 .into_iter()
                 .map(|(slot, tag)| EncryptedUtxoMatch {
@@ -1319,6 +1341,7 @@ mod tests {
                 },
                 matches,
                 next_cursor,
+                scanned_through,
             })
         }
 
@@ -1330,7 +1353,7 @@ mod tests {
             _config: Option<IndexerRpcConfig>,
         ) -> Result<GetShieldedTransactionsByTagsResponse, ClientError> {
             let limit = limit.unwrap_or(1_000).max(1) as usize;
-            let (transactions, next_cursor) = self.matching(&tags, cursor, limit);
+            let (transactions, next_cursor, scanned_through) = self.matching(&tags, cursor, limit);
             Ok(GetShieldedTransactionsByTagsResponse {
                 context: Context {
                     block_time: 0,
@@ -1338,6 +1361,7 @@ mod tests {
                 },
                 transactions,
                 next_cursor,
+                scanned_through,
             })
         }
 
@@ -1428,12 +1452,11 @@ mod tests {
         )
         .expect("round 1");
 
-        // Two requests per round: one for the rows, one that comes back empty
-        // and ends the stream. What matters is that no request ever carries two
-        // tags -- the early tag is never re-queried.
+        // One request per round, each carrying one tag. What matters is that no
+        // request ever carries two tags -- the early tag is never re-queried.
         assert_eq!(
             *indexer.calls.lock().expect("calls poisoned"),
-            vec![(1, None), (1, Some(10)), (1, None), (1, Some(50))],
+            vec![(1, None), (1, None)],
             "round 1 must ask for the late tag alone, not both tags again"
         );
     }
@@ -1478,8 +1501,9 @@ mod tests {
         );
         assert_eq!(
             *indexer.calls.lock().expect("calls poisoned"),
-            vec![(1, None), (1, Some(50))],
-            "one request for the rows, one more that returns none and ends the loop"
+            vec![(1, None)],
+            "one request: the page reported where the scan reached, so there is \
+             nothing left to confirm"
         );
     }
 
@@ -1661,11 +1685,10 @@ mod tests {
             Some(30)
         );
 
-        // The streams that return rows take a second request to reach the empty
-        // page that ends them. The nullifier stream matches nothing, so its
-        // first page is already the last.
-        assert_eq!(indexer.calls.lock().expect("calls poisoned").len(), 2);
-        assert_eq!(indexer.utxo_calls.lock().expect("calls poisoned").len(), 2);
+        // One request per stream: each page says where the scan reached, so none
+        // of them needs a second request to discover it was the last.
+        assert_eq!(indexer.calls.lock().expect("calls poisoned").len(), 1);
+        assert_eq!(indexer.utxo_calls.lock().expect("calls poisoned").len(), 1);
         assert_eq!(
             indexer
                 .nullifier_calls

--- a/services/photon/src/api/method/rings.rs
+++ b/services/photon/src/api/method/rings.rs
@@ -230,11 +230,14 @@ mod tests {
             },
             matches: Vec::new(),
             next_cursor: Some(Base64String(vec![1, 2, 3])),
+            scanned_through: Some(Base64String(vec![4, 5, 6])),
         })
         .unwrap();
 
         assert!(matches!(value, Value::Object(_)));
         assert!(value.get("nextCursor").is_some());
         assert!(value.get("next_cursor").is_none());
+        assert!(value.get("scannedThrough").is_some());
+        assert!(value.get("scanned_through").is_none());
     }
 }

--- a/services/photon/src/api/method/rings/common.rs
+++ b/services/photon/src/api/method/rings/common.rs
@@ -394,6 +394,37 @@ pub(super) fn next_cursor_from_rows<T>(
         .map(|cursor| cursor.map(Base64String))
 }
 
+/// Trim an over-fetched page to `limit`, returning a cursor only when a row was
+/// left behind.
+///
+/// `next_cursor` used to answer two questions at once, and they want different
+/// answers on the last page. As "where did I get to" it has to be present, or a
+/// caller has no watermark and rescans from the start -- the regression
+/// `a_short_page_still_reports_its_last_row` guards. As "is there more" it has to
+/// be absent, or the caller spends an entire request being told there is nothing.
+///
+/// So the two split: `scanned_through` carries the watermark, and this carries
+/// paging. The caller asks for one row past `limit`; that row is never returned,
+/// it is only evidence another page exists.
+pub(super) fn page_cursor<T>(
+    rows: &mut Vec<T>,
+    limit: u64,
+    cursor_from_row: impl FnOnce(&T) -> Result<Vec<u8>, PhotonApiError>,
+) -> Result<Option<Base64String>, PhotonApiError> {
+    let limit = usize::try_from(limit).unwrap_or(usize::MAX);
+    if rows.len() <= limit {
+        return Ok(None);
+    }
+    rows.truncate(limit);
+    next_cursor_from_rows(rows, cursor_from_row)
+}
+
+/// One row past what the caller wants, so the page can tell whether it is the
+/// last. Paired with [`page_cursor`], which drops it.
+pub(super) fn over_fetch(limit: u64) -> u64 {
+    limit.saturating_add(1)
+}
+
 pub(super) fn signature_from_bytes(bytes: &[u8]) -> Result<SerializableSignature, PhotonApiError> {
     Ok(SerializableSignature(Signature::from(signature_array(
         bytes,
@@ -491,6 +522,43 @@ mod tests {
             Some(50u64.to_be_bytes().to_vec()),
             "a page below the limit still reports where it got to"
         );
+    }
+
+    /// The two jobs the cursor used to do at once, now split. A last page must
+    /// not carry a paging cursor -- that cost the caller a request to discover
+    /// the page was the last -- while `scanned_through` keeps the watermark that
+    /// `a_short_page_still_reports_its_last_row` exists to protect.
+    #[test]
+    fn a_last_page_carries_no_paging_cursor() {
+        // Asked for 2, the query found 2: there was no third row.
+        let mut rows = vec![10u64, 50];
+        assert!(page_cursor(&mut rows, 2, cursor_of)
+            .expect("cursor")
+            .is_none());
+        assert_eq!(rows, vec![10, 50], "a last page is returned whole");
+    }
+
+    /// A full page pages from the last row it returned -- not from the
+    /// over-fetched one, which the caller never sees.
+    #[test]
+    fn a_full_page_pages_from_its_last_returned_row() {
+        let mut rows = vec![10u64, 50, 90];
+        let cursor = page_cursor(&mut rows, 2, cursor_of).expect("cursor");
+
+        assert_eq!(rows, vec![10, 50], "the extra row is evidence, not payload");
+        assert_eq!(
+            cursor.map(|c| c.0),
+            Some(50u64.to_be_bytes().to_vec()),
+            "resumes at 50, so 90 is read next rather than skipped"
+        );
+    }
+
+    #[test]
+    fn an_empty_page_carries_no_paging_cursor() {
+        let mut rows: Vec<u64> = Vec::new();
+        assert!(page_cursor(&mut rows, 2, cursor_of)
+            .expect("cursor")
+            .is_none());
     }
 
     /// How the loop terminates now: the client asks once more and gets nothing.

--- a/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
@@ -1,7 +1,7 @@
 use super::common::{
-    bind_u64_as_i64, cursor_sort_key, decode_cursor, encode_cursor, over_fetch, page_cursor,
-    rings_output_slot_from_parts, signature_from_bytes, tags_sql, tx_cursor_sql_condition,
-    u16_from_i16, u64_from_i64, validate_tags, CursorKind,
+    bind_u64_as_i64, cursor_sort_key, decode_cursor, encode_cursor, next_cursor_from_rows,
+    over_fetch, page_cursor, rings_output_slot_from_parts, signature_from_bytes, tags_sql,
+    tx_cursor_sql_condition, u16_from_i16, u64_from_i64, validate_tags, CursorKind,
 };
 use crate::api::error::PhotonApiError;
 use crate::common::bind_sql_value;
@@ -72,12 +72,14 @@ pub async fn get_encrypted_utxos_by_tags(
     )
     .await?;
     let next_cursor = page_cursor(&mut rows, limit, encrypted_utxo_cursor_from_row)?;
-    // The caller's watermark, now that `next_cursor` only reports paging. Only
-    // meaningful on a page the limit did not truncate.
+    // The caller's watermark, now that `next_cursor` only reports paging. The
+    // rows are the answer: on a page the limit did not truncate, the last row
+    // returned is where the scan reached. Reading the stream tip from the
+    // database instead cost about as much as the round trip this saves.
     let scanned_through = if next_cursor.is_some() {
         None
     } else {
-        output_scan_position(&tx).await?
+        next_cursor_from_rows(&rows, encrypted_utxo_cursor_from_row)?
     };
 
     let matches = rows
@@ -181,63 +183,6 @@ fn encrypted_utxo_cursor_sql(
         params,
     )?;
     Ok(format!("AND {condition}"))
-}
-
-/// The last position in the output stream, as a cursor.
-///
-/// The transactions stream has its own version of this; outputs need a separate
-/// one because their cursor carries `output_index`, so the tail of
-/// `rings_transactions` does not describe where an output scan reached.
-///
-/// Read inside the caller's transaction, so it describes the snapshot the scan
-/// saw. Sound while positions are only appended, which is the same assumption
-/// the per-tag cursors already make.
-async fn output_scan_position(
-    tx: &DatabaseTransaction,
-) -> Result<Option<Base64String>, PhotonApiError> {
-    let backend = tx.get_database_backend();
-    // Pinning the slot first keeps this an index lookup rather than a sort of
-    // the whole table, as in `scan_position`.
-    let sql = "SELECT
-            po.slot AS slot,
-            po.signature AS signature,
-            po.event_index AS event_index,
-            po.output_index AS output_index
-         FROM rings_outputs po
-         WHERE po.slot = (SELECT MAX(slot) FROM rings_outputs)
-         ORDER BY po.signature DESC, po.event_index DESC, po.output_index DESC
-         LIMIT 1"
-        .to_string();
-
-    let Some(row) = tx
-        .query_all(Statement::from_sql_and_values(backend, sql, Vec::new()))
-        .await?
-        .into_iter()
-        .next()
-    else {
-        return Ok(None);
-    };
-    let row = EncryptedUtxoScanRow::from_query_result(&row, "")?;
-    let (slot, signature, event_index) =
-        cursor_sort_key(row.slot, &row.signature, row.event_index)?;
-    let cursor = EncryptedUtxoCursor {
-        slot,
-        signature,
-        event_index,
-        output_index: u16_from_i16(row.output_index, "output index")?,
-    };
-    Ok(Some(Base64String(encode_cursor(
-        CursorKind::EncryptedUtxos,
-        &cursor,
-    )?)))
-}
-
-#[derive(FromQueryResult, Debug)]
-struct EncryptedUtxoScanRow {
-    slot: i64,
-    signature: Vec<u8>,
-    event_index: i16,
-    output_index: i16,
 }
 
 fn encrypted_utxo_cursor_from_row(row: &EncryptedUtxoRow) -> Result<Vec<u8>, PhotonApiError> {

--- a/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_encrypted_utxos_by_tags.rs
@@ -1,5 +1,5 @@
 use super::common::{
-    bind_u64_as_i64, cursor_sort_key, decode_cursor, encode_cursor, next_cursor_from_rows,
+    bind_u64_as_i64, cursor_sort_key, decode_cursor, encode_cursor, over_fetch, page_cursor,
     rings_output_slot_from_parts, signature_from_bytes, tags_sql, tx_cursor_sql_condition,
     u16_from_i16, u64_from_i64, validate_tags, CursorKind,
 };
@@ -62,9 +62,23 @@ pub async fn get_encrypted_utxos_by_tags(
     let ring_config = request
         .ring_program_id
         .map(|program| pda::ring_auth(&program.0).0);
-    let rows =
-        fetch_encrypted_utxo_rows(&tx, &request.tags, cursor.as_ref(), limit, ring_config).await?;
-    let next_cursor = next_cursor_from_rows(&rows, encrypted_utxo_cursor_from_row)?;
+    // One row past the limit; see `page_cursor`.
+    let mut rows = fetch_encrypted_utxo_rows(
+        &tx,
+        &request.tags,
+        cursor.as_ref(),
+        over_fetch(limit),
+        ring_config,
+    )
+    .await?;
+    let next_cursor = page_cursor(&mut rows, limit, encrypted_utxo_cursor_from_row)?;
+    // The caller's watermark, now that `next_cursor` only reports paging. Only
+    // meaningful on a page the limit did not truncate.
+    let scanned_through = if next_cursor.is_some() {
+        None
+    } else {
+        output_scan_position(&tx).await?
+    };
 
     let matches = rows
         .into_iter()
@@ -91,6 +105,7 @@ pub async fn get_encrypted_utxos_by_tags(
         context,
         matches,
         next_cursor,
+        scanned_through,
     })
 }
 
@@ -166,6 +181,63 @@ fn encrypted_utxo_cursor_sql(
         params,
     )?;
     Ok(format!("AND {condition}"))
+}
+
+/// The last position in the output stream, as a cursor.
+///
+/// The transactions stream has its own version of this; outputs need a separate
+/// one because their cursor carries `output_index`, so the tail of
+/// `rings_transactions` does not describe where an output scan reached.
+///
+/// Read inside the caller's transaction, so it describes the snapshot the scan
+/// saw. Sound while positions are only appended, which is the same assumption
+/// the per-tag cursors already make.
+async fn output_scan_position(
+    tx: &DatabaseTransaction,
+) -> Result<Option<Base64String>, PhotonApiError> {
+    let backend = tx.get_database_backend();
+    // Pinning the slot first keeps this an index lookup rather than a sort of
+    // the whole table, as in `scan_position`.
+    let sql = "SELECT
+            po.slot AS slot,
+            po.signature AS signature,
+            po.event_index AS event_index,
+            po.output_index AS output_index
+         FROM rings_outputs po
+         WHERE po.slot = (SELECT MAX(slot) FROM rings_outputs)
+         ORDER BY po.signature DESC, po.event_index DESC, po.output_index DESC
+         LIMIT 1"
+        .to_string();
+
+    let Some(row) = tx
+        .query_all(Statement::from_sql_and_values(backend, sql, Vec::new()))
+        .await?
+        .into_iter()
+        .next()
+    else {
+        return Ok(None);
+    };
+    let row = EncryptedUtxoScanRow::from_query_result(&row, "")?;
+    let (slot, signature, event_index) =
+        cursor_sort_key(row.slot, &row.signature, row.event_index)?;
+    let cursor = EncryptedUtxoCursor {
+        slot,
+        signature,
+        event_index,
+        output_index: u16_from_i16(row.output_index, "output index")?,
+    };
+    Ok(Some(Base64String(encode_cursor(
+        CursorKind::EncryptedUtxos,
+        &cursor,
+    )?)))
+}
+
+#[derive(FromQueryResult, Debug)]
+struct EncryptedUtxoScanRow {
+    slot: i64,
+    signature: Vec<u8>,
+    event_index: i16,
+    output_index: i16,
 }
 
 fn encrypted_utxo_cursor_from_row(row: &EncryptedUtxoRow) -> Result<Vec<u8>, PhotonApiError> {

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeMap;
 
 use super::common::{
     bind_u64_as_i64, cursor_sort_key, decode_cursor, encode_cursor, hash_from_vec, int_list_sql,
-    over_fetch, page_cursor, rings_output_slot_from_parts, signature_from_bytes, tags_sql,
-    tx_cursor_sql_condition, u16_from_i16, u64_from_i64, validate_nullifiers, validate_tags,
-    CursorKind,
+    next_cursor_from_rows, over_fetch, page_cursor, rings_output_slot_from_parts,
+    signature_from_bytes, tags_sql, tx_cursor_sql_condition, u16_from_i16, u64_from_i64,
+    validate_nullifiers, validate_tags, CursorKind,
 };
 use crate::api::error::PhotonApiError;
 use crate::common::bind_sql_value;
@@ -178,15 +178,24 @@ async fn get_shielded_transactions(
     })?;
 
     // A cursor now means exactly that the limit cut the scan short, so nothing
-    // can be claimed beyond it. Both streams report the position when it did
-    // not: it is the caller's watermark now that `next_cursor` is only paging,
-    // and a tag query whose page is short would otherwise have nothing to
-    // resume from.
+    // can be claimed beyond it.
     let truncated = next_cursor.is_some();
     let scanned_through = if truncated {
         None
     } else {
-        scan_position(&tx, cursor_kind).await?
+        match match_by {
+            // The rows are the answer: the last one returned is where a scan
+            // that ran out of rows reached. Reading the stream tip from the
+            // database instead cost about as much as the round trip this
+            // watermark exists to save -- 180ms per request, measured.
+            MatchBy::Tags => next_cursor_from_rows(&matched_txs, |row| {
+                shielded_tx_cursor_from_row(row, cursor_kind)
+            })?,
+            // Except here, where they are not: a query for unspent nullifiers
+            // matches nothing, so an untruncated page has no last row and the
+            // position has to come from the stream itself.
+            MatchBy::Nullifiers => scan_position(&tx, cursor_kind).await?,
+        }
     };
 
     let transactions = hydrate_shielded_transactions(&tx, matched_txs)
@@ -562,7 +571,7 @@ mod tests {
     use crate::migration::RingsMigrator;
     use sea_orm::{Database, EntityTrait, Set};
     use sea_orm_migration::MigratorTrait;
-    use zolana_indexer_api::{GetRingsByNullifiersRequest, Limit};
+    use zolana_indexer_api::{GetRingsByNullifiersRequest, GetRingsByTagsRequest, Limit};
 
     fn hash(byte: u8) -> Hash {
         Hash::from([byte; 32])
@@ -832,6 +841,74 @@ mod tests {
             resumed.scanned_through,
             Some(scanned_through),
             "a stream that has not moved reports the same tip"
+        );
+    }
+
+    /// The tag stream's watermark comes from the rows it returned, not from a
+    /// separate look at the stream's tip. Reading the tip cost 180ms per request
+    /// -- about what the round trip it replaces was worth -- and the rows
+    /// already say where a scan that ran out of rows reached.
+    ///
+    /// Asserted by using it: resuming from the watermark must find nothing
+    /// further, which is the only property a caller depends on.
+    #[tokio::test]
+    async fn a_tag_page_reports_a_watermark_that_resumes_past_its_rows() {
+        let db = setup().await;
+        rings_outputs::Entity::insert(rings_outputs::ActiveModel {
+            output_id: Set(1),
+            rings_tx_id: Set(1),
+            slot: Set(7),
+            output_index: Set(0),
+            output_tree: Set(vec![8; 32]),
+            leaf_index: Set(1),
+            view_tag: Set(hash(6).to_vec()),
+            utxo_hash: Set(vec![6; 32]),
+            signature: Set(Some(vec![1; 64])),
+            event_index: Set(Some(0)),
+        })
+        .exec(&db)
+        .await
+        .unwrap();
+        rings_output_payloads::Entity::insert(rings_output_payloads::ActiveModel {
+            output_id: Set(1),
+            payload: Set(vec![1, 2, 3]),
+        })
+        .exec(&db)
+        .await
+        .unwrap();
+
+        let first = get_shielded_transactions_by_tags(
+            &db,
+            GetRingsByTagsRequest {
+                tags: vec![hash(6)],
+                cursor: None,
+                limit: Some(Limit::new(10).unwrap()),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(first.transactions.len(), 1);
+        assert!(
+            first.next_cursor.is_none(),
+            "the page was not truncated, so there is nothing to page to"
+        );
+        let watermark = first.scanned_through.clone().expect("a watermark");
+
+        let resumed = get_shielded_transactions_by_tags(
+            &db,
+            GetRingsByTagsRequest {
+                tags: vec![hash(6)],
+                cursor: Some(watermark),
+                limit: Some(Limit::new(10).unwrap()),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            resumed.transactions.is_empty(),
+            "the watermark must sit past the rows the page returned"
         );
     }
 

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use super::common::{
     bind_u64_as_i64, cursor_sort_key, decode_cursor, encode_cursor, hash_from_vec, int_list_sql,
-    next_cursor_from_rows, rings_output_slot_from_parts, signature_from_bytes, tags_sql,
+    over_fetch, page_cursor, rings_output_slot_from_parts, signature_from_bytes, tags_sql,
     tx_cursor_sql_condition, u16_from_i16, u64_from_i64, validate_nullifiers, validate_tags,
     CursorKind,
 };
@@ -101,6 +101,7 @@ pub async fn get_shielded_transactions_by_tags(
         context: page.context,
         transactions: page.transactions,
         next_cursor: page.next_cursor,
+        scanned_through: page.scanned_through,
     })
 }
 
@@ -160,26 +161,32 @@ async fn get_shielded_transactions(
     let tx = conn.begin().await?;
     crate::api::set_transaction_isolation_if_needed(&tx).await?;
 
-    let matched_txs = fetch_matching_rings_transactions(
+    // One row past the limit, so an absent cursor means "this was the last page"
+    // instead of "the page was empty". Without it a caller spends a whole request
+    // learning there is nothing more -- 170ms of every sync on devnet.
+    let mut matched_txs = fetch_matching_rings_transactions(
         &tx,
         values,
         cursor.as_ref(),
-        limit,
+        over_fetch(limit),
         match_by,
         ring_config,
     )
     .await?;
-    let next_cursor = next_cursor_from_rows(&matched_txs, |row| {
+    let next_cursor = page_cursor(&mut matched_txs, limit, |row| {
         shielded_tx_cursor_from_row(row, cursor_kind)
     })?;
 
-    // A full page means the limit cut the scan short, so nothing can be claimed
-    // beyond it. Only the nullifier stream needs the position: a tag query's
-    // cursor advances on the rows it returns.
-    let truncated = matched_txs.len() as u64 >= limit;
-    let scanned_through = match match_by {
-        MatchBy::Nullifiers if !truncated => scan_position(&tx, cursor_kind).await?,
-        _ => None,
+    // A cursor now means exactly that the limit cut the scan short, so nothing
+    // can be claimed beyond it. Both streams report the position when it did
+    // not: it is the caller's watermark now that `next_cursor` is only paging,
+    // and a tag query whose page is short would otherwise have nothing to
+    // resume from.
+    let truncated = next_cursor.is_some();
+    let scanned_through = if truncated {
+        None
+    } else {
+        scan_position(&tx, cursor_kind).await?
     };
 
     let transactions = hydrate_shielded_transactions(&tx, matched_txs)
@@ -830,13 +837,55 @@ mod tests {
 
     /// The position claims nothing matches at or before it, true only when the
     /// scan ran out of rows rather than out of room.
+    ///
+    /// Needs two matching transactions to be a real test: both fixture
+    /// nullifiers belong to one transaction, so a limit of 1 returns a page that
+    /// fills exactly and is not truncated. Over-fetching one row is what tells
+    /// those two cases apart, where the old rule assumed the worse of them.
     #[tokio::test]
     async fn a_truncated_page_reports_no_scan_position() {
         let db = setup().await;
+        transactions::Entity::insert(transactions::ActiveModel {
+            signature: Set(vec![3; 64]),
+            slot: Set(7),
+            error: Set(None),
+        })
+        .exec(&db)
+        .await
+        .unwrap();
+        rings_transactions::Entity::insert(rings_transactions::ActiveModel {
+            rings_tx_id: Set(3),
+            signature: Set(vec![3; 64]),
+            event_index: Set(0),
+            slot: Set(7),
+            rings_program_id: Set(vec![9; 32]),
+            source_instruction_tag: Set(1),
+            output_tree: Set(vec![8; 32]),
+            first_output_leaf_index: Set(0),
+            tx_viewing_pk: Set(None),
+            salt: Set(None),
+            proofless: Set(false),
+        })
+        .exec(&db)
+        .await
+        .unwrap();
+        rings_tx_nullifiers::Entity::insert(rings_tx_nullifiers::ActiveModel {
+            nullifier_id: Default::default(),
+            rings_tx_id: Set(3),
+            slot: Set(7),
+            input_index: Set(0),
+            nullifier_tree: Set(vec![7; 32]),
+            input_queue_seq: Set(9),
+            nullifier: Set(vec![9; 32]),
+        })
+        .exec(&db)
+        .await
+        .unwrap();
+
         let response = get_shielded_transactions_by_nullifiers(
             &db,
             GetRingsByNullifiersRequest {
-                nullifiers: vec![hash(3), hash(4)],
+                nullifiers: vec![hash(3), hash(9)],
                 cursor: None,
                 limit: Some(Limit::new(1).unwrap()),
             },
@@ -844,7 +893,11 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(response.transactions.len(), 1);
+        assert_eq!(response.transactions.len(), 1, "the limit was reached");
+        assert!(
+            response.next_cursor.is_some(),
+            "another matching transaction is left, so the page must page"
+        );
         assert!(
             response.scanned_through.is_none(),
             "the limit cut the scan short, so nothing can be claimed beyond it"

--- a/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
+++ b/services/photon/src/api/method/rings/get_shielded_transactions_by_tags.rs
@@ -883,6 +883,7 @@ mod tests {
                 tags: vec![hash(6)],
                 cursor: None,
                 limit: Some(Limit::new(10).unwrap()),
+                ring_program_id: None,
             },
         )
         .await
@@ -901,6 +902,7 @@ mod tests {
                 tags: vec![hash(6)],
                 cursor: Some(watermark),
                 limit: Some(Limit::new(10).unwrap()),
+                ring_program_id: None,
             },
         )
         .await
@@ -935,7 +937,7 @@ mod tests {
             signature: Set(vec![3; 64]),
             event_index: Set(0),
             slot: Set(7),
-            rings_program_id: Set(vec![9; 32]),
+            ring_config: Set(None),
             source_instruction_tag: Set(1),
             output_tree: Set(vec![8; 32]),
             first_output_leaf_index: Set(0),

--- a/services/photon/src/api/root_index_cache.rs
+++ b/services/photon/src/api/root_index_cache.rs
@@ -15,14 +15,30 @@
 //!
 //! Held per process. Only the API serves proofs, and a cache that belongs to
 //! the process reading it needs no coordination with the indexer.
+//!
+//! Refreshed ahead of the request, not on it. A miss is not the rare case it
+//! reads as: every transfer appends a root, so the next transfer's proof asks
+//! for a root the ring does not have yet, and the fetch landed on the critical
+//! path of essentially every transfer -- 721ms of a 2971ms devnet transfer, with
+//! the task at 0.06% CPU and the database at 0.26 ReadIOPS, because the time was
+//! spent waiting on the upstream RPC rather than working.
+//!
+//! [`RootIndexCache::refresh_loop`] watches the indexed root's sequence number in
+//! Postgres, which is cheap, and fetches the 1.2 MB account only when that number
+//! moves. The on-miss fetch stays as the fallback: a request that arrives between
+//! a tree update and the next refresh must still be answerable, and only the
+//! common case is being moved, not the contract.
 
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 use solana_pubkey::Pubkey;
 
 use crate::api::error::PhotonApiError;
+use crate::common::rings_tree::RingsTreeKind;
+use crate::dao::generated::{state_trees, tree_metadata};
 use crate::monitor::tree_metadata_sync::rings_utxo_root_history;
 use crate::rpc::RpcClient;
 
@@ -30,6 +46,11 @@ use crate::rpc::RpcClient;
 /// indexes a new root slightly before the next refresh -- but repeated misses
 /// for a root that is not on chain must not become a 1.2 MB fetch per request.
 const MIN_REFRESH_INTERVAL: Duration = Duration::from_millis(500);
+
+/// How often the refresher asks Postgres whether the tree moved. This is a
+/// single-row primary-key read, not the account fetch, so it can be far shorter
+/// than [`MIN_REFRESH_INTERVAL`].
+const CHANGE_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 #[derive(Default)]
 struct TreeRoots {
@@ -109,6 +130,51 @@ impl RootIndexCache {
         ))
     }
 
+    /// Keep every known state tree's ring current, so `index_for` answers from
+    /// memory.
+    ///
+    /// Change detection is the point: refreshing on a timer would fetch 1.2 MB
+    /// per tree per tick whether or not anything moved, and refreshing on a
+    /// request puts that fetch in front of the caller. The indexed root's
+    /// sequence number moves exactly when the tree does, and reading it is a
+    /// primary-key lookup.
+    pub async fn refresh_loop(&self, db: &DatabaseConnection, rpc_client: &RpcClient) {
+        let mut seen: HashMap<Pubkey, Option<i64>> = HashMap::new();
+        loop {
+            match known_state_trees(db).await {
+                Ok(trees) => {
+                    for tree in trees {
+                        let seq = match root_sequence(db, tree).await {
+                            Ok(seq) => seq,
+                            Err(error) => {
+                                log::warn!(
+                                    "root index refresher: reading {tree} sequence: {error}"
+                                );
+                                continue;
+                            }
+                        };
+                        // First sight of a tree refreshes it; after that only a
+                        // moved sequence does.
+                        if seen.get(&tree).is_some_and(|last| *last == seq) {
+                            continue;
+                        }
+                        match self.refresh(rpc_client, tree).await {
+                            Ok(()) => {
+                                seen.insert(tree, seq);
+                            }
+                            // Leave `seen` alone so the next tick tries again.
+                            Err(error) => {
+                                log::warn!("root index refresher: refreshing {tree}: {error}")
+                            }
+                        }
+                    }
+                }
+                Err(error) => log::warn!("root index refresher: listing trees: {error}"),
+            }
+            tokio::time::sleep(CHANGE_POLL_INTERVAL).await;
+        }
+    }
+
     async fn refresh(&self, rpc_client: &RpcClient, tree: Pubkey) -> Result<(), PhotonApiError> {
         let account = rpc_client.get_account(&tree).await.map_err(|error| {
             PhotonApiError::UnexpectedError(format!("Failed to fetch tree {tree}: {error}"))
@@ -134,6 +200,44 @@ impl RootIndexCache {
         );
         Ok(())
     }
+}
+
+/// State trees the indexer knows about. The refresher covers every one rather
+/// than only the trees already asked for, so the first proof after a restart
+/// does not pay the fetch.
+async fn known_state_trees(db: &DatabaseConnection) -> Result<Vec<Pubkey>, PhotonApiError> {
+    let rows = tree_metadata::Entity::find()
+        .all(db)
+        .await
+        .map_err(|error| PhotonApiError::UnexpectedError(error.to_string()))?;
+    rows.into_iter()
+        .map(|row| {
+            <[u8; 32]>::try_from(row.tree_pubkey.as_slice())
+                .map(Pubkey::new_from_array)
+                .map_err(|_| {
+                    PhotonApiError::UnexpectedError("tree_metadata pubkey is not 32 bytes".into())
+                })
+        })
+        .collect()
+}
+
+/// Sequence number the indexer stamped on the tree's root node, which advances
+/// exactly when the tree does.
+async fn root_sequence(
+    db: &DatabaseConnection,
+    tree: Pubkey,
+) -> Result<Option<i64>, PhotonApiError> {
+    let root = state_trees::Entity::find()
+        .filter(
+            state_trees::Column::Tree
+                .eq(tree.to_bytes().to_vec())
+                .and(state_trees::Column::TreeKind.eq(i32::from(RingsTreeKind::State)))
+                .and(state_trees::Column::NodeIdx.eq(1)),
+        )
+        .one(db)
+        .await
+        .map_err(|error| PhotonApiError::UnexpectedError(error.to_string()))?;
+    Ok(root.and_then(|node| node.seq))
 }
 
 #[cfg(test)]
@@ -166,6 +270,42 @@ mod tests {
         assert_eq!(cache.lookup(tree, &[155; 32]), None);
         assert_eq!(cache.lookup(tree, &[1; 32]), Some(155));
         assert_eq!(cache.lookup(tree, &[2; 32]), Some(41));
+    }
+
+    /// The point of refreshing ahead: a request for a root the refresher has
+    /// already brought in must not consult the RPC at all. `index_for` takes an
+    /// `RpcClient`, so the only honest way to assert "did not fetch" is that the
+    /// answer comes back from a cache whose refresh window is closed -- with a
+    /// stale window the on-miss path would fire instead.
+    #[tokio::test]
+    async fn a_root_the_refresher_brought_in_is_answered_without_the_rpc() {
+        let tree = Pubkey::new_from_array([7; 32]);
+        let cache = cache_with(tree, &[([9; 32], 12)], Some(Instant::now()));
+
+        // An unreachable endpoint: reaching for it at all is the failure.
+        let rpc = RpcClient::new("http://127.0.0.1:1".to_string());
+        assert_eq!(cache.index_for(&rpc, tree, [9; 32]).await.unwrap(), 12);
+    }
+
+    /// And the fallback still has to work: a request that arrives between a tree
+    /// update and the next refresh is answered, not failed.
+    #[tokio::test]
+    async fn a_root_the_refresher_has_not_reached_still_reaches_for_the_account() {
+        let tree = Pubkey::new_from_array([7; 32]);
+        let cache = cache_with(
+            tree,
+            &[([9; 32], 12)],
+            Instant::now().checked_sub(MIN_REFRESH_INTERVAL * 2),
+        );
+
+        let rpc = RpcClient::new("http://127.0.0.1:1".to_string());
+        // Unreachable, so this surfaces the fetch as an error rather than a
+        // StaleRoot -- which is the proof that the fetch was attempted.
+        let error = cache.index_for(&rpc, tree, [4; 32]).await.unwrap_err();
+        assert!(
+            matches!(error, PhotonApiError::UnexpectedError(_)),
+            "expected the on-miss fetch to be attempted, got {error:?}"
+        );
     }
 
     #[test]

--- a/services/photon/src/api/root_index_cache.rs
+++ b/services/photon/src/api/root_index_cache.rs
@@ -10,8 +10,9 @@
 //! The tree account is authoritative and holds the whole 200-slot ring, so the
 //! answer is a lookup rather than a count. The account is ~1.2 MB, far too
 //! large to fetch per request, and one fetch brings back every root in the
-//! window -- so it is cached, refreshed on a miss, and rate limited so a root
-//! the chain genuinely does not have cannot turn into a fetch per request.
+//! window -- so it is cached, refreshed on a miss, and that on-miss fetch is
+//! rate limited so a root the chain genuinely does not have cannot turn into a
+//! fetch per request.
 //!
 //! Held per process. Only the API serves proofs, and a cache that belongs to
 //! the process reading it needs no coordination with the indexer.
@@ -27,7 +28,10 @@
 //! Postgres, which is cheap, and fetches the 1.2 MB account only when that number
 //! moves. The on-miss fetch stays as the fallback: a request that arrives between
 //! a tree update and the next refresh must still be answerable, and only the
-//! common case is being moved, not the contract.
+//! common case is being moved, not the contract. The refresher's own fetches
+//! therefore do not count against the on-miss floor: they fire whenever the tree
+//! moves, so letting them close that window would starve the fallback on exactly
+//! the busy tree that needs it.
 
 use std::collections::HashMap;
 use std::sync::RwLock;
@@ -55,7 +59,18 @@ const CHANGE_POLL_INTERVAL: Duration = Duration::from_millis(200);
 #[derive(Default)]
 struct TreeRoots {
     indices: HashMap<[u8; 32], u16>,
-    refreshed: Option<Instant>,
+    /// When the on-demand path last fetched this account, and nothing else. The
+    /// floor is there to stop a caller turning a root the chain does not have
+    /// into a fetch per request; the refresher is already gated on the sequence
+    /// moving, so its fetches must not stamp this.
+    fetched_on_miss: Option<Instant>,
+}
+
+/// Which path is bringing roots in. Only the on-demand one is throttled.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Fetch {
+    OnMiss,
+    Refresher,
 }
 
 #[derive(Default)]
@@ -82,7 +97,7 @@ impl RootIndexCache {
                         .into_iter()
                         .map(|(index, root)| (root, index))
                         .collect(),
-                    refreshed: Some(Instant::now()),
+                    fetched_on_miss: Some(Instant::now()),
                 },
             );
         }
@@ -104,7 +119,7 @@ impl RootIndexCache {
             return Err(self.missing(tree));
         }
 
-        self.refresh(rpc_client, tree).await?;
+        self.refresh(rpc_client, tree, Fetch::OnMiss).await?;
         self.lookup(tree, &root).ok_or_else(|| self.missing(tree))
     }
 
@@ -119,7 +134,7 @@ impl RootIndexCache {
         };
         trees
             .get(&tree)
-            .and_then(|roots| roots.refreshed)
+            .and_then(|roots| roots.fetched_on_miss)
             .is_none_or(|at| at.elapsed() >= MIN_REFRESH_INTERVAL)
     }
 
@@ -158,7 +173,7 @@ impl RootIndexCache {
                         if seen.get(&tree).is_some_and(|last| *last == seq) {
                             continue;
                         }
-                        match self.refresh(rpc_client, tree).await {
+                        match self.refresh(rpc_client, tree, Fetch::Refresher).await {
                             Ok(()) => {
                                 seen.insert(tree, seq);
                             }
@@ -175,7 +190,12 @@ impl RootIndexCache {
         }
     }
 
-    async fn refresh(&self, rpc_client: &RpcClient, tree: Pubkey) -> Result<(), PhotonApiError> {
+    async fn refresh(
+        &self,
+        rpc_client: &RpcClient,
+        tree: Pubkey,
+        fetch: Fetch,
+    ) -> Result<(), PhotonApiError> {
         let account = rpc_client.get_account(&tree).await.map_err(|error| {
             PhotonApiError::UnexpectedError(format!("Failed to fetch tree {tree}: {error}"))
         })?;
@@ -183,21 +203,28 @@ impl RootIndexCache {
             PhotonApiError::UnexpectedError(format!("Account {tree} is not a Rings tree"))
         })?;
 
+        self.store(tree, history, fetch)
+    }
+
+    fn store(
+        &self,
+        tree: Pubkey,
+        history: impl IntoIterator<Item = (u16, [u8; 32])>,
+        fetch: Fetch,
+    ) -> Result<(), PhotonApiError> {
         let mut trees = self.trees.write().map_err(|_| {
             PhotonApiError::UnexpectedError("Root index cache is poisoned".to_string())
         })?;
+        let entry = trees.entry(tree).or_default();
         // Replaced wholesale: a root evicted from the ring must stop resolving,
         // or its stale index outlives the root it described.
-        trees.insert(
-            tree,
-            TreeRoots {
-                indices: history
-                    .into_iter()
-                    .map(|(index, root)| (root, index))
-                    .collect(),
-                refreshed: Some(Instant::now()),
-            },
-        );
+        entry.indices = history
+            .into_iter()
+            .map(|(index, root)| (root, index))
+            .collect();
+        if fetch == Fetch::OnMiss {
+            entry.fetched_on_miss = Some(Instant::now());
+        }
         Ok(())
     }
 }
@@ -247,14 +274,14 @@ mod tests {
     fn cache_with(
         tree: Pubkey,
         entries: &[([u8; 32], u16)],
-        refreshed: Option<Instant>,
+        fetched_on_miss: Option<Instant>,
     ) -> RootIndexCache {
         let cache = RootIndexCache::new();
         cache.trees.write().unwrap().insert(
             tree,
             TreeRoots {
                 indices: entries.iter().copied().collect(),
-                refreshed,
+                fetched_on_miss,
             },
         );
         cache
@@ -305,6 +332,38 @@ mod tests {
         assert!(
             matches!(error, PhotonApiError::UnexpectedError(_)),
             "expected the on-miss fetch to be attempted, got {error:?}"
+        );
+    }
+
+    /// The regression this pairs with: the refresher fetches whenever the tree
+    /// moves, so if its fetches stamped the on-miss floor, every append would
+    /// hold that window shut and the fallback would never fire. A miss right
+    /// after a refresher pass -- a root indexed between the pass and the request
+    /// -- then failed as StaleRoot instead of being fetched, which is a hard
+    /// error on a chain that is merely busy.
+    ///
+    /// Driven through `store`, so it is the code both fetch paths share that is
+    /// under test rather than a hand-built cache.
+    #[test]
+    fn the_refreshers_fetches_do_not_close_the_on_miss_window() {
+        let tree = Pubkey::new_from_array([7; 32]);
+        let cache = RootIndexCache::new();
+
+        cache
+            .store(tree, [(12u16, [9u8; 32])], Fetch::Refresher)
+            .expect("store");
+        assert_eq!(cache.lookup(tree, &[9; 32]), Some(12), "roots are cached");
+        assert!(
+            cache.due_for_refresh(tree),
+            "a miss must still be able to reach for the account"
+        );
+
+        cache
+            .store(tree, [(12u16, [9u8; 32])], Fetch::OnMiss)
+            .expect("store");
+        assert!(
+            !cache.due_for_refresh(tree),
+            "and an on-demand fetch still closes it"
         );
     }
 

--- a/services/photon/src/api/service.rs
+++ b/services/photon/src/api/service.rs
@@ -33,7 +33,7 @@ use super::{
 pub struct PhotonApi {
     db_conn: Arc<DatabaseConnection>,
     rpc_client: Arc<RpcClient>,
-    root_index_cache: RootIndexCache,
+    root_index_cache: Arc<RootIndexCache>,
 }
 
 pub struct OpenApiSpec {
@@ -60,8 +60,21 @@ impl PhotonApi {
         Self {
             db_conn,
             rpc_client,
-            root_index_cache: RootIndexCache::new(),
+            root_index_cache: Arc::new(RootIndexCache::new()),
         }
+    }
+
+    /// Start the task that keeps the root-index ring current.
+    ///
+    /// Without it the ring is only refreshed when a request misses, which is
+    /// every transfer, and that fetch is then the largest single cost of a
+    /// transfer. Callers that only serve reads of other methods can skip it; the
+    /// on-miss path still answers correctly, just slowly.
+    pub fn spawn_root_index_refresher(&self) -> tokio::task::JoinHandle<()> {
+        let cache = Arc::clone(&self.root_index_cache);
+        let db = Arc::clone(&self.db_conn);
+        let rpc_client = Arc::clone(&self.rpc_client);
+        tokio::spawn(async move { cache.refresh_loop(db.as_ref(), rpc_client.as_ref()).await })
     }
 
     pub async fn liveness(&self) -> Result<(), PhotonApiError> {

--- a/services/photon/src/main.rs
+++ b/services/photon/src/main.rs
@@ -122,6 +122,9 @@ async fn start_api_server(
     max_http_connections: u32,
 ) -> Result<ServerHandle> {
     let api = PhotonApi::new(db, rpc_client);
+    // Before the server accepts anything, so the first proof request finds a
+    // populated ring rather than paying for it.
+    api.spawn_root_index_refresher();
     api::rpc_server::run_server(api, api_port, max_http_connections)
         .await
         .context("Failed to start API server")

--- a/services/photon/src/openapi/specs/rings.yaml
+++ b/services/photon/src/openapi/specs/rings.yaml
@@ -109,6 +109,21 @@ paths:
                         oneOf:
                         - type: 'null'
                         - $ref: '#/components/schemas/Base64String'
+                      scannedThrough:
+                        oneOf:
+                        - type: 'null'
+                        - $ref: '#/components/schemas/Base64String'
+                          description: |-
+                            Where the scan reached, when it ran out of rows rather than filling a
+                            page.
+
+                            Separates the two jobs `next_cursor` used to do at once. A cursor on
+                            every non-empty page made "is there more?" cost an extra request, and
+                            dropping it there instead would leave a caller with no watermark to
+                            resume from -- so the watermark moved here, and `next_cursor` now means
+                            only that another page exists. Present only on a page the limit did not
+                            truncate, which is when "nothing further exists at or before this
+                            position" holds.
                     additionalProperties: false
         '429':
           description: Exceeded rate limit.
@@ -864,6 +879,21 @@ paths:
                         oneOf:
                         - type: 'null'
                         - $ref: '#/components/schemas/Base64String'
+                      scannedThrough:
+                        oneOf:
+                        - type: 'null'
+                        - $ref: '#/components/schemas/Base64String'
+                          description: |-
+                            Where the scan reached, when it ran out of rows rather than filling a
+                            page.
+
+                            Separates the two jobs `next_cursor` used to do at once. A cursor on
+                            every non-empty page made "is there more?" cost an extra request, and
+                            dropping it there instead would leave a caller with no watermark to
+                            resume from -- so the watermark moved here, and `next_cursor` now means
+                            only that another page exists. Present only on a page the limit did not
+                            truncate, which is when "nothing further exists at or before this
+                            position" holds.
                       transactions:
                         type: array
                         items:

--- a/services/photon/tests/integration_tests/rings_event_parser_tests.rs
+++ b/services/photon/tests/integration_tests/rings_event_parser_tests.rs
@@ -1498,10 +1498,11 @@ async fn assert_rings_api_exposes_output_hashes(
         .await
         .unwrap();
     assert_eq!(shielded.context.block_time, UNSHIELD_SLOT as i64);
-    // A non-empty page carries the position of its last row even when it is
-    // short, so a client can resume from the tip rather than rescan. The stream
-    // ends on the next page, which comes back empty.
-    assert!(shielded.next_cursor.is_some());
+    // A page the limit did not truncate ends the read, so it carries no paging
+    // cursor. The position to resume from comes back as the watermark instead --
+    // that is what keeps a client from rescanning the tip next sync.
+    assert!(shielded.next_cursor.is_none());
+    assert!(shielded.scanned_through.is_some());
     assert!(!shielded.transactions.is_empty());
     let output_slot = shielded
         .transactions
@@ -1564,7 +1565,8 @@ async fn assert_rings_api_exposes_output_hashes(
 
     let encrypted = get_encrypted_utxos_by_tags(db, request).await.unwrap();
     assert_eq!(encrypted.context.block_time, UNSHIELD_SLOT as i64);
-    assert!(encrypted.next_cursor.is_some());
+    assert!(encrypted.next_cursor.is_none());
+    assert!(encrypted.scanned_through.is_some());
     assert!(!encrypted.matches.is_empty());
     let encrypted_match = encrypted
         .matches

--- a/xtask/src/fund.rs
+++ b/xtask/src/fund.rs
@@ -1,0 +1,190 @@
+//! Top up the shielded balances of a directory of load-test wallets.
+//!
+//! The load generator spends shielded value; when a wallet runs out it fails
+//! with `insufficient balance for asset` and the run measures depletion rather
+//! than capacity. One 220-worker run ended with 209 such failures.
+//!
+//! One funder pays for everything. A deposit names its recipient by shielded
+//! address and needs no shared secret — see `DepositParams` — so the funder both
+//! signs and sources every deposit, and the wallets themselves are never
+//! touched. That removes the step this used to need: a SOL transfer to each
+//! wallet so it could afford to deposit to itself.
+//!
+//! It also removes the second wallet format. The load generator reads plain
+//! `solana-keygen` keypairs and derives the shielded keypair from the funding
+//! key, so this reads exactly the same directory rather than a parallel set of
+//! CLI wallet files holding the same secrets.
+
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+    thread,
+    time::Instant,
+};
+
+use anyhow::{bail, Context, Result};
+use solana_keypair::Keypair;
+use solana_signer::Signer;
+use zolana_client::{Rpc, SolanaRpc};
+use zolana_keypair::ShieldedKeypair;
+use zolana_transaction::Address;
+use zolana_wallet::{create_deposit, DepositParams};
+
+use crate::loadtest::load_keypairs;
+
+pub struct Options {
+    pub rpc_url: String,
+    pub tree: String,
+    /// Directory of `solana-keygen` keypairs — the same one `loadtest` takes.
+    pub keypairs: PathBuf,
+    /// Funder: signs and pays for every deposit.
+    pub funder: PathBuf,
+    /// Lamports to deposit into each wallet.
+    pub amount: u64,
+    /// Deposits in flight at once.
+    pub concurrency: usize,
+}
+
+impl Options {
+    pub fn parse(args: Vec<String>) -> Result<Self> {
+        let mut rpc_url = None;
+        let mut tree = None;
+        let mut keypairs = None;
+        let mut funder = None;
+        let mut amount = 60_000_000u64;
+        let mut concurrency = 16usize;
+
+        let mut iter = args.into_iter();
+        while let Some(arg) = iter.next() {
+            let mut value = || iter.next().context("missing value");
+            match arg.as_str() {
+                "--rpc" => rpc_url = Some(value()?),
+                "--tree" => tree = Some(value()?),
+                "--keypairs" => keypairs = Some(PathBuf::from(value()?)),
+                "--funder" => funder = Some(PathBuf::from(value()?)),
+                "--amount" => amount = value()?.parse().context("--amount")?,
+                "--concurrency" => concurrency = value()?.parse().context("--concurrency")?,
+                other => bail!("unknown flag {other}"),
+            }
+        }
+
+        Ok(Self {
+            rpc_url: rpc_url.context("--rpc is required")?,
+            tree: tree.context("--tree is required")?,
+            keypairs: keypairs.context("--keypairs <dir> is required")?,
+            funder: funder.context("--funder <keypair.json> is required")?,
+            amount,
+            concurrency: concurrency.max(1),
+        })
+    }
+}
+
+fn read_keypair(path: &PathBuf) -> Result<Keypair> {
+    let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+    let raw: Vec<u8> = serde_json::from_slice(&bytes)
+        .with_context(|| format!("{} is not a keypair array", path.display()))?;
+    let array: [u8; 64] = raw
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("{} is not 64 bytes", path.display()))?;
+    Keypair::try_from(&array[..]).context("bad funder keypair")
+}
+
+pub fn run(options: Options) -> Result<()> {
+    let funder = read_keypair(&options.funder)?;
+    let wallets = load_keypairs(&options.keypairs)?;
+    let tree: Address = options.tree.parse().context("--tree is not an address")?;
+    let asset = Address::default();
+
+    let rpc = SolanaRpc::new(options.rpc_url.clone());
+    let funder_address = Address::new_from_array(funder.pubkey().to_bytes());
+    let balance = rpc.get_balance(funder_address)?;
+    let required = options.amount.saturating_mul(wallets.len() as u64);
+    println!(
+        "funding {} wallets with {} lamports each ({:.3} SOL total)\nfunder {} holds {:.3} SOL",
+        wallets.len(),
+        options.amount,
+        required as f64 / 1e9,
+        funder.pubkey(),
+        balance as f64 / 1e9,
+    );
+    if balance < required {
+        bail!(
+            "funder holds {:.3} SOL but {:.3} SOL is needed; airdrop first or lower --amount",
+            balance as f64 / 1e9,
+            required as f64 / 1e9,
+        );
+    }
+
+    let next = AtomicUsize::new(0);
+    let funded = AtomicU64::new(0);
+    let failed = AtomicU64::new(0);
+    let started = Instant::now();
+
+    thread::scope(|scope| {
+        for _ in 0..options.concurrency.min(wallets.len()) {
+            scope.spawn(|| {
+                // Each worker holds its own RPC client; they are cheap and not
+                // shared state.
+                let rpc = SolanaRpc::new(options.rpc_url.clone());
+                loop {
+                    let index = next.fetch_add(1, Ordering::Relaxed);
+                    let Some(wallet) = wallets.get(index) else {
+                        return;
+                    };
+                    match fund_one(&rpc, &funder, wallet, tree, asset, options.amount) {
+                        Ok(()) => {
+                            let done = funded.fetch_add(1, Ordering::Relaxed) + 1;
+                            if done.is_multiple_of(25) {
+                                println!(
+                                    "  {done} funded ({:.0}s)",
+                                    started.elapsed().as_secs_f64()
+                                );
+                            }
+                        }
+                        Err(error) => {
+                            failed.fetch_add(1, Ordering::Relaxed);
+                            eprintln!("  wallet {index} failed: {error:#}");
+                        }
+                    }
+                }
+            });
+        }
+    });
+
+    let funded = funded.into_inner();
+    let failed = failed.into_inner();
+    println!(
+        "\nfunded {funded}, failed {failed}, in {:.0}s",
+        started.elapsed().as_secs_f64()
+    );
+    if funded == 0 {
+        bail!("no wallet was funded");
+    }
+    Ok(())
+}
+
+/// Deposit into one wallet's shielded address, paid for by the funder.
+fn fund_one(
+    rpc: &SolanaRpc,
+    funder: &Keypair,
+    wallet: &Keypair,
+    tree: Address,
+    asset: Address,
+    amount: u64,
+) -> Result<()> {
+    let shielded = ShieldedKeypair::from_solana_keypair(wallet)?;
+    let recipient = shielded.shielded_address()?;
+    let built = create_deposit(DepositParams {
+        recipient: &recipient,
+        asset,
+        amount,
+        spl_token_account: None,
+        spl_token_program: None,
+        memo: None,
+    })?;
+    // Funder is both payer and depositor: the deposited SOL comes from it, so
+    // the recipient needs no balance of its own.
+    let tree = solana_pubkey::Pubkey::new_from_array(tree.to_bytes());
+    built.send(rpc, funder, tree, funder)?;
+    Ok(())
+}

--- a/xtask/src/fund.rs
+++ b/xtask/src/fund.rs
@@ -172,7 +172,7 @@ fn fund_one(
     asset: Address,
     amount: u64,
 ) -> Result<()> {
-    let shielded = ShieldedKeypair::from_solana_keypair(wallet)?;
+    let shielded = ShieldedKeypair::from_keypair(wallet)?;
     let recipient = shielded.shielded_address()?;
     let built = create_deposit(DepositParams {
         recipient: &recipient,

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -31,7 +31,7 @@ use solana_keypair::Keypair;
 use solana_signer::Signer;
 // `Rpc` is in scope for send_transaction, which is a trait method rather than
 // an inherent one on SolanaRpc.
-use zolana_client::{Rpc, SolanaRpc, ZolanaClient};
+use zolana_client::{SolanaRpc, ZolanaClient};
 use zolana_keypair::ShieldedKeypair;
 use zolana_transaction::{Address, AssetRegistry, LocalWalletAuthority, Wallet};
 use zolana_wallet::{
@@ -496,7 +496,7 @@ fn worker(
         timing.prove_ms = mark.elapsed().as_millis() as u64;
 
         let mark = Instant::now();
-        let signature = match client.rpc().send_transaction(&transfer) {
+        let signature = match client.submit_private_transaction_sync(&transfer) {
             Ok(signature) => signature,
             Err(error) => {
                 classify(&error.to_string(), stats, &mut backoff);

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -6,7 +6,10 @@
 //! rather than the protocol doing work. This drives the SDK in-process, holds a
 //! wallet across iterations, and records where the time actually goes.
 //!
-//! The phase breakdown is the point. "Transfers per second" alone cannot tell you
+//! The phase breakdown is the point. This crate times the outer phases itself;
+//! `ZOLANA_TIMING=1` adds the client's finer ones (HTTP versus indexer polling,
+//! each proof fetch) to stderr, which is how a phase gets attributed to a
+//! specific call rather than to "the indexer". "Transfers per second" alone cannot tell you
 //! whether you are bound by proving, by the indexer, or by your own client, and
 //! those have completely different fixes.
 //!

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -83,6 +83,10 @@ pub struct Options {
     pub asset: String,
     /// Where to write the machine-readable summary, if anywhere.
     pub json_out: Option<PathBuf>,
+    /// Concurrent senders. Fewer than the keypair count measures what one user
+    /// waits for, without the generator contending with itself; the remaining
+    /// wallets stay recipients.
+    pub workers: Option<usize>,
 }
 
 impl Options {
@@ -93,6 +97,7 @@ impl Options {
         let mut tree = None;
         let mut keypairs = None;
         let mut json_out = None;
+        let mut workers: Option<usize> = None;
         let mut duration = 300u64;
         let mut amount = 200_000u64;
         let mut asset = "SOL".to_string();
@@ -110,6 +115,7 @@ impl Options {
                 "--amount" => amount = value()?.parse().context("--amount")?,
                 "--asset" => asset = value()?,
                 "--json" => json_out = Some(PathBuf::from(value()?)),
+                "--workers" => workers = Some(value()?.parse().context("--workers")?),
                 other => bail!("unknown flag {other}"),
             }
         }
@@ -121,6 +127,7 @@ impl Options {
             tree: tree.context("--tree is required")?,
             keypairs: keypairs.context("--keypairs <dir> is required")?,
             json_out,
+            workers,
             duration: Duration::from_secs(duration),
             amount,
             asset,
@@ -256,6 +263,16 @@ fn write_json(
 
 pub fn run(options: Options) -> Result<()> {
     let keypairs = load_keypairs(&options.keypairs)?;
+    // Every wallet is a possible recipient; only the first `workers` send. One
+    // sender measures what a single user waits for, which is a different
+    // question from how much the fleet sustains.
+    let senders = options
+        .workers
+        .unwrap_or(keypairs.len())
+        .min(keypairs.len());
+    if senders == 0 {
+        bail!("--workers must be at least 1");
+    }
     let workers = keypairs.len();
     let tree = Address::new_from_array(
         bs58::decode(&options.tree)
@@ -321,7 +338,7 @@ pub fn run(options: Options) -> Result<()> {
             });
         }
 
-        for (index, funding) in keypairs.iter().enumerate() {
+        for (index, funding) in keypairs.iter().enumerate().take(senders) {
             let peer = recipients[(index + 1) % workers];
             let options = &options;
             let stats = Arc::clone(&stats);

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -144,7 +144,7 @@ impl Options {
 /// the shielded keypair is derived from the funding key, so the funding key is
 /// the only secret needed and there is no reason to reimplement the CLI's file
 /// parsing here.
-fn load_keypairs(dir: &Path) -> Result<Vec<Keypair>> {
+pub(crate) fn load_keypairs(dir: &Path) -> Result<Vec<Keypair>> {
     let mut paths: Vec<PathBuf> = fs::read_dir(dir)
         .with_context(|| format!("read {}", dir.display()))?
         .filter_map(|entry| entry.ok().map(|e| e.path()))

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -31,7 +31,7 @@ use solana_keypair::Keypair;
 use solana_signer::Signer;
 // `Rpc` is in scope for send_transaction, which is a trait method rather than
 // an inherent one on SolanaRpc.
-use zolana_client::{SolanaRpc, ZolanaClient};
+use zolana_client::{Rpc, RpcSendTransactionConfig, SolanaRpc, ZolanaClient};
 use zolana_keypair::ShieldedKeypair;
 use zolana_transaction::{Address, AssetRegistry, LocalWalletAuthority, Wallet};
 use zolana_wallet::{
@@ -513,7 +513,13 @@ fn worker(
         timing.prove_ms = mark.elapsed().as_millis() as u64;
 
         let mark = Instant::now();
-        let signature = match client.submit_private_transaction_sync(&transfer) {
+        let signature = match client.rpc().send_transaction_with_config(
+            &transfer,
+            RpcSendTransactionConfig {
+                skip_preflight: true,
+                ..RpcSendTransactionConfig::default()
+            },
+        ) {
             Ok(signature) => signature,
             Err(error) => {
                 classify(&error.to_string(), stats, &mut backoff);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 
 mod create_release;
 mod find_smart_accounts;
+mod fund;
 mod init_protocol;
 mod loadtest;
 mod update_protocol_config;
@@ -60,6 +61,16 @@ fn main() {
             };
             if let Err(error) = loadtest::run(options) {
                 eprintln!("loadtest failed: {error:?}");
+                std::process::exit(1);
+            }
+        }
+        Some("fund") => {
+            let options = match fund::Options::parse(args.collect()) {
+                Ok(options) => options,
+                Err(error) => usage_and_exit(&format!("fund: {error:#}")),
+            };
+            if let Err(error) = fund::run(options) {
+                eprintln!("fund failed: {error:?}");
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
Stacked on #243.

`next_cursor` answered two questions with one field, and on a last page they want opposite answers.

- As **"where did I get to"** it must be present — or the caller has no watermark and rescans its whole history every sync. That's what `a_short_page_still_reports_its_last_row` was added to prevent.
- As **"is there another page"** it must be absent — or the caller spends an entire request being told there is nothing.

It was resolved in favour of the watermark, so every sync paid an extra round trip. Measured on devnet with an instrumented client: **40 of 40 transfers made a second request**, worth **170ms of a 339ms fetch**, on both the tag and proofless streams.

## The split

`scanned_through` already existed for the nullifier stream (whose pages are usually empty, so they carry no last row). It now covers the tag and proofless streams too and carries the watermark. `next_cursor` means only that another page exists, which the endpoints establish by fetching **one row past the limit and returning it to nobody**.

**The client needed no change.** `advance` already preferred `scanned_through` for the watermark and already used `next_cursor` to decide whether to loop — the design anticipated this.

The outputs stream needed its own scan position: its cursor carries `output_index`, so the tail of `rings_transactions` doesn't describe where an output scan reached.

## Why it's not the naive version

The obvious fix — drop the cursor on a short page — is the regression the existing test guards, and I wrote it before reading that test. It would have made every wallet whose history fits in one page refetch all of it, every sync. Trading 170ms for that would have been a bad deal.

## Test changes, and one that's a real improvement

Three wallet tests asserted the two-request behaviour and now assert one. Their substantive assertions — that the cursor still advances to the tip, and that a tipped tag is never re-queried — pass unchanged, which is the evidence the watermark survived.

`a_truncated_page_reports_no_scan_position` now inserts a second matching transaction. Both fixture nullifiers belong to one transaction, so a limit of 1 returned a page that filled *exactly* and was never truncated — the old rule couldn't tell that from a real truncation and assumed the worse of the two. Over-fetching distinguishes them, so the watermark is now reported in a case where it was previously withheld.

## Measurements

Locally **492ms p50, unchanged** from 489ms — as expected, since this removes a round trip and local RTT is ~0. The tail did improve: p99 1290ms → 590ms.

The devnet effect follows from RTT and is not yet measured on the deployed stack; the image is built (`cursorsplit-91c4a710d387`) if you want it deployed.

## Verification

`just check-all`, `just clippy`, `cargo fmt --check`, `cargo machete --skip-target-dir` clean. 88 photon, 112 wallet, 263 TS (`npm run check`: format, lint, typecheck, tests, build). openapi regenerated.
