### PR TITLE
chore: link explorer urls to orbmarkets

### DIFF
--- a/custom-rings/cli/src/status.rs
+++ b/custom-rings/cli/src/status.rs
@@ -13,7 +13,7 @@ use crate::{
     Context,
 };
 
-const EXPLORER: &str = "https://explorer.solana.com/address";
+const EXPLORER: &str = "https://orbmarkets.io/address";
 
 #[derive(Debug, Error)]
 pub enum StatusError {
@@ -200,12 +200,12 @@ ring_rpc = "r"
         let mut config: RingConfig = toml::from_str(TOML).expect("parse");
         assert_eq!(
             explorer_link(&config),
-            "https://explorer.solana.com/address/11111111111111111111111111111111?cluster=devnet"
+            "https://orbmarkets.io/address/11111111111111111111111111111111?cluster=devnet"
         );
         config.target = Target::Localnet;
         assert_eq!(
             explorer_link(&config),
-            "https://explorer.solana.com/address/11111111111111111111111111111111?cluster=custom&customUrl=http%3A%2F%2F127.0.0.1%3A8899"
+            "https://orbmarkets.io/address/11111111111111111111111111111111?cluster=custom&customUrl=http%3A%2F%2F127.0.0.1%3A8899"
         );
     }
 }

--- a/tools/cli_smoke.sh
+++ b/tools/cli_smoke.sh
@@ -76,7 +76,7 @@ LAST_OUT=""
 ts() { date +%H:%M:%S; }
 log()  { printf '%s  %s\n'      "$(ts)" "$*"; }
 info() { printf '%s  ..   %s\n' "$(ts)" "$*"; }
-xurl() { printf 'https://explorer.solana.com/tx/%s?cluster=%s' "$1" "$CLUSTER"; }
+xurl() { printf 'https://orbmarkets.io/tx/%s?cluster=%s' "$1" "$CLUSTER"; }
 
 # kv <key> — extract the value of key=<value> from LAST_OUT (first match).
 kv() { sed -n "s/.*[[:space:]]$1=\([^[:space:]]*\).*/\1/p" <<<"$LAST_OUT" | head -n1; }

--- a/tools/deploy-devnet.sh
+++ b/tools/deploy-devnet.sh
@@ -116,6 +116,6 @@ for target in $targets; do
     fi
 
     deploy_with_retry "$so_path" "$pid_arg"
-    echo "Deployed $target to https://explorer.solana.com/address/$pid?cluster=devnet"
+    echo "Deployed $target to https://orbmarkets.io/address/$pid?cluster=devnet"
     echo
 done


### PR DESCRIPTION
Point the explorer links the ring CLI and the deploy scripts print at orbmarkets.

- `custom-rings/cli/src/status.rs` builds its address link from `https://orbmarkets.io/address`, and the test pinning the devnet and localnet strings moves with it.
- `tools/deploy-devnet.sh` prints the deployed program address at orbmarkets.
- `tools/cli_smoke.sh` prints transaction links at orbmarkets.

The localnet link keeps the `cluster=custom&customUrl=` query it had. That convention is Solana Explorer's, and whether orbmarkets honours it is unverified, so click one localnet link before merging.