### PR TITLE
wallet: leave ring-bound utxos to the ring spend path

### DIFF
--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -3,7 +3,10 @@ use solana_signer::Signer;
 use zolana_client::{Rpc, RpcSendTransactionConfig, SolanaRpc, ZolanaClient};
 use zolana_transaction::Address;
 use zolana_wallet::{
-    actions::{submit::MergeMaterial, transaction::is_plain_utxo},
+    actions::{
+        submit::MergeMaterial,
+        transaction::{is_default_ring_spendable, is_plain_utxo},
+    },
     create_merge, create_split, create_transfer_sync, sign_private_transaction_sync,
     submit_merge_transaction, MergeParams, SplitParams, SubmitMergeTransaction, TransferParams,
 };
@@ -89,10 +92,11 @@ pub(crate) fn run_utxos(opts: UtxosOptions) -> Result<()> {
         .filter(|entry| !entry.spent && entry.utxo.asset == asset)
     {
         count += 1;
-        // Classify with the exact predicate split/merge enforce (`is_plain_utxo`),
-        // so a memo-only utxo (inline `utxo.data`, no data hash) reads as `data`
-        // here rather than as `plain` that those actions would then reject.
-        let kind = if entry.utxo.ring_program_id.is_some() {
+        // Classify with the exact predicates the spend paths enforce -- the
+        // default-ring one for `ring`, `is_plain_utxo` for the rest -- so a
+        // memo-only utxo (inline `utxo.data`, no data hash) reads as `data`
+        // here rather than as `plain` that split and merge would then reject.
+        let kind = if !is_default_ring_spendable(entry) {
             "ring"
         } else if !is_plain_utxo(entry) {
             "data"

--- a/cli/src/wallet_cli/transaction.rs
+++ b/cli/src/wallet_cli/transaction.rs
@@ -92,8 +92,7 @@ pub(crate) fn run_utxos(opts: UtxosOptions) -> Result<()> {
         .filter(|entry| !entry.spent && entry.utxo.asset == asset)
     {
         count += 1;
-        // Classify with the exact predicates the spend paths enforce -- the
-        // default-ring one for `ring`, `is_plain_utxo` for the rest -- so a
+        // Classify with the exact predicates the spend paths enforce, so a
         // memo-only utxo (inline `utxo.data`, no data hash) reads as `data`
         // here rather than as `plain` that split and merge would then reject.
         let kind = if !is_default_ring_spendable(entry) {

--- a/sdk-libs/wallet/src/actions/transaction.rs
+++ b/sdk-libs/wallet/src/actions/transaction.rs
@@ -1045,8 +1045,16 @@ fn select_inputs(
 ) -> Result<Vec<UnsignedSpendInput>, ClientError> {
     let mut selected = Vec::new();
     let mut available = 0u64;
+    // A ring-bound utxo commits to its ring, and this circuit does not cover
+    // that binding. Selecting one produces a witness the prover refuses, which
+    // reads as a prover failure rather than a wrong input; spend it through the
+    // ring's own path instead. Split and merge already refuse one by way of
+    // `is_plain_utxo`.
     for entry in wallet.utxos.iter().filter(|entry| {
-        !entry.spent && entry.utxo.asset == asset && entry.output_context.tree == tree
+        !entry.spent
+            && entry.utxo.asset == asset
+            && entry.output_context.tree == tree
+            && entry.utxo.ring_program_id.is_none()
     }) {
         selected.push(UnsignedSpendInput {
             utxo: entry.utxo.clone(),
@@ -2283,6 +2291,42 @@ mod tests {
                 amount: 1000,
                 parts: 3
             }
+        ));
+    }
+
+    /// A ring-bound utxo commits to its ring; the default-ring circuit does not
+    /// cover that binding. Selecting one builds a witness the prover refuses,
+    /// which surfaces as a prover failure rather than a wrong input, so the
+    /// balance has to look unavailable here instead.
+    #[test]
+    fn select_inputs_leaves_ring_bound_utxos_to_the_ring_path() {
+        let keypair = ShieldedKeypair::new_p256().unwrap();
+        let mut wallet = sol_wallet(&keypair);
+        push_utxo(&mut wallet, &keypair, 10, [1u8; 31]);
+        let ring_bound = push_utxo(&mut wallet, &keypair, 100, [2u8; 31]);
+        let entry = wallet
+            .utxos
+            .iter_mut()
+            .find(|entry| entry.output_context.hash == ring_bound)
+            .expect("pushed utxo");
+        entry.utxo.ring_program_id = Some(Address::new_from_array([7u8; 32]));
+
+        // The plain utxo alone covers this.
+        let selected = select_inputs(&wallet, Address::default(), SOL_MINT, 10)
+            .expect("a plain utxo covers the amount");
+        assert_eq!(selected.len(), 1);
+        assert!(selected
+            .iter()
+            .all(|input| input.utxo.ring_program_id.is_none()));
+
+        // The ring-bound 100 must not be reachable, even though it would cover
+        // the amount on its own.
+        assert!(matches!(
+            select_inputs(&wallet, Address::default(), SOL_MINT, 50),
+            Err(ClientError::InsufficientBalance {
+                requested: 50,
+                available: 10
+            })
         ));
     }
 

--- a/sdk-libs/wallet/src/actions/transaction.rs
+++ b/sdk-libs/wallet/src/actions/transaction.rs
@@ -542,17 +542,8 @@ pub fn create_merge(request: MergeParams<'_>) -> Result<CreatedMerge, ClientErro
     })
 }
 
-/// Whether a wallet utxo is spendable through the default-ring path that
-/// transfers and withdrawals take. A ring-bound utxo's commitment covers its
-/// ring and the default-ring circuit does not, so a witness built over one is
-/// refused by the prover: the balance is reachable only through that ring's own
-/// spend path. Data-carrying utxos stay spendable here -- a transfer and a
-/// withdrawal both carry the committed data hashes through to the witness.
-///
-/// The single predicate for both halves of a default-ring spend: tree
-/// resolution and input selection. Resolving over a wider set than selection
-/// spends would let a ring-bound utxo on a second tree report `AmbiguousTree`
-/// for a balance the spend could never have touched.
+/// A ring-bound utxo's commitment covers its ring, the default-ring circuit
+/// does not.
 pub fn is_default_ring_spendable(entry: &WalletUtxo) -> bool {
     entry.utxo.ring_program_id.is_none()
 }
@@ -990,9 +981,6 @@ fn select_withdrawal_inputs(
                     !entry.spent
                         && entry.utxo.asset == *asset
                         && entry.output_context.tree == asset_tree
-                        // Name a utxo this spend could actually have taken, so
-                        // the reported mismatch matches the tree that was
-                        // resolved over the same predicate.
                         && is_default_ring_spendable(entry)
                 })
                 .map(|entry| entry.output_context.hash)
@@ -1030,12 +1018,7 @@ fn named_input_tree(
         .ok_or(ClientError::InputUtxoUnavailable { hash })
 }
 
-/// Resolve the single tree a spend of `asset` binds, considering only the utxos
-/// `eligible` accepts. Every caller passes the same predicate its input
-/// selection applies -- [`is_default_ring_spendable`] for transfers and
-/// withdrawals, the stricter [`is_plain_utxo`] for split and merge -- so a utxo
-/// that spend could never take does not make the spend tree ambiguous from
-/// another tree.
+/// Each caller passes the predicate its own input selection applies.
 fn resolve_spend_tree(
     wallet: &Wallet,
     asset: Address,
@@ -1066,12 +1049,6 @@ fn select_inputs(
 ) -> Result<Vec<UnsignedSpendInput>, ClientError> {
     let mut selected = Vec::new();
     let mut available = 0u64;
-    // `is_default_ring_spendable` leaves a ring-bound utxo to its ring's own
-    // spend path: selecting one produces a witness the prover refuses, which
-    // reads as a prover failure rather than a wrong input. The same predicate
-    // resolved the tree, so a ring balance is uniformly invisible here instead
-    // of blocking the spend at one step and failing at the next. Split and merge
-    // refuse one by way of the stricter `is_plain_utxo`.
     for entry in wallet.utxos.iter().filter(|entry| {
         !entry.spent
             && entry.utxo.asset == asset
@@ -2317,13 +2294,8 @@ mod tests {
         ));
     }
 
-    /// The tree a second, ring-bound balance sits on. A deposit into a custom
-    /// ring lands wherever that ring's tree is, which need not be the tree the
-    /// wallet's plain balance is on.
     const RING_TREE: Address = Address::new_from_array([9u8; 32]);
 
-    /// Bind an already-pushed utxo to a custom ring on `tree`: the state a
-    /// wallet is in after depositing into a ring.
     fn bind_to_ring(wallet: &mut Wallet, hash: [u8; 32], tree: Address) {
         let entry = wallet
             .utxos
@@ -2334,9 +2306,6 @@ mod tests {
         entry.utxo.ring_program_id = Some(Address::new_from_array([7u8; 32]));
     }
 
-    /// A wallet holding a plain balance on the default tree and a larger
-    /// ring-bound balance on another: the layout a default-ring spend has to
-    /// read as "only the plain tree is reachable".
     fn wallet_with_ring_balance_on_another_tree(keypair: &ShieldedKeypair) -> Wallet {
         let mut wallet = sol_wallet(keypair);
         push_utxo(&mut wallet, keypair, 10, [1u8; 31]);
@@ -2345,9 +2314,7 @@ mod tests {
         wallet
     }
 
-    /// A `MockRpc` serving `owner`'s registry record, so recipient resolution
-    /// finds it registered and the transfer takes the private (non-withdrawal)
-    /// path.
+    /// Registered, so the transfer takes the private path.
     fn registered_recipient_rpc(owner: Pubkey, recipient: &ShieldedKeypair) -> MockRpc {
         let (record_pda, bump) = user_record_pda(&owner);
         let record = UserRecord {
@@ -2372,10 +2339,6 @@ mod tests {
         }
     }
 
-    /// A ring-bound utxo commits to its ring; the default-ring circuit does not
-    /// cover that binding. Selecting one builds a witness the prover refuses,
-    /// which surfaces as a prover failure rather than a wrong input, so the
-    /// balance has to look unavailable here instead.
     #[test]
     fn select_inputs_leaves_ring_bound_utxos_to_the_ring_path() {
         let keypair = ShieldedKeypair::new_p256().unwrap();
@@ -2384,7 +2347,6 @@ mod tests {
         let ring_bound = push_utxo(&mut wallet, &keypair, 100, [2u8; 31]);
         bind_to_ring(&mut wallet, ring_bound, Address::default());
 
-        // The plain utxo alone covers this.
         let selected = select_inputs(&wallet, Address::default(), SOL_MINT, 10)
             .expect("a plain utxo covers the amount");
         assert_eq!(selected.len(), 1);
@@ -2392,8 +2354,6 @@ mod tests {
             .iter()
             .all(|input| input.utxo.ring_program_id.is_none()));
 
-        // The ring-bound 100 must not be reachable, even though it would cover
-        // the amount on its own.
         assert!(matches!(
             select_inputs(&wallet, Address::default(), SOL_MINT, 50),
             Err(ClientError::InsufficientBalance {
@@ -2420,9 +2380,6 @@ mod tests {
         assert_eq!(tree, Address::default());
     }
 
-    /// Tree resolution has to see the same utxos input selection can spend. A
-    /// ring-bound balance on a second tree is unreachable from the default-ring
-    /// path, so it must not make that path's spend tree ambiguous either.
     #[test]
     fn resolve_spend_tree_ignores_ring_bound_utxos_on_other_trees() {
         let keypair = ShieldedKeypair::new_p256().unwrap();
@@ -2434,10 +2391,6 @@ mod tests {
         assert_eq!(tree, Address::default());
     }
 
-    /// The public path: a withdrawal resolves its tree over the same predicate
-    /// it selects inputs with, so a plain balance on one tree plus a ring-bound
-    /// balance on another withdraws from the plain tree instead of failing with
-    /// `AmbiguousTree`.
     #[test]
     fn create_withdrawal_spends_the_plain_tree_when_a_ring_balance_sits_on_another() {
         let keypair = ShieldedKeypair::new_p256().unwrap();
@@ -2459,9 +2412,6 @@ mod tests {
         assert_eq!(created.transaction.input_count(), 1);
     }
 
-    /// The public path reached through `create_transfer_sync`: an unregistered
-    /// recipient becomes a withdrawal, and the tree it resolves before that
-    /// branch must ignore the ring-bound balance too.
     #[test]
     fn create_transfer_sync_public_withdrawal_ignores_a_ring_balance_on_another_tree() {
         let keypair = ShieldedKeypair::new_p256().unwrap();
@@ -2486,8 +2436,6 @@ mod tests {
         assert_eq!(created.transaction.input_count(), 1);
     }
 
-    /// The private path: same two-tree layout, registered recipient. This is
-    /// the flow the ring-bound input was picked up on.
     #[test]
     fn create_transfer_sync_ignores_a_ring_balance_on_another_tree() {
         let keypair = ShieldedKeypair::new_p256().unwrap();
@@ -2514,9 +2462,6 @@ mod tests {
         assert_eq!(created.transaction.input_count(), 1);
     }
 
-    /// A wallet whose whole balance is ring-bound has nothing the default-ring
-    /// path can spend: report that, rather than resolving a tree whose inputs
-    /// selection then refuses.
     #[test]
     fn create_withdrawal_reports_no_balance_when_all_of_it_is_ring_bound() {
         let keypair = ShieldedKeypair::new_p256().unwrap();

--- a/sdk-libs/wallet/src/actions/transaction.rs
+++ b/sdk-libs/wallet/src/actions/transaction.rs
@@ -206,7 +206,7 @@ fn create_transfer_with_recipient<R>(
     recipient: Option<ResolvedAddress>,
     spl_token_program: Option<Pubkey>,
 ) -> Result<CreatedTransfer, ClientError> {
-    let tree = resolve_spend_tree(request.wallet, request.asset, |_| true)?;
+    let tree = resolve_spend_tree(request.wallet, request.asset, is_default_ring_spendable)?;
     let Some(recipient) = recipient else {
         let withdrawal = create_withdrawal(WithdrawalParams {
             wallet: request.wallet,
@@ -542,6 +542,21 @@ pub fn create_merge(request: MergeParams<'_>) -> Result<CreatedMerge, ClientErro
     })
 }
 
+/// Whether a wallet utxo is spendable through the default-ring path that
+/// transfers and withdrawals take. A ring-bound utxo's commitment covers its
+/// ring and the default-ring circuit does not, so a witness built over one is
+/// refused by the prover: the balance is reachable only through that ring's own
+/// spend path. Data-carrying utxos stay spendable here -- a transfer and a
+/// withdrawal both carry the committed data hashes through to the witness.
+///
+/// The single predicate for both halves of a default-ring spend: tree
+/// resolution and input selection. Resolving over a wider set than selection
+/// spends would let a ring-bound utxo on a second tree report `AmbiguousTree`
+/// for a balance the spend could never have touched.
+pub fn is_default_ring_spendable(entry: &WalletUtxo) -> bool {
+    entry.utxo.ring_program_id.is_none()
+}
+
 /// Whether a wallet utxo is plain: no ring binding and no attached data. Only
 /// plain utxos are mergeable or splittable; building a spend input drops the
 /// utxo's committed data hashes, which would desync the commitment from the tree
@@ -549,7 +564,7 @@ pub fn create_merge(request: MergeParams<'_>) -> Result<CreatedMerge, ClientErro
 /// hash value. Public so the CLI's `utxos` listing classifies `kind` with the
 /// exact predicate split/merge enforce, and the two cannot drift.
 pub fn is_plain_utxo(entry: &WalletUtxo) -> bool {
-    entry.utxo.ring_program_id.is_none()
+    is_default_ring_spendable(entry)
         && entry.ring_data_hash.is_none()
         && entry.data_hash.is_none()
         && entry.utxo.data.is_empty()
@@ -962,11 +977,11 @@ fn select_withdrawal_inputs(
         .first()
         .copied()
         .ok_or(TransactionError::NoInterfaceTransfers)?;
-    let tree = resolve_spend_tree(wallet, first_asset, |_| true)?;
+    let tree = resolve_spend_tree(wallet, first_asset, is_default_ring_spendable)?;
     let mut inputs = Vec::new();
 
     for (asset, amount) in required {
-        let asset_tree = resolve_spend_tree(wallet, *asset, |_| true)?;
+        let asset_tree = resolve_spend_tree(wallet, *asset, is_default_ring_spendable)?;
         if asset_tree != tree {
             let hash = wallet
                 .utxos
@@ -975,6 +990,10 @@ fn select_withdrawal_inputs(
                     !entry.spent
                         && entry.utxo.asset == *asset
                         && entry.output_context.tree == asset_tree
+                        // Name a utxo this spend could actually have taken, so
+                        // the reported mismatch matches the tree that was
+                        // resolved over the same predicate.
+                        && is_default_ring_spendable(entry)
                 })
                 .map(|entry| entry.output_context.hash)
                 .ok_or(ClientError::InsufficientBalance {
@@ -1012,9 +1031,11 @@ fn named_input_tree(
 }
 
 /// Resolve the single tree a spend of `asset` binds, considering only the utxos
-/// `eligible` accepts. Transfers and withdrawals can spend any utxo; split and
-/// merge only plain ones, so an ineligible ring-bound or data-carrying utxo
-/// sitting on another tree must not make their spend tree ambiguous.
+/// `eligible` accepts. Every caller passes the same predicate its input
+/// selection applies -- [`is_default_ring_spendable`] for transfers and
+/// withdrawals, the stricter [`is_plain_utxo`] for split and merge -- so a utxo
+/// that spend could never take does not make the spend tree ambiguous from
+/// another tree.
 fn resolve_spend_tree(
     wallet: &Wallet,
     asset: Address,
@@ -1045,16 +1066,17 @@ fn select_inputs(
 ) -> Result<Vec<UnsignedSpendInput>, ClientError> {
     let mut selected = Vec::new();
     let mut available = 0u64;
-    // A ring-bound utxo commits to its ring, and this circuit does not cover
-    // that binding. Selecting one produces a witness the prover refuses, which
-    // reads as a prover failure rather than a wrong input; spend it through the
-    // ring's own path instead. Split and merge already refuse one by way of
-    // `is_plain_utxo`.
+    // `is_default_ring_spendable` leaves a ring-bound utxo to its ring's own
+    // spend path: selecting one produces a witness the prover refuses, which
+    // reads as a prover failure rather than a wrong input. The same predicate
+    // resolved the tree, so a ring balance is uniformly invisible here instead
+    // of blocking the spend at one step and failing at the next. Split and merge
+    // refuse one by way of the stricter `is_plain_utxo`.
     for entry in wallet.utxos.iter().filter(|entry| {
         !entry.spent
             && entry.utxo.asset == asset
             && entry.output_context.tree == tree
-            && entry.utxo.ring_program_id.is_none()
+            && is_default_ring_spendable(entry)
     }) {
         selected.push(UnsignedSpendInput {
             utxo: entry.utxo.clone(),
@@ -1819,7 +1841,8 @@ mod tests {
         let sender = ShieldedKeypair::new_p256().unwrap();
         let wallet = wallet_with_sol(sender, 10);
 
-        let tree = resolve_spend_tree(&wallet, SOL_MINT, |_| true).expect("infer tree");
+        let tree =
+            resolve_spend_tree(&wallet, SOL_MINT, is_default_ring_spendable).expect("infer tree");
 
         assert_eq!(tree, Address::default());
     }
@@ -1833,7 +1856,7 @@ mod tests {
         second.output_context.tree = second_tree;
         wallet.utxos.push(second);
 
-        let error = match resolve_spend_tree(&wallet, SOL_MINT, |_| true) {
+        let error = match resolve_spend_tree(&wallet, SOL_MINT, is_default_ring_spendable) {
             Err(error) => error,
             Ok(_) => panic!("expected ambiguous tree error"),
         };
@@ -2294,6 +2317,61 @@ mod tests {
         ));
     }
 
+    /// The tree a second, ring-bound balance sits on. A deposit into a custom
+    /// ring lands wherever that ring's tree is, which need not be the tree the
+    /// wallet's plain balance is on.
+    const RING_TREE: Address = Address::new_from_array([9u8; 32]);
+
+    /// Bind an already-pushed utxo to a custom ring on `tree`: the state a
+    /// wallet is in after depositing into a ring.
+    fn bind_to_ring(wallet: &mut Wallet, hash: [u8; 32], tree: Address) {
+        let entry = wallet
+            .utxos
+            .iter_mut()
+            .find(|entry| entry.output_context.hash == hash)
+            .expect("pushed utxo");
+        entry.output_context.tree = tree;
+        entry.utxo.ring_program_id = Some(Address::new_from_array([7u8; 32]));
+    }
+
+    /// A wallet holding a plain balance on the default tree and a larger
+    /// ring-bound balance on another: the layout a default-ring spend has to
+    /// read as "only the plain tree is reachable".
+    fn wallet_with_ring_balance_on_another_tree(keypair: &ShieldedKeypair) -> Wallet {
+        let mut wallet = sol_wallet(keypair);
+        push_utxo(&mut wallet, keypair, 10, [1u8; 31]);
+        let ring_bound = push_utxo(&mut wallet, keypair, 100, [2u8; 31]);
+        bind_to_ring(&mut wallet, ring_bound, RING_TREE);
+        wallet
+    }
+
+    /// A `MockRpc` serving `owner`'s registry record, so recipient resolution
+    /// finds it registered and the transfer takes the private (non-withdrawal)
+    /// path.
+    fn registered_recipient_rpc(owner: Pubkey, recipient: &ShieldedKeypair) -> MockRpc {
+        let (record_pda, bump) = user_record_pda(&owner);
+        let record = UserRecord {
+            owner: owner.to_bytes().into(),
+            bump,
+            owner_p256: Some(*recipient.signing_pubkey().as_p256().unwrap().as_bytes()),
+            nullifier_pubkey: recipient.nullifier_key.pubkey().unwrap(),
+            viewing_pubkey: *recipient.viewing_pubkey().as_bytes(),
+            merging_enabled: false,
+        };
+        MockRpc {
+            account: Some((
+                Address::new_from_array(record_pda.to_bytes()),
+                Account {
+                    lamports: 1,
+                    data: account_data(&record),
+                    owner: user_registry_program_id(),
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )),
+        }
+    }
+
     /// A ring-bound utxo commits to its ring; the default-ring circuit does not
     /// cover that binding. Selecting one builds a witness the prover refuses,
     /// which surfaces as a prover failure rather than a wrong input, so the
@@ -2304,12 +2382,7 @@ mod tests {
         let mut wallet = sol_wallet(&keypair);
         push_utxo(&mut wallet, &keypair, 10, [1u8; 31]);
         let ring_bound = push_utxo(&mut wallet, &keypair, 100, [2u8; 31]);
-        let entry = wallet
-            .utxos
-            .iter_mut()
-            .find(|entry| entry.output_context.hash == ring_bound)
-            .expect("pushed utxo");
-        entry.utxo.ring_program_id = Some(Address::new_from_array([7u8; 32]));
+        bind_to_ring(&mut wallet, ring_bound, Address::default());
 
         // The plain utxo alone covers this.
         let selected = select_inputs(&wallet, Address::default(), SOL_MINT, 10)
@@ -2339,18 +2412,133 @@ mod tests {
         let mut wallet = sol_wallet(&keypair);
         push_utxo(&mut wallet, &keypair, 10, [1u8; 31]);
         let ring_bound = push_utxo(&mut wallet, &keypair, 20, [2u8; 31]);
-        let entry = wallet
-            .utxos
-            .iter_mut()
-            .find(|entry| entry.output_context.hash == ring_bound)
-            .expect("pushed utxo");
-        entry.output_context.tree = Address::new_from_array([9u8; 32]);
-        entry.utxo.ring_program_id = Some(Address::new_from_array([7u8; 32]));
+        bind_to_ring(&mut wallet, ring_bound, RING_TREE);
 
         let tree = resolve_spend_tree(&wallet, SOL_MINT, is_plain_utxo)
             .expect("the ring utxo on another tree must not block a plain spend");
 
         assert_eq!(tree, Address::default());
+    }
+
+    /// Tree resolution has to see the same utxos input selection can spend. A
+    /// ring-bound balance on a second tree is unreachable from the default-ring
+    /// path, so it must not make that path's spend tree ambiguous either.
+    #[test]
+    fn resolve_spend_tree_ignores_ring_bound_utxos_on_other_trees() {
+        let keypair = ShieldedKeypair::new_p256().unwrap();
+        let wallet = wallet_with_ring_balance_on_another_tree(&keypair);
+
+        let tree = resolve_spend_tree(&wallet, SOL_MINT, is_default_ring_spendable)
+            .expect("a ring balance on another tree must not make the spend ambiguous");
+
+        assert_eq!(tree, Address::default());
+    }
+
+    /// The public path: a withdrawal resolves its tree over the same predicate
+    /// it selects inputs with, so a plain balance on one tree plus a ring-bound
+    /// balance on another withdraws from the plain tree instead of failing with
+    /// `AmbiguousTree`.
+    #[test]
+    fn create_withdrawal_spends_the_plain_tree_when_a_ring_balance_sits_on_another() {
+        let keypair = ShieldedKeypair::new_p256().unwrap();
+        let wallet = wallet_with_ring_balance_on_another_tree(&keypair);
+
+        let created = create_withdrawal(WithdrawalParams {
+            wallet: &wallet,
+            payer: Address::default(),
+            legs: vec![WithdrawalLeg {
+                recipient: Pubkey::new_unique(),
+                asset: SOL_MINT,
+                amount: 4,
+                spl_token_program: None,
+            }],
+        })
+        .expect("the plain tree covers the withdrawal");
+
+        assert_eq!(created.transaction.tree(), Address::default());
+        assert_eq!(created.transaction.input_count(), 1);
+    }
+
+    /// The public path reached through `create_transfer_sync`: an unregistered
+    /// recipient becomes a withdrawal, and the tree it resolves before that
+    /// branch must ignore the ring-bound balance too.
+    #[test]
+    fn create_transfer_sync_public_withdrawal_ignores_a_ring_balance_on_another_tree() {
+        let keypair = ShieldedKeypair::new_p256().unwrap();
+        let wallet = wallet_with_ring_balance_on_another_tree(&keypair);
+        let rpc = MockRpc { account: None };
+
+        let created = create_transfer_sync(TransferParams {
+            rpc: &rpc,
+            wallet: &wallet,
+            payer: Address::default(),
+            recipient: Pubkey::new_unique(),
+            asset: SOL_MINT,
+            amount: 4,
+        })
+        .expect("the plain tree covers the withdrawal");
+
+        assert!(matches!(
+            created.recipient,
+            TransferRecipient::PublicWithdrawal { .. }
+        ));
+        assert_eq!(created.transaction.tree(), Address::default());
+        assert_eq!(created.transaction.input_count(), 1);
+    }
+
+    /// The private path: same two-tree layout, registered recipient. This is
+    /// the flow the ring-bound input was picked up on.
+    #[test]
+    fn create_transfer_sync_ignores_a_ring_balance_on_another_tree() {
+        let keypair = ShieldedKeypair::new_p256().unwrap();
+        let recipient = ShieldedKeypair::new_p256().unwrap();
+        let owner = Pubkey::new_unique();
+        let wallet = wallet_with_ring_balance_on_another_tree(&keypair);
+        let rpc = registered_recipient_rpc(owner, &recipient);
+
+        let created = create_transfer_sync(TransferParams {
+            rpc: &rpc,
+            wallet: &wallet,
+            payer: Address::default(),
+            recipient: owner,
+            asset: SOL_MINT,
+            amount: 4,
+        })
+        .expect("the plain tree covers the transfer");
+
+        assert!(matches!(
+            created.recipient,
+            TransferRecipient::Registered(resolved) if resolved.owner == owner
+        ));
+        assert_eq!(created.transaction.tree(), Address::default());
+        assert_eq!(created.transaction.input_count(), 1);
+    }
+
+    /// A wallet whose whole balance is ring-bound has nothing the default-ring
+    /// path can spend: report that, rather than resolving a tree whose inputs
+    /// selection then refuses.
+    #[test]
+    fn create_withdrawal_reports_no_balance_when_all_of_it_is_ring_bound() {
+        let keypair = ShieldedKeypair::new_p256().unwrap();
+        let mut wallet = sol_wallet(&keypair);
+        let ring_bound = push_utxo(&mut wallet, &keypair, 100, [1u8; 31]);
+        bind_to_ring(&mut wallet, ring_bound, RING_TREE);
+
+        let error = withdrawal_error(create_withdrawal(WithdrawalParams {
+            wallet: &wallet,
+            payer: Address::default(),
+            legs: vec![WithdrawalLeg {
+                recipient: Pubkey::new_unique(),
+                asset: SOL_MINT,
+                amount: 4,
+                spl_token_program: None,
+            }],
+        }));
+
+        assert!(matches!(
+            error,
+            ClientError::InsufficientBalance { available: 0, .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
A default-ring transfer will select a ring-bound utxo and fail at the prover.

`select_inputs` filters on spent, asset and tree, but not on the ring binding:

```rust
for entry in wallet.utxos.iter().filter(|entry| {
    !entry.spent && entry.utxo.asset == asset && entry.output_context.tree == tree
}) {
```

A ring-bound utxo's commitment covers its ring; the default-ring circuit does not. So the witness is built over an input the circuit cannot account for, the prover refuses it, and the caller sees a prover failure with nothing pointing at the input that caused it.

Split and merge already refuse one, through `is_plain_utxo`. Transfer was the gap.

## Change

Adds `ring_program_id.is_none()` to the filter. A ring balance then looks unavailable to the default path, which is accurate -- it is spendable only through the ring's own path -- and the caller gets `InsufficientBalance` naming what is actually reachable instead of an opaque prover error.

## Test

Pins both halves: a plain utxo still covers its amount, and a ring-bound one is not reachable even when it alone would cover the request.

`cargo test -p zolana-wallet` is green (105 + 12); fmt and clippy clean.

## How it turned up

Depositing into a custom ring from a wallet UI, then trying an ordinary private transfer. The deposit worked, the transfer came back `ExternalProver`, and the cause was several layers from the message.
