### PR TITLE
deps: bump surfpool to v1.5.0-light and litesvm to 0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4790979fc2a3c1c494c9cb84e8b514da4b8c6a992a460a077b31b07657606f8"
+checksum = "93723b88193a51692304c79dc52cfea0389dabe9a6650288dd508b78fbff5a8f"
 dependencies = [
  "ahash 0.8.12",
  "solana-epoch-schedule",
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "agave-precompiles"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c451389a4e48da05d1eddc6d76bbc88f07cf4fea08c806dcd73eeddee199313a"
+checksum = "3d4b7f6df4556094a86b0cfedc931235ddbb738f3a8a0676990f0be26091cca9"
 dependencies = [
  "agave-feature-set",
  "bincode 1.3.3",
@@ -92,13 +92,52 @@ dependencies = [
 
 [[package]]
 name = "agave-reserved-account-keys"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea33710f30b13f62e6d73dbbb114117029d29539cb9439c30ef39a0736f935cc"
+checksum = "823f261d896cedb7f95ecfed70d27aae6c7fd5a8fcc01e21a71382268e0743e4"
 dependencies = [
  "agave-feature-set",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
+]
+
+[[package]]
+name = "agave-transaction-view"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355713e066b40689fca695caa2cb4f3fa582dc7a40c3fa28206b84ad5fa6bf95"
+dependencies = [
+ "solana-hash",
+ "solana-message",
+ "solana-packet 4.2.0",
+ "solana-pubkey 4.2.0",
+ "solana-sdk-ids",
+ "solana-short-vec",
+ "solana-signature",
+ "solana-svm-transaction",
+ "solana-transaction",
+]
+
+[[package]]
+name = "agave-votor-messages"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f13132a1b3bb9c543f19b6de6d47318c6ed6af7978808d9abf1f424c31da2f01"
+dependencies = [
+ "agave-feature-set",
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "solana-address 2.6.1",
+ "solana-bls-signatures",
+ "solana-clock",
+ "solana-epoch-schedule",
+ "solana-hash",
+ "solana-pubkey 4.2.0",
+ "solana-short-vec",
+ "solana-signer-store",
+ "thiserror 2.0.20",
+ "wincode",
 ]
 
 [[package]]
@@ -636,7 +675,7 @@ dependencies = [
  "quick-xml",
  "rust-ini",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "url",
 ]
@@ -670,7 +709,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "838b36c8dc927b6db1b6c6b8f5d05865f2213550b9e83bf92fa99ed6525472c0"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -862,7 +901,7 @@ dependencies = [
  "regex-lite",
  "roxmltree",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1656,8 +1695,8 @@ dependencies = [
  "pinocchio 0.11.2",
  "solana-address 2.6.1",
  "solana-program-error",
- "thiserror 2.0.18",
- "wincode 0.5.5",
+ "thiserror 2.0.20",
+ "wincode",
  "zolana-account-checks",
  "zolana-hasher",
  "zolana-interface",
@@ -1675,7 +1714,7 @@ dependencies = [
  "num-bigint 0.4.8",
  "solana-address 2.6.1",
  "solana-instruction",
- "wincode 0.5.5",
+ "wincode",
  "zolana-client",
  "zolana-hasher",
  "zolana-interface",
@@ -2032,9 +2071,9 @@ dependencies = [
  "solana-signer",
  "solana-system-interface 3.2.0",
  "solana-transaction-error",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "toml",
- "wincode 0.5.5",
+ "wincode",
  "zolana-client",
  "zolana-indexer-api",
  "zolana-interface",
@@ -2051,7 +2090,7 @@ dependencies = [
  "bytemuck",
  "groth16-solana",
  "solana-address 2.6.1",
- "wincode 0.5.5",
+ "wincode",
  "zolana-hasher",
  "zolana-interface",
 ]
@@ -2076,8 +2115,8 @@ dependencies = [
  "solana-loader-v3-interface 8.0.1",
  "solana-program-error",
  "solana-pubkey 4.2.0",
- "thiserror 2.0.18",
- "wincode 0.5.5",
+ "thiserror 2.0.20",
+ "wincode",
  "zolana-account-checks",
  "zolana-interface",
  "zolana-test-utils",
@@ -2110,8 +2149,8 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-transaction",
- "thiserror 2.0.18",
- "wincode 0.5.5",
+ "thiserror 2.0.20",
+ "wincode",
  "zeroize",
  "zolana-client",
  "zolana-interface",
@@ -2255,7 +2294,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2399,8 +2438,8 @@ dependencies = [
  "pinocchio 0.11.2",
  "pinocchio-system",
  "solana-program-error",
- "thiserror 2.0.18",
- "wincode 0.5.5",
+ "thiserror 2.0.20",
+ "wincode",
  "zolana-account-checks",
  "zolana-hasher",
  "zolana-interface",
@@ -2415,7 +2454,7 @@ dependencies = [
  "num-bigint 0.4.8",
  "serde_json",
  "solana-bn254",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zolana-transaction",
 ]
 
@@ -2431,7 +2470,7 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey 4.2.0",
  "solana-system-interface 3.2.0",
- "wincode 0.5.5",
+ "wincode",
  "zolana-client",
  "zolana-interface",
  "zolana-keypair",
@@ -2837,7 +2876,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-transaction",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "tracing-subscriber",
  "zolana-api",
@@ -3051,7 +3090,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "solana-bn254",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3803,7 +3842,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tower",
  "tracing",
@@ -3841,7 +3880,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3858,7 +3897,7 @@ dependencies = [
  "http 1.4.2",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4039,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "light-profiler-macro"
 version = "0.1.1"
-source = "git+https://github.com/Lightprotocol/light-program-profiler?rev=8afb60d66842e5428e562d468a5e4a891c031cbf#8afb60d66842e5428e562d468a5e4a891c031cbf"
+source = "git+https://github.com/Lightprotocol/light-program-profiler?rev=db49f3c801996a80e1cb7e4e92b13a694e962b65#db49f3c801996a80e1cb7e4e92b13a694e962b65"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4049,7 +4088,7 @@ dependencies = [
 [[package]]
 name = "light-program-profiler"
 version = "0.1.1"
-source = "git+https://github.com/Lightprotocol/light-program-profiler?rev=8afb60d66842e5428e562d468a5e4a891c031cbf#8afb60d66842e5428e562d468a5e4a891c031cbf"
+source = "git+https://github.com/Lightprotocol/light-program-profiler?rev=db49f3c801996a80e1cb7e4e92b13a694e962b65#db49f3c801996a80e1cb7e4e92b13a694e962b65"
 dependencies = [
  "light-profiler-macro",
  "mollusk-svm",
@@ -4071,16 +4110,16 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litesvm"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f959134a3232f13a9c38786c49aa0778cb96b5b8559b8429aaef5cc5415f4d18"
+checksum = "a286f10b45b3a8efd78f47846d34af8d109ff5684c2b10a11920b5b089ad6e79"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
  "agave-reserved-account-keys",
  "ansi_term",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "serde",
  "solana-account 4.3.1",
@@ -4112,6 +4151,7 @@ dependencies = [
  "solana-program-error",
  "solana-program-runtime",
  "solana-rent 4.3.0",
+ "solana-runtime-transaction",
  "solana-sdk-ids",
  "solana-sha256-hasher",
  "solana-short-vec",
@@ -4132,8 +4172,8 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
- "thiserror 2.0.18",
- "wincode 0.5.5",
+ "thiserror 2.0.20",
+ "wincode",
 ]
 
 [[package]]
@@ -4261,9 +4301,9 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88dea9343dbba166d4d50f465fb858adb45b2fcd26bc26d42153c163d3042ab2"
+checksum = "7926024cefb20fe555c34ccf66ab3e9e8fd407e8399149ce386b86999c967253"
 dependencies = [
  "bincode 1.3.3",
  "mollusk-svm-error",
@@ -4293,7 +4333,6 @@ dependencies = [
  "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-timings",
- "solana-svm-transaction",
  "solana-syscalls",
  "solana-system-program",
  "solana-sysvar 4.1.0",
@@ -4304,19 +4343,19 @@ dependencies = [
 
 [[package]]
 name = "mollusk-svm-error"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1523cf5f9900fabea3ac9f722172be6b5306110ec9cad36a53c451c9cdf42193"
+checksum = "2566d4c2c6c4aa51b95d70d71fdd2a2d8519d2bb790356d11f2d13608c2f2a0e"
 dependencies = [
  "solana-pubkey 4.2.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "mollusk-svm-result"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44507908cd9e1a9177c647e36466a1a0aa4f1a1b3b1cf6242c7787671057c69f"
+checksum = "d466fd9a244ca531289a707ae68e9720b1fbbb87989ee4e859f3e848c3561806"
 dependencies = [
  "solana-account 4.3.1",
  "solana-instruction",
@@ -4828,7 +4867,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "sqlx",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -5346,7 +5385,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "rustls 0.23.42",
  "socket2 0.6.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -5368,7 +5407,7 @@ dependencies = [
  "rustls 0.23.42",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5890,7 +5929,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sysinfo",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tokio-stream",
@@ -6134,7 +6173,7 @@ dependencies = [
  "serde",
  "sqlx",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "url",
 ]
@@ -6216,7 +6255,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6301,9 +6340,9 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -6330,22 +6369,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6542,7 +6581,7 @@ dependencies = [
  "pinocchio-system",
  "serde_json",
  "solana-loader-v3-interface 8.0.1",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 2.1.0",
  "tinyvec",
  "zolana-account-checks",
  "zolana-hasher",
@@ -6583,9 +6622,9 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-transaction",
  "spl-token",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 2.1.0",
  "tokio",
- "wincode 0.5.5",
+ "wincode",
  "zolana-account-checks",
  "zolana-client",
  "zolana-event",
@@ -6670,7 +6709,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint 0.4.8",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -6765,9 +6804,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1daf7a9ad1ba8952f79d02ff2ff2f75d789bfb9c33aa53da4a377de86c5da02e"
+checksum = "5d539d57ab52c20309711d54fc309adcf7ed1c688277c8ac6437db34c5be39f7"
 dependencies = [
  "Inflector",
  "base64",
@@ -6796,20 +6835,22 @@ dependencies = [
  "solana-stake-interface",
  "solana-sysvar 4.1.0",
  "solana-vote-interface",
+ "solana-zk-sdk-pod",
  "spl-generic-token",
- "spl-token-2022-interface",
+ "spl-token-2022-interface 3.1.1",
  "spl-token-group-interface",
- "spl-token-interface",
- "spl-token-metadata-interface",
- "thiserror 2.0.18",
+ "spl-token-interface 3.0.0",
+ "spl-token-metadata-interface 1.0.1",
+ "thiserror 2.0.20",
+ "wincode",
  "zstd",
 ]
 
 [[package]]
 name = "solana-account-decoder-client-types"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c4eb99bb799650f2c6cb7291d93cf6db05e956320f3c772e58ca49f8b6192e"
+checksum = "ce9eca88c8336e46a990fd6541eadee77685ecb84d771ade0d2ed4cc5801f438"
 dependencies = [
  "base64",
  "bs58",
@@ -6881,7 +6922,7 @@ dependencies = [
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -6912,17 +6953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-big-mod-exp"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
-dependencies = [
- "num-bigint 0.4.8",
- "num-traits",
- "solana-define-syscall 3.0.0",
-]
-
-[[package]]
 name = "solana-bincode"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6946,13 +6976,14 @@ dependencies = [
 
 [[package]]
 name = "solana-bls-signatures"
-version = "3.4.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7e9dbeff4dab3484175666a367171b60fe514b707d6de1ab3b741f0168e735"
+checksum = "654ea8d31bbb4b0b9c28f9c545edb32691de27d4e2fc0e252c1ff47da50c5f2a"
 dependencies = [
  "base64",
  "blst",
  "blstrs",
+ "bytemuck",
  "cfg_eval",
  "ff",
  "group",
@@ -6961,8 +6992,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
- "wincode 0.6.0",
+ "solana-signature",
+ "solana-signer",
+ "subtle",
+ "thiserror 2.0.20",
+ "wincode",
  "zeroize",
 ]
 
@@ -6991,7 +7025,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "bytemuck",
  "solana-define-syscall 5.1.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7005,9 +7039,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073e0a6555480e8f783f930299a5660c2296c8961d9b3a2adaf585561e2d59b9"
+checksum = "fba6be8c60af6076de7e40e54a0ad9d88ad5f7004ecf9be5e93d296dd9b0cbe3"
 dependencies = [
  "bincode 1.3.3",
  "qualifier_attr",
@@ -7032,9 +7066,9 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e54d03edadcb2f38bdb8b6524380a858f5ad51654db1f71eccc3fb5dc4d492"
+checksum = "df6d910a669a1093fef471ffec05e5c69e632a83788d13f7703ece5cba62db5b"
 dependencies = [
  "agave-feature-set",
  "solana-bpf-loader-program",
@@ -7051,9 +7085,9 @@ dependencies = [
 
 [[package]]
 name = "solana-builtins-default-costs"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a63b9b3ae7b09c32f7f15d83e875dbf8715d0853c2354e3306316158f19d9c90"
+checksum = "78a9b9bac7336baf78fcce234a76419940f2b2c0dc10f88aa0a7866a6eebffa7"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -7073,7 +7107,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -7088,9 +7122,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1770e5aeba2f5ec75b2d89031780c760dcf8352a061430f5e74eab1ad9f3b132"
+checksum = "508ef8407ce095d146830943bab8dccbbc6d581615e1de8d449565d16eae3aff"
 dependencies = [
  "solana-fee-structure",
  "solana-program-runtime",
@@ -7098,9 +7132,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-instruction"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ad15d715b0c4e21f6b591f126b7fa8070aadf0d75fcd89bc4c98afc9e5f8f6"
+checksum = "8d9fbc30be58ea9c93c153d48b6e3b7fb646d7c7492484837d43790c952decef"
 dependencies = [
  "agave-feature-set",
  "solana-borsh",
@@ -7128,9 +7162,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653943375fb64b11bcfda0c22280aa87f04902d2c25d0117e91f9788a31ed3db"
+checksum = "c7662ea666daafd5028d981671197d61bc9151e96326749a029bf69ae4cab139"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -7177,7 +7211,7 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-define-syscall 3.0.0",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7191,7 +7225,7 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-define-syscall 5.1.0",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7258,7 +7292,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -7274,7 +7308,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -7298,9 +7332,9 @@ dependencies = [
 
 [[package]]
 name = "solana-fee"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbffe004ec900267fc0bcf0c3b532c01905e6c4e3f318562718d1cdf6db939"
+checksum = "f6b05fdbd78318f6832af2a49d14b59799f4783ff3a307c4a25b50896b57b352"
 dependencies = [
  "agave-feature-set",
  "solana-fee-structure",
@@ -7316,7 +7350,7 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -7347,15 +7381,16 @@ dependencies = [
  "five8",
  "serde",
  "serde_derive",
+ "solana-atomic-u64",
  "solana-sanitize",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-hash-512"
-version = "1.2.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee9c987913768643be3f4fc5f8ec667e8ec19e59e6d131688ade8d1430dafe9"
+checksum = "7ce934b02bab639341f2fd62c3e7e3c39dcceb47f0196b7630ed1f82ecb704bd"
 
 [[package]]
 name = "solana-inflation"
@@ -7375,7 +7410,7 @@ dependencies = [
  "solana-define-syscall 5.1.0",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -7490,7 +7525,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -7520,7 +7555,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-system-interface 3.2.0",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -7563,7 +7598,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-transaction-error",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -7593,7 +7628,7 @@ dependencies = [
  "solana-hash",
  "solana-pubkey 4.2.0",
  "solana-sha256-hasher",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -7606,7 +7641,7 @@ dependencies = [
  "solana-hash",
  "solana-nonce",
  "solana-sdk-ids",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -7624,6 +7659,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7b49f68ccea949a6ea75f485dbe2e17cf4c1d894ed262371d584269359e1a0"
 dependencies = [
+ "borsh",
  "bytemuck",
 ]
 
@@ -7657,7 +7693,7 @@ dependencies = [
  "light-poseidon 0.2.0",
  "light-poseidon 0.4.0",
  "solana-define-syscall 4.0.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -7716,9 +7752,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0364032ca71f9be2ffab27791cd6535dbe9d2990da0e2346e99013a9bcb57f4"
+checksum = "99a3895314c34396758131a8af156944453ebe18e70d2a5cde67eec899df48a1"
 dependencies = [
  "base64",
  "bincode 1.3.3",
@@ -7757,7 +7793,8 @@ dependencies = [
  "solana-sysvar 4.1.0",
  "solana-sysvar-id",
  "solana-transaction-context",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
+ "wincode",
 ]
 
 [[package]]
@@ -7803,7 +7840,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -7814,15 +7851,16 @@ checksum = "dc553b782111862cd6c56bdeba696dcba9722a42154ef1248c5a06ca1d983797"
 dependencies = [
  "serde",
  "serde_derive",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-rpc-client"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849a4576002de8ba30ebb60aa4067b82643b23907be874786473736c616c24ec"
+checksum = "b8b6e398f6df7a0d260d5adb1bc705b267432647f6d63c1f9084cf43cf60330c"
 dependencies = [
+ "agave-votor-messages",
  "async-trait",
  "base64",
  "bincode 1.3.3",
@@ -7838,6 +7876,7 @@ dependencies = [
  "solana-account 4.3.1",
  "solana-account-decoder",
  "solana-account-decoder-client-types",
+ "solana-bls-signatures",
  "solana-clock",
  "solana-commitment-config",
  "solana-epoch-info",
@@ -7855,13 +7894,14 @@ dependencies = [
  "solana-version",
  "solana-vote-interface",
  "tokio",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147f376d3770f495f0bd9158467198cbb399c9a7395ea35ed587061a1a59e61d"
+checksum = "c6f007fc3629ffcda78189a82fee168322edc1c31cb0e792f468455c7bbe3153"
 dependencies = [
  "anyhow",
  "jsonrpc-core",
@@ -7874,14 +7914,14 @@ dependencies = [
  "solana-signer",
  "solana-transaction-error",
  "solana-transaction-status-client-types",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "solana-rpc-client-types"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae18406ee879a0d91da081313f591d1b3e1c370e010c63ee1b1a3741db88693e"
+checksum = "971b17e4f9371aecbf01846b0102f1cb1479da1d1bd98b67f9fd1b12e6ac591c"
 dependencies = [
  "base64",
  "bs58",
@@ -7899,7 +7939,30 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status-client-types",
  "solana-version",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "solana-runtime-transaction"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38332c9f4978f36ea3a6ada645c734b73796c8af16fdabebff35792b74150f7"
+dependencies = [
+ "agave-feature-set",
+ "agave-transaction-view",
+ "solana-compute-budget",
+ "solana-compute-budget-instruction",
+ "solana-hash",
+ "solana-message",
+ "solana-program-entrypoint",
+ "solana-pubkey 4.2.0",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-svm-transaction",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-transaction-error",
+ "wincode",
 ]
 
 [[package]]
@@ -7910,9 +7973,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f84c593fa3d4131045b606dec5acf9d8eac73791bc786ca9911057aec8f43ec"
+checksum = "d777d7a89267dd133e985113c7e7f820fb7cfd9123a4a350cf8b39ebae1920bc"
 dependencies = [
  "byteorder",
  "combine",
@@ -7921,7 +7984,7 @@ dependencies = [
  "log",
  "rand 0.8.7",
  "rustc-demangle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "winapi",
 ]
 
@@ -7968,7 +8031,7 @@ checksum = "e3a1ad3ed7846631c88c71c5d2f21a2ecb6b61da333d9be173b6b061b35609ae"
 dependencies = [
  "k256",
  "solana-define-syscall 5.1.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8052,7 +8115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8250a4495aad49ad20556a607da53bdcb20de78da10b65afbf918b7f1de647"
 dependencies = [
  "serde_core",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -8067,7 +8130,7 @@ dependencies = [
  "serde-big-array",
  "serde_derive",
  "solana-sanitize",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -8082,6 +8145,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-signer-store"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36329bba208f0e41954389ae4ad5d973fe15952672cfd71a9b49deb7d2ecbc2f"
+dependencies = [
+ "bitvec",
+ "num-derive",
+ "num-traits",
+]
+
+[[package]]
 name = "solana-slot-hashes"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8093,7 +8167,7 @@ dependencies = [
  "solana-hash",
  "solana-sdk-ids",
  "solana-sysvar-id",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -8108,7 +8182,7 @@ dependencies = [
  "solana-get-sysvar",
  "solana-sdk-ids",
  "solana-sysvar-id",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -8133,14 +8207,14 @@ dependencies = [
  "solana-get-sysvar",
  "solana-sdk-ids",
  "solana-sysvar-id",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-stake-interface"
-version = "3.1.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49eb5c77484214c3484921e2cdda79d185373118b5458c1b2df0f1a04c3bc30"
+checksum = "252b4291eb25a5a356149ed4d4a940d5f655186210fa84b5d0d8d55c3dd42a81"
 dependencies = [
  "num-traits",
  "serde",
@@ -8157,9 +8231,9 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-callback"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d50ab466a202b3ec768d0d1f808c570822b4d2492801772359b9509baf1e8c6"
+checksum = "3603ca4c273926155ace95887b30cd1e3918835737687bffa8a5d8749dcf0e91"
 dependencies = [
  "solana-account 4.3.1",
  "solana-clock",
@@ -8169,30 +8243,30 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-feature-set"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35320ec1b4460e2f748c9ebb6c42eb3069f8d85ec46a185ae9b5628430f3c606"
+checksum = "bda42b13c4748e47af89010e16a4391e1901be860beb93eedc0ccab66795fe50"
 
 [[package]]
 name = "solana-svm-log-collector"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ba1a825b27776f6a92fae44613d5e7f906f0c56e542bbbe1a6746eb168daff"
+checksum = "eec82e47b4ee1628f6f453f8ce8de5473458470fe60965e4d3be31fa82afdbea"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "solana-svm-measure"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ec9c705bec0fc99b9220e62fbae9fb0a297b9a95ff411badce934103a92ec7"
+checksum = "6b309b60870dc1821d363807cdd40097d52db1529aae04344f361995bb88b084"
 
 [[package]]
 name = "solana-svm-timings"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b72896172acdbce474662e876fdd413092893599156500cc68840abea649441"
+checksum = "44b30b0c61db8d711327c49ab2171984d564a93835ed77acb6aa2da0ecf434ba"
 dependencies = [
  "eager",
  "enum-iterator",
@@ -8201,9 +8275,9 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "4.1.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998e6d7d1197d29a77d3701ae273cfc3e95e79978546faa4d28af637ef5211e7"
+checksum = "736d2cec944c6f8f298a7bd8ada5eb318cca9ab859281b1300842fa0e9a25afa"
 dependencies = [
  "solana-hash",
  "solana-message",
@@ -8215,25 +8289,24 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-type-overrides"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128cad78148dbd90e61a0bdf54706a24c356e858d85f2674dd7755eac594a4df"
+checksum = "9b6cc834d4a01719767e68b9d30c33c4162b2d818afc084cf310715ea087e64f"
 dependencies = [
  "rand 0.9.5",
 ]
 
 [[package]]
 name = "solana-syscalls"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2788d359af16fac879c081bc0b725e8a200702156af92e75e2c18346fcde332"
+checksum = "6976ef46df8e2fd9ce7cc6396a6cf29bcc37c882def849e7d6bc48bd621c88f8"
 dependencies = [
  "bincode 1.3.3",
  "libsecp256k1",
  "num-traits",
  "solana-account 4.3.1",
  "solana-account-info",
- "solana-big-mod-exp",
  "solana-blake3-hasher",
  "solana-bls12-381-syscall",
  "solana-bn254",
@@ -8261,7 +8334,8 @@ dependencies = [
  "solana-sysvar 4.1.0",
  "solana-sysvar-id",
  "solana-transaction-context",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
+ "wincode",
 ]
 
 [[package]]
@@ -8292,14 +8366,14 @@ dependencies = [
  "solana-instruction",
  "solana-msg",
  "solana-program-error",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-system-program"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64154747d8e97a2ac1869e7633b9d5b8cac01d1ca99cf05f5910eb4b5718fbbc"
+checksum = "ba583e7a473426fab4c0b17fde848a6bb798b1ede5a14c4f13a3494a2e748fc6"
 dependencies = [
  "bincode 1.3.3",
  "log",
@@ -8383,7 +8457,7 @@ dependencies = [
  "solana-slot-history",
  "solana-stake-history",
  "solana-sysvar-id",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -8415,21 +8489,21 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-transaction-error",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-transaction-context"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffd061d881fb2c182078e6ca6094fe113e50edbec224c4f8999747eb643cd02"
+checksum = "855e7e2bf38f3a8e18c9dc1f2a4d2fd947f52c81f4e3b73077a3827582be6e03"
 dependencies = [
  "bincode 1.3.3",
  "qualifier_attr",
  "serde",
  "solana-account 4.3.1",
  "solana-instruction",
- "solana-instructions-sysvar 3.0.1",
+ "solana-instructions-sysvar 4.0.0",
  "solana-pubkey 4.2.0",
  "solana-rent 4.3.0",
  "solana-sbpf",
@@ -8450,9 +8524,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status-client-types"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5aafaae40f808411265e0de673c1dc2b8a68bf4ad4d38ba7e141d5232a5f23"
+checksum = "ffbd5a3d85ae247b69fa21578fdd9fbd965345390fddb60fe3586542e30ff98c"
 dependencies = [
  "base64",
  "bincode 1.3.3",
@@ -8468,15 +8542,15 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
- "thiserror 2.0.18",
- "wincode 0.5.5",
+ "thiserror 2.0.20",
+ "wincode",
 ]
 
 [[package]]
 name = "solana-version"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33921090d55beb8dcded76d80982dd4eb02c8bc8115bad8a9aeb901531c10df"
+checksum = "dcc9449982ced50bb21dc4ec401bb75db2e21880980b7c8506811d2ae473d130"
 dependencies = [
  "agave-feature-set",
  "rand 0.9.5",
@@ -8484,6 +8558,8 @@ dependencies = [
  "serde",
  "solana-sanitize",
  "solana-serde-varint",
+ "solana-wincode-varint",
+ "wincode",
 ]
 
 [[package]]
@@ -8514,9 +8590,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "4.1.2"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d772aa219b97b0cd9ec512c9330179714e3bb6231df4a8b81981b6c88f85f1"
+checksum = "7730ce2760d827ae57ef9b525edb5c65e046373c1a76a2f03d1bab70cbe4feec"
 dependencies = [
  "agave-feature-set",
  "bincode 1.3.3",
@@ -8540,6 +8616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-wincode-varint"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6679e72a01dcfe7ff180f0e9d3a0d165e4e9664426930014f2702e7571c259c7"
+dependencies = [
+ "wincode",
+]
+
+[[package]]
 name = "solana-zero-copy"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8551,10 +8636,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-zk-elgamal-proof-program"
-version = "4.1.2"
+name = "solana-zk-elgamal-proof-interface"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d841aa9791a275535f676c9403413c66da7c1bb1c867d3575b58f4e5b881ef"
+checksum = "d8da7f01db2148a1dc16261ff1dc6f3930a1e255a33cece4f1b56658694f27f7"
+dependencies = [
+ "bytemuck",
+ "bytemuck_derive",
+ "num-derive",
+ "num-traits",
+ "solana-address 2.6.1",
+ "solana-instruction",
+ "solana-sdk-ids",
+ "solana-zk-sdk-pod",
+]
+
+[[package]]
+name = "solana-zk-elgamal-proof-program"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ee19bc9c5f7700c6153ebc513f3bacc71645bd174f78b73f66c9acf6e9485"
 dependencies = [
  "bytemuck",
  "solana-instruction",
@@ -8596,7 +8697,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -8631,15 +8732,28 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zeroize",
 ]
 
 [[package]]
-name = "solana-zk-token-proof-program"
-version = "4.1.2"
+name = "solana-zk-sdk-pod"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4841d6e055847c84d011d187cbad022ea4f8832c85a61a1aa220c192bd4dfd0"
+checksum = "a800583b7a4cea3e851686af162cc6e4712eef97fa91dfa9aca2459b95c84777"
+dependencies = [
+ "base64",
+ "bytemuck",
+ "bytemuck_derive",
+ "solana-nullable",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "solana-zk-token-proof-program"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e81d7b076afb34121bb72f0d522cf4ff84a4adebd29ba0d73ae428299b60e5e"
 dependencies = [
  "solana-program-runtime",
 ]
@@ -8726,7 +8840,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-zero-copy",
  "solana-zk-sdk 4.0.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8753,8 +8867,8 @@ dependencies = [
  "solana-rent 3.1.0",
  "solana-sdk-ids",
  "solana-sysvar 3.1.1",
- "spl-token-interface",
- "thiserror 2.0.18",
+ "spl-token-interface 2.0.0",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8777,12 +8891,42 @@ dependencies = [
  "solana-sdk-ids",
  "solana-zk-sdk 4.0.0",
  "spl-pod",
- "spl-token-confidential-transfer-proof-extraction",
+ "spl-token-confidential-transfer-proof-extraction 0.5.1",
  "spl-token-confidential-transfer-proof-generation",
  "spl-token-group-interface",
- "spl-token-metadata-interface",
+ "spl-token-metadata-interface 0.8.0",
  "spl-type-length-value",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "spl-token-2022-interface"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821d96d034ea31c4965d182c742153c491ae0abee531331b55771086c5030d86"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "getrandom 0.2.17",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-account-info",
+ "solana-address 2.6.1",
+ "solana-instruction",
+ "solana-nullable",
+ "solana-program-error",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-sdk-ids",
+ "solana-zero-copy",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk-pod",
+ "spl-token-confidential-transfer-proof-extraction 0.6.1",
+ "spl-token-group-interface",
+ "spl-token-metadata-interface 1.0.1",
+ "spl-type-length-value",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8802,7 +8946,27 @@ dependencies = [
  "solana-sdk-ids",
  "solana-zk-sdk 4.0.0",
  "spl-pod",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "spl-token-confidential-transfer-proof-extraction"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a845ec724e807643a04f1d43439ee3571dd913848112ac76aa90b850eaf7c"
+dependencies = [
+ "bytemuck",
+ "solana-account-info",
+ "solana-address 2.6.1",
+ "solana-curve25519 4.0.1",
+ "solana-instruction",
+ "solana-instructions-sysvar 3.0.1",
+ "solana-msg",
+ "solana-program-error",
+ "solana-sdk-ids",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk-pod",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8813,7 +8977,7 @@ checksum = "a0cd59fce3dc00f563c6fa364d67c3f200d278eae681f4dc250240afcfe044b1"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-zk-sdk 4.0.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8832,7 +8996,7 @@ dependencies = [
  "solana-program-error",
  "solana-zero-copy",
  "spl-discriminator",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8852,7 +9016,27 @@ dependencies = [
  "solana-program-pack",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "spl-token-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7143c4e676984047a400e2fbd7ac29a1659f2b1b52b897cfde19316b562e4589"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8871,7 +9055,27 @@ dependencies = [
  "spl-discriminator",
  "spl-pod",
  "spl-type-length-value",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "spl-token-metadata-interface"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3d96f175e7022ff200464dfa75a3708a4e9b70c83c4ecd04fe52ee479f4fef"
+dependencies = [
+ "borsh",
+ "num-derive",
+ "num-traits",
+ "num_enum",
+ "solana-address 2.6.1",
+ "solana-borsh",
+ "solana-instruction",
+ "solana-nullable",
+ "solana-program-error",
+ "spl-discriminator",
+ "spl-type-length-value",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8888,7 +9092,7 @@ dependencies = [
  "solana-program-error",
  "solana-zero-copy",
  "spl-discriminator",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -8949,7 +9153,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9033,7 +9237,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "whoami",
 ]
@@ -9071,7 +9275,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "whoami",
 ]
@@ -9095,7 +9299,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
  "url",
 ]
@@ -9154,8 +9358,8 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 4.2.0",
- "thiserror 2.0.18",
- "wincode 0.5.5",
+ "thiserror 2.0.20",
+ "wincode",
  "zolana-account-checks",
  "zolana-hasher",
  "zolana-interface",
@@ -9172,7 +9376,7 @@ dependencies = [
  "serde_json",
  "solana-bn254",
  "swap-program",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zolana-transaction",
 ]
 
@@ -9190,7 +9394,7 @@ dependencies = [
  "solana-signature",
  "swap-program",
  "swap-prover",
- "wincode 0.5.5",
+ "wincode",
  "zolana-client",
  "zolana-hasher",
  "zolana-interface",
@@ -9253,6 +9457,17 @@ name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9323,11 +9538,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -9343,13 +9558,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -9408,8 +9623,8 @@ dependencies = [
  "light-program-profiler",
  "pinocchio 0.11.2",
  "solana-program-error",
- "thiserror 2.0.18",
- "wincode 0.5.5",
+ "thiserror 2.0.20",
+ "wincode",
  "zolana-account-checks",
  "zolana-hasher",
  "zolana-interface",
@@ -9424,7 +9639,7 @@ dependencies = [
  "num-bigint 0.4.8",
  "serde_json",
  "solana-bn254",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "timelock-escrow-program",
  "zolana-transaction",
 ]
@@ -9442,7 +9657,7 @@ dependencies = [
  "solana-signature",
  "timelock-escrow-program",
  "timelock-escrow-prover",
- "wincode 0.5.5",
+ "wincode",
  "zolana-hasher",
  "zolana-interface",
  "zolana-keypair",
@@ -9906,7 +10121,7 @@ dependencies = [
  "solana-address 2.6.1",
  "solana-instruction",
  "solana-pubkey 4.2.0",
- "wincode 0.5.5",
+ "wincode",
  "zolana-batched-merkle-tree",
  "zolana-client",
  "zolana-hasher",
@@ -10355,21 +10570,8 @@ dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
- "thiserror 2.0.18",
- "wincode-derive 0.4.6",
-]
-
-[[package]]
-name = "wincode"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d39d1a984eb7ae37afa348f058216d62a6d5f71640f4113a8114386c2a812a"
-dependencies = [
- "pastey",
- "proc-macro2",
- "quote",
- "thiserror 2.0.18",
- "wincode-derive 0.5.0",
+ "thiserror 2.0.20",
+ "wincode-derive",
 ]
 
 [[package]]
@@ -10377,18 +10579,6 @@ name = "wincode-derive"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15ab90b719560d0fda79c74550ad1c948d17b118765942838055ebaf34d67071"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "wincode-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb427b174d0f50b407f003623db1d892986e780651ee9d4231f3c9fe9ffcbb7"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -10788,7 +10978,7 @@ dependencies = [
  "protoc-bin-vendored",
  "siphasher",
  "solana-pubkey 4.2.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -10926,7 +11116,7 @@ dependencies = [
  "solana-address 2.6.1",
  "solana-msg",
  "solana-program-error",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -10958,8 +11148,8 @@ dependencies = [
  "solana-msg",
  "solana-program-error",
  "solana-sysvar 4.1.0",
- "thiserror 2.0.18",
- "wincode 0.5.5",
+ "thiserror 2.0.20",
+ "wincode",
  "zerocopy",
  "zolana-account-checks",
  "zolana-bloom-filter",
@@ -10979,7 +11169,7 @@ dependencies = [
  "rand 0.8.7",
  "solana-nostd-keccak",
  "solana-program-error",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zolana-hasher",
 ]
 
@@ -11042,7 +11232,7 @@ dependencies = [
  "solana-signer",
  "solana-transaction",
  "solana-transaction-status-client-types",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "zeroize",
  "zolana-api",
@@ -11060,7 +11250,7 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "solana-pubkey 4.2.0",
- "wincode 0.5.5",
+ "wincode",
 ]
 
 [[package]]
@@ -11079,7 +11269,7 @@ dependencies = [
  "sha3",
  "solana-program-error",
  "solana-pubkey 4.2.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -11089,7 +11279,7 @@ dependencies = [
  "num-bigint 0.4.8",
  "num-traits",
  "rand 0.8.7",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zolana-hasher",
 ]
 
@@ -11103,7 +11293,7 @@ dependencies = [
  "serde_json",
  "solana-pubkey 4.2.0",
  "solana-signature",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "utoipa",
 ]
 
@@ -11119,8 +11309,8 @@ dependencies = [
  "solana-instruction",
  "solana-program-error",
  "solana-pubkey 4.2.0",
- "thiserror 2.0.18",
- "wincode 0.5.5",
+ "thiserror 2.0.20",
+ "wincode",
  "zolana-batched-merkle-tree",
  "zolana-event",
  "zolana-hasher",
@@ -11150,7 +11340,7 @@ dependencies = [
  "solana-keypair",
  "solana-seed-phrase",
  "solana-signer",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "zeroize",
  "zolana-hasher",
@@ -11163,7 +11353,7 @@ dependencies = [
  "num-bigint 0.4.8",
  "num-traits",
  "rand 0.8.7",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zolana-hasher",
  "zolana-indexed-array",
 ]
@@ -11185,7 +11375,7 @@ dependencies = [
  "solana-signer",
  "solana-transaction",
  "solana-transaction-error",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zolana-client",
  "zolana-event",
  "zolana-hasher",
@@ -11212,7 +11402,7 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-signature",
  "solana-transaction-status-client-types",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zeroize",
  "zolana-client",
  "zolana-event",
@@ -11255,7 +11445,7 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-signature",
  "solana-signer",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tower",
  "tower-http 0.7.0",
@@ -11335,8 +11525,8 @@ dependencies = [
  "serde_json",
  "solana-address 2.6.1",
  "solana-signature",
- "thiserror 2.0.18",
- "wincode 0.5.5",
+ "thiserror 2.0.20",
+ "wincode",
  "zolana-event",
  "zolana-hasher",
  "zolana-interface",
@@ -11348,8 +11538,8 @@ name = "zolana-tree"
 version = "0.1.0"
 dependencies = [
  "pinocchio 0.11.2",
- "thiserror 2.0.18",
- "wincode 0.5.5",
+ "thiserror 2.0.20",
+ "wincode",
  "zolana-batched-merkle-tree",
  "zolana-hasher",
 ]
@@ -11362,7 +11552,7 @@ dependencies = [
  "pinocchio 0.11.2",
  "solana-address 2.6.1",
  "solana-msg",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "zolana-user-registry-interface",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,13 +103,13 @@ zolana-bloom-filter = { path = "program-libs/bloom-filter", version = "0.6.0" }
 zolana-hasher = { path = "program-libs/hasher", version = "5.0.0", default-features = false }
 zolana-indexed-array = { path = "program-libs/indexed-array", version = "0.3.0" }
 light-poseidon = "0.4.0"
-# Pinned to the head of the mollusk-0.14 PR (Lightprotocol/light-program-profiler#1).
+# Pinned to the head of the mollusk-0.15 branch (Lightprotocol/light-program-profiler).
 # Switch back to a released version once that lands upstream.
-light-program-profiler = { git = "https://github.com/Lightprotocol/light-program-profiler", rev = "8afb60d66842e5428e562d468a5e4a891c031cbf" }
+light-program-profiler = { git = "https://github.com/Lightprotocol/light-program-profiler", rev = "db49f3c801996a80e1cb7e4e92b13a694e962b65" }
 light-sparse-merkle-tree = "0.3.0"
 
-# Mollusk test harness. Tracks the workspace's agave 4.1 wire crates.
-mollusk-svm = "0.14.0"
+# Mollusk test harness. Tracks the workspace's agave 4.2 wire crates.
+mollusk-svm = "0.15.0"
 
 # Solana and SPL.
 anchor-lang = "1.1"
@@ -132,7 +132,7 @@ solana-cpi = "3.1"
 solana-curve25519 = "4.0"
 solana-derivation-path = "3.0.0"
 solana-epoch-info = "3.1"
-# Pin solana-hash to 4.5.0: the agave 4.1 graph (agave-feature-set,
+# Pin solana-hash to 4.5.0: the agave 4.2 graph (agave-feature-set,
 # solana-message, solana-transaction) is built against 4.5.x; letting it float
 # duplicates the crate with types the rest of the graph does not share.
 solana-hash = "=4.5.0"
@@ -148,7 +148,7 @@ solana-program-pack = "3.1"
 solana-pubkey = { version = "4.2", features = ["curve25519"] }
 solana-rent = "4.2"
 # Pin solana-reward-info to 6.2.0: 6.3.0 pulls in wincode 0.6.0, which conflicts
-# with the wincode 0.5.x used by the rest of the agave 4.1 graph.
+# with the wincode 0.5.x used by the rest of the agave 4.2 graph.
 solana-reward-info = "=6.2.0"
 solana-rpc-client = "4.1"
 solana-rpc-client-api = "4.1"
@@ -207,7 +207,7 @@ jsonwebtoken = "10.4.0"
 jsonrpsee = { version = "0.26.0", features = ["server", "macros"] }
 lazy_static = "1.5.0"
 log = "0.4"
-litesvm = "0.15"
+litesvm = "0.16"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
 once_cell = "1.21.4"

--- a/cli/release-artifacts.lock
+++ b/cli/release-artifacts.lock
@@ -59,6 +59,6 @@
     }
   ],
   "release_tag": "v0.1.0-alpha.3",
-  "surfpool_tag": "v1.1.1-light",
-  "surfpool_version": "1.1.1"
+  "surfpool_tag": "v1.5.0-light",
+  "surfpool_version": "1.5.0"
 }

--- a/justfile
+++ b/justfile
@@ -3,8 +3,8 @@ set dotenv-load
 
 export RUST_BACKTRACE := env_var_or_default("RUST_BACKTRACE", "0")
 sbf-tools-version := env_var_or_default("SBF_TOOLS_VERSION", "v1.54")
-surfpool-release-tag := env_var_or_default("SURFPOOL_RELEASE_TAG", "v1.1.1-light")
-surfpool-version := env_var_or_default("SURFPOOL_VERSION", "1.1.1")
+surfpool-release-tag := env_var_or_default("SURFPOOL_RELEASE_TAG", "v1.5.0-light")
+surfpool-version := env_var_or_default("SURFPOOL_VERSION", "1.5.0")
 # Per-clone port isolation: set ZOLANA_PORT_OFFSET in a local (gitignored) .env
 # (auto-loaded above) to shift every service port by a fixed amount so concurrent
 # checkouts never contend. Each individual port/URL var can still be overridden

--- a/program-tests/shielded-pool/tests/dispatch/functional.rs
+++ b/program-tests/shielded-pool/tests/dispatch/functional.rs
@@ -4,7 +4,6 @@ use solana_pubkey::Pubkey;
 use zolana_interface::instruction::tag;
 
 use shielded_pool_tests::support::runtime::program_test;
-use zolana_program_test::ZolanaProgramTest;
 
 #[test]
 fn direct_emit_event_is_a_noop_and_is_not_indexed() {
@@ -44,8 +43,8 @@ fn direct_emit_event_leaves_attached_writable_accounts_untouched() {
             },
         )
         .expect("write program-owned account");
-    let system_owned_before = observable_state(&mut rpc, &system_owned);
-    let program_owned_before = observable_state(&mut rpc, &program_owned);
+    let system_owned_before = rpc.svm.get_account(&system_owned).expect("account");
+    let program_owned_before = rpc.svm.get_account(&program_owned).expect("account");
 
     let outcome = rpc
         .create_and_send_default_payer_transaction(
@@ -62,25 +61,18 @@ fn direct_emit_event_leaves_attached_writable_accounts_untouched() {
         .expect("emit-event with writable accounts");
     assert!(outcome.events.is_empty());
     assert_eq!(
-        observable_state(&mut rpc, &system_owned),
-        system_owned_before,
+        rpc.svm.get_account(&system_owned),
+        Some(system_owned_before),
         "system-owned account must be untouched"
     );
     assert_eq!(
-        observable_state(&mut rpc, &program_owned),
-        program_owned_before,
+        rpc.svm.get_account(&program_owned),
+        Some(Account {
+            rent_epoch: u64::MAX,
+            ..program_owned_before
+        }),
         "program-owned account must be untouched"
     );
-}
-
-fn observable_state(rpc: &mut ZolanaProgramTest, address: &Pubkey) -> (u64, Vec<u8>, Pubkey, bool) {
-    let account = rpc.svm.get_account(address).expect("account");
-    (
-        account.lamports,
-        account.data,
-        account.owner,
-        account.executable,
-    )
 }
 
 /// INV-EMIT-EVENT-02: every payload byte string after the tag is accepted --

--- a/program-tests/shielded-pool/tests/dispatch/functional.rs
+++ b/program-tests/shielded-pool/tests/dispatch/functional.rs
@@ -4,6 +4,7 @@ use solana_pubkey::Pubkey;
 use zolana_interface::instruction::tag;
 
 use shielded_pool_tests::support::runtime::program_test;
+use zolana_program_test::ZolanaProgramTest;
 
 #[test]
 fn direct_emit_event_is_a_noop_and_is_not_indexed() {
@@ -43,8 +44,8 @@ fn direct_emit_event_leaves_attached_writable_accounts_untouched() {
             },
         )
         .expect("write program-owned account");
-    let system_owned_before = rpc.svm.get_account(&system_owned).expect("account");
-    let program_owned_before = rpc.svm.get_account(&program_owned).expect("account");
+    let system_owned_before = observable_state(&mut rpc, &system_owned);
+    let program_owned_before = observable_state(&mut rpc, &program_owned);
 
     let outcome = rpc
         .create_and_send_default_payer_transaction(
@@ -61,15 +62,25 @@ fn direct_emit_event_leaves_attached_writable_accounts_untouched() {
         .expect("emit-event with writable accounts");
     assert!(outcome.events.is_empty());
     assert_eq!(
-        rpc.svm.get_account(&system_owned),
-        Some(system_owned_before),
+        observable_state(&mut rpc, &system_owned),
+        system_owned_before,
         "system-owned account must be untouched"
     );
     assert_eq!(
-        rpc.svm.get_account(&program_owned),
-        Some(program_owned_before),
+        observable_state(&mut rpc, &program_owned),
+        program_owned_before,
         "program-owned account must be untouched"
     );
+}
+
+fn observable_state(rpc: &mut ZolanaProgramTest, address: &Pubkey) -> (u64, Vec<u8>, Pubkey, bool) {
+    let account = rpc.svm.get_account(address).expect("account");
+    (
+        account.lamports,
+        account.data,
+        account.owner,
+        account.executable,
+    )
 }
 
 /// INV-EMIT-EVENT-02: every payload byte string after the tag is accepted --


### PR DESCRIPTION
## Summary

- surfpool localnet backend: `v1.1.1-light` -> `v1.5.0-light` (justfile defaults and `cli/release-artifacts.lock`; `just install-surfpool` verified the binary reports `surfpool 1.5.0`).
- litesvm `0.15` -> `0.16`. It pins the agave 4.2 crates, so the agave graph moves from 4.1.2 to 4.2.1 across the lockfile.
- mollusk-svm `0.14` -> `0.15` (tracks agave 4.2) and light-program-profiler pinned to its `mollusk-0.15` branch (`db49f3c`), the same port against the new mollusk.
- litesvm 0.16 now mirrors agave's account loader and stamps writable rent-exempt accounts with `RENT_EXEMPT_RENT_EPOCH` (`u64::MAX`); the EmitEvent frame test expects that value on the seeded program-owned account.

No program source or program dependency changes.

## Testing

- `just check-all`, `just clippy`
- `just test-hermetic` (all suites green)
- `just install-surfpool`
