### PR TITLE
custom-ring: generate rings from source at a pinned revision

### DIFF
--- a/custom-rings/cargo-generate.toml
+++ b/custom-rings/cargo-generate.toml
@@ -1,0 +1,12 @@
+# Stage two of `zolana-ring new`, the ring source template.
+[template]
+cargo_generate_version = ">=0.23.0"
+ignore = [
+    "build",
+    "cli",
+    "client",
+    "interface",
+    "README.md",
+    "custom-ring-keys.CHECKSUM",
+]
+exclude = ["**/*"]

--- a/custom-rings/cli/src/authority.rs
+++ b/custom-rings/cli/src/authority.rs
@@ -1,8 +1,4 @@
-use std::{
-    io,
-    path::Path,
-    process::{Command, ExitStatus},
-};
+use std::{path::Path, process::Command};
 
 use custom_ring_sdk::{CustomRing, SetAuthority, SET_AUTHORITY_COMPUTE_UNIT_LIMIT};
 use solana_address::Address;
@@ -15,6 +11,7 @@ use zolana_client::{Rpc, SolanaRpc};
 use crate::{
     config::{expand_tilde, ConfigError},
     deploy::{read_program_data, DeployError, ProgramDataInfo},
+    tool::{ToolError, SOLANA},
     AuthorityCommand, Context,
 };
 
@@ -30,23 +27,13 @@ pub enum AuthorityError {
     #[error(transparent)]
     Config(#[from] ConfigError),
     #[error(transparent)]
-    Deploy(#[from] DeployError),
+    Deploy(Box<DeployError>),
     #[error("program {program} is not deployed under the upgradeable loader")]
     NotDeployed { program: Address },
-    #[error("program {program} is upgradeable by {authority}, ring.toml names {expected}")]
-    ForeignAuthority {
-        program: Address,
-        authority: Address,
-        expected: Address,
-    },
-    #[error("program {program} is already immutable")]
-    Immutable { program: Address },
     #[error("renouncing is irreversible, pass --yes to make {program} immutable")]
     NeedsConfirmation { program: Address },
-    #[error("cannot run `solana program set-upgrade-authority`, is the Solana CLI installed")]
-    SolanaCli(#[source] io::Error),
-    #[error("`solana program set-upgrade-authority` exited with {status}")]
-    SolanaCliStatus { status: ExitStatus },
+    #[error(transparent)]
+    Tool(#[from] ToolError),
     #[error("cannot read the new authority keypair {path}")]
     NewAuthorityKeypair { path: String },
     #[error("sending set_authority failed")]
@@ -142,33 +129,30 @@ impl SetUpgradeAuthority<'_> {
         let program = self.ring.program_id();
         match self.current.upgrade_authority {
             Some(authority) if authority == self.authority => Ok(()),
-            Some(authority) => Err(AuthorityError::ForeignAuthority {
+            Some(authority) => Err(DeployError::ForeignAuthority {
                 program,
                 authority,
                 expected: self.authority,
-            }),
-            None => Err(AuthorityError::Immutable { program }),
+            }
+            .into()),
+            None => Err(DeployError::Immutable { program }.into()),
         }
     }
 
     fn run(&self, rpc: &SolanaRpc, args: &[&str]) -> Result<(), AuthorityError> {
-        let status = Command::new("solana")
-            .args([
-                "program",
-                "set-upgrade-authority",
-                "--url",
-                &rpc.client().url(),
-                "--keypair",
-            ])
-            .arg(self.authority_keypair)
-            .arg(self.ring.program_id().to_string())
-            .args(args)
-            .status()
-            .map_err(AuthorityError::SolanaCli)?;
-        if !status.success() {
-            return Err(AuthorityError::SolanaCliStatus { status });
-        }
-        Ok(())
+        Ok(SOLANA.named("solana program set-upgrade-authority").run(
+            Command::new("solana")
+                .args([
+                    "program",
+                    "set-upgrade-authority",
+                    "--url",
+                    &rpc.client().url(),
+                    "--keypair",
+                ])
+                .arg(self.authority_keypair)
+                .arg(self.ring.program_id().to_string())
+                .args(args),
+        )?)
     }
 }
 
@@ -179,4 +163,10 @@ pub fn deployed_program_data<R: Rpc>(
     read_program_data(rpc, ring)?.ok_or(AuthorityError::NotDeployed {
         program: ring.program_id(),
     })
+}
+
+impl From<DeployError> for AuthorityError {
+    fn from(error: DeployError) -> Self {
+        Self::Deploy(Box::new(error))
+    }
 }

--- a/custom-rings/cli/src/build_program.rs
+++ b/custom-rings/cli/src/build_program.rs
@@ -34,13 +34,11 @@ pub enum BuildError {
 }
 
 pub struct BuildProgram<'a> {
-    pub name: &'a str,
     pub tools_version: &'a str,
 }
 
-pub fn run(config: &RingConfig, args: BuildArgs) -> Result<(), BuildError> {
+pub fn run(_config: &RingConfig, args: BuildArgs) -> Result<(), BuildError> {
     let artifact = BuildProgram {
-        name: &config.name,
         tools_version: &args.tools_version,
     }
     .build()?;
@@ -63,7 +61,7 @@ impl BuildProgram<'_> {
         if !status.success() {
             return Err(BuildError::BuildFailed { status });
         }
-        let artifact = default_program_so(self.name);
+        let artifact = default_program_so();
         if !artifact.exists() {
             return Err(BuildError::ArtifactMissing { path: artifact });
         }
@@ -107,18 +105,5 @@ fn spawn_error(source: io::Error) -> BuildError {
         BuildError::CargoBuildSbfMissing(source)
     } else {
         BuildError::Spawn(source)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn the_artifact_path_replaces_dashes() {
-        assert_eq!(
-            default_program_so("my-demo-ring"),
-            PathBuf::from("target/deploy/my_demo_ring_program.so")
-        );
     }
 }

--- a/custom-rings/cli/src/build_program.rs
+++ b/custom-rings/cli/src/build_program.rs
@@ -1,7 +1,6 @@
 //! `build`, the SBF program build with pinned platform tools.
 
 use std::{
-    io,
     path::PathBuf,
     process::{Command, ExitStatus},
     thread,
@@ -10,100 +9,74 @@ use std::{
 
 use thiserror::Error;
 
-use crate::{config::RingConfig, deploy::default_program_so, BuildArgs};
+use crate::{
+    deploy::default_program_so,
+    tool::{ToolError, CARGO_BUILD_SBF},
+    BuildArgs,
+};
 
 /// The platform tools pin the zolana checkout builds with.
 pub const DEFAULT_SBF_TOOLS_VERSION: &str = "v1.54";
 const INSTALL_ATTEMPTS: u64 = 3;
-const ANZA_INSTALL: &str = r#"sh -c "$(curl -sSfL https://release.anza.xyz/v4.0.2/install)""#;
 
 #[derive(Debug, Error)]
 pub enum BuildError {
-    #[error("cargo-build-sbf is not installed, install the Anza toolchain with {ANZA_INSTALL}")]
-    CargoBuildSbfMissing(#[source] io::Error),
-    #[error("cannot run cargo-build-sbf")]
-    Spawn(#[source] io::Error),
+    #[error(transparent)]
+    Tool(#[from] ToolError),
     #[error(
         "platform tools {version} install exited with {status} after {INSTALL_ATTEMPTS} attempts"
     )]
     InstallFailed { version: String, status: ExitStatus },
-    #[error("cargo-build-sbf exited with {status}")]
-    BuildFailed { status: ExitStatus },
     #[error("build finished without {path}")]
     ArtifactMissing { path: PathBuf },
 }
 
-pub struct BuildProgram<'a> {
-    pub tools_version: &'a str,
-}
-
-pub fn run(_config: &RingConfig, args: BuildArgs) -> Result<(), BuildError> {
-    let artifact = BuildProgram {
-        tools_version: &args.tools_version,
-    }
-    .build()?;
-    println!("built       {}", artifact.display());
+pub fn run(args: BuildArgs) -> Result<(), BuildError> {
+    let artifact = build(&args.tools_version)?;
+    crate::line("built", artifact.display());
     Ok(())
 }
 
-impl BuildProgram<'_> {
-    pub fn build(self) -> Result<PathBuf, BuildError> {
-        self.install_tools()?;
-        let status = self
-            .command(&[
-                "--manifest-path",
-                "program/Cargo.toml",
-                "--features",
-                "bpf-entrypoint",
-            ])
-            .status()
-            .map_err(spawn_error)?;
-        if !status.success() {
-            return Err(BuildError::BuildFailed { status });
-        }
-        let artifact = default_program_so();
-        if !artifact.exists() {
-            return Err(BuildError::ArtifactMissing { path: artifact });
-        }
-        Ok(artifact)
+fn build(tools_version: &str) -> Result<PathBuf, BuildError> {
+    install_tools(tools_version)?;
+    CARGO_BUILD_SBF.run(&mut command(
+        tools_version,
+        &[
+            "--manifest-path",
+            "program/Cargo.toml",
+            "--features",
+            "bpf-entrypoint",
+        ],
+    ))?;
+    let artifact = default_program_so();
+    if !artifact.exists() {
+        return Err(BuildError::ArtifactMissing { path: artifact });
     }
+    Ok(artifact)
+}
 
-    /// The release download flakes, retries back off like CI.
-    fn install_tools(&self) -> Result<(), BuildError> {
-        let mut attempt = 1;
-        loop {
-            let status = self
-                .command(&["--install-only"])
-                .status()
-                .map_err(spawn_error)?;
-            if status.success() {
-                return Ok(());
-            }
-            if attempt == INSTALL_ATTEMPTS {
-                return Err(BuildError::InstallFailed {
-                    version: self.tools_version.to_owned(),
-                    status,
-                });
-            }
-            println!("platform tools install failed, attempt {attempt}");
-            thread::sleep(Duration::from_secs(15 * attempt));
-            attempt += 1;
+/// The release download flakes, retries back off like CI.
+fn install_tools(tools_version: &str) -> Result<(), BuildError> {
+    let mut attempt = 1;
+    loop {
+        let status = CARGO_BUILD_SBF.status(&mut command(tools_version, &["--install-only"]))?;
+        if status.success() {
+            return Ok(());
         }
-    }
-
-    fn command(&self, args: &[&str]) -> Command {
-        let mut command = Command::new("cargo-build-sbf");
-        command
-            .args(["--tools-version", self.tools_version])
-            .args(args);
-        command
+        if attempt == INSTALL_ATTEMPTS {
+            return Err(BuildError::InstallFailed {
+                version: tools_version.to_owned(),
+                status,
+            });
+        }
+        println!("platform tools install failed, attempt {attempt}");
+        thread::sleep(Duration::from_secs(15 * attempt));
+        attempt += 1;
     }
 }
 
-fn spawn_error(source: io::Error) -> BuildError {
-    if source.kind() == io::ErrorKind::NotFound {
-        BuildError::CargoBuildSbfMissing(source)
-    } else {
-        BuildError::Spawn(source)
-    }
+fn command(tools_version: &str, args: &[&str]) -> Command {
+    let mut command = Command::new("cargo-build-sbf");
+    command.args(["--tools-version", tools_version]).args(args);
+    command
 }

--- a/custom-rings/cli/src/config.rs
+++ b/custom-rings/cli/src/config.rs
@@ -8,8 +8,10 @@ use std::{
 
 use serde::Deserialize;
 use solana_address::Address;
-use solana_keypair::{read_keypair_file, Keypair};
+use solana_keypair::Keypair;
 use thiserror::Error;
+
+use crate::file::{self, FileError};
 
 pub const RING_TOML: &str = "ring.toml";
 
@@ -51,8 +53,7 @@ pub struct Urls {
 }
 
 impl Urls {
-    /// Only a ring RPC on this machine takes its auditor key from `keys/`; any
-    /// other one holds a key of its own.
+    /// Only a ring RPC on this machine takes its auditor key from `keys/`.
     pub fn ring_rpc_is_local(&self) -> bool {
         let rest = match self.ring_rpc.split_once("://") {
             Some((_, rest)) => rest,
@@ -72,24 +73,8 @@ impl Urls {
 
 #[derive(Debug, Error)]
 pub enum ConfigError {
-    #[error("cannot read {path}")]
-    Read {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("cannot parse {path}")]
-    Parse {
-        path: PathBuf,
-        #[source]
-        source: toml::de::Error,
-    },
-    #[error("cannot write {path}")]
-    Write {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
+    #[error(transparent)]
+    File(#[from] FileError),
     #[error("{path} has no target line")]
     NoTargetLine { path: PathBuf },
     #[error("{path} line is not KEY=VALUE, {line}")]
@@ -100,8 +85,6 @@ pub enum ConfigError {
     UnclosedPlaceholder { text: String },
     #[error("HOME is not set")]
     HomeUnset,
-    #[error("cannot read authority keypair {path}, {message}")]
-    Keypair { path: PathBuf, message: String },
     #[error("ring_rpc_pubkey {key} is not a base58 key")]
     RingRpcPubkey { key: String },
 }
@@ -118,11 +101,7 @@ impl Target {
 impl RingConfig {
     /// `.env` next to ring.toml fills `${NAME}` placeholders, the environment wins.
     pub fn load(path: &Path) -> Result<Self, ConfigError> {
-        let text = read(path)?;
-        let mut config: Self = toml::from_str(&text).map_err(|source| ConfigError::Parse {
-            path: path.to_path_buf(),
-            source,
-        })?;
+        let mut config: Self = file::parse_toml(path)?;
         load_dotenv(&path.with_file_name(".env"))?;
         for urls in [&mut config.localnet, &mut config.devnet] {
             for url in [
@@ -146,7 +125,7 @@ impl RingConfig {
 
     /// The rest of the file stays byte for byte.
     pub fn set_target(path: &Path, target: Target) -> Result<(), ConfigError> {
-        let text = read(path)?;
+        let text = file::read(path)?;
         let mut replaced = false;
         let updated: Vec<String> = text
             .lines()
@@ -164,18 +143,11 @@ impl RingConfig {
                 path: path.to_path_buf(),
             });
         }
-        std::fs::write(path, updated.join("\n") + "\n").map_err(|source| ConfigError::Write {
-            path: path.to_path_buf(),
-            source,
-        })
+        Ok(file::write(path, updated.join("\n") + "\n")?)
     }
 
     pub fn authority(&self) -> Result<Keypair, ConfigError> {
-        let path = expand_tilde(&self.authority_keypair)?;
-        read_keypair_file(&path).map_err(|error| ConfigError::Keypair {
-            path,
-            message: error.to_string(),
-        })
+        Ok(file::read_keypair(&expand_tilde(&self.authority_keypair)?)?)
     }
 
     pub fn enabled_features(&self) -> impl Iterator<Item = &str> {
@@ -205,23 +177,17 @@ mod base58_address {
     }
 }
 
-fn read(path: &Path) -> Result<String, ConfigError> {
-    std::fs::read_to_string(path).map_err(|source| ConfigError::Read {
-        path: path.to_path_buf(),
-        source,
-    })
-}
-
 /// Never overrides a variable already set.
 fn load_dotenv(path: &Path) -> Result<(), ConfigError> {
     let text = match std::fs::read_to_string(path) {
         Ok(text) => text,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(source) => {
-            return Err(ConfigError::Read {
+            return Err(FileError::Read {
                 path: path.to_path_buf(),
                 source,
-            })
+            }
+            .into())
         }
     };
     for line in text.lines() {

--- a/custom-rings/cli/src/config.rs
+++ b/custom-rings/cli/src/config.rs
@@ -23,6 +23,8 @@ pub struct RingConfig {
     pub program_id: Address,
     /// Upgrade authority and ring authority, `~` expands to `$HOME`.
     pub authority_keypair: PathBuf,
+    /// Zolana revision the ring source was generated from.
+    pub zolana_revision: String,
     pub localnet: Urls,
     pub devnet: Urls,
     #[serde(default)]
@@ -272,6 +274,7 @@ mod tests {
 name = "demo-ring"
 target = "localnet"
 program_id = "9vyTbYGyh3cwxkAQpjjFQGXmdJP6p9B6YcQ5pNuXPNbh"
+zolana_revision = "851680f7fcc99ccbd88119942760e9309ace0a58"
 authority_keypair = "~/.config/solana/id.json"
 
 [localnet]

--- a/custom-rings/cli/src/deploy.rs
+++ b/custom-rings/cli/src/deploy.rs
@@ -1,20 +1,23 @@
 //! The Solana CLI owns the loader v3 write protocol.
 
 use std::{
-    io,
     path::{Path, PathBuf},
-    process::{Command, ExitStatus},
+    process::Command,
 };
 
 use custom_ring_sdk::CustomRing;
 use solana_address::Address;
-use solana_keypair::read_keypair_file;
 use solana_loader_v3_interface::state::UpgradeableLoaderState;
 use solana_signer::Signer;
 use thiserror::Error;
 use zolana_client::{ClientError, Rpc, SolanaRpc};
 
-use crate::{config::expand_tilde, Context, ContextError, DeployArgs};
+use crate::{
+    config::expand_tilde,
+    file::{self, FileError},
+    tool::{ToolError, SOLANA},
+    Context, ContextError, DeployArgs,
+};
 
 pub struct Deploy<'a> {
     pub ring: CustomRing,
@@ -49,12 +52,8 @@ pub enum DeployError {
     Context(#[from] ContextError),
     #[error("{label} not found at {path}")]
     MissingFile { label: &'static str, path: PathBuf },
-    #[error("cannot read {path}")]
-    Metadata {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
+    #[error(transparent)]
+    File(#[from] FileError),
     #[error("program {program} is upgradeable by {authority}, ring.toml names {expected}")]
     ForeignAuthority {
         program: Address,
@@ -65,21 +64,10 @@ pub enum DeployError {
     Immutable { program: Address },
     #[error("program keypair not found at {path}, the first deploy needs it")]
     MissingProgramKeypair { path: PathBuf },
-    #[error("cannot read program keypair {path}, {message}")]
-    ProgramKeypair { path: PathBuf, message: String },
     #[error("program keypair is {found}, ring.toml names {expected}")]
     ProgramKeypairMismatch { expected: Address, found: Address },
-    #[error("cannot run `solana program {command}`, is the Solana CLI installed")]
-    SolanaCli {
-        command: &'static str,
-        #[source]
-        source: io::Error,
-    },
-    #[error("`solana program {command}` exited with {status}")]
-    SolanaCliStatus {
-        command: &'static str,
-        status: ExitStatus,
-    },
+    #[error(transparent)]
+    Tool(#[from] ToolError),
     #[error("program {program} is not executable after deploy")]
     NotExecutable {
         program: Address,
@@ -90,12 +78,6 @@ pub enum DeployError {
     ProgramData { address: Address },
     #[error(transparent)]
     Client(Box<ClientError>),
-}
-
-impl From<ClientError> for DeployError {
-    fn from(error: ClientError) -> Self {
-        Self::Client(Box::new(error))
-    }
 }
 
 /// The smallest growth of `ProgramData` the loader accepts.
@@ -128,7 +110,6 @@ pub fn run(ctx: &mut Context, args: DeployArgs) -> Result<(), DeployError> {
         ctx.ring.program_id(),
         authority.pubkey()
     );
-    // `init` announces the live ring, a deploy alone does not make one.
     Ok(())
 }
 
@@ -146,7 +127,7 @@ impl Deploy<'_> {
             }
         }
         let so_len = std::fs::metadata(self.program_so)
-            .map_err(|source| DeployError::Metadata {
+            .map_err(|source| FileError::Read {
                 path: self.program_so.to_path_buf(),
                 source,
             })?
@@ -206,20 +187,9 @@ impl Deploy<'_> {
         } else {
             command.arg(self.program_keypair);
         }
-        let status =
-            command
-                .arg(self.program_so)
-                .status()
-                .map_err(|source| DeployError::SolanaCli {
-                    command: "deploy",
-                    source,
-                })?;
-        if !status.success() {
-            return Err(DeployError::SolanaCliStatus {
-                command: "deploy",
-                status,
-            });
-        }
+        SOLANA
+            .named("solana program deploy")
+            .run(command.arg(self.program_so))?;
         rpc.assert_executable(&program)
             .map_err(|source| DeployError::NotExecutable {
                 program,
@@ -238,12 +208,7 @@ impl Deploy<'_> {
                 path: self.program_keypair.to_path_buf(),
             });
         }
-        let found = read_keypair_file(self.program_keypair)
-            .map_err(|error| DeployError::ProgramKeypair {
-                path: self.program_keypair.to_path_buf(),
-                message: error.to_string(),
-            })?
-            .pubkey();
+        let found = file::read_keypair(self.program_keypair)?.pubkey();
         if found != self.ring.program_id() {
             return Err(DeployError::ProgramKeypairMismatch {
                 expected: self.ring.program_id(),
@@ -255,23 +220,13 @@ impl Deploy<'_> {
 
     fn extend(&self, url: String, additional_bytes: usize) -> Result<(), DeployError> {
         println!("extending program data by {additional_bytes} bytes");
-        let status = Command::new("solana")
-            .args(["program", "extend", "--url", &url, "--keypair"])
-            .arg(self.authority_keypair)
-            .arg(self.ring.program_id().to_string())
-            .arg(additional_bytes.to_string())
-            .status()
-            .map_err(|source| DeployError::SolanaCli {
-                command: "extend",
-                source,
-            })?;
-        if !status.success() {
-            return Err(DeployError::SolanaCliStatus {
-                command: "extend",
-                status,
-            });
-        }
-        Ok(())
+        Ok(SOLANA.named("solana program extend").run(
+            Command::new("solana")
+                .args(["program", "extend", "--url", &url, "--keypair"])
+                .arg(self.authority_keypair)
+                .arg(self.ring.program_id().to_string())
+                .arg(additional_bytes.to_string()),
+        )?)
     }
 }
 

--- a/custom-rings/cli/src/deploy.rs
+++ b/custom-rings/cli/src/deploy.rs
@@ -104,9 +104,7 @@ const MIN_EXTEND_BYTES: usize = 10_240;
 const DEPLOY_FEE_BUDGET: u64 = 20_000_000;
 
 pub fn run(ctx: &mut Context, args: DeployArgs) -> Result<(), DeployError> {
-    let program_so = args
-        .program_so
-        .unwrap_or_else(|| default_program_so(&ctx.config.name));
+    let program_so = args.program_so.unwrap_or_else(default_program_so);
     let authority = ctx.config.authority().map_err(ContextError::from)?;
     let authority_keypair =
         expand_tilde(&ctx.config.authority_keypair).map_err(ContextError::from)?;
@@ -341,11 +339,9 @@ pub fn read_program_data<R: Rpc>(
     }))
 }
 
-pub(crate) fn default_program_so(name: &str) -> PathBuf {
-    PathBuf::from(format!(
-        "target/deploy/{}_program.so",
-        name.replace('-', "_")
-    ))
+/// The ring source keeps the upstream crate name, every ring builds the same file.
+pub(crate) fn default_program_so() -> PathBuf {
+    PathBuf::from("target/deploy/custom_ring_program.so")
 }
 
 #[cfg(test)]

--- a/custom-rings/cli/src/error.rs
+++ b/custom-rings/cli/src/error.rs
@@ -2,10 +2,10 @@ use thiserror::Error;
 
 use crate::{
     authority::AuthorityError, build_program::BuildError, config::ConfigError, deploy::DeployError,
-    generate::GenerateError, init::InitError, keys::AuditorKeyError, pipeline::PipelineError,
-    probe::ProbeError, reader::ReaderError, repo::RepoError, ring_rpc::RpcCheckError,
-    transact::TransactError,
+    generate::GenerateError, init::InitError, pipeline::PipelineError, probe::ProbeError,
+    reader::ReaderError, ring_rpc::RingRpcClientError, tool::ToolError, transact::TransactError,
 };
+use zolana_ring_rpc::KeyFileError;
 
 #[derive(Debug, Error)]
 pub enum CliError {
@@ -20,9 +20,9 @@ pub enum CliError {
     #[error(transparent)]
     Pipeline(Box<PipelineError>),
     #[error(transparent)]
-    AuditorKey(Box<AuditorKeyError>),
+    KeyFile(Box<KeyFileError>),
     #[error(transparent)]
-    Repo(Box<RepoError>),
+    Tool(Box<ToolError>),
     #[error(transparent)]
     Deploy(Box<DeployError>),
     #[error(transparent)]
@@ -30,7 +30,7 @@ pub enum CliError {
     #[error(transparent)]
     Transact(Box<TransactError>),
     #[error(transparent)]
-    RpcCheck(Box<RpcCheckError>),
+    RingRpc(Box<RingRpcClientError>),
     #[error(transparent)]
     Authority(Box<AuthorityError>),
     #[error(transparent)]
@@ -54,12 +54,31 @@ boxed_from!(
     Build(BuildError),
     Probe(ProbeError),
     Pipeline(PipelineError),
-    AuditorKey(AuditorKeyError),
-    Repo(RepoError),
+    KeyFile(KeyFileError),
+    Tool(ToolError),
     Deploy(DeployError),
     Init(InitError),
     Transact(TransactError),
-    RpcCheck(RpcCheckError),
+    RingRpc(RingRpcClientError),
     Authority(AuthorityError),
     Reader(ReaderError),
+);
+
+/// One `Client` variant per module, boxed for enum size.
+macro_rules! client_from {
+    ($($error:ty),* $(,)?) => {$(
+        impl From<zolana_client::ClientError> for $error {
+            fn from(error: zolana_client::ClientError) -> Self {
+                Self::Client(Box::new(error))
+            }
+        }
+    )*};
+}
+
+client_from!(
+    crate::ContextError,
+    crate::deploy::DeployError,
+    crate::fund::FundError,
+    crate::status::StatusError,
+    crate::transact::TransactError,
 );

--- a/custom-rings/cli/src/file.rs
+++ b/custom-rings/cli/src/file.rs
@@ -1,0 +1,102 @@
+//! One place the cli touches a path and reports the failure.
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use serde::de::DeserializeOwned;
+use solana_keypair::Keypair;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum FileError {
+    #[error("cannot read {path}")]
+    Read {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("cannot write {path}")]
+    Write {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("cannot parse {path}")]
+    Parse {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+    #[error("cannot read keypair {path}, {message}")]
+    Keypair { path: PathBuf, message: String },
+    #[error("cannot write keypair {path}, {message}")]
+    KeypairWrite { path: PathBuf, message: String },
+}
+
+pub fn read(path: &Path) -> Result<String, FileError> {
+    fs::read_to_string(path).map_err(|source| FileError::Read {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+pub fn write(path: &Path, contents: impl AsRef<[u8]>) -> Result<(), FileError> {
+    fs::write(path, contents).map_err(|source| FileError::Write {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+pub fn create_dir_all(path: &Path) -> Result<(), FileError> {
+    fs::create_dir_all(path).map_err(|source| FileError::Write {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+pub fn rename(from: &Path, to: &Path) -> Result<(), FileError> {
+    fs::rename(from, to).map_err(|source| FileError::Write {
+        path: to.to_path_buf(),
+        source,
+    })
+}
+
+pub fn parse_toml<T: DeserializeOwned>(path: &Path) -> Result<T, FileError> {
+    toml::from_str(&read(path)?).map_err(|source| FileError::Parse {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+pub fn read_keypair(path: &Path) -> Result<Keypair, FileError> {
+    solana_keypair::read_keypair_file(path).map_err(|error| FileError::Keypair {
+        path: path.to_path_buf(),
+        message: error.to_string(),
+    })
+}
+
+pub fn write_keypair(keypair: &Keypair, path: &Path) -> Result<(), FileError> {
+    solana_keypair::write_keypair_file(keypair, path).map_err(|error| FileError::KeypairWrite {
+        path: path.to_path_buf(),
+        message: error.to_string(),
+    })?;
+    restrict_mode(path)
+}
+
+#[cfg(unix)]
+fn restrict_mode(path: &Path) -> Result<(), FileError> {
+    use std::os::unix::fs::PermissionsExt;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600)).map_err(|source| {
+        FileError::Write {
+            path: path.to_path_buf(),
+            source,
+        }
+    })
+}
+
+#[cfg(not(unix))]
+fn restrict_mode(_path: &Path) -> Result<(), FileError> {
+    Ok(())
+}

--- a/custom-rings/cli/src/fund.rs
+++ b/custom-rings/cli/src/fund.rs
@@ -32,14 +32,8 @@ pub enum FundError {
     Client(Box<ClientError>),
 }
 
-impl From<ClientError> for FundError {
-    fn from(error: ClientError) -> Self {
-        Self::Client(Box::new(error))
-    }
-}
-
-/// Rechecks as long as the operator answers, so a pipeline resumes where it
-/// stopped. Without a terminal it fails instead of hanging.
+/// Rechecks as long as the operator answers, without a terminal it fails
+/// instead of hanging.
 pub fn wait_for_balance<R: Rpc>(
     rpc: &R,
     authority: Address,

--- a/custom-rings/cli/src/generate.rs
+++ b/custom-rings/cli/src/generate.rs
@@ -167,9 +167,8 @@ fn render_template(
         command.arg("--silent");
     }
     for define in [
-        format!("silent={silent}"),
         format!("program_id={program_id}"),
-        format!("default_authority_keypair={}", args.authority_keypair),
+        format!("authority_keypair={}", args.authority_keypair),
     ] {
         command.arg("-d").arg(define);
     }

--- a/custom-rings/cli/src/generate.rs
+++ b/custom-rings/cli/src/generate.rs
@@ -19,6 +19,11 @@ use crate::{
 pub const TEMPLATE_GIT: &str = "https://github.com/helius-labs/zolana-ring";
 /// A dev build follows the branch, a release pins its tag here.
 pub const TEMPLATE_REV: &str = "main";
+/// The ring source arrives from here at the revision ring.toml pins.
+pub const ZOLANA_GIT: &str = "https://github.com/helius-labs/zolana";
+const SOURCE_SUBFOLDER: &str = "custom-rings";
+/// Seeds the ring resolution with the versions zolana builds with.
+const WORKSPACE_LOCK: &str = include_str!("../../../Cargo.lock");
 pub const DEFAULT_AUTHORITY_KEYPAIR: &str = "~/.config/solana/id.json";
 
 #[derive(Debug, Error)]
@@ -47,6 +52,8 @@ pub enum GenerateError {
     },
     #[error("{path} records no authority_keypair")]
     NoAuthorityRecorded { path: PathBuf },
+    #[error("{path} records no 40-hex zolana_revision")]
+    NoRevisionRecorded { path: PathBuf },
     #[error("cannot run {tool}")]
     Spawn {
         tool: &'static str,
@@ -93,43 +100,16 @@ pub fn run(args: NewArgs) -> Result<(), GenerateError> {
     restrict_mode(&staged_keypair)?;
     let program_id = program_keypair.pubkey();
 
-    let silent = args.silent || !io::stdin().is_terminal();
-    let mut command = Command::new("cargo");
-    command.arg("generate");
-    template.apply(&mut command, &revision);
-    command.arg("--destination").arg(&args.dest);
-    command.args(["--name", &args.name]);
-    if silent {
-        command.arg("--silent");
-    }
-    for define in [
-        format!("silent={silent}"),
-        format!("program_id={program_id}"),
-        format!("default_authority_keypair={}", args.authority_keypair),
-    ] {
-        command.arg("-d").arg(define);
-    }
-    if let Some(rev) = &args.zolana_rev {
-        command.arg("-d").arg(format!("zolana_revision={rev}"));
-    }
-    run_tool("cargo generate", &mut command)?;
-
-    let keys_dir = ring_dir.join("keys");
-    fs::create_dir_all(&keys_dir).map_err(|source| GenerateError::Io {
-        path: keys_dir.clone(),
-        source,
-    })?;
-    let keypair_path = ring_dir.join(PROGRAM_KEYPAIR_FILE);
-    fs::rename(&staged_keypair, &keypair_path).map_err(|source| GenerateError::Io {
-        path: keypair_path.clone(),
-        source,
-    })?;
+    render_template(&args, &template, &revision, &program_id.to_string())?;
+    let source_rev = copy_ring_source(&args, &ring_dir)?;
+    write_lockfile(&ring_dir)?;
+    place_program_keypair(&ring_dir, &staged_keypair)?;
     ensure_authority(&ring_dir)?;
     commit_generated(&ring_dir, &args.name, &program_id.to_string())?;
 
     println!();
     println!(
-        "generated {} for program {program_id} at template {revision}",
+        "generated {} for program {program_id}, template {revision}, source {source_rev}",
         ring_dir.display()
     );
     println!();
@@ -213,6 +193,69 @@ impl TemplateSource {
     }
 }
 
+/// Renders the ring configuration, ring.toml, guide, and workspace manifest.
+fn render_template(
+    args: &NewArgs,
+    template: &TemplateSource,
+    revision: &str,
+    program_id: &str,
+) -> Result<(), GenerateError> {
+    let silent = args.silent || !io::stdin().is_terminal();
+    let mut command = Command::new("cargo");
+    command.arg("generate");
+    template.apply(&mut command, revision);
+    command.arg("--destination").arg(&args.dest);
+    command.args(["--name", &args.name]);
+    if silent {
+        command.arg("--silent");
+    }
+    for define in [
+        format!("silent={silent}"),
+        format!("program_id={program_id}"),
+        format!("default_authority_keypair={}", args.authority_keypair),
+    ] {
+        command.arg("-d").arg(define);
+    }
+    command
+        .arg("-d")
+        .arg(format!("zolana_git={}", args.zolana_git));
+    if let Some(rev) = &args.zolana_rev {
+        command.arg("-d").arg(format!("zolana_revision={rev}"));
+    }
+    run_tool("cargo generate", &mut command)
+}
+
+/// Copies `program`, `sdk`, and `test` verbatim from zolana at the revision
+/// ring.toml pins.
+fn copy_ring_source(args: &NewArgs, ring_dir: &Path) -> Result<String, GenerateError> {
+    let source_rev = recorded_revision(ring_dir)?;
+    let mut source = Command::new("cargo");
+    source.current_dir(ring_dir);
+    source.args(["generate", "--git", &args.zolana_git, SOURCE_SUBFOLDER]);
+    source.args(["--revision", &source_rev]);
+    source.args(["--init", "--vcs", "none", "--silent"]);
+    source.args(["--name", &args.name]);
+    run_tool("cargo generate (ring source)", &mut source)?;
+    Ok(source_rev)
+}
+
+/// The embedded lock is hints, cargo prunes it to the ring's graph and keeps
+/// registry versions in step with zolana.
+fn write_lockfile(ring_dir: &Path) -> Result<(), GenerateError> {
+    let path = ring_dir.join("Cargo.lock");
+    fs::write(&path, WORKSPACE_LOCK).map_err(|source| GenerateError::Io { path, source })
+}
+
+fn place_program_keypair(ring_dir: &Path, staged: &Path) -> Result<(), GenerateError> {
+    let keys_dir = ring_dir.join("keys");
+    fs::create_dir_all(&keys_dir).map_err(|source| GenerateError::Io {
+        path: keys_dir,
+        source,
+    })?;
+    let path = ring_dir.join(PROGRAM_KEYPAIR_FILE);
+    fs::rename(staged, &path).map_err(|source| GenerateError::Io { path, source })
+}
+
 /// The default path is created on a fresh machine, any other missing path is
 /// the operator's secret to mount.
 fn ensure_authority(ring_dir: &Path) -> Result<(), GenerateError> {
@@ -249,6 +292,21 @@ fn ensure_authority(ring_dir: &Path) -> Result<(), GenerateError> {
 /// Read the recorded path alone, a full config load would expand `${...}` URL
 /// placeholders the operator has not set yet.
 fn recorded_authority(ring_dir: &Path) -> Result<String, GenerateError> {
+    recorded_key(ring_dir, "authority_keypair")?.ok_or_else(|| GenerateError::NoAuthorityRecorded {
+        path: ring_dir.join(RING_TOML),
+    })
+}
+
+/// The revision stage one rendered, stage two takes the source from it.
+fn recorded_revision(ring_dir: &Path) -> Result<String, GenerateError> {
+    recorded_key(ring_dir, "zolana_revision")?
+        .filter(|revision| is_commit(revision))
+        .ok_or_else(|| GenerateError::NoRevisionRecorded {
+            path: ring_dir.join(RING_TOML),
+        })
+}
+
+fn recorded_key(ring_dir: &Path, key: &str) -> Result<Option<String>, GenerateError> {
     let path = ring_dir.join(RING_TOML);
     let text = fs::read_to_string(&path).map_err(|source| GenerateError::Io {
         path: path.clone(),
@@ -258,11 +316,10 @@ fn recorded_authority(ring_dir: &Path) -> Result<String, GenerateError> {
         path: path.clone(),
         source,
     })?;
-    value
-        .get("authority_keypair")
+    Ok(value
+        .get(key)
         .and_then(|value| value.as_str())
-        .map(str::to_owned)
-        .ok_or(GenerateError::NoAuthorityRecorded { path })
+        .map(str::to_owned))
 }
 
 /// The first commit records the generated ring without keys/ and .env, both ignored.

--- a/custom-rings/cli/src/generate.rs
+++ b/custom-rings/cli/src/generate.rs
@@ -4,15 +4,17 @@ use std::{
     fs, io,
     io::IsTerminal,
     path::{Path, PathBuf},
-    process::{Command, ExitStatus},
+    process::Command,
 };
 
-use solana_keypair::{read_keypair_file, write_keypair_file, Keypair};
+use solana_keypair::Keypair;
 use solana_signer::Signer;
 use thiserror::Error;
 
 use crate::{
     config::{expand_tilde, ConfigError},
+    file::{self, FileError},
+    tool::{ToolError, CARGO_GENERATE, GIT},
     NewArgs, PROGRAM_KEYPAIR_FILE, RING_TOML,
 };
 
@@ -30,43 +32,18 @@ pub const DEFAULT_AUTHORITY_KEYPAIR: &str = "~/.config/solana/id.json";
 pub enum GenerateError {
     #[error("{name} is not kebab-case, use lowercase letters, digits and dashes")]
     Name { name: String },
-    #[error("cargo generate is not installed, run `cargo install cargo-generate --locked`")]
-    CargoGenerateMissing,
     #[error("destination {path} already exists")]
     Exists { path: PathBuf },
-    #[error("cannot prepare {path}")]
-    Io {
-        path: PathBuf,
-        #[source]
-        source: io::Error,
-    },
-    #[error("cannot write program keypair {path}, {message}")]
-    ProgramKeypair { path: PathBuf, message: String },
-    #[error("cannot read authority keypair {path}, {message}")]
-    AuthorityKeypair { path: PathBuf, message: String },
-    #[error("cannot parse {path}")]
-    RingToml {
-        path: PathBuf,
-        #[source]
-        source: toml::de::Error,
-    },
     #[error("{path} records no authority_keypair")]
     NoAuthorityRecorded { path: PathBuf },
     #[error("{path} records no 40-hex zolana_revision")]
     NoRevisionRecorded { path: PathBuf },
-    #[error("cannot run {tool}")]
-    Spawn {
-        tool: &'static str,
-        #[source]
-        source: io::Error,
-    },
-    #[error("{tool} exited with {status}")]
-    Failed {
-        tool: &'static str,
-        status: ExitStatus,
-    },
     #[error("cannot resolve template rev {rev} from {origin} to a commit")]
     UnresolvedRev { rev: String, origin: String },
+    #[error(transparent)]
+    File(#[from] FileError),
+    #[error(transparent)]
+    Tool(#[from] ToolError),
     #[error(transparent)]
     Config(#[from] ConfigError),
 }
@@ -78,7 +55,7 @@ pub enum TemplateSource {
 
 pub fn run(args: NewArgs) -> Result<(), GenerateError> {
     validate_name(&args.name)?;
-    check_cargo_generate()?;
+    CARGO_GENERATE.require(Command::new("cargo").args(["generate", "--version"]))?;
     let ring_dir = args.dest.join(&args.name);
     if ring_dir.exists() {
         return Err(GenerateError::Exists { path: ring_dir });
@@ -91,13 +68,7 @@ pub fn run(args: NewArgs) -> Result<(), GenerateError> {
     let staging = Staging::create(&args.dest, &args.name)?;
     let staged_keypair = staging.dir.join("program-keypair.json");
     let program_keypair = Keypair::new();
-    write_keypair_file(&program_keypair, &staged_keypair).map_err(|error| {
-        GenerateError::ProgramKeypair {
-            path: staged_keypair.clone(),
-            message: error.to_string(),
-        }
-    })?;
-    restrict_mode(&staged_keypair)?;
+    file::write_keypair(&program_keypair, &staged_keypair)?;
     let program_id = program_keypair.pubkey();
 
     render_template(&args, &template, &revision, &program_id.to_string())?;
@@ -136,45 +107,30 @@ impl TemplateSource {
     pub fn resolve_commit(&self) -> Result<String, GenerateError> {
         match self {
             Self::Path(path) => {
-                let output = Command::new("git")
-                    .arg("-C")
-                    .arg(path)
-                    .args(["rev-parse", "HEAD"])
-                    .output()
-                    .map_err(|source| GenerateError::Spawn {
-                        tool: "git",
-                        source,
-                    })?;
-                let commit = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-                if !output.status.success() || !is_commit(&commit) {
-                    return Err(GenerateError::UnresolvedRev {
+                let captured = GIT.named("git rev-parse").capture(
+                    Command::new("git")
+                        .arg("-C")
+                        .arg(path)
+                        .args(["rev-parse", "HEAD"]),
+                );
+                match captured {
+                    Ok(commit) if is_commit(&commit) => Ok(commit),
+                    Ok(_) | Err(ToolError::Failed { .. }) => Err(GenerateError::UnresolvedRev {
                         rev: "HEAD".to_owned(),
                         origin: path.display().to_string(),
-                    });
+                    }),
+                    Err(error) => Err(error.into()),
                 }
-                Ok(commit)
             }
             Self::Git { rev, .. } if is_commit(rev) => Ok(rev.clone()),
             Self::Git { url, rev } => {
-                let output = Command::new("git")
-                    .args(["ls-remote", url, rev])
-                    .output()
-                    .map_err(|source| GenerateError::Spawn {
-                        tool: "git",
-                        source,
-                    })?;
-                if !output.status.success() {
-                    return Err(GenerateError::Failed {
-                        tool: "git ls-remote",
-                        status: output.status,
-                    });
-                }
-                commit_from_ls_remote(&String::from_utf8_lossy(&output.stdout), rev).ok_or_else(
-                    || GenerateError::UnresolvedRev {
-                        rev: rev.clone(),
-                        origin: url.clone(),
-                    },
-                )
+                let listed = GIT
+                    .named("git ls-remote")
+                    .capture(Command::new("git").args(["ls-remote", url, rev]))?;
+                commit_from_ls_remote(&listed, rev).ok_or_else(|| GenerateError::UnresolvedRev {
+                    rev: rev.clone(),
+                    origin: url.clone(),
+                })
             }
         }
     }
@@ -193,19 +149,20 @@ impl TemplateSource {
     }
 }
 
-/// Renders the ring configuration, ring.toml, guide, and workspace manifest.
 fn render_template(
     args: &NewArgs,
     template: &TemplateSource,
     revision: &str,
     program_id: &str,
 ) -> Result<(), GenerateError> {
+    crate::line("template", format_args!("rendering at {revision}"));
     let silent = args.silent || !io::stdin().is_terminal();
     let mut command = Command::new("cargo");
     command.arg("generate");
     template.apply(&mut command, revision);
     command.arg("--destination").arg(&args.dest);
-    command.args(["--name", &args.name]);
+    // A ring inside a workspace must never be appended to it as a member.
+    command.args(["--name", &args.name, "--no-workspace"]);
     if silent {
         command.arg("--silent");
     }
@@ -222,66 +179,54 @@ fn render_template(
     if let Some(rev) = &args.zolana_rev {
         command.arg("-d").arg(format!("zolana_revision={rev}"));
     }
-    run_tool("cargo generate", &mut command)
+    Ok(CARGO_GENERATE.run(&mut command)?)
 }
 
-/// Copies `program`, `sdk`, and `test` verbatim from zolana at the revision
-/// ring.toml pins.
 fn copy_ring_source(args: &NewArgs, ring_dir: &Path) -> Result<String, GenerateError> {
     let source_rev = recorded_revision(ring_dir)?;
+    crate::line(
+        "source",
+        format_args!("copying program, sdk and test from zolana {source_rev}"),
+    );
     let mut source = Command::new("cargo");
     source.current_dir(ring_dir);
     source.args(["generate", "--git", &args.zolana_git, SOURCE_SUBFOLDER]);
     source.args(["--revision", &source_rev]);
-    source.args(["--init", "--vcs", "none", "--silent"]);
+    source.args(["--init", "--no-workspace", "--silent"]);
     source.args(["--name", &args.name]);
-    run_tool("cargo generate (ring source)", &mut source)?;
+    // Never prompts, its per-file narration only buries the line above.
+    CARGO_GENERATE
+        .named("cargo generate (ring source)")
+        .run_captured(&mut source)?;
     Ok(source_rev)
 }
 
-/// The embedded lock is hints, cargo prunes it to the ring's graph and keeps
-/// registry versions in step with zolana.
+/// Hints only, cargo prunes them to the ring's graph.
 fn write_lockfile(ring_dir: &Path) -> Result<(), GenerateError> {
-    let path = ring_dir.join("Cargo.lock");
-    fs::write(&path, WORKSPACE_LOCK).map_err(|source| GenerateError::Io { path, source })
+    Ok(file::write(&ring_dir.join("Cargo.lock"), WORKSPACE_LOCK)?)
 }
 
 fn place_program_keypair(ring_dir: &Path, staged: &Path) -> Result<(), GenerateError> {
-    let keys_dir = ring_dir.join("keys");
-    fs::create_dir_all(&keys_dir).map_err(|source| GenerateError::Io {
-        path: keys_dir,
-        source,
-    })?;
-    let path = ring_dir.join(PROGRAM_KEYPAIR_FILE);
-    fs::rename(staged, &path).map_err(|source| GenerateError::Io { path, source })
+    file::create_dir_all(&ring_dir.join("keys"))?;
+    Ok(file::rename(staged, &ring_dir.join(PROGRAM_KEYPAIR_FILE))?)
 }
 
 /// The default path is created on a fresh machine, any other missing path is
 /// the operator's secret to mount.
 fn ensure_authority(ring_dir: &Path) -> Result<(), GenerateError> {
     let recorded = recorded_authority(ring_dir)?;
-    let file = expand_tilde(Path::new(&recorded))?;
-    let read = |path: &Path| {
-        read_keypair_file(path).map_err(|error| GenerateError::AuthorityKeypair {
-            path: path.to_path_buf(),
-            message: error.to_string(),
-        })
-    };
-    if file.is_file() {
-        println!("authority {} from {recorded}", read(&file)?.pubkey());
+    let path = expand_tilde(Path::new(&recorded))?;
+    if path.is_file() {
+        println!(
+            "authority {} from {recorded}",
+            file::read_keypair(&path)?.pubkey()
+        );
     } else if recorded == DEFAULT_AUTHORITY_KEYPAIR {
-        if let Some(parent) = file.parent() {
-            fs::create_dir_all(parent).map_err(|source| GenerateError::Io {
-                path: parent.to_path_buf(),
-                source,
-            })?;
+        if let Some(parent) = path.parent() {
+            file::create_dir_all(parent)?;
         }
         let keypair = Keypair::new();
-        write_keypair_file(&keypair, &file).map_err(|error| GenerateError::AuthorityKeypair {
-            path: file.clone(),
-            message: error.to_string(),
-        })?;
-        restrict_mode(&file)?;
+        file::write_keypair(&keypair, &path)?;
         println!("authority {} created at {recorded}", keypair.pubkey());
     } else {
         eprintln!("note: no authority keypair at {recorded}, mount it before `zolana-ring deploy`");
@@ -289,15 +234,13 @@ fn ensure_authority(ring_dir: &Path) -> Result<(), GenerateError> {
     Ok(())
 }
 
-/// Read the recorded path alone, a full config load would expand `${...}` URL
-/// placeholders the operator has not set yet.
+/// Read raw, unexpanded `${...}` URL placeholders stay untouched.
 fn recorded_authority(ring_dir: &Path) -> Result<String, GenerateError> {
     recorded_key(ring_dir, "authority_keypair")?.ok_or_else(|| GenerateError::NoAuthorityRecorded {
         path: ring_dir.join(RING_TOML),
     })
 }
 
-/// The revision stage one rendered, stage two takes the source from it.
 fn recorded_revision(ring_dir: &Path) -> Result<String, GenerateError> {
     recorded_key(ring_dir, "zolana_revision")?
         .filter(|revision| is_commit(revision))
@@ -307,15 +250,7 @@ fn recorded_revision(ring_dir: &Path) -> Result<String, GenerateError> {
 }
 
 fn recorded_key(ring_dir: &Path, key: &str) -> Result<Option<String>, GenerateError> {
-    let path = ring_dir.join(RING_TOML);
-    let text = fs::read_to_string(&path).map_err(|source| GenerateError::Io {
-        path: path.clone(),
-        source,
-    })?;
-    let value: toml::Value = toml::from_str(&text).map_err(|source| GenerateError::RingToml {
-        path: path.clone(),
-        source,
-    })?;
+    let value: toml::Value = file::parse_toml(&ring_dir.join(RING_TOML))?;
     Ok(value
         .get(key)
         .and_then(|value| value.as_str())
@@ -325,14 +260,14 @@ fn recorded_key(ring_dir: &Path, key: &str) -> Result<Option<String>, GenerateEr
 /// The first commit records the generated ring without keys/ and .env, both ignored.
 fn commit_generated(ring_dir: &Path, name: &str, program_id: &str) -> Result<(), GenerateError> {
     if ring_dir.join(".git").exists() {
-        run_tool(
-            "git checkout",
-            git(ring_dir).args(["checkout", "-qB", "main"]),
-        )?;
+        GIT.named("git checkout")
+            .run(git(ring_dir).args(["checkout", "-qB", "main"]))?;
     } else {
-        run_tool("git init", git(ring_dir).args(["init", "-q", "-b", "main"]))?;
+        GIT.named("git init")
+            .run(git(ring_dir).args(["init", "-q", "-b", "main"]))?;
     }
-    run_tool("git add", git(ring_dir).args(["add", "-A"]))?;
+    GIT.named("git add")
+        .run(git(ring_dir).args(["add", "-A"]))?;
     let mut commit = git(ring_dir);
     // A machine with no git identity, a CI runner, cannot author a commit.
     if !git_config_is_set(ring_dir, "user.name") || !git_config_is_set(ring_dir, "user.email") {
@@ -349,7 +284,7 @@ fn commit_generated(ring_dir: &Path, name: &str, program_id: &str) -> Result<(),
         "-m",
         &format!("ring: generate {name} for program {program_id}"),
     ]);
-    run_tool("git commit", &mut commit)
+    Ok(GIT.named("git commit").run(&mut commit)?)
 }
 
 fn git(dir: &Path) -> Command {
@@ -359,35 +294,7 @@ fn git(dir: &Path) -> Command {
 }
 
 fn git_config_is_set(dir: &Path, key: &str) -> bool {
-    git(dir)
-        .args(["config", key])
-        .output()
-        .map(|output| output.status.success())
-        .unwrap_or(false)
-}
-
-fn run_tool(tool: &'static str, command: &mut Command) -> Result<(), GenerateError> {
-    let status = command
-        .status()
-        .map_err(|source| GenerateError::Spawn { tool, source })?;
-    if !status.success() {
-        return Err(GenerateError::Failed { tool, status });
-    }
-    Ok(())
-}
-
-fn check_cargo_generate() -> Result<(), GenerateError> {
-    let output = Command::new("cargo")
-        .args(["generate", "--version"])
-        .output()
-        .map_err(|source| GenerateError::Spawn {
-            tool: "cargo",
-            source,
-        })?;
-    if !output.status.success() {
-        return Err(GenerateError::CargoGenerateMissing);
-    }
-    Ok(())
+    GIT.capture(git(dir).args(["config", key])).is_ok()
 }
 
 fn validate_name(name: &str) -> Result<(), GenerateError> {
@@ -436,10 +343,7 @@ impl Staging {
     fn create(dest: &Path, name: &str) -> Result<Self, GenerateError> {
         let dir = dest.join(format!(".{name}.keys"));
         let _ = fs::remove_dir_all(&dir);
-        fs::create_dir_all(&dir).map_err(|source| GenerateError::Io {
-            path: dir.clone(),
-            source,
-        })?;
+        file::create_dir_all(&dir)?;
         Ok(Self { dir })
     }
 }
@@ -448,22 +352,6 @@ impl Drop for Staging {
     fn drop(&mut self) {
         let _ = fs::remove_dir_all(&self.dir);
     }
-}
-
-#[cfg(unix)]
-fn restrict_mode(path: &Path) -> Result<(), GenerateError> {
-    use std::os::unix::fs::PermissionsExt;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o600)).map_err(|source| {
-        GenerateError::Io {
-            path: path.to_path_buf(),
-            source,
-        }
-    })
-}
-
-#[cfg(not(unix))]
-fn restrict_mode(_path: &Path) -> Result<(), GenerateError> {
-    Ok(())
 }
 
 #[cfg(test)]

--- a/custom-rings/cli/src/init.rs
+++ b/custom-rings/cli/src/init.rs
@@ -14,6 +14,7 @@ use zolana_keypair::P256Pubkey;
 use zolana_ring_rpc::{read_auditor_pubkey, write_auditor_pubkey, KeyFileError};
 
 use crate::{
+    line,
     ring_rpc::{RingRpcClient, RingRpcClientError, Trust},
     step::{IdempotentStep, Observed, StepError, StepOutcome},
     Context, ContextError, InitArgs,
@@ -57,7 +58,7 @@ pub enum InitError {
     ConfigMismatch { authority: Address, auditor: String },
     #[error("ring config not created, run `init` first")]
     NotInitialized,
-    #[error("{path} holds an auditor key, but the ring rpc at {url} is not on this machine and holds its own. Pinning this key means only a ring rpc serving it can ever open the ring: delete the file to take the service's key, or pass --local-auditor to keep it")]
+    #[error("{path} holds an auditor key, but the ring rpc at {url} is not on this machine and holds its own. Pinning this key means only a ring rpc serving it can ever open the ring. Delete the file to take the service's key, or pass --local-auditor to keep it")]
     LocalAuditorAgainstRemoteRpc { path: PathBuf, url: String },
 }
 
@@ -91,11 +92,14 @@ pub fn run(ctx: &mut Context, args: InitArgs) -> Result<(), InitError> {
     };
     let auditor_pk = source.resolve(ctx.ring.program_id())?;
     if let AuditorKeySource::RingRpc { write_to, .. } = source {
-        println!(
-            "auditor pk  {} (from {}, written to {})",
-            hex::encode(auditor_pk.as_bytes()),
-            ctx.config.urls().ring_rpc,
-            write_to.display()
+        line(
+            "auditor pk",
+            format_args!(
+                "{} (from {}, written to {})",
+                hex::encode(auditor_pk.as_bytes()),
+                ctx.config.urls().ring_rpc,
+                write_to.display()
+            ),
         );
     }
     let outcome = Init {
@@ -104,13 +108,13 @@ pub fn run(ctx: &mut Context, args: InitArgs) -> Result<(), InitError> {
         auditor_pk,
     }
     .run(&ctx.rpc)?;
-    println!("config      {}", outcome.config.label());
-    println!(
-        "spp ring    {}",
+    line("config", outcome.config.label());
+    line(
+        "spp ring",
         match outcome.ring {
             StepOutcome::Created => "registered",
             other => other.label(),
-        }
+        },
     );
     if matches!(outcome.ring, StepOutcome::Created | StepOutcome::Present) {
         crate::status::announce(&ctx.config);
@@ -136,7 +140,6 @@ impl AuditorKeySource<'_> {
 }
 
 impl Init<'_> {
-    /// A rerun after a partial failure finishes the job.
     pub fn run(self, rpc: &SolanaRpc) -> Result<InitOutcome, InitError> {
         let payer = self.authority.pubkey();
         let existing = self.ring.read_config(rpc)?;

--- a/custom-rings/cli/src/keys.rs
+++ b/custom-rings/cli/src/keys.rs
@@ -1,17 +1,10 @@
 //! `auditor-key`, the key file a local ring rpc serves.
 
-use thiserror::Error;
 use zolana_ring_rpc::{write_auditor_key, KeyAccess, KeyFile, KeyFileError};
 
 use crate::AuditorKeyArgs;
 
-#[derive(Debug, Error)]
-pub enum AuditorKeyError {
-    #[error(transparent)]
-    KeyFile(#[from] KeyFileError),
-}
-
-pub fn run(args: AuditorKeyArgs) -> Result<(), AuditorKeyError> {
+pub fn run(args: AuditorKeyArgs) -> Result<(), KeyFileError> {
     if args.create {
         let key = write_auditor_key(&args.key_file)?;
         println!(

--- a/custom-rings/cli/src/lib.rs
+++ b/custom-rings/cli/src/lib.rs
@@ -5,6 +5,7 @@ pub mod build_program;
 pub mod config;
 pub mod deploy;
 pub mod error;
+pub mod file;
 pub mod fund;
 pub mod generate;
 pub mod init;
@@ -16,6 +17,7 @@ pub mod repo;
 pub mod ring_rpc;
 pub mod status;
 pub mod step;
+pub mod tool;
 pub mod transact;
 
 use std::path::PathBuf;
@@ -222,7 +224,8 @@ pub struct TransferArgs {
     pub amount: u64,
 }
 
-/// The pipeline runs each step with the same answers its command defaults to.
+// The pipeline runs each step with the answers its command defaults to.
+
 impl Default for DeployArgs {
     fn default() -> Self {
         Self {
@@ -265,12 +268,6 @@ pub enum ContextError {
     Fund(#[from] FundError),
     #[error(transparent)]
     Client(Box<ClientError>),
-}
-
-impl From<ClientError> for ContextError {
-    fn from(error: ClientError) -> Self {
-        Self::Client(Box::new(error))
-    }
 }
 
 impl Context {
@@ -347,6 +344,11 @@ pub fn parse_and_run() -> Result<(), CliError> {
     run(Cli::parse())
 }
 
+/// The aligned label of every status line.
+pub(crate) fn line(label: &str, value: impl std::fmt::Display) {
+    println!("{label:<12}{value}");
+}
+
 /// `New` runs before any ring.toml exists, `Target` and `Url` before any RPC client.
 pub fn run(cli: Cli) -> Result<(), CliError> {
     if let Command::New(args) = cli.command {
@@ -356,13 +358,14 @@ pub fn run(cli: Cli) -> Result<(), CliError> {
     match cli.command {
         Command::Target { target } => {
             RingConfig::set_target(&cli.config, target)?;
-            println!("target      {}", target.as_str());
+            line("target", target.as_str());
             return Ok(());
         }
         Command::Devnet => {
             RingConfig::set_target(&cli.config, Target::Devnet)?;
             config.target = Target::Devnet;
-            return Ok(probe::run_devnet(&config)?);
+            probe::run_devnet(&config)?;
+            return Ok(());
         }
         Command::Localnet => {
             RingConfig::set_target(&cli.config, Target::Localnet)?;
@@ -390,25 +393,24 @@ pub fn run(cli: Cli) -> Result<(), CliError> {
     }
     let mut ctx = Context::load(cli.config, config);
     match cli.command {
+        Command::Status => status::run(&ctx),
+        Command::Build(args) => build_program::run(args)?,
+        Command::Deploy(args) => deploy::run(&mut ctx, args)?,
+        Command::Init(args) => init::run(&mut ctx, args)?,
+        Command::Pipeline(args) => pipeline::run(&mut ctx, args)?,
+        Command::Transact(args) => transact::run(&mut ctx, args)?,
+        Command::Transfer(args) => transact::run_transfer(&mut ctx, args)?,
+        Command::RpcCheck => ring_rpc::run_check(&ctx)?,
+        Command::Authority(command) => authority::run(&ctx, command)?,
+        Command::Reader(command) => reader::run(&mut ctx, command)?,
+        Command::AuditorKey(args) => keys::run(args)?,
+        Command::Repo => repo::run(&ctx.config)?,
+        // Handled before the context loads.
         Command::New(_)
         | Command::Target { .. }
         | Command::Url { .. }
         | Command::Devnet
-        | Command::Localnet => Ok(()),
-        Command::Status => {
-            status::run(&ctx);
-            Ok(())
-        }
-        Command::Build(args) => Ok(build_program::run(&ctx.config, args)?),
-        Command::Deploy(args) => Ok(deploy::run(&mut ctx, args)?),
-        Command::Init(args) => Ok(init::run(&mut ctx, args)?),
-        Command::Pipeline(args) => pipeline::run(&mut ctx, args),
-        Command::Transact(args) => Ok(transact::run(&mut ctx, args)?),
-        Command::Transfer(args) => Ok(transact::run_transfer(&mut ctx, args)?),
-        Command::RpcCheck => Ok(ring_rpc::run_check(&ctx)?),
-        Command::Authority(command) => Ok(authority::run(&ctx, command)?),
-        Command::Reader(command) => Ok(reader::run(&mut ctx, command)?),
-        Command::AuditorKey(args) => Ok(keys::run(args)?),
-        Command::Repo => Ok(repo::run(&ctx.config)?),
+        | Command::Localnet => {}
     }
+    Ok(())
 }

--- a/custom-rings/cli/src/lib.rs
+++ b/custom-rings/cli/src/lib.rs
@@ -153,8 +153,11 @@ pub struct NewArgs {
     /// Local template directory instead of git.
     #[arg(long)]
     pub template_path: Option<PathBuf>,
-    /// Zolana revision the generated ring builds its program from, the
-    /// template's pinned default rules when absent.
+    /// Git repository the ring source and its crates are taken from.
+    #[arg(long, default_value = generate::ZOLANA_GIT)]
+    pub zolana_git: String,
+    /// Zolana revision of the ring source and its crates, the template's
+    /// pinned default rules when absent.
     #[arg(long)]
     pub zolana_rev: Option<String>,
 }

--- a/custom-rings/cli/src/pipeline.rs
+++ b/custom-rings/cli/src/pipeline.rs
@@ -7,8 +7,8 @@ use thiserror::Error;
 use zolana_ring_client::{ReaderKey, ReaderKeyError};
 
 use crate::{
-    build_program, deploy, error::CliError, init, probe::service_url, reader, ring_rpc, transact,
-    BuildArgs, Context, DeployArgs, InitArgs, ReaderCommand, TransactArgs,
+    build_program, deploy, error::CliError, init, probe, reader, ring_rpc, transact, BuildArgs,
+    Context, DeployArgs, InitArgs, ReaderCommand, TransactArgs,
 };
 
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(5);
@@ -17,8 +17,6 @@ const HEALTH_TIMEOUT: Duration = Duration::from_secs(5);
 pub enum PipelineError {
     #[error(transparent)]
     ReaderKey(#[from] ReaderKeyError),
-    #[error("cannot build the health probe client")]
-    Client(#[source] reqwest::Error),
     #[error("no ring rpc answers at {url}, create its key with `zolana-ring auditor-key --create` and run the ring rpc from a zolana checkout serving keys/auditor.key")]
     RingRpcDown {
         url: String,
@@ -29,7 +27,7 @@ pub enum PipelineError {
 
 /// Steps already on chain are skipped, a rerun resumes where it stopped.
 pub fn run(ctx: &mut Context, build: BuildArgs) -> Result<(), CliError> {
-    build_program::run(&ctx.config, build)?;
+    build_program::run(build)?;
     deploy::run(ctx, DeployArgs::default())?;
     let hosted = !ctx.config.urls().ring_rpc_is_local();
     if hosted {
@@ -51,19 +49,13 @@ pub fn run(ctx: &mut Context, build: BuildArgs) -> Result<(), CliError> {
 /// The binary starts no services, a missing local ring rpc is the operator's step.
 fn check_local_ring_rpc(ctx: &Context) -> Result<(), PipelineError> {
     let base = &ctx.config.urls().ring_rpc;
-    let url = service_url(base, "/health");
-    let http = reqwest::blocking::Client::builder()
-        .connect_timeout(HEALTH_TIMEOUT)
-        .timeout(HEALTH_TIMEOUT)
-        .build()
-        .map_err(PipelineError::Client)?;
-    http.get(&url)
-        .send()
-        .and_then(|response| response.error_for_status())
-        .map_err(|source| PipelineError::RingRpcDown {
+    let http = probe::http(HEALTH_TIMEOUT, HEALTH_TIMEOUT);
+    probe::check(&http, &probe::service_url(base, "/health")).map_err(|source| {
+        PipelineError::RingRpcDown {
             url: base.clone(),
             source,
-        })?;
-    println!("ring rpc    {base} answers");
+        }
+    })?;
+    crate::line("ring rpc", format_args!("{base} answers"));
     Ok(())
 }

--- a/custom-rings/cli/src/probe.rs
+++ b/custom-rings/cli/src/probe.rs
@@ -9,13 +9,11 @@ use thiserror::Error;
 
 use crate::config::RingConfig;
 
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-const TOTAL_TIMEOUT: Duration = Duration::from_secs(30);
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+pub const TOTAL_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Error)]
 pub enum ProbeError {
-    #[error("cannot build the probe client")]
-    Client(#[source] reqwest::Error),
     #[error("devnet {service} at {url} is not ready")]
     NotReady {
         service: &'static str,
@@ -29,7 +27,7 @@ pub enum ProbeError {
 pub fn run_devnet(config: &RingConfig) -> Result<(), ProbeError> {
     print_urls(config);
     println!();
-    let http = probe_client()?;
+    let http = http(CONNECT_TIMEOUT, TOTAL_TIMEOUT);
     let urls = config.urls();
     for (service, base, path) in [
         ("indexer", &urls.indexer, "/readiness"),
@@ -38,8 +36,8 @@ pub fn run_devnet(config: &RingConfig) -> Result<(), ProbeError> {
         let url = service_url(base, path);
         print!("probing {service:<8} {url} ... ");
         let _ = io::stdout().flush();
-        match http.get(&url).send().and_then(|r| r.error_for_status()) {
-            Ok(_) => println!("ready"),
+        match check(&http, &url) {
+            Ok(()) => println!("ready"),
             Err(source) => {
                 println!("not ready");
                 return Err(ProbeError::NotReady {
@@ -76,12 +74,18 @@ pub fn print_urls(config: &RingConfig) {
     println!("  ring rpc  {}  {served}", urls.ring_rpc);
 }
 
-pub fn probe_client() -> Result<reqwest::blocking::Client, ProbeError> {
+/// Panics only where `reqwest::blocking::Client::new` panics, a broken TLS backend.
+pub fn http(connect: Duration, total: Duration) -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()
-        .connect_timeout(CONNECT_TIMEOUT)
-        .timeout(TOTAL_TIMEOUT)
+        .connect_timeout(connect)
+        .timeout(total)
         .build()
-        .map_err(ProbeError::Client)
+        .expect("reqwest client")
+}
+
+pub fn check(http: &reqwest::blocking::Client, url: &str) -> Result<(), reqwest::Error> {
+    http.get(url).send().and_then(|r| r.error_for_status())?;
+    Ok(())
 }
 
 pub fn service_url(base: &str, path: &str) -> String {

--- a/custom-rings/cli/src/reader.rs
+++ b/custom-rings/cli/src/reader.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use zolana_client::SolanaRpc;
 
 use crate::{
+    line,
     step::{no_hint, IdempotentStep, Observed, StepError, StepOutcome},
     Context, ContextError, ReaderCommand,
 };
@@ -52,12 +53,15 @@ pub fn run(ctx: &mut Context, command: ReaderCommand) -> Result<(), ReaderError>
             .revoke(&ctx.rpc)?,
         ),
     };
-    println!("reader      {reader} {}", outcome_label(outcome));
-    println!("record      {}", ctx.ring.read_access_record_pda(&reader));
+    line(
+        "reader",
+        format_args!("{reader} {}", outcome_label(outcome)),
+    );
+    line("record", ctx.ring.read_access_record_pda(&reader));
     Ok(())
 }
 
-pub fn outcome_label(outcome: StepOutcome) -> &'static str {
+fn outcome_label(outcome: StepOutcome) -> &'static str {
     match outcome {
         StepOutcome::Created => "granted",
         StepOutcome::Present => "already granted",
@@ -81,7 +85,6 @@ impl ReaderAccess<'_> {
         )?)
     }
 
-    /// The rent returns to the authority.
     pub fn revoke(self, rpc: &SolanaRpc) -> Result<StepOutcome, ReaderError> {
         let observed = self.observed(rpc)?;
         Ok(self.step(rpc, "revoke_read_access").ensure_absent(

--- a/custom-rings/cli/src/repo.rs
+++ b/custom-rings/cli/src/repo.rs
@@ -1,68 +1,24 @@
 //! `repo`, the GitHub repository for a generated ring.
 
-use std::{
-    io,
-    path::Path,
-    process::{Command, ExitStatus},
+use std::{path::Path, process::Command};
+
+use crate::{
+    config::RingConfig,
+    tool::{ToolError, GH, GIT},
 };
 
-use thiserror::Error;
-
-use crate::config::RingConfig;
-
-#[derive(Debug, Error)]
-pub enum RepoError {
-    #[error("gh is not installed, install the GitHub CLI from https://cli.github.com and run `gh auth login`")]
-    GhMissing(#[source] io::Error),
-    #[error("cannot run {tool}")]
-    Spawn {
-        tool: &'static str,
-        #[source]
-        source: io::Error,
-    },
-    #[error("{tool} exited with {status}")]
-    Failed {
-        tool: &'static str,
-        status: ExitStatus,
-    },
-}
-
-pub fn run(config: &RingConfig) -> Result<(), RepoError> {
+pub fn run(config: &RingConfig) -> Result<(), ToolError> {
     if !Path::new(".git").exists() {
-        let status = Command::new("git")
-            .args(["init", "-q", "-b", "main"])
-            .status()
-            .map_err(|source| RepoError::Spawn {
-                tool: "git",
-                source,
-            })?;
-        if !status.success() {
-            return Err(RepoError::Failed {
-                tool: "git init",
-                status,
-            });
-        }
+        GIT.named("git init")
+            .run(Command::new("git").args(["init", "-q", "-b", "main"]))?;
     }
-    let status = Command::new("gh")
-        .args([
-            "repo",
-            "create",
-            &config.name,
-            "--private",
-            "--source",
-            ".",
-            "--push",
-        ])
-        .status()
-        .map_err(|source| match source.kind() {
-            io::ErrorKind::NotFound => RepoError::GhMissing(source),
-            _ => RepoError::Spawn { tool: "gh", source },
-        })?;
-    if !status.success() {
-        return Err(RepoError::Failed {
-            tool: "gh repo create",
-            status,
-        });
-    }
-    Ok(())
+    GH.named("gh repo create").run(Command::new("gh").args([
+        "repo",
+        "create",
+        &config.name,
+        "--private",
+        "--source",
+        ".",
+        "--push",
+    ]))
 }

--- a/custom-rings/cli/src/ring_rpc.rs
+++ b/custom-rings/cli/src/ring_rpc.rs
@@ -15,6 +15,7 @@ use zolana_ring_rpc::{
 };
 
 use crate::{
+    probe,
     transact::{wait_for, Probe, WaitError},
     Context,
 };
@@ -70,7 +71,7 @@ pub enum RingRpcClientError {
     PinMismatch { pinned: Address, actual: Address },
     #[error("ring.toml pins no ring rpc service key, the rpc signs with {service_pubkey}. Put it in ring_rpc_pubkey after confirming it out of band, or pass --trust-ring-rpc for a local instance")]
     Unpinned { service_pubkey: Address },
-    #[error("the ring rpc at {url} holds auditor {served_tag} for this ring, but the ring's config names {expected_tag}. A config fixes its auditor when it is created, so this service can never open the ring: serve the ring from a ring rpc holding its key, or deploy a new ring")]
+    #[error("the ring rpc at {url} holds auditor {served_tag} for this ring, but the ring's config names {expected_tag}. A config fixes its auditor when it is created, so this service can never open the ring. Serve the ring from a ring rpc holding its key, or deploy a new ring")]
     ForeignAuditor {
         url: String,
         served_tag: Hash,
@@ -91,12 +92,6 @@ pub enum RingRpcClientError {
     },
 }
 
-#[derive(Debug, Error)]
-pub enum RpcCheckError {
-    #[error(transparent)]
-    RingRpc(#[from] RingRpcClientError),
-}
-
 #[derive(Deserialize)]
 struct JsonRpcResponse<T> {
     result: Option<T>,
@@ -105,15 +100,19 @@ struct JsonRpcResponse<T> {
 
 /// Answers before the ring has a config, so a pipeline can stop before `init`
 /// pins an auditor the service does not hold.
-pub fn run_check(ctx: &Context) -> Result<(), RpcCheckError> {
+pub fn run_check(ctx: &Context) -> Result<(), RingRpcClientError> {
     let url = ctx.config.urls().ring_rpc.clone();
     let status = ctx.ring_rpc().ring_status(ctx.ring.program_id())?;
     let served = Hash(auditor_view_tag(status.auditor_pubkey.as_key()));
     match status.state {
-        RingState::Served => println!("ring rpc    {url} serves this ring, auditor {served}"),
-        RingState::Uninitialized => {
-            println!("ring rpc    {url} holds auditor {served} for this ring, `init` pins it")
-        }
+        RingState::Served => crate::line(
+            "ring rpc",
+            format_args!("{url} serves this ring, auditor {served}"),
+        ),
+        RingState::Uninitialized => crate::line(
+            "ring rpc",
+            format_args!("{url} holds auditor {served} for the ring, `init` pins it"),
+        ),
         RingState::ForeignAuditor => {
             let configured = status
                 .config_auditor_pubkey
@@ -123,8 +122,7 @@ pub fn run_check(ctx: &Context) -> Result<(), RpcCheckError> {
                 url,
                 served_tag: served,
                 expected_tag: configured,
-            }
-            .into());
+            });
         }
     }
     Ok(())
@@ -150,7 +148,7 @@ impl RingRpcClient {
     pub fn new(url: impl Into<String>) -> Self {
         Self {
             url: url.into(),
-            http: reqwest::blocking::Client::new(),
+            http: probe::http(probe::CONNECT_TIMEOUT, probe::TOTAL_TIMEOUT),
         }
     }
 
@@ -179,8 +177,7 @@ impl RingRpcClient {
         })
     }
 
-    /// Unsigned, so it decides nothing a key is pinned from; `auditor_pubkey`
-    /// is the attested path `init` uses.
+    /// Unsigned, `auditor_pubkey` is the attested path `init` pins from.
     pub fn ring_status(&self, ring: Address) -> Result<RingStatusResponse, RingRpcClientError> {
         self.call(
             RING_STATUS,

--- a/custom-rings/cli/src/status.rs
+++ b/custom-rings/cli/src/status.rs
@@ -134,6 +134,7 @@ name = "x"
 target = "devnet"
 program_id = "11111111111111111111111111111111"
 authority_keypair = "a.json"
+zolana_revision = "851680f7fcc99ccbd88119942760e9309ace0a58"
 
 [localnet]
 rpc = "http://127.0.0.1:8899"

--- a/custom-rings/cli/src/status.rs
+++ b/custom-rings/cli/src/status.rs
@@ -8,7 +8,7 @@ use zolana_client::{ClientError, Rpc, SolanaRpc};
 use crate::{
     config::{RingConfig, Target},
     deploy::{read_program_data, DeployError},
-    Context,
+    line, Context,
 };
 
 const EXPLORER: &str = "https://explorer.solana.com/address";
@@ -18,35 +18,38 @@ pub enum StatusError {
     #[error(transparent)]
     Client(Box<ClientError>),
     #[error(transparent)]
-    Deploy(#[from] DeployError),
+    Deploy(Box<DeployError>),
     #[error(transparent)]
     AccountRead(#[from] AccountReadError),
 }
 
-impl From<ClientError> for StatusError {
-    fn from(error: ClientError) -> Self {
-        Self::Client(Box::new(error))
+impl From<DeployError> for StatusError {
+    fn from(error: DeployError) -> Self {
+        Self::Deploy(Box::new(error))
     }
 }
 
 pub fn run(ctx: &Context) {
     let config = &ctx.config;
-    println!("ring        {}", config.name);
-    println!("target      {}", config.target.as_str());
-    println!("program id  {}", config.program_id);
+    line("ring", &config.name);
+    line("target", config.target.as_str());
+    line("program id", config.program_id);
     match config.authority() {
-        Ok(authority) => println!("authority   {}", authority.pubkey()),
-        Err(error) => println!("authority   unavailable ({error})"),
+        Ok(authority) => line("authority", authority.pubkey()),
+        Err(error) => line("authority", format_args!("unavailable ({error})")),
     }
-    println!("rpc         {}", config.urls().rpc);
-    println!("indexer     {}", config.urls().indexer);
-    println!("prover      {}", config.urls().prover);
-    println!("ring rpc    {}", config.urls().ring_rpc);
+    line("rpc", &config.urls().rpc);
+    line("indexer", &config.urls().indexer);
+    line("prover", &config.urls().prover);
+    line("ring rpc", &config.urls().ring_rpc);
     let features: Vec<&str> = config.enabled_features().collect();
-    println!("features    {}", features.join(", "));
+    line("features", features.join(", "));
 
     if let Err(error) = print_chain(config, ctx.ring, &ctx.rpc) {
-        println!("chain       unreachable at {} ({error})", config.urls().rpc);
+        line(
+            "chain",
+            format_args!("unreachable at {} ({error})", config.urls().rpc),
+        );
     }
 }
 
@@ -85,42 +88,57 @@ fn percent_encode(text: &str) -> String {
 fn print_chain(config: &RingConfig, ring: CustomRing, rpc: &SolanaRpc) -> Result<(), StatusError> {
     if let Ok(authority) = config.authority() {
         let lamports = rpc.get_balance(authority.pubkey())?;
-        println!(
-            "balance     {} SOL ({lamports} lamports)",
-            lamports as f64 / 1_000_000_000.0
+        line(
+            "balance",
+            format_args!("{} SOL ({lamports} lamports)", lamports as f64 / 1e9),
         );
     }
     match rpc.get_account(ring.program_id())? {
         Some(account) if account.executable => match read_program_data(rpc, ring)? {
-            Some(info) => println!(
-                "program     deployed, upgrade authority {}, capacity {} bytes",
-                info.upgrade_authority
-                    .map(|key| key.to_string())
-                    .unwrap_or_else(|| "none (immutable)".to_owned()),
-                info.capacity
+            Some(info) => line(
+                "program",
+                format_args!(
+                    "deployed, upgrade authority {}, capacity {} bytes",
+                    info.upgrade_authority
+                        .map(|key| key.to_string())
+                        .unwrap_or_else(|| "none (immutable)".to_owned()),
+                    info.capacity
+                ),
             ),
-            None => println!("program     deployed (not upgradeable)"),
+            None => line("program", "deployed (not upgradeable)"),
         },
-        Some(_) => println!("program     account exists but is not executable"),
-        None => println!("program     not deployed"),
+        Some(_) => line("program", "account exists but is not executable"),
+        None => line("program", "not deployed"),
     }
     match ring.read_config(rpc)? {
-        Some(state) => println!(
-            "config      {} authority {} auditor {}",
-            ring.config_pda(),
-            state.authority,
-            hex::encode(state.auditor_pubkey.as_bytes())
+        Some(state) => line(
+            "config",
+            format_args!(
+                "{} authority {} auditor {}",
+                ring.config_pda(),
+                state.authority,
+                hex::encode(state.auditor_pubkey.as_bytes())
+            ),
         ),
-        None => println!("config      not created ({})", ring.config_pda()),
+        None => line(
+            "config",
+            format_args!("not created ({})", ring.config_pda()),
+        ),
     }
     match ring.read_spp_ring_config(rpc)? {
-        Some(state) => println!(
-            "spp ring    {} paused={} authority_transact={}",
-            ring.ring_auth_pda(),
-            state.is_paused(),
-            state.enabled()
+        Some(state) => line(
+            "spp ring",
+            format_args!(
+                "{} paused={} authority_transact={}",
+                ring.ring_auth_pda(),
+                state.is_paused(),
+                state.enabled()
+            ),
         ),
-        None => println!("spp ring    not registered ({})", ring.ring_auth_pda()),
+        None => line(
+            "spp ring",
+            format_args!("not registered ({})", ring.ring_auth_pda()),
+        ),
     }
     Ok(())
 }

--- a/custom-rings/cli/src/step.rs
+++ b/custom-rings/cli/src/step.rs
@@ -36,7 +36,7 @@ pub enum StepError {
     },
 }
 
-/// One instruction signed and paid by the authority, skipped when the chain already agrees.
+/// One authority-signed instruction, skipped when the chain already agrees.
 #[must_use]
 pub struct IdempotentStep<'a> {
     pub rpc: &'a SolanaRpc,

--- a/custom-rings/cli/src/tool.rs
+++ b/custom-rings/cli/src/tool.rs
@@ -1,0 +1,125 @@
+//! One place a subprocess is spawned and its exit judged.
+
+use std::{
+    io,
+    process::{Command, ExitStatus},
+};
+
+use thiserror::Error;
+
+pub const ANZA_INSTALL: &str = r#"install the Anza toolchain with sh -c "$(curl -sSfL https://release.anza.xyz/v4.0.2/install)""#;
+
+pub const GIT: Tool = Tool {
+    name: "git",
+    install: "install git",
+};
+pub const CARGO_GENERATE: Tool = Tool {
+    name: "cargo generate",
+    install: "run `cargo install cargo-generate --locked`",
+};
+pub const SOLANA: Tool = Tool {
+    name: "solana",
+    install: ANZA_INSTALL,
+};
+pub const CARGO_BUILD_SBF: Tool = Tool {
+    name: "cargo-build-sbf",
+    install: ANZA_INSTALL,
+};
+pub const GH: Tool = Tool {
+    name: "gh",
+    install: "install the GitHub CLI from https://cli.github.com and run `gh auth login`",
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct Tool {
+    pub name: &'static str,
+    pub install: &'static str,
+}
+
+#[derive(Debug, Error)]
+pub enum ToolError {
+    #[error("{name} is not installed, {install}")]
+    Missing {
+        name: &'static str,
+        install: &'static str,
+    },
+    #[error("cannot run {name}")]
+    Spawn {
+        name: &'static str,
+        #[source]
+        source: io::Error,
+    },
+    #[error("{name} exited with {status}")]
+    Failed {
+        name: &'static str,
+        status: ExitStatus,
+    },
+}
+
+impl Tool {
+    /// The subcommand the error names, `GIT.named("git init")`.
+    pub fn named(self, name: &'static str) -> Self {
+        Self { name, ..self }
+    }
+
+    /// A failing version probe reads as not installed.
+    pub fn require(self, probe: &mut Command) -> Result<(), ToolError> {
+        match probe.output() {
+            Ok(output) if output.status.success() => Ok(()),
+            _ => Err(ToolError::Missing {
+                name: self.name,
+                install: self.install,
+            }),
+        }
+    }
+
+    pub fn run(self, command: &mut Command) -> Result<(), ToolError> {
+        let status = self.status(command)?;
+        self.check(status)
+    }
+
+    /// Trimmed stdout of a successful run.
+    pub fn capture(self, command: &mut Command) -> Result<String, ToolError> {
+        let output = command.output().map_err(|source| self.spawn(source))?;
+        self.check(output.status)?;
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+    }
+
+    /// Output shown only on failure, the caller narrates the action.
+    pub fn run_captured(self, command: &mut Command) -> Result<(), ToolError> {
+        let output = command.output().map_err(|source| self.spawn(source))?;
+        if !output.status.success() {
+            eprint!("{}", String::from_utf8_lossy(&output.stderr));
+        }
+        self.check(output.status)
+    }
+
+    /// The exit status alone, a retry loop judges it itself.
+    pub fn status(self, command: &mut Command) -> Result<ExitStatus, ToolError> {
+        command.status().map_err(|source| self.spawn(source))
+    }
+
+    pub fn check(self, status: ExitStatus) -> Result<(), ToolError> {
+        if status.success() {
+            Ok(())
+        } else {
+            Err(ToolError::Failed {
+                name: self.name,
+                status,
+            })
+        }
+    }
+
+    fn spawn(self, source: io::Error) -> ToolError {
+        match source.kind() {
+            io::ErrorKind::NotFound => ToolError::Missing {
+                name: self.name,
+                install: self.install,
+            },
+            _ => ToolError::Spawn {
+                name: self.name,
+                source,
+            },
+        }
+    }
+}

--- a/custom-rings/cli/src/transact.rs
+++ b/custom-rings/cli/src/transact.rs
@@ -18,6 +18,7 @@ use zolana_transaction::{
 
 use crate::{
     init::{configured_auditor_pk, InitError},
+    line,
     ring_rpc::{RingRpcClient, RingRpcClientError, TransactionLookup},
     Context, ContextError, TransactArgs, TransferArgs,
 };
@@ -31,19 +32,14 @@ const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 #[must_use]
 pub struct DemoTransfer<'a> {
-    ring: CustomRing,
+    pub ring: CustomRing,
     /// The sender is funded from here and then pays its own v0 transaction.
-    payer: &'a dyn Signer,
-    amount: u64,
-    /// `DEFAULT_TREE_ADDRESS` unless set.
-    tree: Option<Address>,
-    /// `AssetRegistry::default()` unless set.
-    assets: Option<&'a AssetRegistry>,
+    pub payer: &'a dyn Signer,
+    pub amount: u64,
 }
 
 /// One transfer out of a throwaway sender the payer funds and then abandons.
-/// The two deposits fill both input slots the transfer's shape declares; what
-/// they hold above `amount` stays with the sender and is unreachable.
+/// Whatever the two deposits hold above `amount` stays with the sender.
 struct RingTransfer<'a> {
     ring: CustomRing,
     payer: &'a dyn Signer,
@@ -117,54 +113,47 @@ pub enum TransactError {
     AmountTooSmall { amount: u64 },
 }
 
-impl From<ClientError> for TransactError {
-    fn from(error: ClientError) -> Self {
-        Self::Client(Box::new(error))
-    }
-}
-
 pub fn run(ctx: &mut Context, args: TransactArgs) -> Result<(), TransactError> {
-    // The whole cost of the demo, funded before the first deposit.
-    let needed = args
-        .amount
-        .saturating_mul(2)
-        .saturating_add(SENDER_FEE_BUDGET)
-        .saturating_add(PAYER_FEE_BUDGET);
-    let authority = ctx.authority_funded_for(needed)?;
-    let ring = ctx.ring;
-    let auditor_pk = configured_auditor_pk(&ctx.rpc, ring)?;
-    let ring_rpc = ctx.ring_rpc();
-    ring_rpc.check_serves(ring.program_id(), &auditor_pk)?;
-    let reader_key = ReaderKey::ed25519(authority.pubkey())?;
-    if ring.read_access_record(&ctx.rpc, &reader_key)?.is_none() {
+    // The demo deposits the amount twice, funded before the first deposit.
+    let session = Session::open(ctx, args.amount.saturating_mul(2))?;
+    let reader_key = ReaderKey::ed25519(session.authority.pubkey())?;
+    if ctx
+        .ring
+        .read_access_record(&ctx.rpc, &reader_key)?
+        .is_none()
+    {
         return Err(TransactError::ReaderNotGranted { reader: reader_key });
     }
-    let indexer = ctx.indexer();
-    let prover = ctx.prover();
-    let receipt =
-        DemoTransfer::new(ring, &authority, args.amount).run(TransferProofEnvironment {
-            indexer: &indexer,
-            rpc: &ctx.rpc,
-            prover: &prover,
-        })?;
-    println!(
-        "sender      {}  viewing pk {}",
-        receipt.sender.pubkey(),
-        hex::encode(receipt.sender.viewing_pubkey().as_bytes())
-    );
-    println!(
-        "recipient   {}  viewing pk {}",
-        receipt.recipient.pubkey(),
-        hex::encode(receipt.recipient.viewing_pubkey().as_bytes())
-    );
-    for signature in &receipt.deposits {
-        println!("deposit     {signature}");
+    let receipt = DemoTransfer {
+        ring: ctx.ring,
+        payer: &session.authority,
+        amount: args.amount,
     }
-    println!("transact    {}", receipt.transact);
-    for line in program_logs(&ctx.rpc, &receipt.transact)? {
-        println!("  log       {line}");
-    }
-    read_back(&indexer, &ring_rpc, ring, &authority, receipt.transact)?;
+    .run(session.env(ctx))?;
+    line(
+        "sender",
+        format_args!(
+            "{}  viewing pk {}",
+            receipt.sender.pubkey(),
+            hex::encode(receipt.sender.viewing_pubkey().as_bytes())
+        ),
+    );
+    line(
+        "recipient",
+        format_args!(
+            "{}  viewing pk {}",
+            receipt.recipient.pubkey(),
+            hex::encode(receipt.recipient.viewing_pubkey().as_bytes())
+        ),
+    );
+    print_signatures(ctx, &receipt.deposits, receipt.transact)?;
+    read_back(
+        &session.indexer,
+        &session.ring_rpc,
+        ctx.ring,
+        &session.authority,
+        receipt.transact,
+    )?;
     Ok(())
 }
 
@@ -176,53 +165,98 @@ pub fn run_transfer(ctx: &mut Context, args: TransferArgs) -> Result<(), Transac
             amount: args.amount,
         });
     }
-    let needed = args
-        .amount
-        .saturating_add(SENDER_FEE_BUDGET)
-        .saturating_add(PAYER_FEE_BUDGET);
-    let authority = ctx.authority_funded_for(needed)?;
-    let ring = ctx.ring;
-    let auditor_pk = configured_auditor_pk(&ctx.rpc, ring)?;
-    let ring_rpc = ctx.ring_rpc();
-    ring_rpc.check_serves(ring.program_id(), &auditor_pk)?;
-    let indexer = ctx.indexer();
-    let prover = ctx.prover();
+    let session = Session::open(ctx, args.amount)?;
     // The recipient takes the whole amount, so the two deposits split it.
     let half = args.amount / 2;
     let sent = RingTransfer {
-        ring,
-        payer: &authority,
+        ring: ctx.ring,
+        payer: &session.authority,
         deposits: [half, args.amount - half],
         recipient: args.to,
         amount: args.amount,
         tree: Address::from_str_const(DEFAULT_TREE_ADDRESS),
         assets: &AssetRegistry::default(),
     }
-    .send(TransferProofEnvironment {
-        indexer: &indexer,
-        rpc: &ctx.rpc,
-        prover: &prover,
-    })?;
-    println!("to          {}", args.to);
-    println!("amount      {} lamports", args.amount);
-    println!(
-        "sender      {}  a throwaway key, funded and abandoned",
-        sent.sender.pubkey()
+    .send(session.env(ctx))?;
+    line("to", args.to);
+    line("amount", format_args!("{} lamports", args.amount));
+    line(
+        "sender",
+        format_args!(
+            "{}  a throwaway key, funded and abandoned",
+            sent.sender.pubkey()
+        ),
     );
-    for signature in &sent.deposits {
-        println!("deposit     {signature}");
-    }
-    println!("transact    {}", sent.transact);
-    for line in program_logs(&ctx.rpc, &sent.transact)? {
-        println!("  log       {line}");
-    }
+    print_signatures(ctx, &sent.deposits, sent.transact)?;
     // Reading the transfer back is a courtesy, the payment is already on chain.
-    let reader_key = ReaderKey::ed25519(authority.pubkey())?;
-    if ring.read_access_record(&ctx.rpc, &reader_key)?.is_none() {
+    let reader_key = ReaderKey::ed25519(session.authority.pubkey())?;
+    if ctx
+        .ring
+        .read_access_record(&ctx.rpc, &reader_key)?
+        .is_none()
+    {
         println!("auditor view skipped, grant-reader {reader_key} to read the ring");
         return Ok(());
     }
-    read_back(&indexer, &ring_rpc, ring, &authority, sent.transact)?;
+    read_back(
+        &session.indexer,
+        &session.ring_rpc,
+        ctx.ring,
+        &session.authority,
+        sent.transact,
+    )?;
+    Ok(())
+}
+
+/// Opened only after the ring rpc serves the configured auditor.
+struct Session {
+    authority: solana_keypair::Keypair,
+    ring_rpc: RingRpcClient,
+    indexer: ZolanaIndexer,
+    prover: zolana_client::ProverClient,
+}
+
+impl Session {
+    fn open(ctx: &mut Context, deposited: u64) -> Result<Self, TransactError> {
+        let needed = deposited
+            .saturating_add(SENDER_FEE_BUDGET)
+            .saturating_add(PAYER_FEE_BUDGET);
+        let authority = ctx.authority_funded_for(needed)?;
+        let auditor_pk = configured_auditor_pk(&ctx.rpc, ctx.ring)?;
+        let ring_rpc = ctx.ring_rpc();
+        ring_rpc.check_serves(ctx.ring.program_id(), &auditor_pk)?;
+        Ok(Self {
+            authority,
+            ring_rpc,
+            indexer: ctx.indexer(),
+            prover: ctx.prover(),
+        })
+    }
+
+    fn env<'a>(
+        &'a self,
+        ctx: &'a Context,
+    ) -> TransferProofEnvironment<'a, ZolanaIndexer, SolanaRpc> {
+        TransferProofEnvironment {
+            indexer: &self.indexer,
+            rpc: &ctx.rpc,
+            prover: &self.prover,
+        }
+    }
+}
+
+fn print_signatures(
+    ctx: &Context,
+    deposits: &[Signature],
+    transact: Signature,
+) -> Result<(), TransactError> {
+    for signature in deposits {
+        line("deposit", signature);
+    }
+    line("transact", transact);
+    for line in program_logs(&ctx.rpc, &transact)? {
+        println!("  log       {line}");
+    }
     Ok(())
 }
 
@@ -258,41 +292,11 @@ fn read_back(
     Ok(())
 }
 
-impl<'a> DemoTransfer<'a> {
-    pub fn new(ring: CustomRing, payer: &'a dyn Signer, amount: u64) -> Self {
-        Self {
-            ring,
-            payer,
-            amount,
-            tree: None,
-            assets: None,
-        }
-    }
-
-    #[must_use = "use the updated transfer"]
-    pub fn with_tree(mut self, tree: Address) -> Self {
-        self.tree = Some(tree);
-        self
-    }
-
-    #[must_use = "use the updated transfer"]
-    pub fn with_assets(mut self, assets: &'a AssetRegistry) -> Self {
-        self.assets = Some(assets);
-        self
-    }
-
+impl DemoTransfer<'_> {
     pub fn run(
         self,
         env: TransferProofEnvironment<'_, ZolanaIndexer, SolanaRpc>,
     ) -> Result<TransferReceipt, TransactError> {
-        let default_assets;
-        let assets = match self.assets {
-            Some(assets) => assets,
-            None => {
-                default_assets = AssetRegistry::default();
-                &default_assets
-            }
-        };
         let recipient = ShieldedKeypair::new_ed25519()?;
         // The demo deposits the amount twice and keeps the change, so the
         // sender's balance shows in the auditor's view next to the payment.
@@ -302,10 +306,8 @@ impl<'a> DemoTransfer<'a> {
             deposits: [self.amount; 2],
             recipient: recipient.shielded_address()?,
             amount: self.amount,
-            tree: self
-                .tree
-                .unwrap_or(Address::from_str_const(DEFAULT_TREE_ADDRESS)),
-            assets,
+            tree: Address::from_str_const(DEFAULT_TREE_ADDRESS),
+            assets: &AssetRegistry::default(),
         }
         .send(env)?;
 

--- a/custom-rings/cli/tests/new_smoke.rs
+++ b/custom-rings/cli/tests/new_smoke.rs
@@ -1,5 +1,6 @@
-//! `new` against a template checkout named by ZOLANA_RING_TEMPLATE_DIR, needs
-//! cargo-generate and git on PATH.
+//! `new` against a template checkout named by ZOLANA_RING_TEMPLATE_DIR, the
+//! source stage clones the enclosing zolana checkout at HEAD and sees only
+//! committed changes, needs cargo-generate and git on PATH.
 
 use std::{
     fs,
@@ -61,9 +62,25 @@ fn new_generates_a_committed_ring_from_the_local_template() {
     fs::create_dir_all(&dest).expect("dest");
     let template = stage_template(&dest);
 
+    let zolana_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let head = Command::new("git")
+        .arg("-C")
+        .arg(&zolana_root)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .expect("git rev-parse");
+    assert!(head.status.success());
+    let head = String::from_utf8_lossy(&head.stdout).trim().to_owned();
+
     let status = Command::new(env!("CARGO_BIN_EXE_zolana-ring"))
         .args(["new", "smoke-ring", "--silent", "--template-path"])
         .arg(&template)
+        .arg("--zolana-git")
+        .arg(format!(
+            "file://{}",
+            zolana_root.canonicalize().expect("root").display()
+        ))
+        .args(["--zolana-rev", &head])
         .arg("--dest")
         .arg(&dest)
         .status()
@@ -73,6 +90,11 @@ fn new_generates_a_committed_ring_from_the_local_template() {
     let ring = dest.join("smoke-ring");
     assert!(ring.join("ring.toml").is_file());
     assert!(ring.join("keys/program-keypair.json").is_file());
+    assert!(ring.join("program/src/instructions/transact.rs").is_file());
+    assert!(ring.join("Cargo.lock").is_file());
+    assert!(ring.join("sdk/src/transfer.rs").is_file());
+    assert!(!ring.join("cli").exists());
+    assert!(!ring.join("interface").exists());
     let log = Command::new("git")
         .arg("-C")
         .arg(&ring)

--- a/custom-rings/cli/tests/new_smoke.rs
+++ b/custom-rings/cli/tests/new_smoke.rs
@@ -45,6 +45,9 @@ fn copy_tree(source: &Path, dest: &Path) {
     fs::create_dir_all(dest).expect("dest dir");
     for entry in fs::read_dir(source).expect("read template") {
         let entry = entry.expect("entry");
+        if entry.file_name() == ".git" {
+            continue;
+        }
         let target = dest.join(entry.file_name());
         if entry.file_type().expect("type").is_dir() {
             copy_tree(&entry.path(), &target);

--- a/custom-rings/program/tests/common/mod.rs
+++ b/custom-rings/program/tests/common/mod.rs
@@ -13,7 +13,22 @@ use zolana_interface::{
     BPF_LOADER_UPGRADEABLE_PUBKEY, RING_AUTH_PDA_SEED, SHIELDED_POOL_PROGRAM_ID,
 };
 
-const SBF_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../target/deploy");
+/// Nearest ancestor `target/deploy`, the program crate sits one level deeper in
+/// zolana than in a generated ring.
+fn sbf_dir() -> String {
+    let mut dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        let candidate = dir.join("target/deploy");
+        if candidate.is_dir() {
+            return candidate.to_string_lossy().into_owned();
+        }
+        assert!(
+            dir.pop(),
+            "no target/deploy above {}",
+            env!("CARGO_MANIFEST_DIR")
+        );
+    }
+}
 
 pub struct Slot {
     pub label: &'static str,
@@ -118,7 +133,7 @@ impl Fixture {
 
 pub fn setup_mollusk() -> (Mollusk, Pubkey) {
     let (mut mollusk, program_id) = zolana_test_utils::mollusk::mollusk_with_program(
-        SBF_DIR,
+        &sbf_dir(),
         *program_id().as_array(),
         "custom_ring_program",
     );


### PR DESCRIPTION
`zolana-ring new` now copies the ring source, `program`, `sdk` and `test`, from zolana at the revision the template pins. The ring owns that source and edits it in place, `interface` and `client` stay zolana crates. The generated ring also gets the workspace lockfile, embedded in the cli at build time. A fresh ring resolves the versions zolana builds with.

The cli is deduplicated, one subprocess runner, one file error type, one http client with timeouts, one status line printer. The wizard's questions moved into cargo-generate placeholders, `--silent` takes their defaults natively and rhai only assembles the features table.
