### PR TITLE
Skip malformed PDA-tagged outputs in discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,6 +1698,7 @@ dependencies = [
  "solana-signer",
  "zolana-client",
  "zolana-interface",
+ "zolana-keypair",
  "zolana-test-utils",
  "zolana-transaction",
  "zolana-tree",

--- a/sdk-tests/compression/sdk/src/discovery.rs
+++ b/sdk-tests/compression/sdk/src/discovery.rs
@@ -53,29 +53,167 @@ pub fn decode_wallet_utxo(indexed: EncryptedUtxoMatch, pda: &Address) -> Result<
 
 pub fn discover_account(indexer: &ZolanaIndexer, pda: Address) -> Result<DiscoveredAccount> {
     let mut cursor = None;
-    let mut candidates = Vec::new();
+    let mut matches = Vec::new();
     loop {
         let response =
             indexer.get_encrypted_utxos_by_tags(vec![pda.to_bytes()], cursor, Some(100), None)?;
-        for indexed in response.matches {
-            let candidate = decode_wallet_utxo(indexed, &pda)?;
-            let spend = indexer.get_shielded_transactions_by_nullifiers(
-                vec![candidate.utxo.nullifier],
-                None,
-                Some(1),
-                None,
-            )?;
-            if spend.transactions.is_empty() {
-                candidates.push(candidate);
-            }
-        }
+        matches.extend(response.matches);
         cursor = response.next_cursor;
         if cursor.is_none() {
             break;
         }
     }
-    candidates
-        .into_iter()
-        .max_by_key(|candidate| candidate.utxo.output_context.leaf_index)
-        .ok_or_else(|| anyhow!("no unspent UTXO found for PDA {pda}"))
+    discover_from_matches(matches, &pda, |nullifier| {
+        let spend = indexer.get_shielded_transactions_by_nullifiers(
+            vec![*nullifier],
+            None,
+            Some(1),
+            None,
+        )?;
+        Ok(!spend.transactions.is_empty())
+    })
+}
+
+fn discover_from_matches(
+    matches: impl IntoIterator<Item = EncryptedUtxoMatch>,
+    pda: &Address,
+    mut is_spent: impl FnMut(&[u8; 32]) -> Result<bool>,
+) -> Result<DiscoveredAccount> {
+    let mut candidates = Vec::new();
+    for indexed in matches {
+        let Ok(candidate) = decode_wallet_utxo(indexed, pda) else {
+            continue;
+        };
+        if !is_spent(&candidate.utxo.nullifier)? {
+            candidates.push(candidate);
+        }
+    }
+    let mut remaining = candidates.into_iter();
+    match (remaining.next(), remaining.next()) {
+        (None, _) => Err(anyhow!("no unspent UTXO found for PDA {pda}")),
+        (Some(current), None) => Ok(current),
+        (Some(_), Some(_)) => Err(anyhow!("multiple unspent UTXOs found for PDA {pda}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{account_pda, state::AccountState};
+    use zolana_transaction::{OutputContext, OutputSlot};
+
+    const AUTHORITY: [u8; 32] = [7u8; 32];
+
+    fn test_pda() -> Address {
+        account_pda(&Address::new_from_array(AUTHORITY))
+    }
+
+    fn derived_address(pda: &Address) -> [u8; 32] {
+        compression_example_program::state::PdaOwner::new(pda.as_array())
+            .unwrap()
+            .address()
+            .unwrap()
+    }
+
+    fn account_state(pda: &Address, value: u64, version: u64) -> AccountState {
+        AccountState {
+            address: derived_address(pda),
+            authority: AUTHORITY,
+            value,
+            version,
+        }
+    }
+
+    fn state_of(current: &DiscoveredAccount) -> AccountState {
+        decode_state(current.utxo.utxo.data.utxo_data().unwrap()).unwrap()
+    }
+
+    fn tagged_plaintext(pda: Address, state: &AccountState, leaf_index: u64) -> EncryptedUtxoMatch {
+        let account = AccountUtxo {
+            pda,
+            state: state.clone(),
+        };
+        let utxo = account.utxo().unwrap();
+        let data_hash = state.data_hash().unwrap();
+        let hash = utxo
+            .hash(
+                &zero_nullifier_key().pubkey().unwrap(),
+                &data_hash,
+                &[0u8; 32],
+            )
+            .unwrap();
+        EncryptedUtxoMatch {
+            slot: 0,
+            tx_signature: Default::default(),
+            output_slot: OutputSlot {
+                view_tag: pda.to_bytes(),
+                output_context: OutputContext {
+                    hash,
+                    tree: Address::default(),
+                    leaf_index,
+                },
+                payload: state.to_output_data().unwrap(),
+            },
+            tx_viewing_pk: None,
+            salt: None,
+        }
+    }
+
+    fn tagged_garbage(pda: Address, leaf_index: u64) -> EncryptedUtxoMatch {
+        EncryptedUtxoMatch {
+            slot: 0,
+            tx_signature: Default::default(),
+            output_slot: OutputSlot {
+                view_tag: pda.to_bytes(),
+                output_context: OutputContext {
+                    hash: [0u8; 32],
+                    tree: Address::default(),
+                    leaf_index,
+                },
+                payload: borsh::to_vec(&OutputDataEncoding::Plaintext(vec![0xff; 3])).unwrap(),
+            },
+            tx_viewing_pk: None,
+            salt: None,
+        }
+    }
+
+    fn unspent(_: &[u8; 32]) -> Result<bool> {
+        Ok(false)
+    }
+
+    #[test]
+    fn malformed_plaintext_tagged_to_the_pda_is_skipped() {
+        let pda = test_pda();
+        let legit = account_state(&pda, 1, 0);
+        let current = discover_from_matches(
+            [tagged_plaintext(pda, &legit, 10), tagged_garbage(pda, 11)],
+            &pda,
+            unspent,
+        )
+        .unwrap();
+
+        assert_eq!(current.version, 0);
+        assert_eq!(state_of(&current).value, 1);
+    }
+
+    #[test]
+    fn forged_plaintext_with_a_higher_leaf_index_is_not_selected() {
+        let pda = test_pda();
+        let legit = account_state(&pda, 1, 0);
+        let forged = account_state(&pda, 999, 7);
+        match discover_from_matches(
+            [
+                tagged_plaintext(pda, &legit, 10),
+                tagged_plaintext(pda, &forged, 11),
+            ],
+            &pda,
+            unspent,
+        ) {
+            Ok(current) => {
+                assert_eq!(current.version, 0);
+                assert_eq!(state_of(&current).value, 1);
+            }
+            Err(err) => assert!(err.to_string().contains("multiple unspent"), "{err}"),
+        }
+    }
 }

--- a/sdk-tests/compression/test/Cargo.toml
+++ b/sdk-tests/compression/test/Cargo.toml
@@ -16,7 +16,8 @@ solana-keypair = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 zolana-client = { workspace = true, features = ["indexer-api", "solana-rpc"] }
-zolana-interface = { workspace = true }
+zolana-interface = { workspace = true, features = ["solana"] }
+zolana-keypair = { workspace = true }
 zolana-test-utils = { workspace = true }
 zolana-transaction = { workspace = true }
 zolana-tree = { workspace = true }

--- a/sdk-tests/compression/test/tests/compression.rs
+++ b/sdk-tests/compression/test/tests/compression.rs
@@ -8,16 +8,31 @@ use compression_example_sdk::{
         create::{address_input, Create, CreateProofInputParams},
         update::{Update, UpdateCompressedAccount, UpdateProofInputParams},
     },
-    state::decode_state,
+    state::{decode_state, pda_shielded_address},
 };
-use shared::{send, setup, tree_root};
+use shared::{send, send_from, setup, tree_root, Environment};
 use solana_address::Address;
+use solana_signature::Signature;
 use solana_signer::Signer;
 use zolana_client::{ProofCompressed, ProverClient};
-use zolana_test_utils::test_validator_asserts::{
-    wait_for_indexed_utxo, wait_for_non_inclusion_proof,
+use zolana_interface::{
+    event::OutputDataEncoding,
+    instruction::{
+        instruction_data::transact::{OwnerTag, TransactOutput},
+        AssetDeposit, Deposit, DepositAsset, Transact,
+    },
 };
-use zolana_transaction::{Utxo, WalletUtxo};
+use zolana_keypair::{random_blinding, ShieldedKeypair};
+use zolana_test_utils::test_validator_asserts::{
+    wait_for_indexed_utxo, wait_for_merkle_proof, wait_for_non_inclusion_proof,
+};
+use zolana_transaction::{
+    instructions::transact::{ExternalData, SppProofInputs, SppProofOutputUtxo},
+    instructions::types::SppProofInputUtxo,
+    Data, Utxo, WalletUtxo, SOL_MINT,
+};
+
+const POISON_AMOUNT: u64 = 1_000_000;
 
 fn assert_account(
     wallet_utxo: &WalletUtxo,
@@ -47,9 +62,99 @@ fn assert_account(
     Ok(())
 }
 
+fn malformed_plaintext_payload() -> Vec<u8> {
+    let mut payload = vec![OutputDataEncoding::PLAINTEXT_TAG];
+    payload.extend_from_slice(&3u32.to_le_bytes());
+    payload.extend_from_slice(&[0xff; 3]);
+    payload
+}
+
+fn land_malformed_tagged_output(env: &mut Environment, pda: Address) -> Result<Signature> {
+    let attacker = ShieldedKeypair::new_ed25519()?;
+    env.rpc.airdrop(&attacker.pubkey(), 10_000_000_000)?;
+    let attacker_address = attacker.shielded_address()?;
+    let blinding = random_blinding();
+    let deposit_ix = Deposit {
+        tree: env.tree,
+        depositor: attacker.pubkey(),
+        deposits: vec![AssetDeposit {
+            asset: DepositAsset::Sol,
+            view_tag: attacker_address.confidential_view_tag()?,
+            owner: attacker_address.owner_hash()?,
+            blinding,
+            amount: POISON_AMOUNT,
+            utxo_data: None,
+            memo: None,
+        }],
+    }
+    .instruction()?;
+    let deposit_signature = send_from(env, deposit_ix, &attacker, None)?;
+    wait_for_indexed_utxo(
+        &env.indexer,
+        attacker_address.confidential_view_tag()?,
+        deposit_signature,
+    );
+
+    let spend = SppProofInputUtxo::new(
+        Utxo {
+            owner: attacker.signing_pubkey(),
+            asset: SOL_MINT,
+            amount: POISON_AMOUNT,
+            blinding,
+            ring_program_id: None,
+            data: Data::default(),
+        },
+        &attacker,
+    );
+    wait_for_merkle_proof(&env.indexer, env.tree, spend.hash()?);
+
+    let poison_output = SppProofOutputUtxo {
+        asset: SOL_MINT,
+        amount: POISON_AMOUNT,
+        blinding: random_blinding(),
+        owner_address: Some(pda_shielded_address(&pda)?),
+        owner_tag: Some(pda.to_bytes()),
+        data: Data::default(),
+        ..SppProofOutputUtxo::default()
+    };
+    let output_hash = poison_output.hash()?;
+    let external = ExternalData::new(
+        [0u8; 33],
+        [0u8; 16],
+        vec![TransactOutput {
+            utxo_hash: output_hash,
+            owner_tag: OwnerTag::Inline(pda.to_bytes()),
+            data: Some(malformed_plaintext_payload()),
+        }],
+        vec![pda.to_bytes()],
+        Vec::new(),
+    );
+    let transact = env.indexer.prove_transact(
+        env.tree,
+        SppProofInputs::new(
+            vec![spend],
+            vec![poison_output],
+            external,
+            attacker.pubkey(),
+        ),
+    )?;
+    let poison_ix = Transact {
+        payer: attacker.pubkey(),
+        input_tree: env.tree,
+        output_tree: env.tree,
+        owner_signers: Vec::new(),
+        interface_transfer_accounts: Vec::new(),
+        data: transact,
+    }
+    .instruction();
+    let poison_signature = send_from(env, poison_ix, &attacker, None)?;
+    wait_for_indexed_utxo(&env.indexer, pda.to_bytes(), poison_signature);
+    Ok(poison_signature)
+}
+
 #[test]
 fn create_and_update_plaintext_compressed_account() -> Result<()> {
-    let env = setup()?;
+    let mut env = setup()?;
     let pda = account_pda(&env.authority.pubkey());
 
     let (_, _, address) = address_input(&pda)?;
@@ -98,6 +203,20 @@ fn create_and_update_plaintext_compressed_account() -> Result<()> {
     )?;
     if created_state.address != create.input_nullifier {
         bail!("compressed address is not the address-input nullifier");
+    }
+
+    land_malformed_tagged_output(&mut env, pda)?;
+    let after_poison = discover_account(&env.indexer, pda)?;
+    assert_account(
+        &after_poison.utxo,
+        &create.output,
+        create.output_hash,
+        env.authority.pubkey(),
+        1,
+        env.tree,
+    )?;
+    if after_poison.version != 0 {
+        bail!("poisoned scan did not keep the created account");
     }
 
     if send(&env, create_ix, Some(1)).is_ok() {

--- a/sdk-tests/compression/test/tests/shared.rs
+++ b/sdk-tests/compression/test/tests/shared.rs
@@ -115,6 +115,15 @@ pub fn send(
     instruction: Instruction,
     cu_price: Option<u64>,
 ) -> Result<Signature> {
+    send_from(env, instruction, &env.authority, cu_price)
+}
+
+pub fn send_from(
+    env: &Environment,
+    instruction: Instruction,
+    payer: &dyn Signer,
+    cu_price: Option<u64>,
+) -> Result<Signature> {
     let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(
         TRANSACT_CU_LIMIT,
     )];
@@ -122,9 +131,7 @@ pub fn send(
         instructions.push(ComputeBudgetInstruction::set_compute_unit_price(price));
     }
     instructions.push(instruction);
-    Ok(env.rpc.create_and_send_transaction(
-        &instructions,
-        env.authority.pubkey(),
-        &[&env.authority],
-    )?)
+    Ok(env
+        .rpc
+        .create_and_send_transaction(&instructions, payer.pubkey(), &[payer])?)
 }


### PR DESCRIPTION
A sender can land a data_hash=0 SPP output tagged with the public PDA; discovery now skips decode failures and refuses two unspent candidates instead of aborting or taking max leaf index.