### PR TITLE
ring-rpc: stop the auditor-key timestamp test racing the clock

### DIFF
--- a/services/ring-rpc/tests/audit_service.rs
+++ b/services/ring-rpc/tests/audit_service.rs
@@ -1116,7 +1116,6 @@ async fn an_unsigned_auditor_key_request_is_refused() {
 async fn auditor_key_requests_bind_cluster_ring_time_and_nonce() {
     let fixture = Fixture::new();
     let hub = fixture.hub(fixture.source());
-    let now = unix_now().expect("clock");
 
     let other_cluster = CreateAuditorKeyRequest::for_ring(RING, [10; 32])
         .sign(&authority())
@@ -1148,7 +1147,18 @@ async fn auditor_key_requests_bind_cluster_ring_time_and_nonce() {
         Unauthorized::BadSignature
     ));
 
-    for timestamp in [now - AUTH_SKEW.as_secs() - 1, now + AUTH_SKEW.as_secs() + 1] {
+    // Read the clock per bound rather than once at the top of the test.
+    // `unix_now` truncates to whole seconds and the service compares against its
+    // own reading, so the future bound is refused only while no second boundary
+    // has been crossed since the timestamp was chosen. Capturing the clock
+    // before the six authorizations above left a window long enough to cross
+    // one, which coverage runs hit regularly.
+    for offset in [
+        -(AUTH_SKEW.as_secs() as i64) - 1,
+        AUTH_SKEW.as_secs() as i64 + 1,
+    ] {
+        let base = unix_now().expect("clock");
+        let timestamp = base.saturating_add_signed(offset);
         let stale = CreateAuditorKeyRequest::for_ring(RING, GENESIS)
             .at(timestamp)
             .sign(&authority())


### PR DESCRIPTION
`auditor_key_requests_bind_cluster_ring_time_and_nonce` is flaky and coverage runs hit it. It failed [this run](https://github.com/helius-labs/zolana/actions/runs/33059417717/job/98474195490) on a TypeScript-only PR, which is what made it obvious the failure is unrelated to whatever is being changed.

## Cause

The test captures `now` at the top, then checks the future skew bound six authorizations later:

```rust
let now = unix_now().expect("clock");
// ... six authorize() calls ...
for timestamp in [now - AUTH_SKEW.as_secs() - 1, now + AUTH_SKEW.as_secs() + 1] {
```

`unix_now` truncates to whole seconds, and the service compares against its own reading. With the service at `now + d`, the future bound is refused only while `AUTH_SKEW + 1 > d + AUTH_SKEW`, i.e. `d < 1`. Cross a single second boundary and the request lands inside the window, is accepted, and `refused(...)` fails.

So it flakes on elapsed wall-clock time rather than on anything it asserts. The trigger is crossing a second boundary, not taking a whole second, which is why it fires more often than the runtime suggests.

## Fix

Reads the clock per bound. The window shrinks from the whole test to a single authorization. Not airtight without an injectable clock, but microseconds instead of seconds.

## Reproduction

Sleeping 1.1s before the loop, standing in for a slow coverage run:

- original: `assertion failed: refused(authorize(&hub, &stale).await, Unauthorized::StaleTimestamp)`
- fixed: passes

`cargo test -p zolana-ring-rpc` is green -- 22 tests in `audit_service`, 44 in the unit suite. fmt and clippy clean.
