### PR TITLE
fix(circuit): gate address inputs with dummy policy

### DIFF
--- a/prover/server/circuits/spp_transaction/shared/address_test.go
+++ b/prover/server/circuits/spp_transaction/shared/address_test.go
@@ -116,6 +116,17 @@ func TestAddressSlotRingSolves(t *testing.T) {
 	assert.SolvingSucceeded(circuit, asCustomRingEddsaOnly(assignment), test.WithCurves(ecc.BN254))
 }
 
+func TestAddressSlotRejectedWhenDummyPolicyDisabled(t *testing.T) {
+	assert := test.NewAssert(t)
+	shape := protocol.Shape{NInputs: 1, NOutputs: 2}
+	circuit := MustNewCustomRingEddsaOnlyCircuit(Shape(shape))
+	assignment, _, _ := buildRingAddressAssignment(t)
+	assignment.AllowDummyInputs = spptest.Fe(0)
+	refreshPublicInputHash(t, assignment)
+
+	assert.SolvingFailed(circuit, asCustomRingEddsaOnly(assignment), test.WithCurves(ecc.BN254))
+}
+
 func TestAddressSlotConfidentialSolves(t *testing.T) {
 	assert := test.NewAssert(t)
 	shape := protocol.Shape{NInputs: 1, NOutputs: 2}

--- a/prover/server/circuits/spp_transaction/shared/transaction.go
+++ b/prover/server/circuits/spp_transaction/shared/transaction.go
@@ -118,8 +118,9 @@ func (t Transaction) Constrain(api frontend.API, signers Signers, outputSigned [
 	inputHashes := make([]frontend.Variable, t.Shape.NInputs)
 	addressHashes := make([]frontend.Variable, t.Shape.NInputs)
 	for i, in := range t.Inputs {
+		isDummyOrAddress := api.Add(in.isDummy(api), in.isAddress(api))
 		api.AssertIsEqual(
-			api.Mul(api.Sub(1, t.AllowDummyInputs), in.isDummy(api)),
+			api.Mul(api.Sub(1, t.AllowDummyInputs), isDummyOrAddress),
 			0,
 		)
 		signals := PublicInputUtxoInputs{


### PR DESCRIPTION
## Summary

- reject address inputs when `AllowDummyInputs` is disabled
- retain address support while the policy is enabled
- add regression coverage for the disabled-policy case

## Testing

- `GOCACHE=/private/tmp/zolana2-go-build-cache go test ./circuits/spp_transaction/shared`