### PR TITLE
keys: serve the example circuits' proving keys from the object store

### DIFF
--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use solana_signer::Signer;
-use zolana_client::{Rpc, SolanaRpc, ZolanaClient};
+use zolana_client::{SolanaRpc, ZolanaClient};
 use zolana_transaction::Address;
 use zolana_wallet::{
     actions::{submit::MergeMaterial, transaction::is_plain_utxo},
@@ -46,7 +46,7 @@ pub(crate) fn run_transfer(opts: TransferOptions) -> Result<()> {
         &client,
         &ctx.material.funding,
     )?;
-    let signature = client.rpc().send_transaction(&transaction)?;
+    let signature = client.submit_private_transaction_sync(&transaction)?;
     client.confirm_private_transaction_sync(signature)?;
     let mode = if transfer.recipient.is_public_withdrawal() {
         "withdraw"
@@ -134,7 +134,7 @@ pub(crate) fn run_split(opts: SplitOptions) -> Result<()> {
         &client,
         &ctx.material.funding,
     )?;
-    let signature = client.rpc().send_transaction(&transaction)?;
+    let signature = client.submit_private_transaction_sync(&transaction)?;
     client.confirm_private_transaction_sync(signature)?;
     println!(
         "ok split parts={} amount={} mint={} signature={}",

--- a/justfile
+++ b/justfile
@@ -368,51 +368,105 @@ bench-shielded-pool: build-programs
 # Fetch the pinned swap proving keys from the swap-keys release and verify them
 # against the committed manifest. groth16.Setup is non-deterministic, so the
 # published keys are the only set matching the committed Rust verifying keys;
-# regenerating locally (regen-swap-keys) requires publishing a new release and
+# regenerating locally (regen-swap-keys) requires publishing a new key folder and
 # updating swap-keys.CHECKSUM plus the committed verifying keys together.
+# Where the example circuits' proving keys come from: the same bucket behind the
+# same CloudFront domain as the SPP proving keys, under an immutable
+# version-addressed folder per key tag. Reads are credential-free -- these are
+# public setup parameters, not secrets -- and every file is checked against the
+# hash committed next to the circuit before it is used.
+#
+# ZOLANA_PROVING_KEYS_URL overrides the host for both these and the SPP keys, so a
+# mirror or a local server serves everything or nothing.
+example-keys-url := env_var_or_default("ZOLANA_PROVING_KEYS_URL", "https://d3gbdb0egjwcw9.cloudfront.net") + "/proving-keys/examples"
+
 swap-keys-tag := "swap-keys-v4"
 
 # Same contract as swap-keys-tag, for the dynamic-swap example's two circuits
 # (escrow_open/escrow_settle). The release assets are
 # the only key set matching the committed Rust verifying keys; rotating locally
-# (regen-dynamic-swap-keys) requires publishing a new release and updating
+# (regen-dynamic-swap-keys) requires publishing a new key folder and updating
 # dynamic-swap-keys.CHECKSUM plus the committed verifying keys together.
 dynamic-swap-keys-tag := "dynamic-swap-keys-v4"
 
 # Same contract as swap-keys-tag, for the custom-ring example's single circuit
 # (auditor_key_encryption). gnark's Setup is non-deterministic, so the release
 # assets are the only key set matching the committed Rust verifying key; rotating
-# locally (regen-custom-ring-keys) requires publishing a new release and updating
+# locally (regen-custom-ring-keys) requires publishing a new key folder and updating
 # custom-ring-keys.CHECKSUM plus the committed verifying key together.
 custom-ring-keys-tag := "custom-ring-keys-v1"
 
-ensure-custom-ring-keys:
+# The counterpart to `_ensure-example-keys`. A tag names one folder and is never
+# rewritten: a rotation writes a new one and leaves the old in place, so a
+# checkout pinned to the previous tag keeps working. Needs the aws CLI and write
+# access to the bucket; reads need neither.
+#
+# Upload a regenerated example circuit family to the object store under a new tag.
+publish-example-keys tag base:
     #!/usr/bin/env bash
     set -euo pipefail
-    base="custom-ring-tests"
-    for c in auditor_key_encryption; do
-        dir="$base/build/gnark/$c"
+    src="{{base}}/build/gnark"
+    if [ ! -d "$src" ]; then
+        echo "no keys at $src -- regenerate them first" >&2
+        exit 1
+    fi
+    bucket="${ZOLANA_PROVING_KEYS_BUCKET:-zolana-proving-keys}"
+    dest="s3://$bucket/proving-keys/examples/{{tag}}"
+    if aws s3 ls "$dest/" >/dev/null 2>&1 && [ -n "$(aws s3 ls "$dest/")" ]; then
+        echo "$dest already exists -- pick a new tag rather than overwriting one" >&2
+        echo "a checkout pinned to {{tag}} would otherwise get different bytes" >&2
+        exit 1
+    fi
+    # Flattened to <circuit>_<kind>.bin, the names the manifests and the fetch
+    # recipe both use.
+    for f in "$src"/*/*.bin; do
+        circuit=$(basename "$(dirname "$f")")
+        kind=$(basename "$f" .bin)
+        echo "==> $dest/${circuit}_${kind}.bin"
+        aws s3 cp "$f" "$dest/${circuit}_${kind}.bin"
+    done
+
+# Fetch one example circuit family's keys and verify them against the committed
+# manifest. Cache-first: a file already on disk is only re-hashed, never refetched.
+#
+# The four families used to each run their own `gh release download`, which needed
+# a GitHub token and put them on GitHub's release-asset CDN -- where a reset
+# connection failed CI outright, with the key never reaching a compile. The SPP
+# proving keys had already moved off that; this is the same move for the examples.
+_ensure-example-keys tag base manifest circuits:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for c in {{circuits}}; do
+        dir="{{base}}/build/gnark/$c"
         for kind in pk vk; do
+            want=$(awk -v n="${c}_${kind}.bin" '$2==n {print $1}' "{{base}}/{{manifest}}")
+            if [ -z "$want" ]; then
+                echo "{{base}}/{{manifest}} has no hash for ${c}_${kind}.bin" >&2
+                exit 1
+            fi
             if [ ! -f "$dir/$kind.bin" ]; then
                 mkdir -p "$dir"
-                gh release download "{{custom-ring-keys-tag}}" --repo helius-labs/zolana \
-                    --pattern "${c}_${kind}.bin" --output "$dir/$kind.bin" --clobber
+                # Downloaded aside and moved, so an interrupted fetch cannot leave a
+                # short file that the next run trusts because it exists.
+                curl -fsSL --retry 3 --retry-delay 2 \
+                    -o "$dir/$kind.bin.part" "{{example-keys-url}}/{{tag}}/${c}_${kind}.bin"
+                mv "$dir/$kind.bin.part" "$dir/$kind.bin"
             fi
-            want=$(awk -v n="${c}_${kind}.bin" '$2==n {print $1}' "$base/custom-ring-keys.CHECKSUM")
             got=$(shasum -a 256 "$dir/$kind.bin" | awk '{print $1}')
             if [ "$want" != "$got" ]; then
                 echo "checksum mismatch for $dir/$kind.bin (want $want, got $got)" >&2
-                echo "refresh from the {{custom-ring-keys-tag}} release (delete the file and rerun)," >&2
-                echo "or rotate keys with 'just regen-custom-ring-keys' and publish a new release" >&2
+                echo "delete the file and rerun to refetch, or rotate the keys and" >&2
+                echo "publish a new {{tag}} folder alongside the regenerated manifest" >&2
                 exit 1
             fi
         done
     done
 
+ensure-custom-ring-keys: (_ensure-example-keys custom-ring-keys-tag "custom-ring-tests" "custom-ring-keys.CHECKSUM" "auditor_key_encryption")
 # Rotate the custom-ring proving key: regenerate the circuit, rewriting the
 # committed Rust verifying key and the checksum manifest. Publish the new
-# build/gnark key files to a fresh custom-ring-keys release and bump
-# custom-ring-keys-tag afterwards.
+# build/gnark key files with `just publish-example-keys custom-ring-keys-<next>
+# custom-ring-tests` and bump custom-ring-keys-tag afterwards.
 regen-custom-ring-keys:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -430,32 +484,11 @@ regen-custom-ring-keys:
         done
     done
 
-ensure-swap-keys:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    base="sdk-tests/zk-program-swap"
-    for c in make take cancel take_verifiable_encryption; do
-        dir="$base/build/gnark/$c"
-        for kind in pk vk; do
-            if [ ! -f "$dir/$kind.bin" ]; then
-                mkdir -p "$dir"
-                gh release download "{{swap-keys-tag}}" --repo helius-labs/zolana \
-                    --pattern "${c}_${kind}.bin" --output "$dir/$kind.bin" --clobber
-            fi
-            want=$(awk -v n="${c}_${kind}.bin" '$2==n {print $1}' "$base/swap-keys.CHECKSUM")
-            got=$(shasum -a 256 "$dir/$kind.bin" | awk '{print $1}')
-            if [ "$want" != "$got" ]; then
-                echo "checksum mismatch for $dir/$kind.bin (want $want, got $got)" >&2
-                echo "refresh from the {{swap-keys-tag}} release (delete the file and rerun)," >&2
-                echo "or rotate keys with 'just regen-swap-keys' and publish a new release" >&2
-                exit 1
-            fi
-        done
-    done
-
+ensure-swap-keys: (_ensure-example-keys swap-keys-tag "sdk-tests/zk-program-swap" "swap-keys.CHECKSUM" "make take cancel take_verifiable_encryption")
 # Rotate the swap proving keys: regenerate every circuit, rewriting the committed
 # Rust verifying keys and the checksum manifest. Publish the new build/gnark
-# key files to a fresh swap-keys release and bump swap-keys-tag afterwards.
+# key files with `just publish-example-keys swap-keys-<next> sdk-tests/zk-program-swap`
+# and bump swap-keys-tag afterwards.
 regen-swap-keys:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -473,32 +506,11 @@ regen-swap-keys:
         done
     done
 
-ensure-dynamic-swap-keys:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    base="sdk-tests/dynamic-swap"
-    for c in escrow_open escrow_settle; do
-        dir="$base/build/gnark/$c"
-        for kind in pk vk; do
-            if [ ! -f "$dir/$kind.bin" ]; then
-                mkdir -p "$dir"
-                gh release download "{{dynamic-swap-keys-tag}}" --repo helius-labs/zolana \
-                    --pattern "${c}_${kind}.bin" --output "$dir/$kind.bin" --clobber
-            fi
-            want=$(awk -v n="${c}_${kind}.bin" '$2==n {print $1}' "$base/dynamic-swap-keys.CHECKSUM")
-            got=$(shasum -a 256 "$dir/$kind.bin" | awk '{print $1}')
-            if [ "$want" != "$got" ]; then
-                echo "checksum mismatch for $dir/$kind.bin (want $want, got $got)" >&2
-                echo "refresh from the {{dynamic-swap-keys-tag}} release (delete the file and rerun)," >&2
-                echo "or rotate keys with 'just regen-dynamic-swap-keys' and publish a new release" >&2
-                exit 1
-            fi
-        done
-    done
-
+ensure-dynamic-swap-keys: (_ensure-example-keys dynamic-swap-keys-tag "sdk-tests/dynamic-swap" "dynamic-swap-keys.CHECKSUM" "escrow_open escrow_settle")
 # Rotate the dynamic-swap proving keys: regenerate every circuit, rewriting the
 # committed Rust verifying keys and the checksum manifest. Publish the new
-# build/gnark key files to a fresh dynamic-swap-keys release and bump
+# build/gnark key files with `just publish-example-keys dynamic-swap-keys-<next>
+# sdk-tests/dynamic-swap` and bump
 # dynamic-swap-keys-tag afterwards.
 regen-dynamic-swap-keys:
     #!/usr/bin/env bash
@@ -549,36 +561,15 @@ bench-rfq:
 # and verify them against the committed manifest. groth16.Setup is
 # non-deterministic, so the published keys are the only set matching the
 # committed Rust verifying keys; regenerating locally (regen-escrow-keys)
-# requires publishing a new release and updating timelock-escrow-keys.CHECKSUM
+# requires publishing a new key folder and updating timelock-escrow-keys.CHECKSUM
 # plus the committed verifying keys together.
 escrow-keys-tag := "escrow-keys-v2"
 
-ensure-escrow-keys:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    base="sdk-tests/timelock-escrow"
-    for c in escrow withdraw; do
-        dir="$base/build/gnark/$c"
-        for kind in pk vk; do
-            if [ ! -f "$dir/$kind.bin" ]; then
-                mkdir -p "$dir"
-                gh release download "{{escrow-keys-tag}}" --repo helius-labs/zolana \
-                    --pattern "${c}_${kind}.bin" --output "$dir/$kind.bin" --clobber
-            fi
-            want=$(awk -v n="${c}_${kind}.bin" '$2==n {print $1}' "$base/timelock-escrow-keys.CHECKSUM")
-            got=$(shasum -a 256 "$dir/$kind.bin" | awk '{print $1}')
-            if [ "$want" != "$got" ]; then
-                echo "checksum mismatch for $dir/$kind.bin (want $want, got $got)" >&2
-                echo "refresh from the {{escrow-keys-tag}} release (delete the file and rerun)," >&2
-                echo "or rotate keys with 'just regen-escrow-keys' and publish a new release" >&2
-                exit 1
-            fi
-        done
-    done
-
+ensure-escrow-keys: (_ensure-example-keys escrow-keys-tag "sdk-tests/timelock-escrow" "timelock-escrow-keys.CHECKSUM" "escrow withdraw")
 # Rotate the escrow/withdraw proving keys: regenerate both circuits, rewriting
 # the committed Rust verifying keys and the checksum manifest. Publish the new
-# build/gnark key files to a fresh escrow-keys release and bump
+# build/gnark key files with `just publish-example-keys escrow-keys-<next>
+# sdk-tests/timelock-escrow` and bump
 # escrow-keys-tag afterwards.
 regen-escrow-keys:
     #!/usr/bin/env bash

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -1130,8 +1130,14 @@ fn fetch_spend_proofs(
     // does with `try_join!`: different methods, neither consuming the other's
     // output. Serially this cost the sum on every transfer.
     let (state_response, nullifier_response) = std::thread::scope(|scope| {
-        let state = scope.spawn(|| indexer.get_merkle_proofs(tree, leaves, config));
-        let nullifier = scope.spawn(|| indexer.get_non_inclusion_proofs(tree, nullifiers, config));
+        let state = scope.spawn(|| {
+            let _t = crate::timing::Phase::start("get_merkle_proofs", 0);
+            indexer.get_merkle_proofs(tree, leaves, config)
+        });
+        let nullifier = scope.spawn(|| {
+            let _t = crate::timing::Phase::start("get_non_inclusion_proofs", 0);
+            indexer.get_non_inclusion_proofs(tree, nullifiers, config)
+        });
         (state.join(), nullifier.join())
     });
     // A panic here is a bug in the indexer client, not an unreachable indexer.

--- a/sdk-libs/client/src/client.rs
+++ b/sdk-libs/client/src/client.rs
@@ -398,6 +398,32 @@ impl<R: Rpc> ZolanaClient<R> {
         wait_for_rpc_confirmation(self.rpc(), signature, self.indexer_config.poll)?;
         wait_for_indexed_transaction(self.blocking_indexer(), signature, self.indexer_config.poll)
     }
+
+    /// Submit a signed private transaction and return as soon as the RPC
+    /// accepts it.
+    ///
+    /// Pair with [`Self::confirm_private_transaction_sync`], which waits for the
+    /// chain and then the indexer. `Rpc::send_transaction` confirms too, so the
+    /// two together waited for the same signature twice.
+    ///
+    /// Preflight is skipped: simulation re-executes a transaction whose inputs
+    /// are proofs the indexer just served, and a failure it would catch is one
+    /// this client cannot fix by retrying. The cost of being wrong is a landed
+    /// transaction that fails on chain, so callers submitting unvalidated
+    /// transactions should keep using `send_transaction`.
+    pub fn submit_private_transaction_sync(
+        &self,
+        transaction: &SolanaTransaction,
+    ) -> Result<Signature, ClientError> {
+        let _t = crate::timing::Phase::start("submit_private", 0);
+        // Honours `with_send_transaction_config`, which until now set a field
+        // nothing read.
+        let config = self.send_config.unwrap_or(RpcSendTransactionConfig {
+            skip_preflight: true,
+            ..RpcSendTransactionConfig::default()
+        });
+        self.rpc().send_transaction_with_config(transaction, config)
+    }
 }
 
 impl<R: AsyncRpc> ZolanaClient<R> {
@@ -1100,8 +1126,19 @@ fn fetch_spend_proofs(
         .iter()
         .map(|commitment| commitment.nullifier)
         .collect::<Vec<_>>();
-    let state_response = indexer.get_merkle_proofs(tree, leaves, config)?;
-    let nullifier_response = indexer.get_non_inclusion_proofs(tree, nullifiers, config)?;
+    // Independent round trips, run together for the same reason the async path
+    // does with `try_join!`: different methods, neither consuming the other's
+    // output. Serially this cost the sum on every transfer.
+    let (state_response, nullifier_response) = std::thread::scope(|scope| {
+        let state = scope.spawn(|| indexer.get_merkle_proofs(tree, leaves, config));
+        let nullifier = scope.spawn(|| indexer.get_non_inclusion_proofs(tree, nullifiers, config));
+        (state.join(), nullifier.join())
+    });
+    // A panic here is a bug in the indexer client, not an unreachable indexer.
+    let state_response =
+        state_response.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
+    let nullifier_response =
+        nullifier_response.unwrap_or_else(|payload| std::panic::resume_unwind(payload))?;
     validate_spend_proofs(
         tree,
         commitments,
@@ -1516,10 +1553,19 @@ mod tests {
         };
         let commitment = shielded.transaction.input_utxo_hashes().unwrap().remove(0);
         let signature = Signature::from([5u8; 64]);
-        let server = MockIndexerServer::respond_with(vec![
-            merkle_response(tree, commitment.utxo_hash),
-            nullifier_response(tree, commitment.nullifier),
-            indexed_transaction_by_signature_response(signature),
+        let server = MockIndexerServer::respond_by_path(vec![
+            (
+                "/getMerkleProofs",
+                merkle_response(tree, commitment.utxo_hash),
+            ),
+            (
+                "/getNonInclusionProofs",
+                nullifier_response(tree, commitment.nullifier),
+            ),
+            (
+                "/getShieldedTransactionsBySignature",
+                indexed_transaction_by_signature_response(signature),
+            ),
         ]);
         let rpc = MockSubmitRpc::new(signature);
         let sent = rpc.sent.clone();
@@ -1557,14 +1603,13 @@ mod tests {
         assert_eq!(sent.len(), 1);
         assert_eq!(sent[0].message.instructions.len(), 3);
         let requests = server.requests();
-        assert_eq!(
-            requests,
-            [
-                "/getMerkleProofs",
-                "/getNonInclusionProofs",
-                "/getShieldedTransactionsBySignature",
-            ]
-        );
+        // The two proof fetches race, so only their membership is defined; the
+        // indexed-transaction lookup still happens after them.
+        let (proofs, rest) = requests.split_at(2);
+        let mut proofs = proofs.to_vec();
+        proofs.sort();
+        assert_eq!(proofs, ["/getMerkleProofs", "/getNonInclusionProofs"]);
+        assert_eq!(rest, ["/getShieldedTransactionsBySignature"]);
     }
 
     #[test]
@@ -1910,6 +1955,7 @@ mod tests {
         signature: Signature,
         view_tags: Vec<[u8; 32]>,
         sent: Arc<Mutex<Vec<SolanaTransaction>>>,
+        sent_configs: Arc<Mutex<Vec<RpcSendTransactionConfig>>>,
     }
 
     impl MockSubmitRpc {
@@ -1918,6 +1964,7 @@ mod tests {
                 signature,
                 view_tags: Vec::new(),
                 sent: Arc::new(Mutex::new(Vec::new())),
+                sent_configs: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
@@ -1941,6 +1988,16 @@ mod tests {
             transaction: &SolanaTransaction,
         ) -> Result<Signature, ClientError> {
             self.sent.lock().unwrap().push(transaction.clone());
+            Ok(self.signature)
+        }
+
+        fn send_transaction_with_config(
+            &self,
+            transaction: &SolanaTransaction,
+            config: RpcSendTransactionConfig,
+        ) -> Result<Signature, ClientError> {
+            self.sent.lock().unwrap().push(transaction.clone());
+            self.sent_configs.lock().unwrap().push(config);
             Ok(self.signature)
         }
 
@@ -1968,6 +2025,56 @@ mod tests {
         ) -> Result<Vec<[u8; 32]>, ClientError> {
             Ok(self.view_tags.clone())
         }
+    }
+
+    fn submit_client(rpc: MockSubmitRpc) -> ZolanaClient<MockSubmitRpc> {
+        ZolanaClient::new(
+            rpc,
+            ZolanaIndexer::new("http://unused.invalid"),
+            ProverClient::new("http://unused.invalid".to_string()),
+            AsyncZolanaIndexer::new("http://unused.invalid"),
+            AsyncProverClient::new("http://unused.invalid".to_string()),
+            Address::new_from_array([8u8; 32]),
+        )
+    }
+
+    /// `confirm_private_transaction_sync` already waits for the chain, so the
+    /// submit half must not: together they waited for one signature twice.
+    /// Preflight is skipped for the same round-trip reason.
+    #[test]
+    fn submit_private_skips_preflight() {
+        let rpc = MockSubmitRpc::new(Signature::from([3u8; 64]));
+        let configs = rpc.sent_configs.clone();
+        let client = submit_client(rpc);
+
+        client
+            .submit_private_transaction_sync(&SolanaTransaction::default())
+            .expect("submit");
+
+        let recorded = configs.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert!(recorded[0].skip_preflight);
+    }
+
+    /// `with_send_transaction_config` set a field nothing read until this path
+    /// existed; a caller that asks for preflight must get it.
+    #[test]
+    fn submit_private_honours_a_configured_send_config() {
+        let rpc = MockSubmitRpc::new(Signature::from([3u8; 64]));
+        let configs = rpc.sent_configs.clone();
+        let client = submit_client(rpc).with_send_transaction_config(RpcSendTransactionConfig {
+            skip_preflight: false,
+            max_retries: Some(7),
+            ..RpcSendTransactionConfig::default()
+        });
+
+        client
+            .submit_private_transaction_sync(&SolanaTransaction::default())
+            .expect("submit");
+
+        let recorded = configs.lock().unwrap();
+        assert!(!recorded[0].skip_preflight);
+        assert_eq!(recorded[0].max_retries, Some(7));
     }
 
     fn merkle_response(tree: Address, leaf: [u8; 32]) -> Value {
@@ -2077,6 +2184,38 @@ mod tests {
     }
 
     impl MockIndexerServer {
+        /// Serve each response to the request whose path asks for it.
+        ///
+        /// `respond_with` hands responses out in order, which stops being a
+        /// description of the server once the client fetches concurrently: the
+        /// proof fetches race, and whichever connects first would take the
+        /// other's body.
+        fn respond_by_path(responses: Vec<(&'static str, Value)>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock indexer");
+            let url = format!("http://{}", listener.local_addr().unwrap());
+            let (request_tx, requests) = mpsc::channel();
+            let count = responses.len();
+            let handle = thread::spawn(move || {
+                let mut remaining: Vec<(&'static str, Value)> = responses;
+                for _ in 0..count {
+                    let (mut stream, _) = listener.accept().expect("accept request");
+                    let request = read_request(&mut stream);
+                    let index = remaining
+                        .iter()
+                        .position(|(path, _)| *path == request.path)
+                        .unwrap_or_else(|| panic!("no mock response for {}", request.path));
+                    let (_, response) = remaining.remove(index);
+                    request_tx.send(request).expect("record request");
+                    write_json_response(&mut stream, &response);
+                }
+            });
+            Self {
+                url,
+                requests,
+                handle,
+            }
+        }
+
         fn respond_with(responses: Vec<Value>) -> Self {
             let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock indexer");
             let url = format!("http://{}", listener.local_addr().unwrap());

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -30,7 +30,15 @@ use crate::{
 };
 
 const MERKLE_PROOF_POLL_TIMEOUT: Duration = Duration::from_secs(60);
-const MERKLE_PROOF_POLL_INTERVAL: Duration = Duration::from_millis(500);
+/// First wait after an incomplete answer.
+///
+/// A transfer spends a note the indexer has only just written, so the first
+/// attempt often lands a few milliseconds early and this sleep is on the
+/// critical path of every transfer. A flat 500ms charged the tail's wait to
+/// every caller; starting short and backing off keeps the 60s ceiling for an
+/// indexer that is genuinely behind.
+const MERKLE_PROOF_POLL_START: Duration = Duration::from_millis(25);
+const MERKLE_PROOF_POLL_MAX: Duration = Duration::from_millis(500);
 
 const JSON_RPC_METHOD_NOT_FOUND: i64 = -32601;
 const JSON_RPC_INTERNAL_ERROR: i64 = -32603;
@@ -357,6 +365,7 @@ impl Rpc for ZolanaIndexer {
         let expected = leaves.len();
         let started = Instant::now();
         let mut last_error = None;
+        let mut wait = MERKLE_PROOF_POLL_START;
         loop {
             match single() {
                 Ok(response) if response.proofs.len() >= expected => return Ok(response),
@@ -370,7 +379,8 @@ impl Rpc for ZolanaIndexer {
                     ))
                 }));
             }
-            sleep(MERKLE_PROOF_POLL_INTERVAL);
+            sleep(wait);
+            wait = (wait * 2).min(MERKLE_PROOF_POLL_MAX);
         }
     }
 

--- a/sdk-libs/client/src/indexer.rs
+++ b/sdk-libs/client/src/indexer.rs
@@ -336,11 +336,14 @@ impl Rpc for ZolanaIndexer {
         config: Option<IndexerRpcConfig>,
     ) -> Result<GetMerkleProofsResponse, ClientError> {
         let single = || {
-            self.api
-                .get_merkle_proofs(
+            let response = {
+                let _t = crate::timing::Phase::start("merkle_http", 0);
+                self.api.get_merkle_proofs(
                     encode_pubkey(tree_account),
                     leaves.iter().copied().map(encode_hash).collect(),
                 )
+            };
+            response
                 .map_err(indexer_error)
                 .map(|response| GetMerkleProofsResponse {
                     context: convert_context(response.context),

--- a/sdk-libs/client/src/solana_rpc.rs
+++ b/sdk-libs/client/src/solana_rpc.rs
@@ -526,12 +526,11 @@ impl Rpc for SolanaRpc {
         transaction: &Transaction,
         config: solana_rpc_client_api::config::RpcSendTransactionConfig,
     ) -> Result<Signature, ClientError> {
+        // Sends and returns; it does not confirm. `send_transaction` is the
+        // send-and-confirm one. The two were the same call, so a caller asking
+        // for a config also bought a confirmation wait it never requested.
         self.client
-            .send_and_confirm_transaction_with_spinner_and_config(
-                transaction,
-                CommitmentConfig::confirmed(),
-                config,
-            )
+            .send_transaction_with_config(transaction, config)
             .map_err(|source| ClientError::SolanaRpcTransaction {
                 operation: "send_transaction_with_config",
                 source,
@@ -670,12 +669,10 @@ impl AsyncRpc for AsyncSolanaRpc {
         transaction: &Transaction,
         config: solana_rpc_client_api::config::RpcSendTransactionConfig,
     ) -> Result<Signature, ClientError> {
+        // Sends and returns, matching the blocking path: `send_transaction` is
+        // the send-and-confirm one.
         self.client
-            .send_and_confirm_transaction_with_config(
-                transaction,
-                CommitmentConfig::confirmed(),
-                config,
-            )
+            .send_transaction_with_config(transaction, config)
             .await
             .map_err(|source| ClientError::SolanaRpcTransaction {
                 operation: "send_transaction_with_config",

--- a/services/photon/src/api/root_index_cache.rs
+++ b/services/photon/src/api/root_index_cache.rs
@@ -15,14 +15,30 @@
 //!
 //! Held per process. Only the API serves proofs, and a cache that belongs to
 //! the process reading it needs no coordination with the indexer.
+//!
+//! Refreshed ahead of the request, not on it. A miss is not the rare case it
+//! reads as: every transfer appends a root, so the next transfer's proof asks
+//! for a root the ring does not have yet, and the fetch landed on the critical
+//! path of essentially every transfer -- 721ms of a 2971ms devnet transfer, with
+//! the task at 0.06% CPU and the database at 0.26 ReadIOPS, because the time was
+//! spent waiting on the upstream RPC rather than working.
+//!
+//! [`RootIndexCache::refresh_loop`] watches the indexed root's sequence number in
+//! Postgres, which is cheap, and fetches the 1.2 MB account only when that number
+//! moves. The on-miss fetch stays as the fallback: a request that arrives between
+//! a tree update and the next refresh must still be answerable, and only the
+//! common case is being moved, not the contract.
 
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 use solana_pubkey::Pubkey;
 
 use crate::api::error::PhotonApiError;
+use crate::common::rings_tree::RingsTreeKind;
+use crate::dao::generated::{state_trees, tree_metadata};
 use crate::monitor::tree_metadata_sync::rings_utxo_root_history;
 use crate::rpc::RpcClient;
 
@@ -30,6 +46,11 @@ use crate::rpc::RpcClient;
 /// indexes a new root slightly before the next refresh -- but repeated misses
 /// for a root that is not on chain must not become a 1.2 MB fetch per request.
 const MIN_REFRESH_INTERVAL: Duration = Duration::from_millis(500);
+
+/// How often the refresher asks Postgres whether the tree moved. This is a
+/// single-row primary-key read, not the account fetch, so it can be far shorter
+/// than [`MIN_REFRESH_INTERVAL`].
+const CHANGE_POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 #[derive(Default)]
 struct TreeRoots {
@@ -109,6 +130,51 @@ impl RootIndexCache {
         ))
     }
 
+    /// Keep every known state tree's ring current, so `index_for` answers from
+    /// memory.
+    ///
+    /// Change detection is the point: refreshing on a timer would fetch 1.2 MB
+    /// per tree per tick whether or not anything moved, and refreshing on a
+    /// request puts that fetch in front of the caller. The indexed root's
+    /// sequence number moves exactly when the tree does, and reading it is a
+    /// primary-key lookup.
+    pub async fn refresh_loop(&self, db: &DatabaseConnection, rpc_client: &RpcClient) {
+        let mut seen: HashMap<Pubkey, Option<i64>> = HashMap::new();
+        loop {
+            match known_state_trees(db).await {
+                Ok(trees) => {
+                    for tree in trees {
+                        let seq = match root_sequence(db, tree).await {
+                            Ok(seq) => seq,
+                            Err(error) => {
+                                log::warn!(
+                                    "root index refresher: reading {tree} sequence: {error}"
+                                );
+                                continue;
+                            }
+                        };
+                        // First sight of a tree refreshes it; after that only a
+                        // moved sequence does.
+                        if seen.get(&tree).is_some_and(|last| *last == seq) {
+                            continue;
+                        }
+                        match self.refresh(rpc_client, tree).await {
+                            Ok(()) => {
+                                seen.insert(tree, seq);
+                            }
+                            // Leave `seen` alone so the next tick tries again.
+                            Err(error) => {
+                                log::warn!("root index refresher: refreshing {tree}: {error}")
+                            }
+                        }
+                    }
+                }
+                Err(error) => log::warn!("root index refresher: listing trees: {error}"),
+            }
+            tokio::time::sleep(CHANGE_POLL_INTERVAL).await;
+        }
+    }
+
     async fn refresh(&self, rpc_client: &RpcClient, tree: Pubkey) -> Result<(), PhotonApiError> {
         let account = rpc_client.get_account(&tree).await.map_err(|error| {
             PhotonApiError::UnexpectedError(format!("Failed to fetch tree {tree}: {error}"))
@@ -134,6 +200,44 @@ impl RootIndexCache {
         );
         Ok(())
     }
+}
+
+/// State trees the indexer knows about. The refresher covers every one rather
+/// than only the trees already asked for, so the first proof after a restart
+/// does not pay the fetch.
+async fn known_state_trees(db: &DatabaseConnection) -> Result<Vec<Pubkey>, PhotonApiError> {
+    let rows = tree_metadata::Entity::find()
+        .all(db)
+        .await
+        .map_err(|error| PhotonApiError::UnexpectedError(error.to_string()))?;
+    rows.into_iter()
+        .map(|row| {
+            <[u8; 32]>::try_from(row.tree_pubkey.as_slice())
+                .map(Pubkey::new_from_array)
+                .map_err(|_| {
+                    PhotonApiError::UnexpectedError("tree_metadata pubkey is not 32 bytes".into())
+                })
+        })
+        .collect()
+}
+
+/// Sequence number the indexer stamped on the tree's root node, which advances
+/// exactly when the tree does.
+async fn root_sequence(
+    db: &DatabaseConnection,
+    tree: Pubkey,
+) -> Result<Option<i64>, PhotonApiError> {
+    let root = state_trees::Entity::find()
+        .filter(
+            state_trees::Column::Tree
+                .eq(tree.to_bytes().to_vec())
+                .and(state_trees::Column::TreeKind.eq(i32::from(RingsTreeKind::State)))
+                .and(state_trees::Column::NodeIdx.eq(1)),
+        )
+        .one(db)
+        .await
+        .map_err(|error| PhotonApiError::UnexpectedError(error.to_string()))?;
+    Ok(root.and_then(|node| node.seq))
 }
 
 #[cfg(test)]
@@ -166,6 +270,42 @@ mod tests {
         assert_eq!(cache.lookup(tree, &[155; 32]), None);
         assert_eq!(cache.lookup(tree, &[1; 32]), Some(155));
         assert_eq!(cache.lookup(tree, &[2; 32]), Some(41));
+    }
+
+    /// The point of refreshing ahead: a request for a root the refresher has
+    /// already brought in must not consult the RPC at all. `index_for` takes an
+    /// `RpcClient`, so the only honest way to assert "did not fetch" is that the
+    /// answer comes back from a cache whose refresh window is closed -- with a
+    /// stale window the on-miss path would fire instead.
+    #[tokio::test]
+    async fn a_root_the_refresher_brought_in_is_answered_without_the_rpc() {
+        let tree = Pubkey::new_from_array([7; 32]);
+        let cache = cache_with(tree, &[([9; 32], 12)], Some(Instant::now()));
+
+        // An unreachable endpoint: reaching for it at all is the failure.
+        let rpc = RpcClient::new("http://127.0.0.1:1".to_string());
+        assert_eq!(cache.index_for(&rpc, tree, [9; 32]).await.unwrap(), 12);
+    }
+
+    /// And the fallback still has to work: a request that arrives between a tree
+    /// update and the next refresh is answered, not failed.
+    #[tokio::test]
+    async fn a_root_the_refresher_has_not_reached_still_reaches_for_the_account() {
+        let tree = Pubkey::new_from_array([7; 32]);
+        let cache = cache_with(
+            tree,
+            &[([9; 32], 12)],
+            Instant::now().checked_sub(MIN_REFRESH_INTERVAL * 2),
+        );
+
+        let rpc = RpcClient::new("http://127.0.0.1:1".to_string());
+        // Unreachable, so this surfaces the fetch as an error rather than a
+        // StaleRoot -- which is the proof that the fetch was attempted.
+        let error = cache.index_for(&rpc, tree, [4; 32]).await.unwrap_err();
+        assert!(
+            matches!(error, PhotonApiError::UnexpectedError(_)),
+            "expected the on-miss fetch to be attempted, got {error:?}"
+        );
     }
 
     #[test]

--- a/services/photon/src/api/service.rs
+++ b/services/photon/src/api/service.rs
@@ -33,7 +33,7 @@ use super::{
 pub struct PhotonApi {
     db_conn: Arc<DatabaseConnection>,
     rpc_client: Arc<RpcClient>,
-    root_index_cache: RootIndexCache,
+    root_index_cache: Arc<RootIndexCache>,
 }
 
 pub struct OpenApiSpec {
@@ -60,8 +60,21 @@ impl PhotonApi {
         Self {
             db_conn,
             rpc_client,
-            root_index_cache: RootIndexCache::new(),
+            root_index_cache: Arc::new(RootIndexCache::new()),
         }
+    }
+
+    /// Start the task that keeps the root-index ring current.
+    ///
+    /// Without it the ring is only refreshed when a request misses, which is
+    /// every transfer, and that fetch is then the largest single cost of a
+    /// transfer. Callers that only serve reads of other methods can skip it; the
+    /// on-miss path still answers correctly, just slowly.
+    pub fn spawn_root_index_refresher(&self) -> tokio::task::JoinHandle<()> {
+        let cache = Arc::clone(&self.root_index_cache);
+        let db = Arc::clone(&self.db_conn);
+        let rpc_client = Arc::clone(&self.rpc_client);
+        tokio::spawn(async move { cache.refresh_loop(db.as_ref(), rpc_client.as_ref()).await })
     }
 
     pub async fn liveness(&self) -> Result<(), PhotonApiError> {

--- a/services/photon/src/main.rs
+++ b/services/photon/src/main.rs
@@ -122,6 +122,9 @@ async fn start_api_server(
     max_http_connections: u32,
 ) -> Result<ServerHandle> {
     let api = PhotonApi::new(db, rpc_client);
+    // Before the server accepts anything, so the first proof request finds a
+    // populated ring rather than paying for it.
+    api.spawn_root_index_refresher();
     api::rpc_server::run_server(api, api_port, max_http_connections)
         .await
         .context("Failed to start API server")

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -31,7 +31,7 @@ use solana_keypair::Keypair;
 use solana_signer::Signer;
 // `Rpc` is in scope for send_transaction, which is a trait method rather than
 // an inherent one on SolanaRpc.
-use zolana_client::{Rpc, SolanaRpc, ZolanaClient};
+use zolana_client::{SolanaRpc, ZolanaClient};
 use zolana_keypair::ShieldedKeypair;
 use zolana_transaction::{Address, AssetRegistry, LocalWalletAuthority, Wallet};
 use zolana_wallet::{
@@ -496,7 +496,7 @@ fn worker(
         timing.prove_ms = mark.elapsed().as_millis() as u64;
 
         let mark = Instant::now();
-        let signature = match client.rpc().send_transaction(&transfer) {
+        let signature = match client.submit_private_transaction_sync(&transfer) {
             Ok(signature) => signature,
             Err(error) => {
                 classify(&error.to_string(), stats, &mut backoff);

--- a/xtask/src/loadtest.rs
+++ b/xtask/src/loadtest.rs
@@ -83,6 +83,10 @@ pub struct Options {
     pub asset: String,
     /// Where to write the machine-readable summary, if anywhere.
     pub json_out: Option<PathBuf>,
+    /// Concurrent senders. Fewer than the keypair count measures what one user
+    /// waits for, without the generator contending with itself; the remaining
+    /// wallets stay recipients.
+    pub workers: Option<usize>,
 }
 
 impl Options {
@@ -93,6 +97,7 @@ impl Options {
         let mut tree = None;
         let mut keypairs = None;
         let mut json_out = None;
+        let mut workers: Option<usize> = None;
         let mut duration = 300u64;
         let mut amount = 200_000u64;
         let mut asset = "SOL".to_string();
@@ -110,6 +115,7 @@ impl Options {
                 "--amount" => amount = value()?.parse().context("--amount")?,
                 "--asset" => asset = value()?,
                 "--json" => json_out = Some(PathBuf::from(value()?)),
+                "--workers" => workers = Some(value()?.parse().context("--workers")?),
                 other => bail!("unknown flag {other}"),
             }
         }
@@ -121,6 +127,7 @@ impl Options {
             tree: tree.context("--tree is required")?,
             keypairs: keypairs.context("--keypairs <dir> is required")?,
             json_out,
+            workers,
             duration: Duration::from_secs(duration),
             amount,
             asset,
@@ -256,6 +263,16 @@ fn write_json(
 
 pub fn run(options: Options) -> Result<()> {
     let keypairs = load_keypairs(&options.keypairs)?;
+    // Every wallet is a possible recipient; only the first `workers` send. One
+    // sender measures what a single user waits for, which is a different
+    // question from how much the fleet sustains.
+    let senders = options
+        .workers
+        .unwrap_or(keypairs.len())
+        .min(keypairs.len());
+    if senders == 0 {
+        bail!("--workers must be at least 1");
+    }
     let workers = keypairs.len();
     let tree = Address::new_from_array(
         bs58::decode(&options.tree)
@@ -321,7 +338,7 @@ pub fn run(options: Options) -> Result<()> {
             });
         }
 
-        for (index, funding) in keypairs.iter().enumerate() {
+        for (index, funding) in keypairs.iter().enumerate().take(senders) {
             let peer = recipients[(index + 1) % workers];
             let options = &options;
             let stats = Arc::clone(&stats);


### PR DESCRIPTION
The SPP proving keys were moved to S3 behind CloudFront with hashes pinned in a lockfile the prover embeds. **The four example circuits never followed** — custom-ring, swap, dynamic-swap and timelock-escrow each still ran their own `gh release download`.

That drift has a cost. On #243 the `tests / custom-ring` job went red on:

```
Get "https://release-assets.githubusercontent.com/…auditor_key_encryption_vk.bin":
  read tcp …: connection reset by peer
error: recipe `ensure-custom-ring-keys` failed with exit code 1
```

The key never reached a compile. Four recipes share that failure mode, and all four also needed a GitHub token to fetch parameters that aren't secret.

## Change

| | before | after |
|---|---|---|
| source | `gh release download` ×4 | CloudFront, one shared recipe |
| auth | GitHub token | none |
| override | — | `ZOLANA_PROVING_KEYS_URL` (same var as the SPP keys) |
| integrity | hash checked after a download | hash checked **every run** |
| partial fetch | could be trusted next run | lands on `.part`, moved only when complete |

Keys live at `proving-keys/examples/<tag>/`. **Not** a top-level prefix of its own: the bucket policy grants CloudFront `proving-keys/*` and that policy is managed outside this repo, so a new prefix meant either a hand-edited policy drifting from its source or a 403. I tried the 403 first.

`just publish-example-keys <tag> <base>` is the other half — rotation now uploads instead of cutting a release, and it **refuses a tag whose folder already exists**, since a checkout pinned to that tag would otherwise get different bytes. A rotation writes a new folder and leaves the old one readable.

The GitHub releases are untouched. Nothing reads them now, but they're the way back.

## Verification

All 18 files were downloaded from the releases, checked against the committed manifests, and uploaded only after every hash matched. Then, with every cached key deleted:

- all four recipes fetch over CloudFront and exit 0 — **18 files, each matching its committed hash**
- appending a byte to one is rejected with the mismatch printed
- deleting one refetches it
- a second run re-hashes in 0.3s without refetching
- `publish-example-keys swap-keys-v4 …` refuses, because that folder exists
- `cargo test -p custom-ring-sdk` passes against the fetched keys
- every dependent recipe still resolves (`test-custom-ring`, `bench-swap`, `test-swap-validator`, `test-custom-ring-validator`, `test-escrow-validator`, …)

## Not included

The SPP keys' lockfile is embedded in the prover binary so pk↔vk↔code can't drift. These manifests stay as committed `*.CHECKSUM` files read by the recipe, because the consumer is a test-time `just` recipe rather than a running binary. Worth revisiting if these keys ever get loaded at runtime.
