### PR TITLE
custom-ring: prove a transfer over an async transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,6 +2091,7 @@ dependencies = [
  "bytemuck",
  "curve25519-dalek 4.1.3",
  "custom-ring-interface",
+ "futures",
  "groth16-solana",
  "hex",
  "p256",

--- a/custom-rings/sdk/Cargo.toml
+++ b/custom-rings/sdk/Cargo.toml
@@ -21,6 +21,8 @@ solana-rpc = [
 borsh = { workspace = true }
 custom-ring-interface = { workspace = true }
 bytemuck = { workspace = true }
+# `try_join` for the two independent prover requests `prove_async` issues.
+futures = { workspace = true }
 p256 = { workspace = true }
 rand = { workspace = true }
 # Only for the uncompressed SEC1 encoding of the auditor key that the circuit

--- a/custom-rings/sdk/Cargo.toml
+++ b/custom-rings/sdk/Cargo.toml
@@ -25,6 +25,7 @@ p256 = { workspace = true }
 rand = { workspace = true }
 # Only for the uncompressed SEC1 encoding of the auditor key that the circuit
 # witnesses; `zolana-keypair` hands out compressed keys.
+solana-account = { workspace = true }
 solana-address = { workspace = true, features = ["curve25519"] }
 solana-address-lookup-table-interface = { workspace = true, optional = true }
 solana-compute-budget-interface = { workspace = true }
@@ -52,5 +53,4 @@ curve25519-dalek = "4.1"
 groth16-solana = { workspace = true, features = ["bsb22"] }
 sha2 = { workspace = true }
 hex = { workspace = true }
-solana-account = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/custom-rings/sdk/src/lib.rs
+++ b/custom-rings/sdk/src/lib.rs
@@ -36,8 +36,8 @@ pub use crate::{
     },
     shared::{AccountReadError, CustomRing, CustomRingConfig, ReaderKey, ReaderKeyError},
     transfer::{
-        CustomRingTransfer, CustomRingTransferInput, DepositError, ProvenTransfer, RingDeposit,
-        RingDepositReceipt, TransferError, TransferProofEnvironment,
+        AsyncTransferProofEnvironment, CustomRingTransfer, CustomRingTransferInput, DepositError,
+        ProvenTransfer, RingDeposit, RingDepositReceipt, TransferError, TransferProofEnvironment,
     },
 };
 

--- a/custom-rings/sdk/src/shared.rs
+++ b/custom-rings/sdk/src/shared.rs
@@ -4,9 +4,10 @@ use bytemuck::Pod;
 use custom_ring_interface::{
     ReadAccessRecord, RingProgramConfig, READ_ACCESS_RECORD, RING_PROGRAM_CONFIG,
 };
+use solana_account::Account;
 use solana_address::Address;
 use thiserror::Error;
-use zolana_client::{ClientError, Rpc};
+use zolana_client::{AsyncRpc, ClientError, Rpc};
 use zolana_interface::{
     is_reserved_p256_derivation_point, pda, state::RingConfig, BPF_LOADER_UPGRADEABLE_ID,
     RING_AUTH_PDA_SEED,
@@ -71,12 +72,27 @@ impl CustomRing {
         rpc: &R,
     ) -> Result<Option<CustomRingConfig>, AccountReadError> {
         let address = self.config_pda();
-        let Some(config) = (AccountRead {
-            rpc,
-            program_id: self.program_id,
-            address,
-        })
-        .read::<RingProgramConfig>()?
+        self.decode_config(address, rpc.get_account(address)?)
+    }
+
+    /// The async twin of [`Self::read_config`], over [`AsyncRpc`]. A host that
+    /// cannot link a blocking Solana client -- an enclave pinned below the
+    /// versions it needs -- reaches the same config through its own transport.
+    pub async fn read_config_async<R: AsyncRpc>(
+        self,
+        rpc: &R,
+    ) -> Result<Option<CustomRingConfig>, AccountReadError> {
+        let address = self.config_pda();
+        self.decode_config(address, rpc.get_account(address).await?)
+    }
+
+    fn decode_config(
+        self,
+        address: Address,
+        account: Option<Account>,
+    ) -> Result<Option<CustomRingConfig>, AccountReadError> {
+        let Some(config) =
+            AccountRead::decode::<RingProgramConfig>(self.program_id, address, account)?
         else {
             return Ok(None);
         };
@@ -98,12 +114,11 @@ impl CustomRing {
         reader: &ReaderKey,
     ) -> Result<Option<ReadAccessRecord>, AccountReadError> {
         let address = self.read_access_record_pda(reader);
-        let Some(record) = (AccountRead {
-            rpc,
-            program_id: self.program_id,
+        let Some(record) = AccountRead::decode::<ReadAccessRecord>(
+            self.program_id,
             address,
-        })
-        .read::<ReadAccessRecord>()?
+            rpc.get_account(address)?,
+        )?
         else {
             return Ok(None);
         };
@@ -169,33 +184,27 @@ impl ReadableAccount for ReadAccessRecord {
     }
 }
 
-struct AccountRead<'a, R> {
-    rpc: &'a R,
-    program_id: Address,
-    address: Address,
-}
+struct AccountRead;
 
-impl<R: Rpc> AccountRead<'_, R> {
-    fn read<T: ReadableAccount>(self) -> Result<Option<T>, AccountReadError> {
-        let Some(account) = self.rpc.get_account(self.address)? else {
+impl AccountRead {
+    /// Shared by both transports: only fetching the account differs.
+    fn decode<T: ReadableAccount>(
+        program_id: Address,
+        address: Address,
+        account: Option<Account>,
+    ) -> Result<Option<T>, AccountReadError> {
+        let Some(account) = account else {
             return Ok(None);
         };
-        if account.owner.to_bytes() != *self.program_id.as_array()
+        if account.owner.to_bytes() != *program_id.as_array()
             || account.data.len() != core::mem::size_of::<T>()
         {
-            return Err(AccountReadError::InvalidAccount {
-                address: self.address,
-            });
+            return Err(AccountReadError::InvalidAccount { address });
         }
-        let value = bytemuck::try_from_bytes::<T>(&account.data).map_err(|_| {
-            AccountReadError::InvalidAccount {
-                address: self.address,
-            }
-        })?;
+        let value = bytemuck::try_from_bytes::<T>(&account.data)
+            .map_err(|_| AccountReadError::InvalidAccount { address })?;
         if value.discriminator() != T::DISCRIMINATOR {
-            return Err(AccountReadError::InvalidAccount {
-                address: self.address,
-            });
+            return Err(AccountReadError::InvalidAccount { address });
         }
         Ok(Some(*value))
     }

--- a/custom-rings/sdk/src/transfer.rs
+++ b/custom-rings/sdk/src/transfer.rs
@@ -43,7 +43,7 @@ const NO_RING_DATA_HASH: [u8; 32] = [0u8; 32];
 #[must_use = "prove or discard the transfer explicitly"]
 pub struct CustomRingTransfer<'a> {
     ring: CustomRing,
-    sender: &'a dyn ViewingKeyTrait,
+    sender: &'a (dyn ViewingKeyTrait + Send + Sync),
     prepared: PreparedTransfer,
     interface_transfer_accounts: Vec<TransactInterfaceTransferAccounts>,
     tree: Option<Address>,
@@ -59,7 +59,11 @@ pub struct CustomRingTransferInput<'a> {
     /// owner signs the assembled Solana transaction.
     ///
     /// `ShieldedKeypair` implements the trait, so passing one still works.
-    pub sender: &'a dyn ViewingKeyTrait,
+    ///
+    /// `Send + Sync` so that [`Self::prove_async`]'s future is `Send`. Without
+    /// it the async path cannot be awaited on a multi-threaded runtime, which
+    /// is exactly where a host that needs the async path runs.
+    pub sender: &'a (dyn ViewingKeyTrait + Send + Sync),
     pub prepared: PreparedTransfer,
 }
 
@@ -883,6 +887,35 @@ mod tests {
             )],
         )
         .expect("withdrawal accounts");
+    }
+
+    /// Every `AsyncRpc` method has a default, so an empty type is a valid one.
+    struct NoRpc;
+    impl AsyncRpc for NoRpc {}
+
+    #[test]
+    fn the_async_prove_future_is_send() {
+        // A host reaches for the async path because it runs on a multi-threaded
+        // runtime; a future that cannot cross threads is no use to it. The
+        // `Send + Sync` bound on `sender` is what makes this hold, and dropping
+        // it fails here rather than in whatever server tries to await it.
+        fn assert_send<F: Send>(_: F) {}
+
+        let (keypair, prepared) = prepared_transfer(4);
+        let prover = AsyncProverClient::new(String::new());
+        let rpc = NoRpc;
+        assert_send(
+            CustomRingTransfer::new(CustomRingTransferInput {
+                ring: ring(),
+                sender: &keypair,
+                prepared,
+            })
+            .prove_async(AsyncTransferProofEnvironment {
+                indexer: &rpc,
+                rpc: &rpc,
+                prover: &prover,
+            }),
+        );
     }
 
     #[test]

--- a/custom-rings/sdk/src/transfer.rs
+++ b/custom-rings/sdk/src/transfer.rs
@@ -1,13 +1,14 @@
 use rand::{rngs::OsRng, RngCore};
+use solana_account::Account;
 use solana_address::Address;
 use solana_instruction::Instruction;
 use solana_signature::Signature;
 use solana_signer::Signer;
 use thiserror::Error;
 use zolana_client::{
-    ClientError, ProofCompressed, ProverClient, RingTransferProofResult, RingTransferProver, Rpc,
-    SettlementAccountValidation, Shape, SpendProof, SppProofInputUtxo, SppProofInputs,
-    TransferSpendInput,
+    AsyncProverClient, AsyncRpc, ClientError, MerkleProof, NonInclusionProof, ProofCompressed,
+    ProverClient, RingTransferProofResult, RingTransferProver, Rpc, SettlementAccountValidation,
+    Shape, SpendProof, SppProofInputUtxo, SppProofInputs, TransferSpendInput,
 };
 use zolana_interface::event::OutputDataEncoding;
 use zolana_interface::{
@@ -19,7 +20,8 @@ use zolana_interface::{
     N_PUBLIC_SLOTS, SHIELDED_POOL_PROGRAM_ID,
 };
 use zolana_keypair::{
-    random_blinding, random_salt, KeypairError, ShieldedKeypair, ViewingKey, ViewingKeyTrait,
+    random_blinding, random_salt, KeypairError, P256Pubkey, ShieldedKeypair, ViewingKey,
+    ViewingKeyTrait,
 };
 use zolana_transaction::{
     instructions::transact::{
@@ -32,7 +34,8 @@ use zolana_tree::{TreeAccount, TreeError};
 
 use crate::{
     to_instruction_proof, AccountReadError, CustomRing, CustomRingProof, CustomRingProofError,
-    CustomRingProofInputError, CustomRingProofParams, CustomRingTransact, Deposit, EncryptedAudit,
+    CustomRingProofInputError, CustomRingProofParams, CustomRingProofRequest, CustomRingTransact,
+    Deposit, EncryptedAudit, PendingCustomRingProof,
 };
 
 const NO_RING_DATA_HASH: [u8; 32] = [0u8; 32];
@@ -64,6 +67,13 @@ pub struct TransferProofEnvironment<'a, I: Rpc, R: Rpc> {
     pub indexer: &'a I,
     pub rpc: &'a R,
     pub prover: &'a ProverClient,
+}
+
+/// The async counterpart of [`TransferProofEnvironment`].
+pub struct AsyncTransferProofEnvironment<'a, I: AsyncRpc, R: AsyncRpc> {
+    pub indexer: &'a I,
+    pub rpc: &'a R,
+    pub prover: &'a AsyncProverClient,
 }
 
 #[must_use = "build or submit the proven transfer"]
@@ -183,17 +193,85 @@ impl<'a> CustomRingTransfer<'a> {
         self
     }
 
+    /// Proves the transfer over a blocking transport.
     pub fn prove<I: Rpc, R: Rpc>(
         self,
         environment: TransferProofEnvironment<'_, I, R>,
     ) -> Result<ProvenTransfer, TransferError> {
-        let tree = self.tree.ok_or(TransferError::TreeRequired)?;
-        let assets = self.assets.ok_or(TransferError::MissingAssetRegistry)?;
         let auditor_pk = self
             .ring
             .read_config(environment.rpc)?
             .ok_or(TransferError::MissingRingConfig)?
             .auditor_pubkey;
+        let mut staged = self.stage(auditor_pk)?;
+        let spend_inputs = RingSpendInputs {
+            indexer: environment.indexer,
+            tree: staged.tree,
+            spends: &staged.proof_inputs.input_utxos,
+        }
+        .load()?;
+        let allow_dummy_inputs = read_dummy_input_policy(environment.rpc, staged.tree)?;
+        let ring_result = staged.ring_proof(spend_inputs, allow_dummy_inputs)?;
+        let spp_proof = ProofCompressed::try_from(
+            environment
+                .prover
+                .prove_transfer_ring(&ring_result.inputs)?,
+        )?
+        .to_transact_proof();
+        let (request, ring_result) = staged.proof_request(ring_result)?;
+        let proof = to_instruction_proof(environment.prover.prove(&request)?)?;
+        staged.finish(ring_result, spp_proof, proof)
+    }
+
+    /// The async twin of [`Self::prove`], over [`AsyncRpc`] and
+    /// [`AsyncProverClient`].
+    ///
+    /// The blocking path needs `zolana-client`'s `solana-rpc` feature for its
+    /// only Solana `Rpc` implementation, which a host pinned below the versions
+    /// that feature requires cannot link. Such a host already speaks `AsyncRpc`
+    /// over its own transport, and the rest of this SDK is async-first, so the
+    /// ring transfer being blocking-only was the outlier.
+    ///
+    /// Both paths run the same proof assembly; only the five reads differ.
+    pub async fn prove_async<I: AsyncRpc, R: AsyncRpc>(
+        self,
+        environment: AsyncTransferProofEnvironment<'_, I, R>,
+    ) -> Result<ProvenTransfer, TransferError> {
+        let auditor_pk = self
+            .ring
+            .read_config_async(environment.rpc)
+            .await?
+            .ok_or(TransferError::MissingRingConfig)?
+            .auditor_pubkey;
+        let mut staged = self.stage(auditor_pk)?;
+        let spend_inputs = RingSpendInputs {
+            indexer: environment.indexer,
+            tree: staged.tree,
+            spends: &staged.proof_inputs.input_utxos,
+        }
+        .load_async()
+        .await?;
+        let allow_dummy_inputs =
+            read_dummy_input_policy_async(environment.rpc, staged.tree).await?;
+        let ring_result = staged.ring_proof(spend_inputs, allow_dummy_inputs)?;
+        let spp_proof = ProofCompressed::try_from(
+            environment
+                .prover
+                .prove_transfer_ring(&ring_result.inputs)
+                .await?,
+        )?
+        .to_transact_proof();
+        let (request, ring_result) = staged.proof_request(ring_result)?;
+        let proof = to_instruction_proof(environment.prover.prove(&request).await?)?;
+        staged.finish(ring_result, spp_proof, proof)
+    }
+
+    /// Everything before the first read: validation, the transaction viewing
+    /// key, and the auditor encryption that has to be inside `external_data`
+    /// before anything hashes it.
+    fn stage(self, auditor_pk: P256Pubkey) -> Result<StagedTransfer, TransferError> {
+        let tree = self.tree.ok_or(TransferError::TreeRequired)?;
+        let assets = self.assets.ok_or(TransferError::MissingAssetRegistry)?;
         // A padded change slot pushes the custom-ring instruction past the packet
         // limit even behind an address lookup table, and every published slot
         // must be one the auditor can open.
@@ -202,7 +280,6 @@ impl<'a> CustomRingTransfer<'a> {
         }
         let prepared = self.prepared;
         let program_id = self.ring.program_id();
-        let allow_dummy_inputs = read_dummy_input_policy(environment.rpc, tree)?;
         RingMembership {
             program_id,
             inputs: &prepared.inputs,
@@ -241,51 +318,90 @@ impl<'a> CustomRingTransfer<'a> {
         // private_tx_hash, so it must be bound before anything hashes external data.
         proof_inputs.external_data.instruction_discriminator = RING_TRANSACT;
 
-        // Prove the SPP ring transfer over the message-bearing external data.
-        let tx_shape = proof_inputs.check_shape()?;
-        let ring_result = RingTransferProver {
-            inputs: RingSpendInputs {
-                indexer: environment.indexer,
-                tree,
-                spends: &proof_inputs.input_utxos,
-            }
-            .load()?,
-            outputs: proof_inputs.output_utxos.clone(),
-            external_data: proof_inputs.external_data.clone(),
-            public_transfers: proof_inputs.public_transfers()?,
-            signer_pk_hashes: proof_inputs.signer_pk_hashes(tx_shape.n_inputs() + 1)?,
+        Ok(StagedTransfer {
+            tx_viewing_key,
+            pending_proof: Some(pending_proof),
+            proof_inputs,
+            payer,
+            tree,
+            program_id,
+            interface_transfer_accounts: self.interface_transfer_accounts,
+            ring: self.ring,
+        })
+    }
+}
+
+/// A transfer past validation and auditor encryption, waiting on the reads.
+struct StagedTransfer {
+    tx_viewing_key: ViewingKey,
+    /// Taken by [`Self::proof_request`]; `finish` cannot run before it does.
+    pending_proof: Option<PendingCustomRingProof>,
+    proof_inputs: SppProofInputs,
+    payer: Address,
+    tree: Address,
+    program_id: Address,
+    interface_transfer_accounts: Vec<TransactInterfaceTransferAccounts>,
+    ring: CustomRing,
+}
+
+impl StagedTransfer {
+    /// Proves the SPP ring transfer over the message-bearing external data.
+    fn ring_proof(
+        &self,
+        inputs: Vec<TransferSpendInput>,
+        allow_dummy_inputs: bool,
+    ) -> Result<RingTransferProofResult, TransferError> {
+        let tx_shape = self.proof_inputs.check_shape()?;
+        Ok(RingTransferProver {
+            inputs,
+            outputs: self.proof_inputs.output_utxos.clone(),
+            external_data: self.proof_inputs.external_data.clone(),
+            public_transfers: self.proof_inputs.public_transfers()?,
+            signer_pk_hashes: self
+                .proof_inputs
+                .signer_pk_hashes(tx_shape.n_inputs() + 1)?,
             allow_dummy_inputs,
-            ring_program_id: Some(program_id),
+            ring_program_id: Some(self.program_id),
             shape: Some(Shape::new(tx_shape.n_inputs(), tx_shape.n_outputs())),
         }
-        .build()?;
-        let spp_proof = ProofCompressed::try_from(
-            environment
-                .prover
-                .prove_transfer_ring(&ring_result.inputs)?,
-        )?
-        .to_transact_proof();
+        .build()?)
+    }
 
-        // Now the real `private_tx_hash` exists, so the pending encryption can be
-        // finished into the proof request over the unchanged ciphertext. The program
-        // recomputes that same public-input chain from the payload and the config
-        // account.
-        let proof_request = pending_proof.finish(ring_result.private_tx_hash.try_into()?)?;
-        let proof = to_instruction_proof(environment.prover.prove(&proof_request)?)?;
+    /// Now the real `private_tx_hash` exists, so the pending encryption can be
+    /// finished into the proof request over the unchanged ciphertext. The program
+    /// recomputes that same public-input chain from the payload and the config
+    /// account.
+    fn proof_request(
+        &mut self,
+        ring_result: RingTransferProofResult,
+    ) -> Result<(CustomRingProofRequest, RingTransferProofResult), TransferError> {
+        let pending = self
+            .pending_proof
+            .take()
+            .ok_or(TransferError::MissingRingConfig)?;
+        let request = pending.finish(ring_result.private_tx_hash.try_into()?)?;
+        Ok((request, ring_result))
+    }
 
+    fn finish(
+        self,
+        ring_result: RingTransferProofResult,
+        spp_proof: TransactProof,
+        proof: CustomRingProof,
+    ) -> Result<ProvenTransfer, TransferError> {
         Ok(ProvenTransfer {
-            tx_viewing_key,
+            tx_viewing_key: self.tx_viewing_key,
             data: RingEddsaInstructionData {
-                proof_inputs: &proof_inputs,
+                proof_inputs: &self.proof_inputs,
                 result: &ring_result,
                 proof: spp_proof,
             }
             .assemble()?,
             proof,
-            owner_signers: proof_inputs.owner_signer_pubkeys()?,
+            owner_signers: self.proof_inputs.owner_signer_pubkeys()?,
             interface_transfer_accounts: self.interface_transfer_accounts,
-            payer,
-            tree,
+            payer: self.payer,
+            tree: self.tree,
             ring: self.ring,
         })
     }
@@ -350,7 +466,19 @@ impl RingDeposit<'_> {
 }
 
 fn read_dummy_input_policy<R: Rpc>(rpc: &R, tree: Address) -> Result<bool, TransferError> {
-    let mut account = rpc.get_account(tree)?.ok_or(TransferError::MissingTree)?;
+    dummy_input_policy(rpc.get_account(tree)?, tree)
+}
+
+async fn read_dummy_input_policy_async<R: AsyncRpc>(
+    rpc: &R,
+    tree: Address,
+) -> Result<bool, TransferError> {
+    dummy_input_policy(rpc.get_account(tree).await?, tree)
+}
+
+/// Reading the policy out of a fetched tree account is transport-independent.
+fn dummy_input_policy(account: Option<Account>, tree: Address) -> Result<bool, TransferError> {
+    let mut account = account.ok_or(TransferError::MissingTree)?;
     if account.owner.to_bytes() != SHIELDED_POOL_PROGRAM_ID {
         return Err(TransferError::InvalidTreeOwner);
     }
@@ -465,15 +593,20 @@ fn frame_dummy_outputs(proof_inputs: &mut SppProofInputs) -> Result<(), Transfer
     Ok(())
 }
 
+/// Inclusion hashes and nullifiers for one spend set.
+type SpendQueries = (Vec<[u8; 32]>, Vec<[u8; 32]>);
+
 #[must_use = "use the updated transfer"]
-struct RingSpendInputs<'a, I: Rpc> {
+struct RingSpendInputs<'a, I> {
     indexer: &'a I,
     tree: Address,
     spends: &'a [SppProofInputUtxo],
 }
 
-impl<I: Rpc> RingSpendInputs<'_, I> {
-    fn load(self) -> Result<Vec<TransferSpendInput>, TransferError> {
+impl<'a, I> RingSpendInputs<'a, I> {
+    /// The hashes to prove inclusion for, and the nullifiers to prove absence
+    /// of. Independent of transport.
+    fn queries(&self) -> Result<SpendQueries, TransferError> {
         let real_hashes = self
             .spends
             .iter()
@@ -485,6 +618,30 @@ impl<I: Rpc> RingSpendInputs<'_, I> {
             .iter()
             .map(SppProofInputUtxo::nullifier)
             .collect::<Result<Vec<_>, _>>()?;
+        Ok((real_hashes, nullifiers))
+    }
+}
+
+impl<I: AsyncRpc> RingSpendInputs<'_, I> {
+    async fn load_async(self) -> Result<Vec<TransferSpendInput>, TransferError> {
+        let (real_hashes, nullifiers) = self.queries()?;
+        let states = self
+            .indexer
+            .get_merkle_proofs(self.tree, real_hashes, None)
+            .await?
+            .proofs;
+        let non_inclusions = self
+            .indexer
+            .get_non_inclusion_proofs(self.tree, nullifiers, None)
+            .await?
+            .proofs;
+        self.assemble(states, non_inclusions)
+    }
+}
+
+impl<I: Rpc> RingSpendInputs<'_, I> {
+    fn load(self) -> Result<Vec<TransferSpendInput>, TransferError> {
+        let (real_hashes, nullifiers) = self.queries()?;
         let states = self
             .indexer
             .get_merkle_proofs(self.tree, real_hashes, None)?
@@ -493,6 +650,17 @@ impl<I: Rpc> RingSpendInputs<'_, I> {
             .indexer
             .get_non_inclusion_proofs(self.tree, nullifiers, None)?
             .proofs;
+        self.assemble(states, non_inclusions)
+    }
+}
+
+impl<I> RingSpendInputs<'_, I> {
+    /// Pairs each spend with its proofs. Both transports share this.
+    fn assemble(
+        self,
+        states: Vec<MerkleProof>,
+        non_inclusions: Vec<NonInclusionProof>,
+    ) -> Result<Vec<TransferSpendInput>, TransferError> {
         let real_count = self.spends.iter().filter(|spend| !spend.is_dummy()).count();
         if states.len() != real_count || non_inclusions.len() != self.spends.len() {
             return Err(TransferError::IncompleteProofSet);

--- a/custom-rings/sdk/src/transfer.rs
+++ b/custom-rings/sdk/src/transfer.rs
@@ -1,3 +1,4 @@
+use futures::future::try_join;
 use rand::{rngs::OsRng, RngCore};
 use solana_account::Account;
 use solana_address::Address;
@@ -8,7 +9,7 @@ use thiserror::Error;
 use zolana_client::{
     AsyncProverClient, AsyncRpc, ClientError, MerkleProof, NonInclusionProof, ProofCompressed,
     ProverClient, RingTransferProofResult, RingTransferProver, Rpc, SettlementAccountValidation,
-    Shape, SpendProof, SppProofInputUtxo, SppProofInputs, TransferSpendInput,
+    Shape, SpendProof, SppProofInputUtxo, SppProofInputs, TransferInputs, TransferSpendInput,
 };
 use zolana_interface::event::OutputDataEncoding;
 use zolana_interface::{
@@ -207,24 +208,24 @@ impl<'a> CustomRingTransfer<'a> {
             .read_config(environment.rpc)?
             .ok_or(TransferError::MissingRingConfig)?
             .auditor_pubkey;
-        let mut staged = self.stage(auditor_pk)?;
+        let staged = self.stage(auditor_pk)?;
+        // The tree is read and validated first. A tree that is absent, owned by
+        // another program, or not a tree account at all fails here rather than
+        // after the indexer has served a full inclusion and non-inclusion proof
+        // set that nothing can use.
+        let allow_dummy_inputs = read_dummy_input_policy(environment.rpc, staged.tree)?;
         let spend_inputs = RingSpendInputs {
             indexer: environment.indexer,
             tree: staged.tree,
             spends: &staged.proof_inputs.input_utxos,
         }
         .load()?;
-        let allow_dummy_inputs = read_dummy_input_policy(environment.rpc, staged.tree)?;
-        let ring_result = staged.ring_proof(spend_inputs, allow_dummy_inputs)?;
-        let spp_proof = ProofCompressed::try_from(
-            environment
-                .prover
-                .prove_transfer_ring(&ring_result.inputs)?,
-        )?
-        .to_transact_proof();
-        let (request, ring_result) = staged.proof_request(ring_result)?;
+        let (request, witnessed) = staged.witness(spend_inputs, allow_dummy_inputs)?;
+        let spp_proof =
+            ProofCompressed::try_from(environment.prover.prove_transfer_ring(witnessed.spp())?)?
+                .to_transact_proof();
         let proof = to_instruction_proof(environment.prover.prove(&request)?)?;
-        staged.finish(ring_result, spp_proof, proof)
+        witnessed.finish(spp_proof, proof)
     }
 
     /// The async twin of [`Self::prove`], over [`AsyncRpc`] and
@@ -236,7 +237,8 @@ impl<'a> CustomRingTransfer<'a> {
     /// over its own transport, and the rest of this SDK is async-first, so the
     /// ring transfer being blocking-only was the outlier.
     ///
-    /// Both paths run the same proof assembly; only the five reads differ.
+    /// Both paths run the same proof assembly; only the five reads differ, and
+    /// this one asks for its two proofs together rather than one after the other.
     pub async fn prove_async<I: AsyncRpc, R: AsyncRpc>(
         self,
         environment: AsyncTransferProofEnvironment<'_, I, R>,
@@ -247,7 +249,11 @@ impl<'a> CustomRingTransfer<'a> {
             .await?
             .ok_or(TransferError::MissingRingConfig)?
             .auditor_pubkey;
-        let mut staged = self.stage(auditor_pk)?;
+        let staged = self.stage(auditor_pk)?;
+        // Same ordering reason as the blocking path: validate the tree before
+        // asking the indexer for proofs against it.
+        let allow_dummy_inputs =
+            read_dummy_input_policy_async(environment.rpc, staged.tree).await?;
         let spend_inputs = RingSpendInputs {
             indexer: environment.indexer,
             tree: staged.tree,
@@ -255,19 +261,25 @@ impl<'a> CustomRingTransfer<'a> {
         }
         .load_async()
         .await?;
-        let allow_dummy_inputs =
-            read_dummy_input_policy_async(environment.rpc, staged.tree).await?;
-        let ring_result = staged.ring_proof(spend_inputs, allow_dummy_inputs)?;
-        let spp_proof = ProofCompressed::try_from(
-            environment
-                .prover
-                .prove_transfer_ring(&ring_result.inputs)
-                .await?,
-        )?
-        .to_transact_proof();
-        let (request, ring_result) = staged.proof_request(ring_result)?;
-        let proof = to_instruction_proof(environment.prover.prove(&request).await?)?;
-        staged.finish(ring_result, spp_proof, proof)
+        let (request, witnessed) = staged.witness(spend_inputs, allow_dummy_inputs)?;
+        // Both witnesses are complete, and neither proof is an input to the
+        // other: SPP proves the transfer, the ring circuit proves the auditor
+        // encryption over the `private_tx_hash` the SPP witness already fixed.
+        // So both requests go out together instead of the second waiting on the
+        // first's proof, which it never needed. Whether they then prove at once
+        // is the prover's call -- its sync admission control bounds in-request
+        // proving, and one gnark proof already spreads across every free core --
+        // but that bound belongs there, not in a caller that cannot see the
+        // fleet. The blocking path has no way to express this.
+        let (spp, ring) = try_join(
+            environment.prover.prove_transfer_ring(witnessed.spp()),
+            environment.prover.prove(&request),
+        )
+        .await?;
+        witnessed.finish(
+            ProofCompressed::try_from(spp)?.to_transact_proof(),
+            to_instruction_proof(ring)?,
+        )
     }
 
     /// Everything before the first read: validation, the transaction viewing
@@ -324,7 +336,7 @@ impl<'a> CustomRingTransfer<'a> {
 
         Ok(StagedTransfer {
             tx_viewing_key,
-            pending_proof: Some(pending_proof),
+            pending_proof,
             proof_inputs,
             payer,
             tree,
@@ -336,10 +348,15 @@ impl<'a> CustomRingTransfer<'a> {
 }
 
 /// A transfer past validation and auditor encryption, waiting on the reads.
+///
+/// The stages are types, not flags: [`Self::witness`] consumes this one and is
+/// the only way to reach [`WitnessedTransfer`], which is the only type
+/// [`WitnessedTransfer::finish`] is defined on. Skipping a step, or repeating
+/// one, does not compile, so no state has to be checked at run time and no
+/// error variant has to stand in for "called out of order".
 struct StagedTransfer {
     tx_viewing_key: ViewingKey,
-    /// Taken by [`Self::proof_request`]; `finish` cannot run before it does.
-    pending_proof: Option<PendingCustomRingProof>,
+    pending_proof: PendingCustomRingProof,
     proof_inputs: SppProofInputs,
     payer: Address,
     tree: Address,
@@ -349,14 +366,22 @@ struct StagedTransfer {
 }
 
 impl StagedTransfer {
-    /// Proves the SPP ring transfer over the message-bearing external data.
-    fn ring_proof(
-        &self,
+    /// Builds the SPP ring witness over the message-bearing external data, then
+    /// finishes the pending auditor encryption over the `private_tx_hash` that
+    /// witness fixes, into the custom-ring proof request over the unchanged
+    /// ciphertext. The program recomputes that same public-input chain from the
+    /// payload and the config account.
+    ///
+    /// Both witnesses leave together because the second only ever needed the
+    /// first's `private_tx_hash`, not its proof: a caller can then ask for both
+    /// proofs at once.
+    fn witness(
+        self,
         inputs: Vec<TransferSpendInput>,
         allow_dummy_inputs: bool,
-    ) -> Result<RingTransferProofResult, TransferError> {
+    ) -> Result<(CustomRingProofRequest, WitnessedTransfer), TransferError> {
         let tx_shape = self.proof_inputs.check_shape()?;
-        Ok(RingTransferProver {
+        let ring_result = RingTransferProver {
             inputs,
             outputs: self.proof_inputs.output_utxos.clone(),
             external_data: self.proof_inputs.external_data.clone(),
@@ -368,28 +393,45 @@ impl StagedTransfer {
             ring_program_id: Some(self.program_id),
             shape: Some(Shape::new(tx_shape.n_inputs(), tx_shape.n_outputs())),
         }
-        .build()?)
-    }
-
-    /// Now the real `private_tx_hash` exists, so the pending encryption can be
-    /// finished into the proof request over the unchanged ciphertext. The program
-    /// recomputes that same public-input chain from the payload and the config
-    /// account.
-    fn proof_request(
-        &mut self,
-        ring_result: RingTransferProofResult,
-    ) -> Result<(CustomRingProofRequest, RingTransferProofResult), TransferError> {
-        let pending = self
+        .build()?;
+        let request = self
             .pending_proof
-            .take()
-            .ok_or(TransferError::MissingRingConfig)?;
-        let request = pending.finish(ring_result.private_tx_hash.try_into()?)?;
-        Ok((request, ring_result))
+            .finish(ring_result.private_tx_hash.try_into()?)?;
+        Ok((
+            request,
+            WitnessedTransfer {
+                tx_viewing_key: self.tx_viewing_key,
+                proof_inputs: self.proof_inputs,
+                ring_result,
+                payer: self.payer,
+                tree: self.tree,
+                interface_transfer_accounts: self.interface_transfer_accounts,
+                ring: self.ring,
+            },
+        ))
+    }
+}
+
+/// Both witnesses built and the auditor encryption closed over the transfer's
+/// `private_tx_hash`. Only the two proofs are outstanding.
+struct WitnessedTransfer {
+    tx_viewing_key: ViewingKey,
+    proof_inputs: SppProofInputs,
+    ring_result: RingTransferProofResult,
+    payer: Address,
+    tree: Address,
+    interface_transfer_accounts: Vec<TransactInterfaceTransferAccounts>,
+    ring: CustomRing,
+}
+
+impl WitnessedTransfer {
+    /// The SPP transfer witness to prove.
+    fn spp(&self) -> &TransferInputs {
+        &self.ring_result.inputs
     }
 
     fn finish(
         self,
-        ring_result: RingTransferProofResult,
         spp_proof: TransactProof,
         proof: CustomRingProof,
     ) -> Result<ProvenTransfer, TransferError> {
@@ -397,7 +439,7 @@ impl StagedTransfer {
             tx_viewing_key: self.tx_viewing_key,
             data: RingEddsaInstructionData {
                 proof_inputs: &self.proof_inputs,
-                result: &ring_result,
+                result: &self.ring_result,
                 proof: spp_proof,
             }
             .assemble()?,
@@ -597,8 +639,17 @@ fn frame_dummy_outputs(proof_inputs: &mut SppProofInputs) -> Result<(), Transfer
     Ok(())
 }
 
-/// Inclusion hashes and nullifiers for one spend set.
-type SpendQueries = (Vec<[u8; 32]>, Vec<[u8; 32]>);
+/// The two indexer queries one spend set needs.
+///
+/// Named fields rather than a pair of `Vec<[u8; 32]>`: the two have the same
+/// type, so a tuple lets a caller hand the nullifiers to the inclusion query and
+/// the hashes to the non-inclusion one without the compiler noticing.
+struct SpendQueries {
+    /// Hashes of the real spends, whose inclusion in the tree is proved.
+    utxo_hashes: Vec<[u8; 32]>,
+    /// Nullifiers of every spend, real and dummy, whose absence is proved.
+    nullifiers: Vec<[u8; 32]>,
+}
 
 #[must_use = "use the updated transfer"]
 struct RingSpendInputs<'a, I> {
@@ -611,7 +662,7 @@ impl<'a, I> RingSpendInputs<'a, I> {
     /// The hashes to prove inclusion for, and the nullifiers to prove absence
     /// of. Independent of transport.
     fn queries(&self) -> Result<SpendQueries, TransferError> {
-        let real_hashes = self
+        let utxo_hashes = self
             .spends
             .iter()
             .filter(|spend| !spend.is_dummy())
@@ -622,16 +673,22 @@ impl<'a, I> RingSpendInputs<'a, I> {
             .iter()
             .map(SppProofInputUtxo::nullifier)
             .collect::<Result<Vec<_>, _>>()?;
-        Ok((real_hashes, nullifiers))
+        Ok(SpendQueries {
+            utxo_hashes,
+            nullifiers,
+        })
     }
 }
 
 impl<I: AsyncRpc> RingSpendInputs<'_, I> {
     async fn load_async(self) -> Result<Vec<TransferSpendInput>, TransferError> {
-        let (real_hashes, nullifiers) = self.queries()?;
+        let SpendQueries {
+            utxo_hashes,
+            nullifiers,
+        } = self.queries()?;
         let states = self
             .indexer
-            .get_merkle_proofs(self.tree, real_hashes, None)
+            .get_merkle_proofs(self.tree, utxo_hashes, None)
             .await?
             .proofs;
         let non_inclusions = self
@@ -645,10 +702,13 @@ impl<I: AsyncRpc> RingSpendInputs<'_, I> {
 
 impl<I: Rpc> RingSpendInputs<'_, I> {
     fn load(self) -> Result<Vec<TransferSpendInput>, TransferError> {
-        let (real_hashes, nullifiers) = self.queries()?;
+        let SpendQueries {
+            utxo_hashes,
+            nullifiers,
+        } = self.queries()?;
         let states = self
             .indexer
-            .get_merkle_proofs(self.tree, real_hashes, None)?
+            .get_merkle_proofs(self.tree, utxo_hashes, None)?
             .proofs;
         let non_inclusions = self
             .indexer
@@ -899,6 +959,11 @@ mod tests {
         // runtime; a future that cannot cross threads is no use to it. The
         // `Send + Sync` bound on `sender` is what makes this hold, and dropping
         // it fails here rather than in whatever server tries to await it.
+        //
+        // This only type-checks the future. Running one to completion against a
+        // live chain, prover and indexer -- and comparing it against a blocking
+        // proof of the same note -- is `auditor_sees_every_ring_transfer` in
+        // custom-rings/test/tests/ring.rs.
         fn assert_send<F: Send>(_: F) {}
 
         let (keypair, prepared) = prepared_transfer(4);

--- a/custom-rings/test/tests/ring.rs
+++ b/custom-rings/test/tests/ring.rs
@@ -10,7 +10,10 @@
 //! SPP, ring-deposit SOL, then a ring transact whose proof binds the verifiable
 //! encryption of the transaction viewing key to that auditor key) and asserts
 //! that the amounts, assets and blindings the AUDITOR CLIENT decrypts are the
-//! ones the sender actually sent -- not merely that decryption succeeded.
+//! ones the sender actually sent -- not merely that decryption succeeded. Its
+//! second hop is proven over BOTH transports and lands the async one, so
+//! `CustomRingTransfer::prove_async` is exercised end to end and held to parity
+//! with `prove` (see [`AsyncHopParity`]).
 //!
 //! [`ring_value_leaves_and_enters_through_audited_transfers`] crosses the ring
 //! boundary in both directions under the auditor and pins that a note of
@@ -27,9 +30,9 @@ use anyhow::{anyhow, Context, Result};
 use custom_ring_interface::{RingProgramConfig, CONFIG_PDA_SEED, RING_PROGRAM_CONFIG};
 use custom_ring_program::CustomRingError;
 use custom_ring_sdk::{
-    auditor_view_tag, CreateConfig, CustomRing, CustomRingTransact, CustomRingTransfer,
-    CustomRingTransferInput, InitSppRingConfig, ProvenTransfer, RingDeposit, RingDepositReceipt,
-    SetAuthority, TransferError, TransferProofEnvironment, V0WithLookupTable,
+    auditor_view_tag, AsyncTransferProofEnvironment, CreateConfig, CustomRing, CustomRingTransact,
+    CustomRingTransfer, CustomRingTransferInput, InitSppRingConfig, ProvenTransfer, RingDeposit,
+    RingDepositReceipt, SetAuthority, TransferError, TransferProofEnvironment, V0WithLookupTable,
 };
 use shared::{
     custom_ring_program_id, prover_url, send, send_v0_expecting_rejection, setup, TestEnv,
@@ -40,7 +43,10 @@ use solana_packet::PACKET_DATA_SIZE;
 use solana_signature::Signature;
 use solana_signer::Signer;
 use zeroize::Zeroizing;
-use zolana_client::{ProverClient, Rpc, ShieldedTransaction, SolanaRpc};
+use zolana_client::{
+    AsyncProverClient, AsyncSolanaRpc, AsyncZolanaIndexer, ProverClient, Rpc, ShieldedTransaction,
+    SolanaRpc,
+};
 use zolana_interface::{
     instruction::{AssetDeposit, Deposit as SppDeposit, DepositAsset},
     pda,
@@ -737,24 +743,37 @@ fn auditor_sees_every_ring_transfer() -> Result<()> {
         .find(|held| !held.spent)
         .map(|held| held.utxo.clone())
         .ok_or_else(|| anyhow!("recipient note"))?;
-    let hop_inputs = vec![SppProofInputUtxo::new(received, &env.recipient.keypair)];
-    let mut hop_transfer = ConfidentialTransfer::new(
-        env.recipient.keypair.shielded_address()?,
-        hop_inputs,
-        env.recipient.keypair.pubkey(),
-    )
-    .with_compact_change()
-    .with_ring_program_id(ring_program);
-    hop_transfer.send(
-        &env.sender.keypair.shielded_address()?,
-        SOL_MINT,
-        SECOND_HOP_AMOUNT,
-    )?;
-    let hop_prepared = hop_transfer.prepare()?;
-    let hop = RingTransfer {
+    // 10. The second hop goes over the ASYNC transport, with a blocking proof of
+    //     the same note alongside it as the parity reference. `prove_async`
+    //     exists for a host that cannot link the blocking Solana client, and a
+    //     path only that host runs is a path nothing checks; proving the same
+    //     spend both ways and landing the async proof is what keeps the two
+    //     honest. `PreparedTransfer` is not `Clone` and preparing draws fresh
+    //     output blindings, so the two are prepared independently: equivalent,
+    //     not identical.
+    let prepare_hop = || -> Result<PreparedTransfer> {
+        let mut hop_transfer = ConfidentialTransfer::new(
+            env.recipient.keypair.shielded_address()?,
+            vec![SppProofInputUtxo::new(
+                received.clone(),
+                &env.recipient.keypair,
+            )],
+            env.recipient.keypair.pubkey(),
+        )
+        .with_compact_change()
+        .with_ring_program_id(ring_program);
+        hop_transfer.send(
+            &env.sender.keypair.shielded_address()?,
+            SOL_MINT,
+            SECOND_HOP_AMOUNT,
+        )?;
+        Ok(hop_transfer.prepare()?)
+    };
+    let hop = AsyncHopParity {
         ring,
         sender: &env.recipient.keypair,
-        prepared: hop_prepared,
+        blocking: prepare_hop()?,
+        asynchronous: prepare_hop()?,
         auditor_tag,
     }
     .send(&env, &prover)?;
@@ -1115,6 +1134,118 @@ impl RingTransfer<'_> {
         let indexed = wait_for_indexed_transaction(indexer, self.auditor_tag, signature);
         Ok(RingTransferReceipt { signature, indexed })
     }
+}
+
+/// One ring transfer proven over BOTH transports, of which the async proof is
+/// the one that lands.
+///
+/// The blocking proof is the parity reference. Everything the spent note fixes
+/// -- the circuit, the nullifiers, the transaction viewing key and the owner
+/// signers -- has to agree across the two paths; only what is freshly drawn per
+/// proof (output blindings, the salt, the auditor ciphertext, and with them
+/// `private_tx_hash`) may differ, which is why the two are compared field by
+/// field rather than whole.
+///
+/// The root indices in `data.inputs` are deliberately left out: they record the
+/// tree state each read saw, not anything about the transport.
+struct AsyncHopParity<'a> {
+    ring: CustomRing,
+    sender: &'a ShieldedKeypair,
+    blocking: PreparedTransfer,
+    asynchronous: PreparedTransfer,
+    auditor_tag: [u8; 32],
+}
+
+impl AsyncHopParity<'_> {
+    fn send(self, env: &TestEnv, prover: &ProverClient) -> Result<RingTransferReceipt> {
+        let rpc = env.client.rpc();
+        let indexer = env.client.indexer();
+        let blocking = CustomRingTransfer::new(CustomRingTransferInput {
+            ring: self.ring,
+            sender: self.sender,
+            prepared: self.blocking,
+        })
+        .with_tree(env.tree)
+        .with_assets(&env.assets)
+        .prove(TransferProofEnvironment {
+            indexer,
+            rpc,
+            prover,
+        })?;
+
+        // A separate async transport all the way down: a non-blocking Solana
+        // client for the config and tree reads, an async Photon client for the
+        // inclusion and non-inclusion proofs, and an async prover client.
+        let async_rpc = AsyncSolanaRpc::new(env.rpc_url.clone());
+        let async_indexer = AsyncZolanaIndexer::new(env.indexer_url.clone());
+        // `local()` on both clients, so the two paths resolve the prover the
+        // same way and a parity failure cannot be two different servers.
+        let async_prover = AsyncProverClient::local();
+        let runtime = tokio::runtime::Runtime::new()?;
+        let proven = runtime.block_on(
+            CustomRingTransfer::new(CustomRingTransferInput {
+                ring: self.ring,
+                sender: self.sender,
+                prepared: self.asynchronous,
+            })
+            .with_tree(env.tree)
+            .with_assets(&env.assets)
+            .prove_async(AsyncTransferProofEnvironment {
+                indexer: &async_indexer,
+                rpc: &async_rpc,
+                prover: &async_prover,
+            }),
+        )?;
+
+        assert_eq!(
+            proven.tx_viewing_key.pubkey(),
+            blocking.tx_viewing_key.pubkey(),
+            "async and blocking derive the same transaction viewing key"
+        );
+        assert_eq!(
+            proven.data.tx_viewing_pk, blocking.data.tx_viewing_pk,
+            "async and blocking publish the same tx_viewing_pk"
+        );
+        assert_eq!(
+            proven.data.circuit, blocking.data.circuit,
+            "async and blocking select the same circuit"
+        );
+        assert_eq!(
+            nullifier_hashes(&proven),
+            nullifier_hashes(&blocking),
+            "async and blocking nullify the same note"
+        );
+        assert_eq!(
+            proven.owner_signers, blocking.owner_signers,
+            "async and blocking require the same owner signatures"
+        );
+        assert_eq!(
+            proven.data.expiry_unix_ts, blocking.data.expiry_unix_ts,
+            "async and blocking carry the same expiry"
+        );
+        assert_ne!(
+            proven.data.private_tx_hash, blocking.data.private_tx_hash,
+            "each proof draws its own blindings, salt and auditor ciphertext"
+        );
+
+        let signature = V0WithLookupTable {
+            payer: self.sender,
+            signers: &[],
+            instruction: proven.instruction()?,
+        }
+        .send(rpc)?;
+        let indexed = wait_for_indexed_transaction(indexer, self.auditor_tag, signature);
+        Ok(RingTransferReceipt { signature, indexed })
+    }
+}
+
+fn nullifier_hashes(proven: &ProvenTransfer) -> Vec<[u8; 32]> {
+    proven
+        .data
+        .inputs
+        .iter()
+        .map(|input| input.nullifier_hash)
+        .collect()
 }
 
 struct AuditLookup<'a> {


### PR DESCRIPTION
`CustomRingTransfer::prove` is blocking-only, and the only Solana `Rpc` implementation lives behind `zolana-client`'s `solana-rpc` feature. A host that cannot link that feature cannot prove a ring transfer at all, even though it already speaks `AsyncRpc` over its own transport.

The rest of this SDK is async-first -- `sync_wallet_async`, `create_transfer`, `AsyncProverClient` -- so the ring transfer was the outlier.

## Change

Adds `prove_async` over `AsyncRpc` and `AsyncProverClient`, **alongside** the blocking path rather than replacing it. Every existing call site is untouched; the CLI and the ring test validator build unchanged.

Five reads separate the two paths:

1. the ring config,
2. the tree's dummy-input policy,
3. the indexer's inclusion proofs,
4. the indexer's non-inclusion proofs,
5. the two prover calls.

Everything between them is proof assembly. Duplicating it would have let the two paths drift on the ordering the auditor message depends on -- the comment in `prove` is emphatic about it for good reason. So the reads move to the edges and the middle is shared:

- `AccountRead::decode` -- validating a fetched account is transport-independent
- `dummy_input_policy` -- likewise for the tree account
- `RingSpendInputs::{queries, assemble}` -- what to ask for, and how to pair the answers
- `StagedTransfer` -- the work between the reads

`StagedTransfer` takes the pending proof out rather than borrowing it, so `finish` cannot run before `proof_request` has bound the real `private_tx_hash`. That is the same invariant `PendingCustomRingProof` already encodes, kept across the split.

## Verified

- builds and tests with default features and with `--no-default-features`
- `custom-ring-cli` and `custom-ring-test-validator` build untouched
- fmt and clippy clean

Also checked against the actual consumer: with this branch patched in, a QOS enclave wallet -- which cannot link `solana-rpc`, because that pulls tokio past the libc version `qos_core` pins -- compiles a call to `prove_async` using its own `AsyncRpc` transports. That was the motivating case, and it does not build without this.

## Why

Building custom-ring support into a TVC enclave wallet. #270 made the crate linkable there; this makes the transfer path usable there.
