### PR TITLE
fix: close ECDH point-negation guard bypass and harden keypair edges

### DIFF
--- a/sdk-libs/keypair/src/derivation.rs
+++ b/sdk-libs/keypair/src/derivation.rs
@@ -248,9 +248,14 @@ pub(crate) fn p_pda() -> P256Pubkey {
 /// tag and the transaction-viewing secret. The roots themselves are reached
 /// through [`view_root`] and the `ecdh_raw` entry points, which bypass this
 /// check.
+///
+/// Compares x-coordinates rather than full SEC1 encodings. ECDH uses only x,
+/// so `x(sk·P) == x(sk·-P)`, and the negation `-P` carries the same x under the
+/// opposite parity byte (`0x03`→`0x02`). A byte-equality guard would accept
+/// `-P` while it still produces the protected shared secret.
 pub(crate) fn is_derivation_point(pubkey: &P256Pubkey) -> bool {
-    let bytes = pubkey.as_bytes();
-    bytes == &P_DERIVE_SEC1 || bytes == &P_PDA_SEC1 || bytes == &P_CONST_SEC1
+    let x = pubkey.x();
+    x == P_DERIVE_SEC1[1..] || x == P_PDA_SEC1[1..] || x == P_CONST_SEC1[1..]
 }
 
 /// `view_root = HKDF-Extract(salt=∅, IKM=ECDH(viewing_sk, P_const))` — the PRK

--- a/sdk-libs/keypair/src/pda.rs
+++ b/sdk-libs/keypair/src/pda.rs
@@ -37,8 +37,14 @@ impl AsRef<NullifierKey> for ShieldedPda {
 impl ShieldedPda {
     /// Derives both roles from `ECDH(own, counterparty)`, so either
     /// participant reconstructs the identity from its own viewing key and the
-    /// counterparty's viewing public key; nothing is transported. A sole
-    /// holder passes its own viewing public key as the counterparty.
+    /// counterparty's viewing public key; nothing is transported. This is the
+    /// two-or-more-party exchange; for a sole holder use [`Self::from_viewing_key`].
+    ///
+    /// Passing `own.pubkey()` as the counterparty yields a different identity
+    /// than [`Self::from_viewing_key`] for the same `(pda, own)`: this root is
+    /// `ECDH(own, own.pubkey())`, that one `ECDH(own, P_pda)`. The two roots do
+    /// not collide, so the constructors are not interchangeable; an account
+    /// created with one cannot be reopened with the other.
     pub fn from_key_exchange(
         pda: Address,
         own: &ViewingKey,
@@ -53,11 +59,14 @@ impl ShieldedPda {
         })
     }
 
-    /// Derives both roles from the holder's viewing key alone via
-    /// `ECDH(own, P_pda)`, a committed point with unknown discrete log, so the
-    /// identity exists before any counterparty does and its `nullifier_pk` can
-    /// be published at account-creation time. The holder set is the same as
-    /// the sole-holder exchange; only the holder of `own` derives it.
+    /// The sole-holder constructor. Derives both roles from the holder's
+    /// viewing key alone via `ECDH(own, P_pda)`, a committed point with unknown
+    /// discrete log, so the identity exists before any counterparty does and its
+    /// `nullifier_pk` can be published at account-creation time. Only the holder
+    /// of `own` can derive it.
+    ///
+    /// This root differs from [`Self::from_key_exchange`] with `own.pubkey()` as
+    /// the counterparty; see that constructor for the disjointness.
     pub fn from_viewing_key(pda: Address, own: &ViewingKey) -> Result<Self, KeypairError> {
         let shared = Zeroizing::new(own.ecdh_raw(&p_pda())?);
         let expansion = PdaRoleExpansion::new(&shared, pda.to_bytes());

--- a/sdk-libs/keypair/src/pubkey.rs
+++ b/sdk-libs/keypair/src/pubkey.rs
@@ -168,6 +168,12 @@ impl PublicKey {
     }
 
     pub fn confidential_view_tag(&self) -> Result<[u8; 32], KeypairError> {
+        // The all-zero dummy marker reads as a P256 tag. Reject it here so a
+        // padding owner does not hash to a real identity, rather than depending
+        // on `as_p256`'s SEC1 re-parse to fail.
+        if self.is_zero() {
+            return Err(KeypairError::InvalidPublicKey);
+        }
         match self.curve()? {
             Curve::P256 => Ok(self.as_p256()?.x()),
             Curve::Ed25519 => self.as_ed25519(),

--- a/sdk-libs/keypair/src/shielded.rs
+++ b/sdk-libs/keypair/src/shielded.rs
@@ -104,6 +104,20 @@ impl Signer for ShieldedKeypair {
         Ok(solana_keypair::Signature::from(self.sign_message(message)?))
     }
 
+    // The `Signer` defaults route the infallible forms through
+    // `unwrap_or_default()`, so a non-ed25519 keypair would return the all-zero
+    // `Address` (the system program) and a zero signature. Override both to
+    // panic instead.
+    fn pubkey(&self) -> solana_address::Address {
+        self.try_pubkey()
+            .expect("ShieldedKeypair::pubkey is ed25519-only; P-256/PDA owners have no Solana address, use try_pubkey")
+    }
+
+    fn sign_message(&self, message: &[u8]) -> solana_keypair::Signature {
+        self.try_sign_message(message)
+            .expect("ShieldedKeypair::sign_message is ed25519-only; use try_sign_message")
+    }
+
     fn is_interactive(&self) -> bool {
         false
     }

--- a/sdk-libs/keypair/tests/cases/nullifier.rs
+++ b/sdk-libs/keypair/tests/cases/nullifier.rs
@@ -217,6 +217,18 @@ pub(crate) fn primitives_refuse_derivation_inputs(world: &mut KeypairWorld, key:
     assert_eq!(vk.ecdh(&p_pda), Err(KeypairError::DerivationInput));
     assert_eq!(vk.ecdh(&p_const), Err(KeypairError::DerivationInput));
     assert!(vk.ecdh(&benign).is_ok());
+
+    // The negation of a committed point (same x, flipped parity byte) is a
+    // valid on-curve point with the same ECDH x-coordinate. A byte-equality
+    // guard would accept it; this one must reject it.
+    for mut point in [P_DERIVE_SEC1, P_PDA_SEC1, P_CONST_SEC1] {
+        let canonical = point;
+        point[0] ^= 0x01;
+        let neg = P256Pubkey::from_bytes(point).expect("negated committed point is valid SEC1");
+        assert_ne!(neg.as_bytes(), &canonical, "negation differs in bytes");
+        assert_eq!(sk.ecdh(&neg), Err(KeypairError::DerivationInput));
+        assert_eq!(vk.ecdh(&neg), Err(KeypairError::DerivationInput));
+    }
 }
 
 pub(crate) fn nullifier_deterministic(world: &mut KeypairWorld, key: String) {

--- a/sdk-libs/keypair/tests/cases/pubkey.rs
+++ b/sdk-libs/keypair/tests/cases/pubkey.rs
@@ -79,6 +79,21 @@ pub(crate) fn last_byte_zero(world: &mut KeypairWorld, name: String) {
     assert_eq!(world.tag(&name).as_bytes()[PUBLIC_KEY_LEN - 1], 0);
 }
 
+/// The all-zero dummy marker reads as a P256 tag, so identity derivation must
+/// reject it explicitly rather than rely on SEC1 parsing to fail downstream.
+pub(crate) fn zeroed_owner_is_rejected() {
+    let zeroed = PublicKey::zeroed();
+    assert!(zeroed.is_zero());
+    assert_eq!(
+        zeroed.confidential_view_tag(),
+        Err(KeypairError::InvalidPublicKey)
+    );
+    assert_eq!(
+        zeroed.owner_proof_input_hash(),
+        Err(KeypairError::InvalidPublicKey)
+    );
+}
+
 pub(crate) fn parse_public_key_bad_prefix(world: &mut KeypairWorld, prefix: u8) {
     let mut bytes = [0u8; PUBLIC_KEY_LEN];
     bytes[0] = prefix;

--- a/sdk-libs/keypair/tests/cases/shielded.rs
+++ b/sdk-libs/keypair/tests/cases/shielded.rs
@@ -137,6 +137,19 @@ pub(crate) fn solana_signer_matches_solana_keypair() {
         .is_err());
 }
 
+/// The infallible `Signer::pubkey` on an ed25519 keypair returns the real
+/// address; the P-256 panic path is pinned by the `#[should_panic]` tests in
+/// `keypair.rs`.
+pub(crate) fn signer_infallible_pubkey_matches_ed25519() {
+    use solana_signer::Signer;
+
+    let ed = ShieldedKeypair::new_ed25519().unwrap();
+    assert_eq!(
+        Signer::pubkey(&ed).to_bytes(),
+        ed.signing_pubkey().as_ed25519().unwrap()
+    );
+}
+
 pub(crate) fn facade_sign_nullifier(world: &mut KeypairWorld, name: String) {
     let kp = world.keypair(&name);
     let msg = [7u8; 32];

--- a/sdk-libs/keypair/tests/cases/transaction.rs
+++ b/sdk-libs/keypair/tests/cases/transaction.rs
@@ -66,3 +66,48 @@ pub(crate) fn golden_decrypts(world: &mut KeypairWorld, recipient: String, ephem
         .unwrap();
     assert_eq!(plaintext, b"deterministic");
 }
+
+/// A golden vector with a non-palindromic salt, slot 1, and a plaintext that
+/// crosses an AES block boundary. A reversed salt or a big-endian/little-endian
+/// slot swap in `derive_key_nonce` changes the ciphertext and fails this test;
+/// the all-zero salt / slot-0 golden above catches neither.
+pub(crate) fn golden_wire_format_is_pinned(
+    world: &mut KeypairWorld,
+    ephemeral: String,
+    recipient: String,
+) {
+    let mut salt = [0u8; 16];
+    for (i, byte) in salt.iter_mut().enumerate() {
+        *byte = i as u8 + 1;
+    }
+    let plaintext = b"deterministic-slot01";
+    let recipient_pk = world.vk(&recipient).pubkey();
+    let ephemeral_vk = world.vk(&ephemeral);
+
+    let ct = ephemeral_vk
+        .encrypt_slot(&recipient_pk, plaintext, salt, 1)
+        .unwrap();
+    assert_eq!(hex::encode(&ct), "1398efa64945062160825853bfe6819163666caa");
+
+    let recovered = world
+        .vk(&recipient)
+        .decrypt_utxo(&ct, &ephemeral_vk.pubkey(), salt, 1)
+        .unwrap();
+    assert_eq!(recovered, plaintext);
+
+    // A reversed salt and a different slot must both change the keystream.
+    let mut reversed = salt;
+    reversed.reverse();
+    assert_ne!(
+        ephemeral_vk
+            .encrypt_slot(&recipient_pk, plaintext, reversed, 1)
+            .unwrap(),
+        ct
+    );
+    assert_ne!(
+        ephemeral_vk
+            .encrypt_slot(&recipient_pk, plaintext, salt, 0)
+            .unwrap(),
+        ct
+    );
+}

--- a/sdk-libs/keypair/tests/keypair.rs
+++ b/sdk-libs/keypair/tests/keypair.rs
@@ -118,6 +118,25 @@ fn public_key_encodings_are_typed_and_canonical() {
     cases::pubkey::public_key_parse_fails(&mut world, KeypairError::InvalidSignatureType(9));
     cases::pubkey::parse_ed25519_nonzero_pad(&mut world);
     cases::pubkey::public_key_parse_fails(&mut world, KeypairError::InvalidPublicKey);
+    cases::pubkey::zeroed_owner_is_rejected();
+}
+
+#[test]
+#[should_panic(expected = "ed25519-only")]
+fn signer_pubkey_panics_on_p256_keypair() {
+    use solana_signer::Signer;
+
+    let kp = ShieldedKeypair::new_p256().unwrap();
+    let _ = Signer::pubkey(&kp);
+}
+
+#[test]
+#[should_panic(expected = "ed25519-only")]
+fn signer_sign_message_panics_on_p256_keypair() {
+    use solana_signer::Signer;
+
+    let kp = ShieldedKeypair::new_p256().unwrap();
+    let _ = Signer::sign_message(&kp, b"tx");
 }
 
 #[test]
@@ -139,6 +158,7 @@ fn shielded_keypair_facade_round_trips_full_transfers() {
     cases::shielded::new_derives_viewing_key_from_signing_key(&mut world, "alice".into());
     cases::shielded::random_constructors_pick_their_rail();
     cases::shielded::solana_signer_matches_solana_keypair();
+    cases::shielded::signer_infallible_pubkey_matches_ed25519();
 
     cases::common::random_shielded_keypair(&mut world, "sender".into());
     cases::common::random_shielded_keypair(&mut world, "recipient".into());
@@ -191,6 +211,7 @@ fn encrypted_slots_are_unique_and_recipient_bound() {
     cases::common::viewing_key_from_scalar(&mut world, "eph".into(), 1);
     cases::common::viewing_key_from_scalar(&mut world, "rcpt".into(), 2);
     cases::transaction::golden_decrypts(&mut world, "rcpt".into(), "eph".into());
+    cases::transaction::golden_wire_format_is_pinned(&mut world, "eph".into(), "rcpt".into());
 }
 
 #[test]


### PR DESCRIPTION
## Changes

1. ECDH derivation-point guard (`is_derivation_point`) compares x-coordinates instead of full SEC1 encodings, so the negation of a committed point (`-P`: same x, flipped `0x03`/`0x02` parity byte) no longer bypasses it while yielding the same shared secret. This was the review's one open higher-severity item: `SigningKey::ecdh(-P_derive)` returned the P-256 derivation seed and `ViewingKey::ecdh(-P_pda)` the PDA nullifier root.
2. `PublicKey::confidential_view_tag` rejects the all-zero dummy owner explicitly, instead of relying on `as_p256`'s SEC1 re-parse to fail.
3. `ShieldedKeypair`'s `Signer::pubkey` / `sign_message` panic on a non-ed25519 keypair. Behavior change: a P-256/PDA keypair used through the infallible `Signer` API previously returned the system-program address (`Pubkey::default()`) and a zero signature.
4. `ShieldedPda::from_key_exchange` / `from_viewing_key` docs now state the two roots are disjoint and the constructors are not interchangeable.

## Tests

Negated committed points are rejected on both the `SigningKey` and `ViewingKey` ecdh rails; the zeroed owner is rejected by `confidential_view_tag` / `owner_proof_input_hash`; the P-256 `Signer` panic is pinned with `#[should_panic]`; and a non-degenerate encryption golden (non-palindromic salt, slot 1, block-crossing plaintext) pins the salt/slot wire encoding that the existing all-zero-salt / slot-0 golden did not.

## Verification

- `cargo test -p zolana-keypair` — 26 pass (13 integration + 9 HSM + 4 seed-based)
- `cargo clippy -p zolana-keypair --all-targets` and `cargo fmt --check` — clean
- `cargo check` on `zolana-transaction`, `zolana-wallet`, `zolana-client`, `zolana-program-test`, `zolana-cli` — all compile