### PR TITLE
ts: export the plaintext decoders for relayed decryption

### DIFF
--- a/sdk-libs/ts/src/transaction/index.ts
+++ b/sdk-libs/ts/src/transaction/index.ts
@@ -104,5 +104,28 @@ export {
   type OutputDataEncoding,
   type OwnerContext,
 } from "./serialization/index.js";
+// The plaintext decoders, for a client that decrypts somewhere other than in
+// this process. `syncWallet` decrypts and decodes together and needs the
+// viewing key locally; a client whose viewing key is held remotely gets
+// plaintext back and still has to read it. `decodeOutputData` names the scheme
+// of a slot payload and hands back the body to decrypt; the per-scheme decoders
+// turn the returned plaintext into fields.
+export {
+  decodeAnonymousRecipient,
+  decodeAnonymousSender,
+  decodeConfidential,
+  decodeData,
+  decodeOutputData,
+  decodePlaintextTransfer,
+  decodeProofless,
+  decodeSplitBundle,
+  decodeSplitEncrypted,
+  type AnonymousRecipientPlaintext,
+  type AnonymousSenderPlaintext,
+  type ConfidentialOutputPlaintext,
+  type ProoflessOutput,
+  type SplitEncryptedUtxos,
+  type TransferPlaintextUtxos,
+} from "./serialization/index.js";
 
 export const VIEW_TAG_LEN = 32;

--- a/sdk-libs/ts/test/public-api.test.ts
+++ b/sdk-libs/ts/test/public-api.test.ts
@@ -8,6 +8,9 @@ import {
 } from "@solana/kit";
 import { describe, expect, it, vi } from "vitest";
 
+import { EncryptedScheme, decodeOutputData } from "../src/transaction/index.js";
+// The encoder stays internal; only the decoders are needed by a relayed client.
+import { encodeOutputData } from "../src/transaction/serialization/index.js";
 import {
   DEFAULT_TREE_ADDRESS,
   SHIELDED_POOL_PROGRAM_ID,
@@ -389,5 +392,44 @@ describe("address and instruction builders", () => {
       address: OWNER,
       role: AccountRole.WRITABLE,
     });
+  });
+});
+
+describe("relayed decryption surface", () => {
+  it("exports the plaintext decoders through @heliuslabs/zolana/transaction", async () => {
+    // `syncWallet` decrypts and decodes in one step and needs the viewing key in
+    // this process. A client whose viewing key is held remotely -- an enclave,
+    // an HSM -- gets plaintext back and still has to read it, so the decoders
+    // have to be reachable on their own. They live in the serialization barrel;
+    // this asserts the outer entry point forwards them.
+    const transaction = await import("../src/transaction/index.js");
+
+    for (const name of [
+      "decodeOutputData",
+      "decodeConfidential",
+      "decodeAnonymousRecipient",
+      "decodeAnonymousSender",
+      "decodeSplitBundle",
+      "decodeSplitEncrypted",
+      "decodePlaintextTransfer",
+      "decodeProofless",
+      "decodeData",
+    ]) {
+      expect(transaction, name).toHaveProperty(name);
+      expect(typeof (transaction as Record<string, unknown>)[name]).toBe("function");
+    }
+  });
+
+  it("names the scheme of a slot payload and hands back the body to decrypt", () => {
+    // The header is not encrypted; decrypting the framed payload whole would
+    // feed the discriminator bytes to the cipher and return garbage. A relayed
+    // client has to split the frame before it sends anything to be decrypted.
+    const body = Uint8Array.from([1, 2, 3, 4]);
+    const framed = encodeOutputData(EncryptedScheme.ringConfidential, body);
+    const frame = decodeOutputData(framed);
+
+    expect(frame.scheme).toBe(EncryptedScheme.ringConfidential);
+    expect(frame.body).toEqual(body);
+    expect(frame.body.length).toBeLessThan(framed.length);
   });
 });


### PR DESCRIPTION
`syncWallet` decrypts and decodes in one step, so it needs the viewing key in the calling process. A client whose viewing key is held elsewhere -- an enclave, an HSM -- gets plaintext back and still has to read it.

Today it cannot. The decoders are exported from `src/transaction/serialization/index.ts`, but `src/transaction/index.ts` forwards only part of that barrel, and `package.json` has no `./transaction/serialization` subpath. So there is no supported way to turn a decrypted payload into fields.

## Change

Forwards `decodeOutputData` and the per-scheme decoders with their plaintext types.

The omission looks accidental rather than deliberate: `decodeContextForSlot` is a decoder and was already forwarded. The encoders stay internal, which seems right -- a relayed client reads plaintext, it does not produce it.

## Tests

Two, both regression guards:

1. The decoders are reachable from the public `transaction` entry point.
2. `decodeOutputData` names the scheme and returns the body. This pins the framing a relayed client has to get right: the header is not encrypted, so decrypting a framed slot payload whole feeds the discriminator bytes to the cipher and returns garbage. We hit exactly that bug building a relayed client, and nothing in the public API said otherwise.

The two failing suites under `test/e2e/` are the live tests; they fail identically on `main` without `ZOLANA_LOCALNET_URL` and `RING_PROGRAM_ID`. Everything else passes: 354 tests across 29 files.

## Why

We are building a TVC enclave wallet where the enclave holds the viewing key and the browser relays: the enclave derives view tags, the browser queries the indexer, the enclave decrypts and returns plaintext. The browser then has to read that plaintext to show a balance -- including `ringProgramId`, which is what tells it which custom ring a UTXO belongs to.
