### PR TITLE
custom-ring: use the sdk without a concrete Solana RPC

### DIFF
--- a/custom-rings/sdk/Cargo.toml
+++ b/custom-rings/sdk/Cargo.toml
@@ -4,6 +4,19 @@ version = "0.1.0"
 edition.workspace = true
 publish = false
 
+[features]
+# The on-chain lookup-table flow in `v0`. It drives a concrete Solana RPC client
+# and signs locally, so a host that owns its own transport -- or keeps the
+# signing key in an enclave and signs through a separate rail -- cannot use it.
+# Default-on keeps every existing caller unchanged; turning it off leaves the
+# instruction builders, proof inputs, and auditor codec, none of which need RPC.
+default = ["solana-rpc"]
+solana-rpc = [
+    "dep:solana-address-lookup-table-interface",
+    "dep:solana-rpc-client-api",
+    "zolana-client/solana-rpc",
+]
+
 [dependencies]
 borsh = { workspace = true }
 custom-ring-interface = { workspace = true }
@@ -13,11 +26,11 @@ rand = { workspace = true }
 # Only for the uncompressed SEC1 encoding of the auditor key that the circuit
 # witnesses; `zolana-keypair` hands out compressed keys.
 solana-address = { workspace = true, features = ["curve25519"] }
-solana-address-lookup-table-interface = { workspace = true }
+solana-address-lookup-table-interface = { workspace = true, optional = true }
 solana-compute-budget-interface = { workspace = true }
 solana-instruction = { workspace = true }
 solana-message = { workspace = true }
-solana-rpc-client-api = { workspace = true }
+solana-rpc-client-api = { workspace = true, optional = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -26,7 +39,7 @@ solana-transaction = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
 wincode = { workspace = true }
 zeroize = { workspace = true }
-zolana-client = { workspace = true, features = ["indexer-api", "solana-rpc"] }
+zolana-client = { workspace = true, features = ["indexer-api"] }
 # `solana` pulls in the instruction builders this crate wraps for ring deposits.
 zolana-interface = { workspace = true, features = ["solana"] }
 zolana-keypair = { workspace = true }

--- a/custom-rings/sdk/src/lib.rs
+++ b/custom-rings/sdk/src/lib.rs
@@ -4,8 +4,10 @@
 //! definition serves both sides.
 
 mod instructions;
+mod lookup_table;
 mod shared;
 mod transfer;
+#[cfg(feature = "solana-rpc")]
 mod v0;
 
 pub use custom_ring_interface::{
@@ -37,5 +39,11 @@ pub use crate::{
         CustomRingTransfer, CustomRingTransferInput, DepositError, ProvenTransfer, RingDeposit,
         RingDepositReceipt, TransferError, TransferProofEnvironment,
     },
-    v0::{SendV0Error, V0WithLookupTable, TRANSACT_COMPUTE_UNIT_LIMIT},
 };
+
+/// Every account a custom-ring transact must place in a lookup table. A key left
+/// out costs 32 message bytes the transact cannot spare, so a host assembling
+/// the v0 message itself needs the same list [`V0WithLookupTable`] builds.
+pub use crate::lookup_table::{lookup_table_addresses, TRANSACT_COMPUTE_UNIT_LIMIT};
+#[cfg(feature = "solana-rpc")]
+pub use crate::v0::{SendV0Error, V0WithLookupTable};

--- a/custom-rings/sdk/src/lookup_table.rs
+++ b/custom-rings/sdk/src/lookup_table.rs
@@ -1,0 +1,66 @@
+//! Lookup-table facts a custom-ring transact needs, independent of transport.
+//!
+//! A transact does not fit a legacy packet, so it must go out as a v0 message
+//! over an address lookup table. Which accounts belong in that table is a
+//! property of the instruction, not of how the caller reaches the chain, so it
+//! lives here rather than in the RPC-driven `v0` module.
+
+use solana_address::Address;
+use solana_instruction::Instruction;
+
+pub const TRANSACT_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+
+/// A key left out of the table costs 32 message bytes the transact cannot spare.
+///
+/// Signers are excluded: a lookup table cannot supply them.
+pub fn lookup_table_addresses(instruction: &Instruction, compute_program: Address) -> Vec<Address> {
+    let mut addresses = Vec::new();
+    for address in instruction
+        .accounts
+        .iter()
+        .filter(|meta| !meta.is_signer)
+        .map(|meta| meta.pubkey)
+        .chain([instruction.program_id, compute_program])
+    {
+        if !addresses.contains(&address) {
+            addresses.push(address);
+        }
+    }
+    addresses
+}
+
+#[cfg(test)]
+mod tests {
+    use solana_instruction::{AccountMeta, Instruction};
+
+    use super::*;
+
+    fn address(byte: u8) -> Address {
+        Address::new_from_array([byte; 32])
+    }
+
+    #[test]
+    fn signers_are_excluded_and_every_key_appears_once() {
+        let signer = address(1);
+        let writable = address(2);
+        let program = address(3);
+        let compute = address(4);
+        let instruction = Instruction {
+            program_id: program,
+            accounts: vec![
+                AccountMeta::new(signer, true),
+                AccountMeta::new(writable, false),
+                // The same account twice must not consume two table slots.
+                AccountMeta::new_readonly(writable, false),
+            ],
+            data: Vec::new(),
+        };
+
+        let addresses = lookup_table_addresses(&instruction, compute);
+
+        // A lookup table cannot supply a signer, so including one would produce
+        // a message the runtime rejects.
+        assert!(!addresses.contains(&signer));
+        assert_eq!(addresses, vec![writable, program, compute]);
+    }
+}

--- a/custom-rings/sdk/src/v0.rs
+++ b/custom-rings/sdk/src/v0.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use solana_address::Address;
 use solana_address_lookup_table_interface::instruction::{
     create_lookup_table, extend_lookup_table,
 };
@@ -14,7 +13,7 @@ use solana_transaction::{versioned::VersionedTransaction, Transaction};
 use thiserror::Error;
 use zolana_client::SolanaRpc;
 
-pub const TRANSACT_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+use crate::lookup_table::{lookup_table_addresses, TRANSACT_COMPUTE_UNIT_LIMIT};
 
 const SLOT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -102,23 +101,6 @@ impl V0WithLookupTable<'_> {
             &all_signers,
         )?)
     }
-}
-
-/// A key left out of the table costs 32 message bytes the transact cannot spare.
-fn lookup_table_addresses(instruction: &Instruction, compute_program: Address) -> Vec<Address> {
-    let mut addresses = Vec::new();
-    for address in instruction
-        .accounts
-        .iter()
-        .filter(|meta| !meta.is_signer)
-        .map(|meta| meta.pubkey)
-        .chain([instruction.program_id, compute_program])
-    {
-        if !addresses.contains(&address) {
-            addresses.push(address);
-        }
-    }
-    addresses
 }
 
 /// A lookup table resolves only from the slot after the one it was written in.


### PR DESCRIPTION
`custom-ring-sdk` required `zolana-client`'s `solana-rpc` feature, which pulls `solana-rpc-client` and with it tokio >= 1.52.3. That makes the crate unusable from a host pinned lower. Concretely, a QOS enclave pins libc through `qos_core` (`libc =0.2.174`) and the tokio bump drags mio past that pin, so resolution fails outright:

```
error: failed to select a version for `libc`.
    ... required by package `mio v1.2.0`
    ... which satisfies dependency `mio = "^1.2.0"` of package `tokio v1.53.1`
  previously selected package `libc v0.2.174`
    ... which satisfies dependency `libc = "=0.2.174"` of package `qos_core v0.12.1`
```

Only the lookup-table flow in `v0` needs a concrete client -- its single import is `zolana_client::SolanaRpc`. Everything else is generic over the `Rpc` trait, which is not feature-gated.

## Change

Gates `v0` behind a **default-on** `solana-rpc` feature, so every existing caller is unchanged and `custom-ring-cli` and `custom-ring-test-validator` build untouched. With the feature off, the instruction builders, proof inputs, config reads, and auditor codec remain -- which is what a host that owns its transport actually needs.

`lookup_table_addresses` and `TRANSACT_COMPUTE_UNIT_LIMIT` move to their own module and become public. Which accounts belong in the table is a property of the instruction rather than of how the caller reaches the chain, and a host assembling the v0 message itself needs exactly the list `V0WithLookupTable` builds.

## Test

The moved function gains a test pinning the two things a caller cannot infer: signers are excluded because a lookup table cannot supply them, and a repeated account takes one slot rather than two.

Built and tested with and without the feature.

## Why

`V0WithLookupTable` is unusable from an enclave for a second reason anyway -- it takes `&dyn Signer` and signs locally, while the key sits in Turnkey. So the host has to assemble the v0 message itself, and needs the address list to do it.
