### PR TITLE
prover: answer a transfer proof in the request, under a bound

### DIFF
--- a/prover/server/server/metrics.go
+++ b/prover/server/server/metrics.go
@@ -44,6 +44,16 @@ var (
 		[]string{"circuit_type"},
 	)
 
+	// Sheds are the signal that the sync bound is too low for the offered load,
+	// or that the fleet is undersized -- a client-visible 429, so it must be
+	// visible here too rather than only in a log line.
+	SyncProofsShedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "prover_sync_proofs_shed_total",
+			Help: "Total number of synchronous proof requests rejected at the concurrency limit",
+		},
+	)
+
 	QueueWaitTime = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "prover_queue_wait_time_seconds",

--- a/prover/server/server/rail_test.go
+++ b/prover/server/server/rail_test.go
@@ -1,0 +1,51 @@
+package server
+
+import "testing"
+
+// The header has to decide the rail. It was parsed and logged but never
+// consulted, so `X-Sync: true` returned a job handle anyway -- a client could
+// not opt out of the poll schedule at all.
+func TestUseQueueHonoursTheRequestedRail(t *testing.T) {
+	for _, tc := range []struct {
+		name                                          string
+		forceSync, forceAsync, queued, queueAvailable bool
+		want                                          bool
+	}{
+		{
+			name: "a queueable circuit queues by default",
+			// No headers: unchanged behaviour, which is what production runs on.
+			queued: true, queueAvailable: true, want: true,
+		},
+		{
+			name:      "X-Sync takes a queueable circuit off the queue",
+			forceSync: true, queued: true, queueAvailable: true, want: false,
+		},
+		{
+			name:       "X-Async wins a contradiction, because queueing cannot time out a connection",
+			forceSync:  true,
+			forceAsync: true, queued: true, queueAvailable: true, want: true,
+		},
+		{
+			name:       "X-Async cannot queue a circuit that has no queue",
+			forceAsync: true, queued: false, queueAvailable: true, want: false,
+		},
+		{
+			name:   "a circuit without a queue is proved in the request",
+			queued: false, queueAvailable: true, want: false,
+		},
+		{
+			name: "no queue configured means every rail is the sync one",
+			// A local prover with no Redis: X-Async must not route into a queue
+			// that does not exist.
+			forceAsync: true, queued: true, queueAvailable: false, want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := useQueue(tc.forceSync, tc.forceAsync, tc.queued, tc.queueAvailable)
+			if got != tc.want {
+				t.Fatalf("useQueue(sync=%v, async=%v, queued=%v, available=%v) = %v, want %v",
+					tc.forceSync, tc.forceAsync, tc.queued, tc.queueAvailable, got, tc.want)
+			}
+		})
+	}
+}

--- a/prover/server/server/server.go
+++ b/prover/server/server/server.go
@@ -272,6 +272,9 @@ type proveHandler struct {
 	keyManager  *common.LazyKeyManager
 	redisQueue  *RedisQueue
 	enableQueue bool
+	// Bounds proving done inside a request. Shared across requests, so it must
+	// be the same instance for every one of them.
+	admission *syncAdmission
 }
 
 func isValidJobID(jobID string) bool {
@@ -403,11 +406,34 @@ func (handler proveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ProofRequestsTotal.WithLabelValues(string(proofRequestMeta.CircuitType)).Inc()
 	RecordCircuitInputSize(string(proofRequestMeta.CircuitType), len(buf))
 
-	if shouldUseQueue && handler.enableQueue && handler.redisQueue != nil {
+	if useQueue(forceSync, forceAsync, shouldUseQueue, handler.enableQueue && handler.redisQueue != nil) {
 		handler.handleAsyncProof(w, r, buf, proofRequestMeta)
 	} else {
 		handler.handleSyncProof(w, r, buf, proofRequestMeta)
 	}
+}
+
+// useQueue decides which rail proves a request.
+//
+// X-Sync and X-Async were computed and logged here but never consulted, so a
+// caller asking for its proof in the response still got a job handle to poll --
+// the header looked supported and did nothing.
+//
+// A contradiction resolves to the queue: queueing cannot exceed a connection or
+// load balancer idle timeout, and answering inside the request can. X-Async can
+// only be honoured for a circuit that has a queue to go on; for anything else the
+// sync path takes it, with the heavy-operation warning it already emits.
+func useQueue(forceSync, forceAsync, circuitQueued, queueAvailable bool) bool {
+	if !queueAvailable {
+		return false
+	}
+	if forceAsync {
+		return circuitQueued
+	}
+	if forceSync {
+		return false
+	}
+	return circuitQueued
 }
 
 func (handler proveHandler) shouldUseQueueForCircuit(circuitType common.CircuitType) bool {
@@ -569,6 +595,7 @@ func RunEnhanced(config *EnhancedConfig, redisQueue *RedisQueue, keyManager *com
 		keyManager:  keyManager,
 		redisQueue:  redisQueue,
 		enableQueue: config.Queue != nil && config.Queue.Enabled,
+		admission:   newSyncAdmission(syncPermits()),
 	})
 
 	proverMux.Handle("/health", healthHandler{})
@@ -947,6 +974,18 @@ func (handler proveHandler) handleSyncProof(w http.ResponseWriter, r *http.Reque
 	ctx, cancel := context.WithTimeout(r.Context(), timeoutDuration)
 	defer cancel()
 
+	// Wait for a permit before starting work. Doing this here rather than around
+	// the whole handler keeps parsing and validation off the bound: a malformed
+	// request should be rejected while the prover is busy, not queued behind it.
+	release, admitErr := handler.admission.admit(ctx)
+	if admitErr != nil {
+		logging.Logger().Warn().
+			Str("circuit_type", string(meta.CircuitType)).
+			Msg("Shedding synchronous proof at the concurrency limit")
+		sendOverloaded(w, admitErr)
+		return
+	}
+
 	type proofResult struct {
 		proof *common.Proof
 		err   *Error
@@ -955,6 +994,7 @@ func (handler proveHandler) handleSyncProof(w http.ResponseWriter, r *http.Reque
 	resultChan := make(chan proofResult, 1)
 
 	go func() {
+		defer release()
 		// Recover from panics to prevent server crash from malformed input
 		defer func() {
 			if r := recover(); r != nil {

--- a/prover/server/server/server.go
+++ b/prover/server/server/server.go
@@ -387,14 +387,20 @@ func (handler proveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	forceAsync := r.Header.Get("X-Async") == "true" || r.URL.Query().Get("async") == "true"
 	forceSync := r.Header.Get("X-Sync") == "true" || r.URL.Query().Get("sync") == "true"
 
-	shouldUseQueue := handler.shouldUseQueueForCircuit(proofRequestMeta.CircuitType)
+	queueAvailable := handler.enableQueue && handler.redisQueue != nil
+	circuitQueued := handler.shouldUseQueueForCircuit(proofRequestMeta.CircuitType)
+	// `use_queue` is the decision, not the circuit's queueability: logging the
+	// latter under that name said use_queue=true on requests that were proved in
+	// the response, which is exactly the question the line exists to answer.
+	queued := useQueue(forceSync, forceAsync, circuitQueued, queueAvailable)
 
 	logging.Logger().Info().
 		Str("circuit_type", string(proofRequestMeta.CircuitType)).
 		Bool("force_async", forceAsync).
 		Bool("force_sync", forceSync).
-		Bool("use_queue", shouldUseQueue).
-		Bool("queue_available", handler.enableQueue && handler.redisQueue != nil).
+		Bool("circuit_queued", circuitQueued).
+		Bool("use_queue", queued).
+		Bool("queue_available", queueAvailable).
 		Msg("Processing prove request")
 
 	// Counted here, once, because this is the only point every request passes
@@ -406,7 +412,7 @@ func (handler proveHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ProofRequestsTotal.WithLabelValues(string(proofRequestMeta.CircuitType)).Inc()
 	RecordCircuitInputSize(string(proofRequestMeta.CircuitType), len(buf))
 
-	if useQueue(forceSync, forceAsync, shouldUseQueue, handler.enableQueue && handler.redisQueue != nil) {
+	if queued {
 		handler.handleAsyncProof(w, r, buf, proofRequestMeta)
 	} else {
 		handler.handleSyncProof(w, r, buf, proofRequestMeta)

--- a/prover/server/server/sync_admission.go
+++ b/prover/server/server/sync_admission.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strconv"
+	"sync/atomic"
+
+	"zolana/prover/logging"
+)
+
+// Bound on proofs proved inside a request, and on callers waiting for a slot.
+//
+// gnark spreads one proof across every free core, so admitting N at once does
+// not finish them any sooner -- it multiplies each one's wall time by roughly N.
+// Measured on devnet: uncontended proofs land at 143ms p50 (p90 150ms), while
+// runs with several in flight per instance sat at 400-500ms for the same
+// circuits. The queue path has always had this bound (getMaxConcurrency); the
+// sync path had none, which is why transfer and merge were routed to the queue
+// rather than answered directly.
+//
+// Waiting is deliberately bounded too. A permit-less caller parked on a
+// connection for as long as it takes is how a burst turns into a pile of held
+// connections and a load balancer timing out; past the wait bound the server
+// says so with 429 and a Retry-After instead.
+const (
+	// Waiters allowed to queue behind the permits before the server sheds load.
+	// Enough to absorb a burst that the in-flight proofs will drain shortly, not
+	// enough to hide a prover that is simply undersized.
+	syncWaitMultiple = 4
+	// Seconds a shed caller is asked to wait. One proof's worth, rounded up: by
+	// then a permit has almost certainly turned over.
+	syncRetryAfterSecs = 1
+)
+
+// syncAdmission bounds concurrent in-request proving.
+type syncAdmission struct {
+	permits chan struct{}
+	waiting atomic.Int64
+	maxWait int64
+}
+
+func newSyncAdmission(permits int) *syncAdmission {
+	if permits < 1 {
+		permits = 1
+	}
+	logging.Logger().Info().
+		Int("permits", permits).
+		Int64("max_waiting", int64(permits*syncWaitMultiple)).
+		Msg("Sync proof admission control")
+	return &syncAdmission{
+		permits: make(chan struct{}, permits),
+		maxWait: int64(permits * syncWaitMultiple),
+	}
+}
+
+// syncPermits is the in-request proving bound. PROVER_SYNC_CONCURRENCY overrides
+// it; otherwise the sync path uses the same bound as a queue worker, so moving a
+// circuit between the two rails does not change how much work an instance takes
+// on at once.
+func syncPermits() int {
+	if val := os.Getenv("PROVER_SYNC_CONCURRENCY"); val != "" {
+		if permits, err := strconv.Atoi(val); err == nil && permits > 0 {
+			return permits
+		}
+		logging.Logger().Warn().
+			Str("value", val).
+			Msg("Ignoring unparseable PROVER_SYNC_CONCURRENCY")
+	}
+	return getMaxConcurrency()
+}
+
+// admit takes a permit, waiting until ctx expires. The returned release must be
+// called exactly once, when the proof is done rather than when the handler
+// returns: a handler that gives up on its deadline leaves the proof running, and
+// releasing early would admit work the CPU is still busy with.
+//
+// The error is nil iff a permit was taken.
+func (a *syncAdmission) admit(ctx context.Context) (func(), *Error) {
+	if waiting := a.waiting.Add(1); waiting > a.maxWait {
+		a.waiting.Add(-1)
+		SyncProofsShedTotal.Inc()
+		return nil, overloadedError()
+	}
+	defer a.waiting.Add(-1)
+
+	select {
+	case a.permits <- struct{}{}:
+		var once atomic.Bool
+		return func() {
+			// Guard the release so a double call cannot hand out a permit that
+			// was never held.
+			if once.CompareAndSwap(false, true) {
+				<-a.permits
+			}
+		}, nil
+	case <-ctx.Done():
+		SyncProofsShedTotal.Inc()
+		return nil, overloadedError()
+	}
+}
+
+func overloadedError() *Error {
+	return &Error{
+		StatusCode: http.StatusTooManyRequests,
+		Code:       "prover_busy",
+		Message:    "Prover is at its concurrency limit; retry shortly or submit with X-Async: true",
+	}
+}
+
+// sendWithRetryAfter sheds a caller, telling it when to come back. Without the
+// header a client is left to guess, and guessing wrong is what turns a shed
+// request into a retry storm.
+func sendOverloaded(w http.ResponseWriter, e *Error) {
+	w.Header().Set("Retry-After", strconv.Itoa(syncRetryAfterSecs))
+	e.send(w)
+}

--- a/prover/server/server/sync_admission_test.go
+++ b/prover/server/server/sync_admission_test.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// The whole point of the bound: a second proof waits rather than joining the
+// first one on the same cores.
+func TestAdmitBoundsConcurrency(t *testing.T) {
+	a := newSyncAdmission(1)
+
+	release, err := a.admit(context.Background())
+	if err != nil {
+		t.Fatalf("first admit: %v", err)
+	}
+
+	// A waiter with a deadline it cannot meet is shed rather than admitted.
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := a.admit(ctx); err == nil {
+		t.Fatal("expected the second proof to be refused while the permit is held")
+	} else if err.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", err.StatusCode)
+	}
+
+	release()
+
+	// And the permit is reusable once the first proof is done.
+	release2, err := a.admit(context.Background())
+	if err != nil {
+		t.Fatalf("admit after release: %v", err)
+	}
+	release2()
+}
+
+// A caller that arrives while a permit is turning over should wait for it, not
+// be shed: shedding a request the prover is about to be free for is the failure
+// mode that makes clients retry for no reason.
+func TestAdmitWaitsForAReleasedPermit(t *testing.T) {
+	a := newSyncAdmission(1)
+	release, err := a.admit(context.Background())
+	if err != nil {
+		t.Fatalf("first admit: %v", err)
+	}
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		release()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	second, err := a.admit(ctx)
+	if err != nil {
+		t.Fatalf("expected to wait for the permit, got %v", err)
+	}
+	second()
+}
+
+// Past the wait bound the server sheds immediately instead of parking another
+// caller on a held connection.
+func TestAdmitShedsBeyondTheWaitBound(t *testing.T) {
+	permits := 1
+	a := newSyncAdmission(permits)
+
+	held, err := a.admit(context.Background())
+	if err != nil {
+		t.Fatalf("first admit: %v", err)
+	}
+	defer held()
+
+	// Fill the wait queue with callers that stay parked.
+	blocked := make(chan struct{})
+	defer close(blocked)
+	for i := 0; i < permits*syncWaitMultiple; i++ {
+		go func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() {
+				<-blocked
+				cancel()
+			}()
+			if release, err := a.admit(ctx); err == nil {
+				release()
+			}
+		}()
+	}
+
+	// Wait for the queue to fill, then confirm the next caller is refused
+	// without waiting for its own deadline.
+	deadline := time.Now().Add(2 * time.Second)
+	for a.waiting.Load() < int64(permits*syncWaitMultiple) {
+		if time.Now().After(deadline) {
+			t.Fatalf("wait queue never filled, waiting=%d", a.waiting.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := a.admit(ctx); err == nil {
+		t.Fatal("expected the overflow caller to be shed")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("shed should be immediate, took %s", elapsed)
+	}
+}
+
+// Releasing twice must not conjure a permit that was never held, or the bound
+// silently stops bounding.
+func TestReleaseIsIdempotent(t *testing.T) {
+	a := newSyncAdmission(1)
+	release, err := a.admit(context.Background())
+	if err != nil {
+		t.Fatalf("admit: %v", err)
+	}
+	release()
+	release()
+
+	first, err := a.admit(context.Background())
+	if err != nil {
+		t.Fatalf("admit after double release: %v", err)
+	}
+	defer first()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := a.admit(ctx); err == nil {
+		t.Fatal("a double release handed out a second permit")
+	}
+}

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -146,6 +146,8 @@ pub struct ProverClient {
     server_address: String,
     http: reqwest::blocking::Client,
     async_poll: AsyncPollConfig,
+    /// Rail for transfer-shaped proofs. Batch proofs are always queued.
+    delivery: Delivery,
 }
 
 /// Async client for the transfer proving endpoints of the prover server.
@@ -153,6 +155,8 @@ pub struct AsyncProverClient {
     server_address: String,
     http: reqwest::Client,
     async_poll: AsyncPollConfig,
+    /// Rail for transfer-shaped proofs. Batch proofs are always queued.
+    delivery: Delivery,
 }
 
 impl Default for ProverClient {
@@ -177,6 +181,7 @@ impl ProverClient {
             server_address,
             http: build_http_client(),
             async_poll: AsyncPollConfig::default(),
+            delivery: Delivery::InResponse,
         }
     }
 
@@ -186,35 +191,45 @@ impl ProverClient {
         self
     }
 
+    /// Queue transfer-shaped proofs instead of asking for them in the response.
+    ///
+    /// The response is the faster rail and the default. Queueing is still the
+    /// right choice for a caller sharing a prover with heavier work, and it is
+    /// the rail the queue's own tests have to exercise.
+    pub fn with_queued_proofs(mut self) -> Self {
+        self.delivery = Delivery::Queued;
+        self
+    }
+
     /// Prove a Solana-only (eddsa) transfer, returning the uncompressed negated proof.
     /// Call [`Proof::compress`] for the wire format.
     pub fn prove_transfer(&self, inputs: &TransferInputs) -> Result<Proof, ClientError> {
-        self.send(to_json(inputs), Delivery::InResponse)
+        self.send(to_json(inputs), self.delivery)
     }
 
     /// Prove an 8-in/1-out merge, returning the uncompressed negated proof.
     /// Call [`Proof::compress`] for the wire format.
     pub fn prove_merge(&self, inputs: &MergeInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_merge(inputs), Delivery::InResponse)
+        self.send(to_json_merge(inputs), self.delivery)
     }
 
     /// Prove a ring-authority transfer (anonymous, no signature), returning the
     /// uncompressed negated proof. Reuses the Solana-only [`TransferInputs`] witness;
     /// call [`Proof::compress`] for the wire format.
     pub fn prove_ring_authority(&self, inputs: &TransferInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_ring_authority(inputs), Delivery::InResponse)
+        self.send(to_json_ring_authority(inputs), self.delivery)
     }
 
     /// Prove a policy-ring merge (`merge-ring`), returning the uncompressed negated
     /// proof. Reuses the [`MergeInputs`] witness; call [`Proof::compress`] for the
     /// wire format.
     pub fn prove_merge_ring(&self, inputs: &MergeInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_merge_ring(inputs), Delivery::InResponse)
+        self.send(to_json_merge_ring(inputs), self.delivery)
     }
 
     /// Prove an eddsa confidential policy-ring transfer (`transfer-ring`).
     pub fn prove_transfer_ring(&self, inputs: &TransferInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_ring(inputs), Delivery::InResponse)
+        self.send(to_json_ring(inputs), self.delivery)
     }
 
     /// Prove a custom-ring P256 transfer.
@@ -222,7 +237,7 @@ impl ProverClient {
         &self,
         inputs: &TransferP256Inputs,
     ) -> Result<Proof, ClientError> {
-        self.send(to_json_p256_ring(inputs), Delivery::InResponse)
+        self.send(to_json_p256_ring(inputs), self.delivery)
     }
 
     /// Prove a nullifier-tree batch address-append update, returning the
@@ -479,6 +494,7 @@ impl AsyncProverClient {
             server_address,
             http: build_async_http_client(),
             async_poll: AsyncPollConfig::default(),
+            delivery: Delivery::InResponse,
         }
     }
 
@@ -488,39 +504,47 @@ impl AsyncProverClient {
         self
     }
 
+    /// Queue transfer-shaped proofs instead of asking for them in the response.
+    ///
+    /// The response is the faster rail and the default. Queueing is still the
+    /// right choice for a caller sharing a prover with heavier work, and it is
+    /// the rail the queue's own tests have to exercise.
+    pub fn with_queued_proofs(mut self) -> Self {
+        self.delivery = Delivery::Queued;
+        self
+    }
+
     /// Prove a Solana-only (eddsa) transfer, returning the uncompressed negated proof.
     /// Call [`Proof::compress`] for the wire format.
     pub async fn prove_transfer(&self, inputs: &TransferInputs) -> Result<Proof, ClientError> {
-        self.send(to_json(inputs), Delivery::InResponse).await
+        self.send(to_json(inputs), self.delivery).await
     }
 
     pub async fn prove_merge(&self, inputs: &MergeInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_merge(inputs), Delivery::InResponse).await
+        self.send(to_json_merge(inputs), self.delivery).await
     }
 
     pub async fn prove_ring_authority(
         &self,
         inputs: &TransferInputs,
     ) -> Result<Proof, ClientError> {
-        self.send(to_json_ring_authority(inputs), Delivery::InResponse)
+        self.send(to_json_ring_authority(inputs), self.delivery)
             .await
     }
 
     pub async fn prove_merge_ring(&self, inputs: &MergeInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_merge_ring(inputs), Delivery::InResponse)
-            .await
+        self.send(to_json_merge_ring(inputs), self.delivery).await
     }
 
     pub async fn prove_transfer_ring(&self, inputs: &TransferInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_ring(inputs), Delivery::InResponse).await
+        self.send(to_json_ring(inputs), self.delivery).await
     }
 
     pub async fn prove_transfer_p256_ring(
         &self,
         inputs: &TransferP256Inputs,
     ) -> Result<Proof, ClientError> {
-        self.send(to_json_p256_ring(inputs), Delivery::InResponse)
-            .await
+        self.send(to_json_p256_ring(inputs), self.delivery).await
     }
 
     pub async fn prove_batch_address_append(

--- a/sdk-libs/client/src/prover/client.rs
+++ b/sdk-libs/client/src/prover/client.rs
@@ -7,6 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use reqwest::StatusCode;
 use tokio::time::sleep as async_sleep;
 
 use crate::{
@@ -58,6 +59,23 @@ static IS_LOADING: AtomicBool = AtomicBool::new(false);
 // 205k-constraint Groth16 prove) can drop the HTTP connection under CPU/memory
 // contention while the server stays up. Proof generation is idempotent, so the
 // request is retried; the key is warm by the next attempt and proves quickly.
+/// Whether the prover should answer with the proof or with a job handle.
+///
+/// A transfer-shaped proof is ~150ms of work, and asking for it in the response
+/// costs one round trip. Queueing it costs an enqueue, then a poll schedule that
+/// starts at 25ms and doubles -- so the proof is collected somewhere between one
+/// and several round trips after it was ready, and the client sleeps through the
+/// difference. Batch proofs are the other way round: they run far longer than a
+/// connection or a load balancer's idle timeout should be held open.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Delivery {
+    /// Ask for the proof in the response, falling back to the queue if the
+    /// prover says it is at its concurrency limit.
+    InResponse,
+    /// Let the prover queue it and poll for the result.
+    Queued,
+}
+
 const PROVE_MAX_ATTEMPTS: usize = 3;
 const PROVE_RETRY_BACKOFF_SECS: u64 = 2;
 // Generous bound so a slow cold prove never hangs the client forever; the server
@@ -171,32 +189,32 @@ impl ProverClient {
     /// Prove a Solana-only (eddsa) transfer, returning the uncompressed negated proof.
     /// Call [`Proof::compress`] for the wire format.
     pub fn prove_transfer(&self, inputs: &TransferInputs) -> Result<Proof, ClientError> {
-        self.send(to_json(inputs))
+        self.send(to_json(inputs), Delivery::InResponse)
     }
 
     /// Prove an 8-in/1-out merge, returning the uncompressed negated proof.
     /// Call [`Proof::compress`] for the wire format.
     pub fn prove_merge(&self, inputs: &MergeInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_merge(inputs))
+        self.send(to_json_merge(inputs), Delivery::InResponse)
     }
 
     /// Prove a ring-authority transfer (anonymous, no signature), returning the
     /// uncompressed negated proof. Reuses the Solana-only [`TransferInputs`] witness;
     /// call [`Proof::compress`] for the wire format.
     pub fn prove_ring_authority(&self, inputs: &TransferInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_ring_authority(inputs))
+        self.send(to_json_ring_authority(inputs), Delivery::InResponse)
     }
 
     /// Prove a policy-ring merge (`merge-ring`), returning the uncompressed negated
     /// proof. Reuses the [`MergeInputs`] witness; call [`Proof::compress`] for the
     /// wire format.
     pub fn prove_merge_ring(&self, inputs: &MergeInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_merge_ring(inputs))
+        self.send(to_json_merge_ring(inputs), Delivery::InResponse)
     }
 
     /// Prove an eddsa confidential policy-ring transfer (`transfer-ring`).
     pub fn prove_transfer_ring(&self, inputs: &TransferInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_ring(inputs))
+        self.send(to_json_ring(inputs), Delivery::InResponse)
     }
 
     /// Prove a custom-ring P256 transfer.
@@ -204,7 +222,7 @@ impl ProverClient {
         &self,
         inputs: &TransferP256Inputs,
     ) -> Result<Proof, ClientError> {
-        self.send(to_json_p256_ring(inputs))
+        self.send(to_json_p256_ring(inputs), Delivery::InResponse)
     }
 
     /// Prove a nullifier-tree batch address-append update, returning the
@@ -214,22 +232,28 @@ impl ProverClient {
         &self,
         inputs: &BatchAddressAppendInputs,
     ) -> Result<Proof, ClientError> {
-        self.send(to_json_batch_address_append(inputs))
+        self.send(to_json_batch_address_append(inputs), Delivery::Queued)
     }
 
-    fn send(&self, body: String) -> Result<Proof, ClientError> {
-        let url = format!("{}{}", self.server_address, PROVE_PATH);
-        crate::timing::note(0, "prover_request_bytes", body.len());
+    /// One POST to `/prove`, retried only for transport failures. Returns the
+    /// status alongside the body so the caller can act on a shed request.
+    fn post(
+        &self,
+        url: &str,
+        body: &str,
+        delivery: Delivery,
+    ) -> Result<(StatusCode, String), ClientError> {
         let mut attempt = 0;
         let response = loop {
             attempt += 1;
-            let outcome = self
+            let mut request = self
                 .http
-                .post(&url)
-                .header("Content-Type", "application/json")
-                .body(body.clone())
-                .send();
-            match outcome {
+                .post(url)
+                .header("Content-Type", "application/json");
+            if delivery == Delivery::InResponse {
+                request = request.header("X-Sync", "true");
+            }
+            match request.body(body.to_string()).send() {
                 Ok(response) => break response,
                 Err(_) if attempt < PROVE_MAX_ATTEMPTS => {
                     sleep(Duration::from_secs(PROVE_RETRY_BACKOFF_SECS));
@@ -241,11 +265,29 @@ impl ProverClient {
                 }
             }
         };
-
         let status = response.status();
         let text = response
             .text()
             .map_err(|e| ClientError::ProverServer(format!("failed to read response body: {e}")))?;
+        Ok((status, text))
+    }
+
+    fn send(&self, body: String, delivery: Delivery) -> Result<Proof, ClientError> {
+        let url = format!("{}{}", self.server_address, PROVE_PATH);
+        crate::timing::note(0, "prover_request_bytes", body.len());
+        // Dropped to `Queued` if the prover sheds the synchronous request, so a
+        // busy prover degrades to waiting in line rather than to an error.
+        let mut delivery = delivery;
+        let (status, text) = loop {
+            let (status, text) = self.post(&url, &body, delivery)?;
+            if status == StatusCode::TOO_MANY_REQUESTS && delivery == Delivery::InResponse {
+                // Retrying synchronously would compete for the same permit that
+                // was just refused; queueing waits for it once instead.
+                delivery = Delivery::Queued;
+                continue;
+            }
+            break (status, text);
+        };
         if !status.is_success() {
             return Err(ClientError::ProverServer(format!(
                 "status {status}: {text}"
@@ -449,75 +491,96 @@ impl AsyncProverClient {
     /// Prove a Solana-only (eddsa) transfer, returning the uncompressed negated proof.
     /// Call [`Proof::compress`] for the wire format.
     pub async fn prove_transfer(&self, inputs: &TransferInputs) -> Result<Proof, ClientError> {
-        self.send(to_json(inputs)).await
+        self.send(to_json(inputs), Delivery::InResponse).await
     }
 
     pub async fn prove_merge(&self, inputs: &MergeInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_merge(inputs)).await
+        self.send(to_json_merge(inputs), Delivery::InResponse).await
     }
 
     pub async fn prove_ring_authority(
         &self,
         inputs: &TransferInputs,
     ) -> Result<Proof, ClientError> {
-        self.send(to_json_ring_authority(inputs)).await
+        self.send(to_json_ring_authority(inputs), Delivery::InResponse)
+            .await
     }
 
     pub async fn prove_merge_ring(&self, inputs: &MergeInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_merge_ring(inputs)).await
+        self.send(to_json_merge_ring(inputs), Delivery::InResponse)
+            .await
     }
 
     pub async fn prove_transfer_ring(&self, inputs: &TransferInputs) -> Result<Proof, ClientError> {
-        self.send(to_json_ring(inputs)).await
+        self.send(to_json_ring(inputs), Delivery::InResponse).await
     }
 
     pub async fn prove_transfer_p256_ring(
         &self,
         inputs: &TransferP256Inputs,
     ) -> Result<Proof, ClientError> {
-        self.send(to_json_p256_ring(inputs)).await
+        self.send(to_json_p256_ring(inputs), Delivery::InResponse)
+            .await
     }
 
     pub async fn prove_batch_address_append(
         &self,
         inputs: &BatchAddressAppendInputs,
     ) -> Result<Proof, ClientError> {
-        self.send(to_json_batch_address_append(inputs)).await
+        self.send(to_json_batch_address_append(inputs), Delivery::Queued)
+            .await
     }
 
-    async fn send(&self, body: String) -> Result<Proof, ClientError> {
+    async fn send(&self, body: String, delivery: Delivery) -> Result<Proof, ClientError> {
         let url = format!("{}{}", self.server_address, PROVE_PATH);
+        let mut delivery = delivery;
+        let (status, text) = loop {
+            let (status, text) = self.post(&url, &body, delivery).await?;
+            if status == StatusCode::TOO_MANY_REQUESTS && delivery == Delivery::InResponse {
+                delivery = Delivery::Queued;
+                continue;
+            }
+            break (status, text);
+        };
+        if !status.is_success() {
+            return Err(ClientError::ProverServer(format!(
+                "status {status}: {text}"
+            )));
+        }
+
+        let value: serde_json::Value = serde_json::from_str(&text)
+            .map_err(|e| ClientError::ProofParse(format!("invalid response JSON: {e}")))?;
+        if value.get("proof").is_none() {
+            if let Some(job_id) = value.get("jobId").and_then(|v| v.as_str()) {
+                return self.poll_async(job_id).await;
+            }
+        }
+        ProverClient::proof_from_value(&value, &text)
+    }
+
+    async fn post(
+        &self,
+        url: &str,
+        body: &str,
+        delivery: Delivery,
+    ) -> Result<(StatusCode, String), ClientError> {
         let mut attempt = 0;
         loop {
             attempt += 1;
-            let outcome = self
+            let mut request = self
                 .http
-                .post(&url)
-                .header("Content-Type", "application/json")
-                .body(body.clone())
-                .send()
-                .await;
-            match outcome {
+                .post(url)
+                .header("Content-Type", "application/json");
+            if delivery == Delivery::InResponse {
+                request = request.header("X-Sync", "true");
+            }
+            match request.body(body.to_string()).send().await {
                 Ok(response) => {
                     let status = response.status();
                     let text = response.text().await.map_err(|e| {
                         ClientError::ProverServer(format!("failed to read response body: {e}"))
                     })?;
-                    if !status.is_success() {
-                        return Err(ClientError::ProverServer(format!(
-                            "status {status}: {text}"
-                        )));
-                    }
-
-                    let value: serde_json::Value = serde_json::from_str(&text).map_err(|e| {
-                        ClientError::ProofParse(format!("invalid response JSON: {e}"))
-                    })?;
-                    if value.get("proof").is_none() {
-                        if let Some(job_id) = value.get("jobId").and_then(|v| v.as_str()) {
-                            return self.poll_async(job_id).await;
-                        }
-                    }
-                    return ProverClient::proof_from_value(&value, &text);
+                    return Ok((status, text));
                 }
                 Err(_) if attempt < PROVE_MAX_ATTEMPTS => {
                     async_sleep(Duration::from_secs(PROVE_RETRY_BACKOFF_SECS)).await;
@@ -861,7 +924,7 @@ mod tests {
         ]);
         let started = std::time::Instant::now();
         queued_prover_client(server.url())
-            .send("{}".to_string())
+            .send("{}".to_string(), Delivery::Queued)
             .expect("queued proof should complete");
         let elapsed = started.elapsed();
 
@@ -920,7 +983,7 @@ mod tests {
             ),
         ]);
         let proof = queued_prover_client(server.url())
-            .send("{}".to_string())
+            .send("{}".to_string(), Delivery::Queued)
             .expect("queued proof should complete");
         let requests = server.requests();
 
@@ -951,7 +1014,7 @@ mod tests {
             ),
         ]);
         let err = queued_prover_client(server.url())
-            .send("{}".to_string())
+            .send("{}".to_string(), Delivery::Queued)
             .expect_err("failed async status should surface");
         let requests = server.requests();
 
@@ -989,7 +1052,7 @@ mod tests {
 
         let started = Instant::now();
         let err = queued_prover_client(server.url())
-            .send("{}".to_string())
+            .send("{}".to_string(), Delivery::Queued)
             .expect_err("a deadline measured in wall clock must expire");
         let elapsed = started.elapsed();
 
@@ -1019,7 +1082,7 @@ mod tests {
             MockResponse::json(200, json!({ "status": "processing" })),
         ]);
         let err = queued_prover_client(server.url())
-            .send("{}".to_string())
+            .send("{}".to_string(), Delivery::Queued)
             .expect_err("slow async proof should time out");
         let requests = server.requests();
 
@@ -1041,7 +1104,7 @@ mod tests {
             MockResponse::text(200, "not json"),
         ]);
         let err = queued_prover_client(server.url())
-            .send("{}".to_string())
+            .send("{}".to_string(), Delivery::Queued)
             .expect_err("malformed status body should fail");
         let requests = server.requests();
 
@@ -1062,7 +1125,7 @@ mod tests {
             ),
         ]);
         let err = queued_prover_client(server.url())
-            .send("{}".to_string())
+            .send("{}".to_string(), Delivery::Queued)
             .expect_err("404 status should fail immediately");
         let requests = server.requests();
 
@@ -1089,7 +1152,7 @@ mod tests {
             ),
         ]);
         let proof = queued_prover_client(server.url())
-            .send("{}".to_string())
+            .send("{}".to_string(), Delivery::Queued)
             .expect("transient poll error should be retried");
         let requests = server.requests();
 
@@ -1121,7 +1184,7 @@ mod tests {
             ),
         ]);
         let proof = async_prover_client(server.url())
-            .send("{}".to_string())
+            .send("{}".to_string(), Delivery::Queued)
             .await
             .expect("queued async proof should complete");
         let requests = server.requests();
@@ -1153,7 +1216,7 @@ mod tests {
             ),
         ]);
         async_prover_client(server.url())
-            .send("{}".to_string())
+            .send("{}".to_string(), Delivery::Queued)
             .await
             .expect("transient async poll error should be retried");
         let requests = server.requests();
@@ -1165,6 +1228,73 @@ mod tests {
                 "/prove/status?jobId=async-transient",
                 "/prove/status?jobId=async-transient",
             ],
+        );
+    }
+
+    /// Transfer-shaped proofs ask for the proof in the response: the queue's
+    /// enqueue plus poll schedule costs more round trips than the proof takes.
+    #[test]
+    fn a_transfer_proof_asks_for_the_proof_in_the_response() {
+        let server = MockServer::respond_with(vec![MockResponse::json(
+            200,
+            json!({ "proof": gnark_proof() }),
+        )]);
+        queued_prover_client(server.url())
+            .send("{}".to_string(), Delivery::InResponse)
+            .expect("a synchronous prover answers with the proof");
+
+        let requests = server.requests();
+        assert_paths(&requests, ["/prove"]);
+        assert!(
+            requests
+                .first()
+                .expect("one request was recorded")
+                .sync_requested,
+            "the request must say it wants the proof back"
+        );
+    }
+
+    /// And a prover at its concurrency limit must not turn into a failed
+    /// transfer. Retrying synchronously would compete for the permit that was
+    /// just refused, so the client queues instead -- one wait rather than a
+    /// storm.
+    #[test]
+    fn a_shed_sync_proof_falls_back_to_the_queue() {
+        let server = MockServer::respond_with(vec![
+            MockResponse::json(429, json!({ "code": "prover_busy" })),
+            MockResponse::json(202, json!({ "jobId": "queued-after-shed" })),
+            MockResponse::json(
+                200,
+                json!({
+                    "status": "completed",
+                    "result": { "proof": gnark_proof() },
+                }),
+            ),
+        ]);
+
+        let proof = queued_prover_client(server.url())
+            .send("{}".to_string(), Delivery::InResponse)
+            .expect("a shed proof should be queued, not failed");
+        assert_eq!(proof.a, [0u8; 64]);
+
+        let requests = server.requests();
+        assert_paths(
+            &requests,
+            ["/prove", "/prove", "/prove/status?jobId=queued-after-shed"],
+        );
+        assert!(
+            requests
+                .first()
+                .expect("the shed request was recorded")
+                .sync_requested,
+            "the first attempt asked for the proof in the response"
+        );
+        assert!(
+            !requests
+                .get(1)
+                .expect("the retry was recorded")
+                .sync_requested,
+            "the retry must queue rather than ask again for a permit just refused"
         );
     }
 
@@ -1220,6 +1350,8 @@ mod tests {
 
     struct RecordedRequest {
         path: String,
+        /// Whether the request asked for the proof in the response.
+        sync_requested: bool,
     }
 
     enum MockResponse {
@@ -1441,7 +1573,13 @@ mod tests {
             .and_then(|line| line.split_whitespace().nth(1))
             .expect("request line should include a path")
             .to_string();
-        RecordedRequest { path }
+        RecordedRequest {
+            path,
+            sync_requested: header.lines().any(|line| {
+                let lower = line.to_ascii_lowercase();
+                lower.strip_prefix("x-sync:").map(str::trim) == Some("true")
+            }),
+        }
     }
 
     fn parse_content_length(header: &str) -> Option<usize> {

--- a/sdk-libs/client/tests/transfer_dummy.rs
+++ b/sdk-libs/client/tests/transfer_dummy.rs
@@ -332,7 +332,16 @@ fn dummy_transfer_2_3_proof_verifies() {
 
     let result = prover.build().expect("build witness with one real input");
 
-    let proof = ProverClient::local()
+    // The queue is what this test covers, and transfers otherwise take the
+    // faster in-response rail, so ask for the queued one where it is being
+    // asserted on.
+    let client = ProverClient::local();
+    let client = if queued_results_before.is_some() {
+        client.with_queued_proofs()
+    } else {
+        client
+    };
+    let proof = client
         .prove_transfer(&result.inputs)
         .expect("prove transfer-eddsa");
 


### PR DESCRIPTION
A transfer proof is ~143ms of work on devnet (p50, p90 150ms, n=242, taken from the prover's own `duration_ms` on the current c7a instance). Queueing one costs an enqueue round trip and then a poll schedule that starts at 25ms and doubles, so the proof is collected one to several round trips after it was ready and the client sleeps through the difference. This asks for it in the response instead.

Three things had to change together.

**`X-Sync`/`X-Async` did nothing.** They were parsed, logged, and then never consulted -- the routing read only whether the circuit had a dedicated queue. A client asking for its proof in the response got a job handle anyway, so the header looked supported and was inert. `useQueue` now decides, and a contradiction resolves to the queue: queueing cannot exceed a connection or load-balancer idle timeout, and answering inside the request can.

**The sync path had no admission control.** That absence is why transfer and merge were routed to the queue in the first place -- gnark spreads one proof across every free core, so admitting N at once multiplies each one's wall time by roughly N rather than finishing them any sooner. The same logs show it: the uncontended 143ms becomes 400-500ms for identical circuits when several are in flight per instance. Sync proofs now take a permit (default `PROVER_MAX_CONCURRENCY`, overridable with `PROVER_SYNC_CONCURRENCY`), wait bounded by the request deadline, and past a bounded wait queue are shed with 429 and a `Retry-After` rather than parked on a held connection. Sheds are counted in `prover_sync_proofs_shed_total`.

**The client asks for the fast rail only where it fits.** Transfer, merge and ring proofs ask for the proof in the response; batch address-append stays queued, since it runs far longer than a connection should be held. On a 429 the client falls back to queueing rather than retrying into the permit it was just refused.

## Expected effect

One proof per transfer. With a 143ms proof and a ~35ms round trip, the queued path collects it at roughly 215-315ms depending on where completion falls relative to the doubling schedule; answering in the request is ~178ms. So on the order of 35-140ms per transfer, and the schedule-quantised tail goes away. It also removes the status-endpoint polling load, which a previously recorded experiment showed contends with proving (a 250ms poll ceiling made throughput *worse*: 3632ms/0.92 tps against 2025ms/1.14 tps).

Confirming the end-to-end number needs this prover image on devnet; the figures above are measured inputs plus the poll constants, not an end-to-end A/B.

## Verification

- local full stack proves through this path (`just test-ts-e2e`, 8 tests)
- the admission bound holds under `-race`: permits bound concurrency, a waiter gets a released permit, overflow sheds immediately, and a double release cannot conjure a permit
- the rail decision is pinned per header combination, including "no queue configured means every rail is the sync one"
- client-side: the transfer request carries the header, and a shed request is queued rather than failed (asserted on typed recorded-request fields, not response text)