### PR TITLE
ci: fix the flaky tests and prebuild the localnet matrix

### DIFF
--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -52,6 +52,8 @@ jobs:
         with:
           path: prover/server/formal-verification/.lake
           key: lean-${{ hashFiles('prover/server/formal-verification/lean-toolchain') }}-${{ hashFiles('prover/server/formal-verification/lake-manifest.json') }}
+          restore-keys: |
+            lean-${{ hashFiles('prover/server/formal-verification/lean-toolchain') }}-
 
       - name: Build Lean project (checks all theorems)
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -204,10 +204,47 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  build-localnet-tests:
+    name: build / localnet suites
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    env:
+      AGAVE_VERSION: v4.0.2
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: prover/server/go.mod
+          cache-dependency-path: prover/server/go.sum
+      - uses: ./.github/actions/setup-rust
+        with:
+          shared-key: localnet-photon
+          private-libs-token: ${{ secrets.PRIVATE_LIBS_TOKEN }}
+      - name: Install Anza CLI
+        uses: ./.github/actions/install-anza
+        with:
+          version: ${{ env.AGAVE_VERSION }}
+      - name: Install pinned SBF platform tools
+        uses: ./.github/actions/install-sbf-tools
+        with:
+          version: ${{ env.SBF_TOOLS_VERSION }}
+      - run: just build-localnet-archives
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: localnet-tests-${{ github.sha }}
+          path: |
+            target/nextest-archives/
+            target/deploy/*.so
+            target/debug/zolana
+            target/debug/xtask
+            target/prover-server
+          if-no-files-found: error
+          retention-days: 1
+
   test-localnet-photon:
     name: tests / localnet photon / ${{ matrix.name }}
-    runs-on: ubuntu-latest
-    needs: build-photon
+    runs-on: ${{ matrix.runner }}
+    needs: [build-photon, build-localnet-tests]
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -215,26 +252,37 @@ jobs:
         include:
           - name: e2e
             recipe: test-localnet-e2e-photon
+            runner: ubuntu-latest
           - name: spp lifecycle/decode
             recipe: test-spp-validator-lifecycle-decode
+            runner: ubuntu-latest
           - name: spp merge
             recipe: test-spp-validator-merge
+            runner: ubuntu-latest
           - name: spp randomized
             recipe: test-spp-validator-randomized
+            runner: ubuntu-latest
           - name: spp proof cu
             recipe: test-spp-validator-proof-cu
+            runner: ubuntu-latest
           - name: ring lifecycle
             recipe: test-ring-validator
+            runner: ubuntu-latest
           - name: swap and escrow lifecycle
             recipe: test-swap-and-escrow-validator
+            runner: ubuntu-latest
           - name: dynamic-swap lifecycle
             recipe: test-dynamic-swap
+            runner: ubuntu-latest
           - name: compression lifecycle
             recipe: test-compression-validator
+            runner: ubuntu-latest
           - name: custom-ring lifecycle
             recipe: test-custom-ring-validator
+            runner: ubuntu-latest
           - name: rfq settlement
             recipe: test-rfq-validator
+            runner: ubuntu-latest
     env:
       AGAVE_VERSION: v4.0.2
       # GH_TOKEN is for the gh-release swap/escrow/custom-ring key downloads
@@ -242,6 +290,9 @@ jobs:
       # proving keys come from CloudFront and need no token.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ZOLANA_PHOTON_BIN: target/bin/photon
+      ZOLANA_PREBUILT: "1"
+      ZOLANA_XTASK_BIN: target/debug/xtask
+      ZOLANA_NEXTEST_ARCHIVE_DIR: target/nextest-archives
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -271,6 +322,12 @@ jobs:
           name: photon-linux-x86_64-${{ github.sha }}
           path: target/bin
       - run: chmod 0755 "$ZOLANA_PHOTON_BIN"
+      - name: Download prebuilt localnet suites
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: localnet-tests-${{ github.sha }}
+          path: target
+      - run: chmod 0755 target/debug/zolana target/debug/xtask target/prover-server
       - name: Cache Squads smart account binary
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: squads-cache

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -191,12 +191,20 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Cache the photon binary
+        id: photon-bin-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: target/release/photon
+          key: photon-bin-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', 'services/photon/**', 'program-libs/account-checks/**', 'program-libs/batched-merkle-tree/**', 'program-libs/bloom-filter/**', 'program-libs/event/**', 'program-libs/hasher/**', 'program-libs/interface/**', 'program-libs/tree/**', 'sdk-libs/indexer-api/**') }}
       - uses: ./.github/actions/setup-rust
+        if: steps.photon-bin-cache.outputs.cache-hit != 'true'
         with:
           install-just: "false"
           shared-key: localnet-photon
           private-libs-token: ${{ secrets.PRIVATE_LIBS_TOKEN }}
-      - run: cargo build --locked --release -p photon-indexer --bin photon
+      - if: steps.photon-bin-cache.outputs.cache-hit != 'true'
+        run: cargo build --locked --release -p photon-indexer --bin photon
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: photon-linux-x86_64-${{ github.sha }}

--- a/justfile
+++ b/justfile
@@ -585,6 +585,8 @@ cli *args:
     cargo run -p zolana-cli -- {{args}}
 
 build-cli:
+    #!/usr/bin/env bash
+    [[ -z "${ZOLANA_PREBUILT:-}" ]] || exit 0
     cargo build -p zolana-cli --target-dir target
 
 test-cli:
@@ -879,7 +881,7 @@ test-localnet-e2e: build-programs build-prover-server build-cli
     dev_start
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" cargo nextest run -p shielded-pool-tests --features localnet --test localnet_e2e --no-capture
     dev_start
-    env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" cargo nextest run -p shielded-pool-tests --features localnet --test localnet_deposit --no-capture
+    env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" tools/ci/nextest-suite.sh -p shielded-pool-tests --features localnet --test localnet_deposit --no-capture
 
 # Local-validator SOL cycle backed by a real Photon Zolana indexer. Each
 # `#[serial]` test restarts a fresh validator + Photon via the `zolana` CLI,
@@ -887,7 +889,7 @@ test-localnet-e2e: build-programs build-prover-server build-cli
 test-localnet-e2e-photon: build-programs build-prover-server build-cli ensure-photon ensure-smart-account
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -900,9 +902,9 @@ test-localnet-e2e-photon: build-programs build-prover-server build-cli ensure-ph
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p shielded-pool-tests --features localnet --test localnet_photon --no-capture
+      tools/ci/nextest-suite.sh -p shielded-pool-tests --features localnet --test localnet_photon --no-capture
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p shielded-pool-tests --features localnet --test localnet_wallet_cli --no-capture
+      tools/ci/nextest-suite.sh -p shielded-pool-tests --features localnet --test localnet_wallet_cli --no-capture
 
 # Spawn a localnet (validator + prover + photon) via the `zolana` CLI, bootstrap a
 # pool tree with an authority wallet, then run the tools/cli_smoke.sh coverage
@@ -913,7 +915,7 @@ test-localnet-e2e-photon: build-programs build-prover-server build-cli ensure-ph
 test-cli-smoke: build-programs build-prover-server build-cli ensure-photon
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     export ZOLANA_PHOTON_BIN="{{photon-bin}}"
     export ZOLANA_PROVER_KEYS_DIR="$PWD/{{spp-keys-dir}}"
     bin="target/debug/zolana"
@@ -963,7 +965,7 @@ test-cli-smoke: build-programs build-prover-server build-cli ensure-photon
 test-nullifier-batch-proof-cu: build-programs build-prover-server build-cli ensure-photon ensure-smart-account
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -976,7 +978,7 @@ test-nullifier-batch-proof-cu: build-programs build-prover-server build-cli ensu
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p shielded-pool-tests --features localnet --test localnet_photon \
+      tools/ci/nextest-suite.sh -p shielded-pool-tests --features localnet --test localnet_photon \
       --no-capture -E 'test(nullifier_test_forester_batches_queued_nullifiers_with_photon_indexer)'
 
 # Decrypt-and-spend lifecycle tests over a fresh validator + Photon per test
@@ -984,7 +986,7 @@ test-nullifier-batch-proof-cu: build-programs build-prover-server build-cli ensu
 test-spp-validator: build-programs build-prover-server build-cli ensure-photon
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -996,13 +998,13 @@ test-spp-validator: build-programs build-prover-server build-cli ensure-photon
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p spp-test-validator --test lifecycle --test proof_cu
+      tools/ci/nextest-suite.sh -p spp-test-validator --test lifecycle --test proof_cu
 
 # Run only real-validator CU ceilings for P256 transact and maximal 8x1 merge.
 test-spp-validator-proof-cu: build-programs build-prover-server build-cli ensure-photon
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -1014,13 +1016,13 @@ test-spp-validator-proof-cu: build-programs build-prover-server build-cli ensure
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p spp-test-validator --test proof_cu --no-capture
+      tools/ci/nextest-suite.sh -p spp-test-validator --test proof_cu --no-capture
 
 # Run the transfer case that also decodes the emitted event.
 test-spp-validator-decode: build-programs build-prover-server build-cli ensure-photon
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -1032,7 +1034,7 @@ test-spp-validator-decode: build-programs build-prover-server build-cli ensure-p
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p spp-test-validator --test lifecycle --no-capture -E 'test(=actor_payer_transfers_cover_sol_and_spl_assets)'
+      tools/ci/nextest-suite.sh -p spp-test-validator --test lifecycle --no-capture -E 'test(=actor_payer_transfers_cover_sol_and_spl_assets)'
 
 # Run only the merge scenarios from test-spp-validator (the 1-8 consolidation
 # outline plus the disabled-service negative). For debugging the merge flow without
@@ -1040,7 +1042,7 @@ test-spp-validator-decode: build-programs build-prover-server build-cli ensure-p
 test-spp-validator-merge: build-programs build-prover-server build-cli ensure-photon
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -1052,14 +1054,14 @@ test-spp-validator-merge: build-programs build-prover-server build-cli ensure-ph
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p spp-test-validator --test lifecycle --no-capture -E 'test(merge)'
+      tools/ci/nextest-suite.sh -p spp-test-validator --test lifecycle --no-capture -E 'test(merge)'
 
 # Run only the randomized 50-transaction workload from test-spp-validator.
 # Set ZOLANA_RANDOM_SEED (decimal or 0x-prefixed hex) to replay a run.
 test-spp-validator-randomized: build-programs build-prover-server build-cli ensure-photon
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -1071,13 +1073,13 @@ test-spp-validator-randomized: build-programs build-prover-server build-cli ensu
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p spp-test-validator --test lifecycle --no-capture -E 'test(randomized_mixed_asset)'
+      tools/ci/nextest-suite.sh -p spp-test-validator --test lifecycle --no-capture -E 'test(randomized_mixed_asset)'
 
 # Run the non-randomized spp-validator lifecycle tests.
 test-spp-validator-lifecycle-decode: build-programs build-prover-server build-cli ensure-photon
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -1089,14 +1091,14 @@ test-spp-validator-lifecycle-decode: build-programs build-prover-server build-cl
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p spp-test-validator --test lifecycle --no-capture \
+      tools/ci/nextest-suite.sh -p spp-test-validator --test lifecycle --no-capture \
       -E 'not test(randomized_mixed_asset) and not test(merge)'
 
 # Run the transfer lifecycle case.
 test-spp-validator-lifecycle: build-programs build-prover-server build-cli ensure-photon
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -1108,7 +1110,7 @@ test-spp-validator-lifecycle: build-programs build-prover-server build-cli ensur
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p spp-test-validator --test lifecycle --no-capture -E 'test(transfer)'
+      tools/ci/nextest-suite.sh -p spp-test-validator --test lifecycle --no-capture -E 'test(transfer)'
 
 # Ring lifecycle tests over a fresh validator + Photon per test
 # (program-tests/ring-test-program). Mirrors test-spp-validator but loads the
@@ -1121,7 +1123,7 @@ test-spp-validator-lifecycle: build-programs build-prover-server build-cli ensur
 test-ring-validator: build-programs build-prover-server build-cli ensure-photon ensure-smart-account
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -1135,14 +1137,14 @@ test-ring-validator: build-programs build-prover-server build-cli ensure-photon 
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p ring-test-program --test ring_lifecycle --test p256_ring_lifecycle --test proof_cu --release
+      tools/ci/nextest-suite.sh -p ring-test-program --test ring_lifecycle --test p256_ring_lifecycle --test proof_cu --release
 
 # Run only real-validator CU ceilings for ring EdDSA/P256 transact,
 # ring-authority transact, and maximal 8x1 merge-ring.
 test-ring-validator-proof-cu: build-programs build-prover-server build-cli ensure-photon ensure-smart-account
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -1156,7 +1158,7 @@ test-ring-validator-proof-cu: build-programs build-prover-server build-cli ensur
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p ring-test-program --test proof_cu --release --no-capture
+      tools/ci/nextest-suite.sh -p ring-test-program --test proof_cu --release --no-capture
 
 # Regenerate services/photon/tests/fixtures/ring_transact.json from a real ring
 # CPI. The fixture is committed; Photon replays it without a validator. Run this
@@ -1164,7 +1166,7 @@ test-ring-validator-proof-cu: build-programs build-prover-server build-cli ensur
 dump-ring-fixture: build-programs build-prover-server build-cli ensure-photon ensure-smart-account
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -1178,7 +1180,7 @@ dump-ring-fixture: build-programs build-prover-server build-cli ensure-photon en
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p ring-test-program --test ring_lifecycle --release \
+      tools/ci/nextest-suite.sh -p ring-test-program --test ring_lifecycle --release \
       --run-ignored all --no-capture -E 'test(=dump_ring_transact_fixture)'
 
 # Fully-inlined create+fill (derived and verifiable-encryption take rails) and
@@ -1192,7 +1194,7 @@ dump-ring-fixture: build-programs build-prover-server build-cli ensure-photon en
 test-swap-validator: ensure-swap-keys build-programs build-prover-server build-cli ensure-photon ensure-smart-account
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -1205,7 +1207,7 @@ test-swap-validator: ensure-swap-keys build-programs build-prover-server build-c
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p swap-test-validator --test swap --test take_verifiable_encryption --test cancel --no-capture
+      tools/ci/nextest-suite.sh -p swap-test-validator --test swap --test take_verifiable_encryption --test cancel --no-capture
 
 # Custom-ring lifecycle on a local validator
 # (custom-rings/test/tests/ring.rs): create the ring config holding the
@@ -1235,9 +1237,9 @@ test-custom-ring-validator: ensure-custom-ring-live-keys build-programs build-cl
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     cargo build -q -p custom-ring-cli
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p custom-ring-test-validator --test ring --no-capture
+      tools/ci/nextest-suite.sh -p custom-ring-test-validator --test ring --no-capture
     # The custom-ring proving key is guaranteed here.
-    cargo nextest run -p custom-ring-sdk --run-ignored all -E 'binary(custom_ring_circuit)'
+    tools/ci/nextest-suite.sh -p custom-ring-sdk --run-ignored all -E 'binary(custom_ring_circuit)'
 
 # Timelock escrow lifecycle on a local validator, driven against a real
 # localnet (sdk-tests/timelock-escrow/test/tests/escrow.rs). Boots
@@ -1257,7 +1259,7 @@ test-escrow-validator: ensure-escrow-keys build-programs build-prover-server bui
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p timelock-escrow-test --test escrow --no-capture
+      tools/ci/nextest-suite.sh -p timelock-escrow-test --test escrow --no-capture
 
 # Runs the swap and escrow lifecycle suites back to back in one CI job.
 test-swap-and-escrow-validator: test-swap-validator test-escrow-validator
@@ -1283,7 +1285,7 @@ test-compression-validator: build-programs build-prover-server build-cli ensure-
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p compression-example-test --test compression --no-capture
+      tools/ci/nextest-suite.sh -p compression-example-test --test compression --no-capture
 
 # Minimal zolana-client SDK example: deposit, shielded transfer, and withdrawal
 # building the SPP instructions by hand and submitting them
@@ -1294,7 +1296,7 @@ test-compression-validator: build-programs build-prover-server build-cli ensure-
 test-client-example: build-programs build-prover-server build-cli ensure-photon ensure-smart-account
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -1333,7 +1335,7 @@ test-dynamic-swap *args: ensure-dynamic-swap-keys build-programs build-prover-se
     export ZOLANA_LOCALNET_RPC_PORT="{{localnet-rpc-port}}"
     export ZOLANA_LOCALNET_PHOTON_PORT="{{localnet-photon-port}}"
     env ZOLANA_LOCALNET_URL="{{localnet-rpc-url}}" ZOLANA_INDEXER_URL="{{localnet-photon-url}}" \
-      cargo nextest run -p dynamic-swap-test {{args}} --no-capture
+      tools/ci/nextest-suite.sh -p dynamic-swap-test {{args}} --no-capture
 
 # Confidential RFQ settlement on a local validator: the maker and taker co-sign
 # one shielded-pool transact that swaps SOL for USDC with no escrow and no custom
@@ -1343,7 +1345,7 @@ test-dynamic-swap *args: ensure-dynamic-swap-keys build-programs build-prover-se
 test-rfq-validator: build-programs build-prover-server build-cli ensure-photon ensure-smart-account
     #!/usr/bin/env bash
     set -euo pipefail
-    eval "$(cargo run -q -p xtask -- program-ids)"
+    eval "$(tools/ci/xtask.sh program-ids)"
     cleanup() {
       lsof -ti "tcp:{{localnet-rpc-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
       lsof -ti "tcp:{{localnet-photon-port}}" 2>/dev/null | xargs kill -9 2>/dev/null || true
@@ -1387,6 +1389,8 @@ install-surfpool:
 
 # Build local SBF programs into `target/deploy`.
 build-programs:
+    #!/usr/bin/env bash
+    [[ -z "${ZOLANA_PREBUILT:-}" ]] || exit 0
     SBF_TOOLS_VERSION={{sbf-tools-version}} ./tools/build-programs.sh
 
 # Deploy/upgrade programs to devnet using the local `solana` CLI config.
@@ -1425,8 +1429,27 @@ rings-test command *args:
     tools/rings-test-deploy.sh {{command}} {{args}}
 
 build-prover-server:
+    #!/usr/bin/env bash
+    [[ -z "${ZOLANA_PREBUILT:-}" ]] || exit 0
     mkdir -p target
     cd prover/server && go build -o ../../target/prover-server .
+
+# CI prebuild for the localnet matrix, with ZOLANA_PREBUILT and
+# ZOLANA_NEXTEST_ARCHIVE_DIR set the suite recipes run from it without building.
+build-localnet-archives dir="target/nextest-archives": build-programs build-cli build-prover-server
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p {{dir}}
+    cargo build -p xtask --target-dir target
+    cargo nextest archive -p shielded-pool-tests --features localnet --test localnet_photon --test localnet_wallet_cli --archive-file {{dir}}/shielded-pool-tests.tar.zst
+    cargo nextest archive -p spp-test-validator --test lifecycle --test proof_cu --archive-file {{dir}}/spp-test-validator.tar.zst
+    cargo nextest archive -p ring-test-program --release --test ring_lifecycle --test p256_ring_lifecycle --test proof_cu --archive-file {{dir}}/ring-test-program.tar.zst
+    cargo nextest archive -p swap-test-validator --test swap --test take_verifiable_encryption --test cancel --archive-file {{dir}}/swap-test-validator.tar.zst
+    cargo nextest archive -p timelock-escrow-test --test escrow --archive-file {{dir}}/timelock-escrow-test.tar.zst
+    cargo nextest archive -p dynamic-swap-test --archive-file {{dir}}/dynamic-swap-test.tar.zst
+    cargo nextest archive -p custom-ring-test-validator --test ring --archive-file {{dir}}/custom-ring-test-validator.tar.zst
+    cargo nextest archive -p custom-ring-sdk --test custom_ring_circuit --archive-file {{dir}}/custom-ring-sdk.tar.zst
+    cargo nextest archive -p compression-example-test --test compression --archive-file {{dir}}/compression-example-test.tar.zst
 
 # Regenerate all proving keys (transfer, merge, custom ring, and batch
 # address-append), the committed verifying keys in both crates, and

--- a/program-tests/shielded-pool/tests/cross_cutting/cu_budget.rs
+++ b/program-tests/shielded-pool/tests/cross_cutting/cu_budget.rs
@@ -17,7 +17,7 @@ const CONFIG_UPDATE_CU_CEILING: u64 = 750;
 const CREATE_TREE_CU_CEILING: u64 = 1_800; // observed 581
 const PAUSE_TREE_CU_CEILING: u64 = 800; // observed 250-251
 const CREATE_ASSET_COUNTER_CU_CEILING: u64 = 14_000; // observed 4_600
-const CREATE_SPL_INTERFACE_CU_CEILING: u64 = 23_000; // observed 7_638
+const CREATE_SPL_INTERFACE_CU_CEILING: u64 = 23_000; // observed 7_706
 const DEPOSIT_SOL_CU_CEILING: u64 = 90_000; // observed 38_393
 const DEPOSIT_SPL_CU_CEILING: u64 = 100_000; // observed 39_424
 const CREATE_RING_CONFIG_CU_CEILING: u64 = 20_000; // observed 6_658
@@ -51,7 +51,8 @@ fn assert_last_under(test: &ZolanaProgramTest, operation: &str, limit: u64) {
 #[test]
 fn proofless_instruction_families_stay_within_transaction_budgets() {
     let mut test = ZolanaProgramTest::new().expect("program test");
-    let authority = Keypair::new();
+    // PDA bump search cost moves with the address, fixed keypairs pin the metered CU.
+    let authority = Keypair::new_from_array([1; 32]);
     test.create_protocol_config(&authority)
         .expect("create protocol config");
     assert_last_under(
@@ -106,7 +107,12 @@ fn proofless_instruction_families_stay_within_transaction_budgets() {
         .expect("unpause tree");
     assert_last_under(&test, "unpause tree", PAUSE_TREE_CU_CEILING);
 
-    let mint = test.create_mint().expect("create mint");
+    let mint = test
+        .create_mint_from(
+            &Keypair::new_from_array([2; 32]),
+            ZolanaProgramTest::token_program_id(),
+        )
+        .expect("create mint");
     test.create_asset_counter(&authority)
         .expect("create asset counter");
     assert_last_under(
@@ -122,7 +128,7 @@ fn proofless_instruction_families_stay_within_transaction_budgets() {
         CREATE_SPL_INTERFACE_CU_CEILING,
     );
 
-    let depositor = Keypair::new();
+    let depositor = Keypair::new_from_array([3; 32]);
     test.airdrop(&depositor.pubkey(), 1_000_000_000)
         .expect("fund depositor");
     test.deposit_sol(&tree.pubkey(), &depositor, 1_000_000, [1; 32], [2; 32])
@@ -156,7 +162,7 @@ fn proofless_instruction_families_stay_within_transaction_budgets() {
         .expect("ring deposit SOL");
     assert_last_under(&test, "ring deposit SOL", RING_DEPOSIT_SOL_CU_CEILING);
 
-    let next_ring_owner = Keypair::new();
+    let next_ring_owner = Keypair::new_from_array([4; 32]);
     test.update_ring_config_owner(&authority, &ring_config, &next_ring_owner)
         .expect("rotate ring config owner");
     assert_last_under(

--- a/sdk-libs/program-test/src/spl.rs
+++ b/sdk-libs/program-test/src/spl.rs
@@ -29,7 +29,15 @@ impl ZolanaProgramTest {
         &mut self,
         token_program: Pubkey,
     ) -> Result<Pubkey, ProgramTestError> {
-        let mint = Keypair::new();
+        self.create_mint_from(&Keypair::new(), token_program)
+    }
+
+    /// A fixed mint pins mint-seeded PDA bump search costs.
+    pub fn create_mint_from(
+        &mut self,
+        mint: &Keypair,
+        token_program: Pubkey,
+    ) -> Result<Pubkey, ProgramTestError> {
         let rent = self
             .svm
             .minimum_balance_for_rent_exemption(SPL_TOKEN_MINT_ACCOUNT_LEN);
@@ -48,7 +56,7 @@ impl ZolanaProgramTest {
             accounts: vec![AccountMeta::new(mint.pubkey(), false)],
             data,
         };
-        self.send(&[create_ix, init_ix], &[&mint])?;
+        self.send(&[create_ix, init_ix], &[mint])?;
         Ok(mint.pubkey())
     }
 

--- a/sdk-tests/dynamic-swap/test/tests/escrow_flow.rs
+++ b/sdk-tests/dynamic-swap/test/tests/escrow_flow.rs
@@ -20,6 +20,7 @@ use dynamic_swap_sdk::{
 };
 use shared::{
     escrow_authority_identity, get_slot_with_retry, send_v0_with_lookup_table, setup_with_pair,
+    wait_until,
 };
 use solana_signer::Signer;
 use zolana_client::Rpc;
@@ -84,17 +85,16 @@ fn create_pair_escrow_and_settle() -> Result<()> {
             // deposit blinding the test happens to know client-side.
             let mut user_wallet = Wallet::new(env.user.address()?, env.assets.clone())
                 .map_err(|e| anyhow!("user wallet: {e:?}"))?;
-            sync_wallet(&mut user_wallet, &env.user.keypair, env.client.indexer())
-                .map_err(|e| anyhow!("sync user wallet: {e:?}"))?;
-            let funding_utxo = user_wallet
-                .balance(env.spl_mint, Some(Filter::MinAmount(ORDER_AMOUNT)))
-                .map_err(|e| anyhow!("user balance: {e:?}"))?
-                .utxos
-                .first()
-                .cloned()
-                .ok_or_else(|| {
-                    anyhow!("no spendable utxo of {} >= {ORDER_AMOUNT}", env.spl_mint)
-                })?;
+            let funding_utxo = wait_until("funding note", || {
+                sync_wallet(&mut user_wallet, &env.user.keypair, env.client.indexer())
+                    .map_err(|e| anyhow!("sync user wallet: {e:?}"))?;
+                Ok(user_wallet
+                    .balance(env.spl_mint, Some(Filter::MinAmount(ORDER_AMOUNT)))
+                    .map_err(|e| anyhow!("user balance: {e:?}"))?
+                    .utxos
+                    .first()
+                    .cloned())
+            })?;
             let source_in = SppProofInputUtxo::new(funding_utxo.clone(), &env.user.keypair);
             let remainder_amount = funding_utxo
                 .amount
@@ -148,15 +148,16 @@ fn create_pair_escrow_and_settle() -> Result<()> {
 
             // Re-sync and select the freshly created exact-`ORDER_AMOUNT` note
             // from Photon, rather than reconstructing it from the split blinding.
-            sync_wallet(&mut user_wallet, &env.user.keypair, env.client.indexer())
-                .map_err(|e| anyhow!("resync user wallet: {e:?}"))?;
-            user_wallet
-                .balance(env.spl_mint, None)
-                .map_err(|e| anyhow!("user balance after split: {e:?}"))?
-                .utxos
-                .into_iter()
-                .find(|utxo| utxo.amount == ORDER_AMOUNT)
-                .ok_or_else(|| anyhow!("no exact-{ORDER_AMOUNT} utxo after split"))?
+            wait_until("exact split note", || {
+                sync_wallet(&mut user_wallet, &env.user.keypair, env.client.indexer())
+                    .map_err(|e| anyhow!("resync user wallet: {e:?}"))?;
+                Ok(user_wallet
+                    .balance(env.spl_mint, None)
+                    .map_err(|e| anyhow!("user balance after split: {e:?}"))?
+                    .utxos
+                    .into_iter()
+                    .find(|utxo| utxo.amount == ORDER_AMOUNT))
+            })?
         };
 
         let escrow_owner = escrow_authority_identity(&env.authority.keypair, &pair)?;

--- a/sdk-tests/dynamic-swap/test/tests/shared.rs
+++ b/sdk-tests/dynamic-swap/test/tests/shared.rs
@@ -6,7 +6,7 @@
 // here; every dynamic-swap domain flow is inlined into the test that uses it.
 #![allow(dead_code)]
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
 use dynamic_swap_sdk::{escrow_authority_pda, instructions::create_pair::CreatePair, pair_pda};
@@ -396,6 +396,22 @@ pub fn setup_with_pair(price: u64) -> Result<(TestEnv, Pubkey)> {
         )
         .map_err(|e| anyhow!("send create_pair: {e:?}"))?;
     Ok((env, pair))
+}
+
+/// Photon indexes a send asynchronously, poll until the value appears or the deadline passes.
+pub fn wait_until<T>(what: &str, mut poll: impl FnMut() -> Result<Option<T>>) -> Result<T> {
+    const DEADLINE: Duration = Duration::from_secs(30);
+    const INTERVAL: Duration = Duration::from_millis(500);
+    let start = Instant::now();
+    loop {
+        if let Some(value) = poll()? {
+            return Ok(value);
+        }
+        if start.elapsed() >= DEADLINE {
+            return Err(anyhow!("{what} did not appear within {DEADLINE:?}"));
+        }
+        std::thread::sleep(INTERVAL);
+    }
 }
 
 /// The validator's RPC connection can transiently drop a request right after

--- a/services/ring-rpc/src/audit.rs
+++ b/services/ring-rpc/src/audit.rs
@@ -11,10 +11,9 @@ use zolana_ring_client::{
 
 use crate::{
     api::{
-        cursor_in_bounds, limit_in_bounds, unix_now, AuthorityAuth, DecryptedOutput,
-        DecryptedTransaction, DecryptedTransactionsPage, DecryptedWithdrawal,
-        GetDecryptedTransactionsResponse, ReadAttestation, ReadAuth, SkippedReason,
-        SkippedTransaction, AUDIT_PAGE_LIMIT,
+        cursor_in_bounds, limit_in_bounds, AuthorityAuth, DecryptedOutput, DecryptedTransaction,
+        DecryptedTransactionsPage, DecryptedWithdrawal, GetDecryptedTransactionsResponse,
+        ReadAttestation, ReadAuth, SkippedReason, SkippedTransaction, AUDIT_PAGE_LIMIT,
     },
     authorize::{self, AuthorityCheck, ReadCheck, Unauthorized},
     error::RingRpcError,
@@ -141,7 +140,7 @@ impl<S: TransactionSource> AuditService<S> {
     /// Before the config exists only the upgrade authority can ask, afterwards
     /// only the config authority, the same split the program enforces.
     pub async fn authorize_auditor_key(&self, auth: &AuthorityAuth) -> Result<(), RingRpcError> {
-        let now = unix_now().map_err(|_| RingRpcError::StateUnavailable)?;
+        let now = self.shared.clock.now()?;
         let claim = AuthorityCheck {
             auth,
             ring: self.ring,
@@ -171,7 +170,7 @@ impl<S: TransactionSource> AuditService<S> {
         request: AuditRead<'a>,
     ) -> Result<AuthorizedRead<'a, S>, RingRpcError> {
         // One reading for the skew rule and for the nonce eviction window.
-        let now = unix_now().map_err(|_| RingRpcError::StateUnavailable)?;
+        let now = self.shared.clock.now()?;
         let nonce = authorize::nonce(&request.auth.nonce)?;
         let attestation = ReadAttestation {
             ring: self.ring,

--- a/services/ring-rpc/src/authorize.rs
+++ b/services/ring-rpc/src/authorize.rs
@@ -318,6 +318,10 @@ mod tests {
     }
 
     fn decide(auth: &ReadAuth) -> Result<Claim, Unauthorized> {
+        decide_at(auth, unix_now().expect("clock"))
+    }
+
+    fn decide_at(auth: &ReadAuth, now: u64) -> Result<Claim, Unauthorized> {
         let nonce: [u8; 32] = auth.nonce.0.as_slice().try_into().unwrap_or([0; 32]);
         ReadCheck::new(
             auth,
@@ -329,7 +333,7 @@ mod tests {
                 limit: None,
             },
         )
-        .at(unix_now().expect("clock"))
+        .at(now)
         .against(&Origins::default())
         .decide()
     }
@@ -387,7 +391,20 @@ mod tests {
                 .sign(&wallet())
                 .expect("signed request")
                 .auth;
-            assert_eq!(decide(&auth), Err(Unauthorized::StaleTimestamp));
+            assert_eq!(decide_at(&auth, now), Err(Unauthorized::StaleTimestamp));
+        }
+    }
+
+    #[test]
+    fn a_timestamp_on_the_skew_boundary_is_accepted() {
+        let now = unix_now().expect("clock");
+        for timestamp in [now - AUTH_SKEW.as_secs(), now + AUTH_SKEW.as_secs()] {
+            let auth = GetDecryptedTransactionsRequest::read(RING)
+                .at(timestamp)
+                .sign(&wallet())
+                .expect("signed request")
+                .auth;
+            assert!(decide_at(&auth, now).is_ok());
         }
     }
 

--- a/services/ring-rpc/src/hub.rs
+++ b/services/ring-rpc/src/hub.rs
@@ -16,6 +16,7 @@ use zolana_ring_client::{auditor_view_tag, ReaderKey};
 use zolana_transaction::AssetRegistry;
 
 use crate::{
+    api::unix_now,
     audit::{AuditService, ASSET_REFRESH_INTERVAL},
     authorize::Unauthorized,
     config::RootSecret,
@@ -65,18 +66,36 @@ impl NotReady {
     }
 }
 
+/// Unix seconds for the auth skew rule and the nonce eviction window.
+#[derive(Debug, Clone, Copy)]
+pub enum Clock {
+    System,
+    Fixed(u64),
+}
+
+impl Clock {
+    pub(crate) fn now(self) -> Result<u64, RingRpcError> {
+        match self {
+            Self::System => unix_now().map_err(|_| RingRpcError::StateUnavailable),
+            Self::Fixed(now) => Ok(now),
+        }
+    }
+}
+
 #[must_use]
 pub struct HubBuilder<S> {
     source: S,
     genesis_hash: [u8; 32],
     assets: AssetRegistry,
     origins: Origins,
+    clock: Clock,
 }
 
 pub(crate) struct Shared<S> {
     pub(crate) source: S,
     /// Captured at boot, every authority signature and derived key binds to it.
     pub(crate) genesis_hash: [u8; 32],
+    pub(crate) clock: Clock,
     assets: AsyncMutex<AssetCache>,
     pub(crate) origins: Origins,
     pub(crate) replay: ReplayGuard,
@@ -157,6 +176,7 @@ impl<S: TransactionSource> Hub<S> {
             genesis_hash,
             assets: AssetRegistry::default(),
             origins: Origins::default(),
+            clock: Clock::System,
         }
     }
 
@@ -381,6 +401,12 @@ impl<S: TransactionSource> HubBuilder<S> {
         self
     }
 
+    #[must_use = "use the updated builder"]
+    pub fn with_clock(mut self, clock: Clock) -> Self {
+        self.clock = clock;
+        self
+    }
+
     pub fn local(self, ring: Address, auditor: ViewingKey) -> Result<Hub<S>, RingRpcError> {
         let signer = service_keypair(auditor.secret_bytes().as_slice())?;
         Ok(Hub {
@@ -403,6 +429,7 @@ impl<S: TransactionSource> HubBuilder<S> {
         Arc::new(Shared {
             source: self.source,
             genesis_hash: self.genesis_hash,
+            clock: self.clock,
             assets: AsyncMutex::new(AssetCache {
                 registry: self.assets,
                 refresh: RefreshState::Never,

--- a/services/ring-rpc/src/lib.rs
+++ b/services/ring-rpc/src/lib.rs
@@ -30,7 +30,7 @@ pub use config::{
     KeygenArgs, RootSecret, RootSecretError, ServeArgs,
 };
 pub use error::RingRpcError;
-pub use hub::{Hub, HubBuilder, NotReady};
+pub use hub::{Clock, Hub, HubBuilder, NotReady};
 pub use keys::KeyMode;
 pub use origins::{OriginError, OriginPolicy, OriginTransport, Origins};
 pub use server::{rpc_module, run_server, BindPolicy, ServerError, ServerOptions};

--- a/services/ring-rpc/tests/audit_service.rs
+++ b/services/ring-rpc/tests/audit_service.rs
@@ -22,14 +22,15 @@ use zolana_ring_client::{
     auditor_view_tag, AuditorEncryption, OriginError, ReaderKey, RingOrigin, RingWithdrawal,
 };
 use zolana_ring_rpc::{
-    auditor_key_attestation, rpc_module, unix_now, AuditRead, Claim, CreateAuditorKeyRequest,
-    CreateAuditorKeyResponse, DecryptedWithdrawal, DepositHistory, DepositPage, DepositRecord,
-    GetDecryptedTransactionsRequest, GetDecryptedTransactionsResponse, HealthResponse, Hub,
-    KeyMode, OriginPolicy, Origins, Page, PageOptions, ReadAttestation, ReadAuth, ReadBuildError,
-    ReadCheck, ReadSignature, ReadSigner, ReaderGrant, RingConfiguration, RingDepositsRequest,
-    RingDepositsResponse, RingRpcError, RingState, RingStatusRequest, RingStatusResponse,
-    RootSecret, SkippedReason, TransactionPage, TransactionSource, Unauthorized, WebAuthnAssertion,
-    AUTH_SKEW, CREATE_AUDITOR_KEY, GET_DECRYPTED_TRANSACTIONS, HEALTH, RING_DEPOSITS, RING_STATUS,
+    auditor_key_attestation, rpc_module, unix_now, AuditRead, Claim, Clock,
+    CreateAuditorKeyRequest, CreateAuditorKeyResponse, DecryptedWithdrawal, DepositHistory,
+    DepositPage, DepositRecord, GetDecryptedTransactionsRequest, GetDecryptedTransactionsResponse,
+    HealthResponse, Hub, KeyMode, OriginPolicy, Origins, Page, PageOptions, ReadAttestation,
+    ReadAuth, ReadBuildError, ReadCheck, ReadSignature, ReadSigner, ReaderGrant, RingConfiguration,
+    RingDepositsRequest, RingDepositsResponse, RingRpcError, RingState, RingStatusRequest,
+    RingStatusResponse, RootSecret, SkippedReason, TransactionPage, TransactionSource,
+    Unauthorized, WebAuthnAssertion, AUTH_SKEW, CREATE_AUDITOR_KEY, GET_DECRYPTED_TRANSACTIONS,
+    HEALTH, RING_DEPOSITS, RING_STATUS,
 };
 use zolana_transaction::{
     serialization::confidential::{Confidential, ConfidentialEncode, ConfidentialOutputPlaintext},
@@ -609,6 +610,14 @@ impl Fixture {
             .local(RING, self.auditor.clone())
             .expect("hub")
     }
+
+    fn hub_at(&self, source: StaticSource, now: u64) -> Hub<StaticSource> {
+        Hub::builder(source, GENESIS)
+            .with_origins(origins())
+            .with_clock(Clock::Fixed(now))
+            .local(RING, self.auditor.clone())
+            .expect("hub")
+    }
 }
 
 fn page() -> Page {
@@ -1116,7 +1125,6 @@ async fn an_unsigned_auditor_key_request_is_refused() {
 async fn auditor_key_requests_bind_cluster_ring_time_and_nonce() {
     let fixture = Fixture::new();
     let hub = fixture.hub(fixture.source());
-    let now = unix_now().expect("clock");
 
     let other_cluster = CreateAuditorKeyRequest::for_ring(RING, [10; 32])
         .sign(&authority())
@@ -1148,16 +1156,12 @@ async fn auditor_key_requests_bind_cluster_ring_time_and_nonce() {
         Unauthorized::BadSignature
     ));
 
-    for timestamp in [now - AUTH_SKEW.as_secs() - 1, now + AUTH_SKEW.as_secs() + 1] {
-        let stale = CreateAuditorKeyRequest::for_ring(RING, GENESIS)
-            .at(timestamp)
-            .sign(&authority())
-            .expect("signed request");
-        assert!(refused(
-            authorize(&hub, &stale).await,
-            Unauthorized::StaleTimestamp
-        ));
-    }
+    let mut shifted = signed_by(&authority());
+    shifted.auth.timestamp += 1;
+    assert!(refused(
+        authorize(&hub, &shifted).await,
+        Unauthorized::BadSignature
+    ));
 
     let request = signed_by(&authority());
     authorize(&hub, &request).await.expect("first use");
@@ -1165,6 +1169,32 @@ async fn auditor_key_requests_bind_cluster_ring_time_and_nonce() {
         authorize(&hub, &request).await,
         Unauthorized::Replay
     ));
+}
+
+#[tokio::test]
+async fn auditor_key_requests_are_accepted_exactly_within_the_skew_window() {
+    let fixture = Fixture::new();
+    let now = 1_000_000_000;
+    let hub = fixture.hub_at(fixture.source(), now);
+
+    for timestamp in [now - AUTH_SKEW.as_secs() - 1, now + AUTH_SKEW.as_secs() + 1] {
+        let outside = CreateAuditorKeyRequest::for_ring(RING, GENESIS)
+            .at(timestamp)
+            .sign(&authority())
+            .expect("signed request");
+        assert!(refused(
+            authorize(&hub, &outside).await,
+            Unauthorized::StaleTimestamp
+        ));
+    }
+
+    for timestamp in [now - AUTH_SKEW.as_secs(), now + AUTH_SKEW.as_secs()] {
+        let boundary = CreateAuditorKeyRequest::for_ring(RING, GENESIS)
+            .at(timestamp)
+            .sign(&authority())
+            .expect("signed request");
+        authorize(&hub, &boundary).await.expect("boundary request");
+    }
 }
 
 #[tokio::test]

--- a/tools/ci/nextest-suite.sh
+++ b/tools/ci/nextest-suite.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Runs one nextest suite, from the ZOLANA_NEXTEST_ARCHIVE_DIR archive when set,
+# else from source.
+set -euo pipefail
+
+if [[ -z "${ZOLANA_NEXTEST_ARCHIVE_DIR:-}" ]]; then
+  exec cargo nextest run "$@"
+fi
+
+package=""
+binaries=()
+expr=""
+run_args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p)
+      package="$2"
+      shift 2
+      ;;
+    --test)
+      binaries+=("binary($2)")
+      shift 2
+      ;;
+    # Build-only flags, already baked into the archive.
+    --features)
+      shift 2
+      ;;
+    --release)
+      shift
+      ;;
+    -E)
+      expr="$2"
+      shift 2
+      ;;
+    *)
+      run_args+=("$1")
+      shift
+      ;;
+  esac
+done
+if [[ -z "$package" ]]; then
+  echo "nextest-suite.sh needs -p <package>" >&2
+  exit 2
+fi
+
+selection=""
+for term in ${binaries[@]+"${binaries[@]}"}; do
+  if [[ -z "$selection" ]]; then
+    selection="$term"
+  else
+    selection="$selection or $term"
+  fi
+done
+if [[ -n "$selection" && -n "$expr" ]]; then
+  selection="($selection) and ($expr)"
+elif [[ -n "$expr" ]]; then
+  selection="$expr"
+fi
+
+archive_args=(
+  --archive-file "$ZOLANA_NEXTEST_ARCHIVE_DIR/$package.tar.zst"
+  --workspace-remap "$PWD"
+)
+if [[ -n "$selection" ]]; then
+  archive_args+=(-E "$selection")
+fi
+exec cargo nextest run "${archive_args[@]}" ${run_args[@]+"${run_args[@]}"}

--- a/tools/ci/xtask.sh
+++ b/tools/ci/xtask.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Runs xtask from ZOLANA_XTASK_BIN when set, else through cargo.
+set -euo pipefail
+if [[ -n "${ZOLANA_XTASK_BIN:-}" ]]; then
+  exec "$ZOLANA_XTASK_BIN" "$@"
+fi
+exec cargo run -q -p xtask -- "$@"


### PR DESCRIPTION
Fixes the three flaky CI tests and removes repeated build work from the pipeline.

- `ring-rpc` unit skew tests take one clock reading through `decide_at`, boundary timestamps stay outside the window under any load.
- The hub takes a `Clock` (`System` in production, `Fixed` in tests), the audit service test pins time and asserts the exact window, ±60 s accepted, ±61 s refused, replay eviction at the edge.
- `dynamic-swap` escrow tests poll photon with a 30 s deadline (`wait_until`) after each send, note selection waits for indexing.
- A `build / localnet suites` job compiles the programs, the cli, xtask, the prover, and nine nextest archives once, the localnet matrix jobs run from the archives with zero compilation (`tools/ci/nextest-suite.sh`, plain `cargo nextest run` when `ZOLANA_NEXTEST_ARCHIVE_DIR` is unset).
- The photon binary is cached by the hash of its source closure, pushes outside it skip the build.
- The lean cache gets a `restore-keys` prefix, a manifest bump rebuilds incrementally.
