### PR TITLE
photon: add getRegisteredAssets

### DIFF
--- a/sdk-libs/indexer-api/src/lib.rs
+++ b/sdk-libs/indexer-api/src/lib.rs
@@ -20,6 +20,7 @@ pub const GET_SHIELDED_TRANSACTIONS_BY_NULLIFIERS: &str = "getShieldedTransactio
 pub const GET_MERKLE_PROOFS: &str = "getMerkleProofs";
 pub const GET_NON_INCLUSION_PROOFS: &str = "getNonInclusionProofs";
 pub const GET_NULLIFIER_QUEUE_ELEMENTS: &str = "getNullifierQueueElements";
+pub const GET_REGISTERED_ASSETS: &str = "getRegisteredAssets";
 
 const MAX_BASE58_32_LEN: usize = 44;
 const LIMIT_EXPECTATION: &str = "a value between 1 and 1000";
@@ -42,6 +43,7 @@ pub mod method {
     pub struct GetMerkleProofs;
     pub struct GetNonInclusionProofs;
     pub struct GetNullifierQueueElements;
+    pub struct GetRegisteredAssets;
 
     impl RpcMethod for GetEncryptedUtxosByTags {
         const NAME: &'static str = GET_ENCRYPTED_UTXOS_BY_TAGS;
@@ -83,6 +85,12 @@ pub mod method {
         const NAME: &'static str = GET_NULLIFIER_QUEUE_ELEMENTS;
         type Request = GetNullifierQueueElementsRequest;
         type Response = GetNullifierQueueElementsResponse;
+    }
+
+    impl RpcMethod for GetRegisteredAssets {
+        const NAME: &'static str = GET_REGISTERED_ASSETS;
+        type Request = GetRegisteredAssetsRequest;
+        type Response = GetRegisteredAssetsResponse;
     }
 }
 
@@ -756,6 +764,30 @@ pub struct NonInclusionProof {
     pub root_index: u16,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct GetRegisteredAssetsRequest {}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct RegisteredAsset {
+    pub mint: SerializablePubkey,
+    pub asset_id: u64,
+}
+
+/// SPL asset registry for the shielded pool, plus SOL (assetId 1). Same list for
+/// Default Ring and Custom Rings. context.slot is the indexer-persisted slot,
+/// not the getProgramAccounts tip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct GetRegisteredAssetsResponse {
+    pub context: Context,
+    pub assets: Vec<RegisteredAsset>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -779,6 +811,22 @@ mod tests {
             method::GetShieldedTransactionsBySignature::NAME,
             "getShieldedTransactionsBySignature"
         );
+        assert_eq!(method::GetRegisteredAssets::NAME, "getRegisteredAssets");
+    }
+
+    #[test]
+    fn get_registered_assets_request_accepts_empty_object() {
+        let request = serde_json::from_str::<GetRegisteredAssetsRequest>("{}").unwrap();
+        assert_eq!(request, GetRegisteredAssetsRequest {});
+    }
+
+    #[test]
+    fn get_registered_assets_request_rejects_ring_program_id() {
+        let err = serde_json::from_str::<GetRegisteredAssetsRequest>(
+            r#"{"ringProgramId":"11111111111111111111111111111111"}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("ringProgramId"));
     }
 
     #[test]

--- a/services/photon/src/api/method/rings.rs
+++ b/services/photon/src/api/method/rings.rs
@@ -3,6 +3,7 @@ mod get_encrypted_utxos_by_tags;
 mod get_merkle_proofs;
 mod get_non_inclusion_proofs;
 mod get_nullifier_queue_elements;
+mod get_registered_assets;
 mod get_shielded_transactions_by_signature;
 mod get_shielded_transactions_by_tags;
 
@@ -10,6 +11,7 @@ pub use get_encrypted_utxos_by_tags::get_encrypted_utxos_by_tags;
 pub use get_merkle_proofs::get_merkle_proofs;
 pub use get_non_inclusion_proofs::get_non_inclusion_proofs;
 pub use get_nullifier_queue_elements::get_nullifier_queue_elements;
+pub use get_registered_assets::get_registered_assets;
 pub use get_shielded_transactions_by_signature::get_shielded_transactions_by_signature;
 pub use get_shielded_transactions_by_tags::get_shielded_transactions_by_nullifiers;
 pub use get_shielded_transactions_by_tags::get_shielded_transactions_by_tags;

--- a/services/photon/src/api/method/rings/get_registered_assets.rs
+++ b/services/photon/src/api/method/rings/get_registered_assets.rs
@@ -1,0 +1,258 @@
+use std::collections::HashSet;
+
+use sea_orm::DatabaseConnection;
+use solana_account::Account;
+use solana_pubkey::Pubkey;
+use zolana_indexer_api::{GetRegisteredAssetsResponse, RegisteredAsset, SerializablePubkey};
+use zolana_interface::{pda, state::SplAssetRegistry};
+
+use crate::api::error::PhotonApiError;
+use crate::common::indexer_context::extract as extract_context;
+use crate::rpc::RpcClient;
+
+const MAX_REGISTERED_ASSET_ACCOUNTS: usize = 4096; // parity with ring-rpc audit.rs MAX_ASSET_REGISTRY_ACCOUNTS
+const SOL_ASSET_ID: u64 = 1;
+const SOL_MINT: [u8; 32] = [0u8; 32];
+// Matches `SOL_ASSET_ID` / `SOL_MINT` in sdk-libs/transaction/src/wallet/asset.rs.
+
+fn sol_asset() -> RegisteredAsset {
+    RegisteredAsset {
+        mint: SerializablePubkey::from(SOL_MINT),
+        asset_id: SOL_ASSET_ID,
+    }
+}
+
+fn assets_from_accounts(
+    accounts: Vec<(Pubkey, Account)>,
+) -> Result<Vec<RegisteredAsset>, PhotonApiError> {
+    if accounts.len() > MAX_REGISTERED_ASSET_ACCOUNTS {
+        return Err(PhotonApiError::UnexpectedError(
+            "asset registry response is too large".to_string(),
+        ));
+    }
+
+    let program_id = pda::shielded_pool_program_id();
+    let mut seen_ids = HashSet::new();
+    let mut seen_mints = HashSet::new();
+    let mut assets = Vec::new();
+
+    for (_pubkey, account) in accounts {
+        if account.owner != program_id {
+            continue;
+        }
+        let Ok(registry) = SplAssetRegistry::from_account_bytes(&account.data) else {
+            continue;
+        };
+        if registry.asset_id < 2 {
+            continue;
+        }
+        let mint = registry.mint.to_bytes();
+        if mint == SOL_MINT {
+            continue;
+        }
+        if seen_ids.contains(&registry.asset_id) || seen_mints.contains(&mint) {
+            continue;
+        }
+        seen_ids.insert(registry.asset_id);
+        seen_mints.insert(mint);
+        assets.push(RegisteredAsset {
+            mint: SerializablePubkey::from(mint),
+            asset_id: registry.asset_id,
+        });
+    }
+
+    assets.sort_by_key(|asset| asset.asset_id);
+    assets.insert(0, sol_asset());
+    Ok(assets)
+}
+
+pub async fn get_registered_assets(
+    conn: &DatabaseConnection,
+    rpc: &RpcClient,
+) -> Result<GetRegisteredAssetsResponse, PhotonApiError> {
+    let context = extract_context(conn).await?;
+    let accounts = rpc
+        .get_spl_asset_registry_accounts(&pda::shielded_pool_program_id())
+        .await
+        .map_err(|error| PhotonApiError::UnexpectedError(format!("RPC error: {error}")))?;
+    Ok(GetRegisteredAssetsResponse {
+        context,
+        assets: assets_from_accounts(accounts)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        thread::JoinHandle,
+    };
+
+    use super::*;
+    use crate::dao::generated::blocks;
+    use crate::migration::RingsMigrator;
+    use sea_orm::{Database, DatabaseConnection, EntityTrait, Set};
+    use sea_orm_migration::MigratorTrait;
+    use zolana_interface::state::discriminator::SPL_ASSET_REGISTRY;
+
+    fn serve_once(status: &str, body: &str) -> (String, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let response = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 4096];
+            let _ = stream.read(&mut request).unwrap();
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        (format!("http://{address}"), handle)
+    }
+
+    fn registry_data(mint: [u8; 32], asset_id: u64) -> Vec<u8> {
+        let mut data = vec![0u8; SplAssetRegistry::SIZE];
+        data[0] = SPL_ASSET_REGISTRY;
+        data[8..40].copy_from_slice(&mint);
+        data[40..48].copy_from_slice(&asset_id.to_le_bytes());
+        data
+    }
+
+    fn account(data: Vec<u8>, owner: Pubkey) -> Account {
+        Account {
+            lamports: 1,
+            data,
+            owner,
+            executable: false,
+            rent_epoch: 0,
+        }
+    }
+
+    fn registry_account(mint: [u8; 32], asset_id: u64) -> (Pubkey, Account) {
+        (
+            Pubkey::new_unique(),
+            account(
+                registry_data(mint, asset_id),
+                pda::shielded_pool_program_id(),
+            ),
+        )
+    }
+
+    async fn setup_indexed() -> DatabaseConnection {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        RingsMigrator::up(&db, None).await.unwrap();
+        blocks::Entity::insert(blocks::ActiveModel {
+            slot: Set(7),
+            parent_slot: Set(0),
+            parent_blockhash: Set(vec![0; 32]),
+            blockhash: Set(vec![1; 32]),
+            block_height: Set(1),
+            block_time: Set(1),
+        })
+        .exec(&db)
+        .await
+        .unwrap();
+        db
+    }
+
+    #[test]
+    fn assets_from_accounts_empty_is_sol_only() {
+        assert_eq!(assets_from_accounts(Vec::new()).unwrap(), vec![sol_asset()]);
+    }
+
+    #[test]
+    fn assets_from_accounts_keeps_one_valid_row() {
+        let mint = [2u8; 32];
+        let assets = assets_from_accounts(vec![registry_account(mint, 2)]).unwrap();
+        assert_eq!(
+            assets,
+            vec![
+                sol_asset(),
+                RegisteredAsset {
+                    mint: SerializablePubkey::from(mint),
+                    asset_id: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn assets_from_accounts_skips_bad_discriminator() {
+        let mut data = registry_data([2u8; 32], 2);
+        data[0] = 1;
+        let accounts = vec![(
+            Pubkey::new_unique(),
+            account(data, pda::shielded_pool_program_id()),
+        )];
+        assert_eq!(assets_from_accounts(accounts).unwrap(), vec![sol_asset()]);
+    }
+
+    #[test]
+    fn assets_from_accounts_skips_reserved_sol_id() {
+        let assets = assets_from_accounts(vec![registry_account([2u8; 32], 1)]).unwrap();
+        assert_eq!(assets, vec![sol_asset()]);
+    }
+
+    #[test]
+    fn assets_from_accounts_keeps_first_duplicate_asset_id() {
+        let first = [3u8; 32];
+        let second = [4u8; 32];
+        let assets = assets_from_accounts(vec![
+            registry_account(first, 5),
+            registry_account(second, 5),
+        ])
+        .unwrap();
+        assert_eq!(
+            assets,
+            vec![
+                sol_asset(),
+                RegisteredAsset {
+                    mint: SerializablePubkey::from(first),
+                    asset_id: 5,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn assets_from_accounts_rejects_over_cap() {
+        let accounts = (0..=MAX_REGISTERED_ASSET_ACCOUNTS)
+            .map(|_| registry_account([2u8; 32], 2))
+            .collect();
+        let error = assets_from_accounts(accounts).unwrap_err();
+        assert!(matches!(
+            error,
+            PhotonApiError::UnexpectedError(message)
+                if message == "asset registry response is too large"
+        ));
+    }
+
+    #[tokio::test]
+    async fn get_registered_assets_returns_sol_when_gpa_empty() {
+        let db = setup_indexed().await;
+        let (url, server) = serve_once("200 OK", r#"{"jsonrpc":"2.0","id":1,"result":[]}"#);
+        let response = get_registered_assets(&db, &RpcClient::new(url))
+            .await
+            .unwrap();
+        server.join().unwrap();
+
+        assert_eq!(response.context.slot, 7);
+        assert_eq!(response.assets, vec![sol_asset()]);
+    }
+
+    #[tokio::test]
+    async fn get_registered_assets_errors_when_unindexed() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+        RingsMigrator::up(&db, None).await.unwrap();
+        let error = get_registered_assets(&db, &RpcClient::new("http://127.0.0.1:1".to_string()))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            PhotonApiError::RecordNotFound(message) if message == "No data has been indexed"
+        ));
+    }
+}

--- a/services/photon/src/api/rpc_server.rs
+++ b/services/photon/src/api/rpc_server.rs
@@ -11,10 +11,10 @@ use tower_http::cors::{Any, CorsLayer};
 use zolana_indexer_api::{
     method::{
         GetEncryptedUtxosByTags, GetMerkleProofs, GetNonInclusionProofs, GetNullifierQueueElements,
-        GetShieldedTransactionsByNullifiers, GetShieldedTransactionsBySignature,
-        GetShieldedTransactionsByTags,
+        GetRegisteredAssets, GetShieldedTransactionsByNullifiers,
+        GetShieldedTransactionsBySignature, GetShieldedTransactionsByTags,
     },
-    RpcMethod,
+    GetRegisteredAssetsRequest, RpcMethod,
 };
 
 use super::service::PhotonApi;
@@ -165,6 +165,17 @@ fn build_rpc_module(api_and_indexer: PhotonApi) -> Result<RpcModule<PhotonApi>, 
         },
     )?;
 
+    module.register_async_method(
+        GetRegisteredAssets::NAME,
+        |rpc_params, rpc_context, _extensions| async move {
+            let api = rpc_context.as_ref();
+            let _request: GetRegisteredAssetsRequest = rpc_params.parse()?;
+            api.get_registered_assets()
+                .await
+                .map_err(ErrorObjectOwned::from)
+        },
+    )?;
+
     Ok(module)
 }
 
@@ -190,6 +201,7 @@ mod tests {
         assert!(methods.contains(&"getMerkleProofs"));
         assert!(methods.contains(&"getNonInclusionProofs"));
         assert!(methods.contains(&"getNullifierQueueElements"));
+        assert!(methods.contains(&"getRegisteredAssets"));
     }
 
     async fn test_api() -> PhotonApi {

--- a/services/photon/src/api/service.rs
+++ b/services/photon/src/api/service.rs
@@ -8,14 +8,15 @@ use utoipa::PartialSchema;
 use zolana_indexer_api::{
     method::{
         GetEncryptedUtxosByTags, GetMerkleProofs, GetNonInclusionProofs, GetNullifierQueueElements,
-        GetShieldedTransactionsByNullifiers, GetShieldedTransactionsBySignature,
-        GetShieldedTransactionsByTags,
+        GetRegisteredAssets, GetShieldedTransactionsByNullifiers,
+        GetShieldedTransactionsBySignature, GetShieldedTransactionsByTags,
     },
     GetEncryptedUtxosByTagsResponse, GetMerkleProofsRequest, GetMerkleProofsResponse,
     GetNonInclusionProofsRequest, GetNonInclusionProofsResponse, GetNullifierQueueElementsRequest,
-    GetNullifierQueueElementsResponse, GetRingsByNullifiersRequest, GetRingsByTagsRequest,
-    GetShieldedTransactionsByNullifiersResponse, GetShieldedTransactionsBySignatureRequest,
-    GetShieldedTransactionsBySignatureResponse, GetShieldedTransactionsByTagsResponse, RpcMethod,
+    GetNullifierQueueElementsResponse, GetRegisteredAssetsResponse, GetRingsByNullifiersRequest,
+    GetRingsByTagsRequest, GetShieldedTransactionsByNullifiersResponse,
+    GetShieldedTransactionsBySignatureRequest, GetShieldedTransactionsBySignatureResponse,
+    GetShieldedTransactionsByTagsResponse, RpcMethod,
 };
 
 use super::{
@@ -25,8 +26,9 @@ use super::{
         get_indexer_slot::get_indexer_slot,
         rings::{
             get_encrypted_utxos_by_tags, get_merkle_proofs, get_non_inclusion_proofs,
-            get_nullifier_queue_elements, get_shielded_transactions_by_nullifiers,
-            get_shielded_transactions_by_signature, get_shielded_transactions_by_tags,
+            get_nullifier_queue_elements, get_registered_assets,
+            get_shielded_transactions_by_nullifiers, get_shielded_transactions_by_signature,
+            get_shielded_transactions_by_tags,
         },
     },
 };
@@ -155,6 +157,12 @@ impl PhotonApi {
         get_nullifier_queue_elements(self.db_conn.as_ref(), request).await
     }
 
+    pub async fn get_registered_assets(
+        &self,
+    ) -> Result<GetRegisteredAssetsResponse, PhotonApiError> {
+        get_registered_assets(self.db_conn.as_ref(), &self.rpc_client).await
+    }
+
     pub fn rings_method_api_specs() -> Vec<OpenApiSpec> {
         vec![
             method_api_spec::<GetEncryptedUtxosByTags>(),
@@ -164,6 +172,7 @@ impl PhotonApi {
             method_api_spec::<GetMerkleProofs>(),
             method_api_spec::<GetNonInclusionProofs>(),
             method_api_spec::<GetNullifierQueueElements>(),
+            method_api_spec::<GetRegisteredAssets>(),
         ]
     }
 }

--- a/services/photon/src/openapi/mod.rs
+++ b/services/photon/src/openapi/mod.rs
@@ -9,11 +9,12 @@ use zolana_indexer_api::{
     Base64String, Context, EncryptedUtxoMatch, GetEncryptedUtxosByTagsResponse,
     GetMerkleProofsRequest, GetMerkleProofsResponse, GetNonInclusionProofsRequest,
     GetNonInclusionProofsResponse, GetNullifierQueueElementsRequest,
-    GetNullifierQueueElementsResponse, GetRingsByTagsRequest,
-    GetShieldedTransactionsBySignatureRequest, GetShieldedTransactionsBySignatureResponse,
-    GetShieldedTransactionsByTagsResponse, Hash, IndexedShieldedTransaction, Limit, MerkleContext,
-    MerkleProof, NonInclusionProof, NullifierQueueElement, RingsMessage, RingsOutputContext,
-    RingsOutputSlot, SerializablePubkey, SerializableSignature, ShieldedTransaction,
+    GetNullifierQueueElementsResponse, GetRegisteredAssetsRequest, GetRegisteredAssetsResponse,
+    GetRingsByTagsRequest, GetShieldedTransactionsBySignatureRequest,
+    GetShieldedTransactionsBySignatureResponse, GetShieldedTransactionsByTagsResponse, Hash,
+    IndexedShieldedTransaction, Limit, MerkleContext, MerkleProof, NonInclusionProof,
+    NullifierQueueElement, RegisteredAsset, RingsMessage, RingsOutputContext, RingsOutputSlot,
+    SerializablePubkey, SerializableSignature, ShieldedTransaction,
 };
 
 use crate::common::relative_project_path;
@@ -68,6 +69,9 @@ const RINGS_API_TEST_SPEC_FILE: &str = "rings.test.yaml";
     NonInclusionProof,
     GetNullifierQueueElementsRequest,
     GetNullifierQueueElementsResponse,
+    GetRegisteredAssetsRequest,
+    RegisteredAsset,
+    GetRegisteredAssetsResponse,
     NullifierQueueElement,
 )))]
 struct ApiDoc;

--- a/services/photon/src/openapi/specs/rings.yaml
+++ b/services/photon/src/openapi/specs/rings.yaml
@@ -515,6 +515,120 @@ paths:
                     type: string
                   jsonrpc:
                     type: string
+  /getRegisteredAssets:
+    summary: getRegisteredAssets
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - jsonrpc
+              - id
+              - method
+              - params
+              properties:
+                id:
+                  type: string
+                  description: An ID to identify the request.
+                  enum:
+                  - test-account
+                jsonrpc:
+                  type: string
+                  description: The version of the JSON-RPC protocol.
+                  enum:
+                  - '2.0'
+                method:
+                  type: string
+                  description: The name of the method to invoke.
+                  enum:
+                  - getRegisteredAssets
+                params:
+                  type: object
+                  additionalProperties: false
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - jsonrpc
+                - id
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: integer
+                      message:
+                        type: string
+                  id:
+                    type: string
+                    description: An ID to identify the response.
+                    enum:
+                    - test-account
+                  jsonrpc:
+                    type: string
+                    description: The version of the JSON-RPC protocol.
+                    enum:
+                    - '2.0'
+                  result:
+                    type: object
+                    description: |-
+                      SPL asset registry for the shielded pool, plus SOL (assetId 1). Same list for
+                      Default Ring and Custom Rings. context.slot is the indexer-persisted slot,
+                      not the getProgramAccounts tip.
+                    required:
+                    - context
+                    - assets
+                    properties:
+                      assets:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/RegisteredAsset'
+                      context:
+                        $ref: '#/components/schemas/Context'
+                    additionalProperties: false
+        '429':
+          description: Exceeded rate limit.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: integer
+                      message:
+                        type: string
+                  id:
+                    type: string
+                  jsonrpc:
+                    type: string
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: integer
+                      message:
+                        type: string
+                  id:
+                    type: string
+                  jsonrpc:
+                    type: string
   /getShieldedTransactionsByNullifiers:
     summary: getShieldedTransactionsByNullifiers
     post:
@@ -1089,6 +1203,19 @@ components:
           minimum: 0
         value:
           $ref: '#/components/schemas/Hash'
+      additionalProperties: false
+    RegisteredAsset:
+      type: object
+      required:
+      - mint
+      - assetId
+      properties:
+        assetId:
+          type: integer
+          format: u-int64
+          minimum: 0
+        mint:
+          $ref: '#/components/schemas/SerializablePubkey'
       additionalProperties: false
     RingsMessage:
       type: object

--- a/services/photon/src/rpc.rs
+++ b/services/photon/src/rpc.rs
@@ -147,15 +147,20 @@ impl RpcClient {
                 json!([program_id.to_string(), account_config()]),
             )
             .await?;
-        accounts
-            .into_iter()
-            .map(|item| {
-                let pubkey = Pubkey::from_str(&item.pubkey).map_err(|error| {
-                    RpcError::InvalidAccount(format!("invalid pubkey {}: {error}", item.pubkey))
-                })?;
-                Ok((pubkey, item.account.decode()?))
-            })
-            .collect()
+        decode_program_accounts(accounts)
+    }
+
+    pub async fn get_spl_asset_registry_accounts(
+        &self,
+        program_id: &Pubkey,
+    ) -> Result<Vec<(Pubkey, Account)>, RpcError> {
+        let accounts: Vec<ProgramAccount> = self
+            .call(
+                "getProgramAccounts",
+                spl_asset_registry_gpa_params(program_id),
+            )
+            .await?;
+        decode_program_accounts(accounts)
     }
 
     async fn call<T>(&self, method: &'static str, params: Value) -> Result<T, RpcError>
@@ -219,11 +224,39 @@ impl EncodedAccount {
     }
 }
 
+fn decode_program_accounts(
+    accounts: Vec<ProgramAccount>,
+) -> Result<Vec<(Pubkey, Account)>, RpcError> {
+    accounts
+        .into_iter()
+        .map(|item| {
+            let pubkey = Pubkey::from_str(&item.pubkey).map_err(|error| {
+                RpcError::InvalidAccount(format!("invalid pubkey {}: {error}", item.pubkey))
+            })?;
+            Ok((pubkey, item.account.decode()?))
+        })
+        .collect()
+}
+
 fn account_config() -> Value {
     json!({
         "commitment": "confirmed",
         "encoding": "base64",
     })
+}
+
+fn spl_asset_registry_gpa_params(program_id: &Pubkey) -> Value {
+    json!([
+        program_id.to_string(),
+        {
+            "commitment": "confirmed",
+            "encoding": "base64",
+            "filters": [
+                { "dataSize": 48 },
+                { "memcmp": { "offset": 0, "bytes": "BQ==", "encoding": "base64" } }
+            ]
+        }
+    ])
 }
 
 fn block_params(slot: u64, transaction_details: TransactionDetails) -> Value {
@@ -344,5 +377,60 @@ mod tests {
                 "transactionDetails": "full",
             }])
         );
+    }
+
+    #[test]
+    fn get_spl_asset_registry_accounts_request_matches_wire_format() {
+        let program = Pubkey::from([9; 32]);
+        assert_eq!(
+            spl_asset_registry_gpa_params(&program),
+            json!([
+                program.to_string(),
+                {
+                    "commitment": "confirmed",
+                    "encoding": "base64",
+                    "filters": [
+                        { "dataSize": 48 },
+                        { "memcmp": { "offset": 0, "bytes": "BQ==", "encoding": "base64" } }
+                    ]
+                }
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn get_spl_asset_registry_accounts_decodes_one_account() {
+        let owner = Pubkey::from([3; 32]);
+        let pubkey = Pubkey::from([4; 32]);
+        let data = BASE64.encode([5u8; 48]);
+        let body = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"result":[{{"pubkey":"{pubkey}","account":{{"lamports":1,"data":["{data}","base64"],"owner":"{owner}","executable":false,"rentEpoch":0}}}}]}}"#,
+        );
+        let (url, server) = serve_once("200 OK", &body);
+        let accounts = RpcClient::new(url)
+            .get_spl_asset_registry_accounts(&Pubkey::from([9; 32]))
+            .await
+            .unwrap();
+        server.join().unwrap();
+
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0].0, pubkey);
+        assert_eq!(accounts[0].1.data, vec![5u8; 48]);
+        assert_eq!(accounts[0].1.owner, owner);
+    }
+
+    #[tokio::test]
+    async fn get_spl_asset_registry_accounts_preserves_method_not_found() {
+        let (url, server) = serve_once(
+            "200 OK",
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"Method not found"}}"#,
+        );
+        let error = RpcClient::new(url)
+            .get_spl_asset_registry_accounts(&Pubkey::from([9; 32]))
+            .await
+            .unwrap_err();
+        server.join().unwrap();
+
+        assert_eq!(error.response_code(), Some(-32601));
     }
 }

--- a/services/photon/tests/integration_tests/open_api_tests.rs
+++ b/services/photon/tests/integration_tests/open_api_tests.rs
@@ -1,11 +1,12 @@
 use photon_indexer::openapi::update_docs;
 use utoipa::openapi::{OpenApi, RefOr, Required};
 
-const METHODS: [&str; 7] = [
+const METHODS: [&str; 8] = [
     "getEncryptedUtxosByTags",
     "getMerkleProofs",
     "getNonInclusionProofs",
     "getNullifierQueueElements",
+    "getRegisteredAssets",
     "getShieldedTransactionsByNullifiers",
     "getShieldedTransactionsBySignature",
     "getShieldedTransactionsByTags",


### PR DESCRIPTION
## Summary
- Add Photon's `getRegisteredAssets` JSON-RPC method: empty `params`, returns `{ context, assets }` with SOL (`assetId` 1) first, then parsed `SplAssetRegistry` rows.
- Uses filtered `getProgramAccounts` (`dataSize` 48 + discriminator memcmp). The list is protocol-wide; there is no `ringProgramId` field.

## Test plan
- [x] `cargo test -p zolana-indexer-api method_markers_have_canonical_names`
- [x] `cargo test -p zolana-indexer-api get_registered_assets_request`
- [x] `cargo test -p photon-indexer get_spl_asset_registry_accounts`
- [x] `cargo test -p photon-indexer get_registered_assets`
- [x] `cargo test -p photon-indexer registers_only_rings_product_methods`
- [x] `cargo test -p photon-indexer --test integration_tests test_documentation_generation`