### PR TITLE
Fix merge replay dependency order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3896,7 +3896,7 @@
     },
     "sdk-libs/ts": {
       "name": "@heliuslabs/zolana",
-      "version": "0.1.5-alpha",
+      "version": "0.1.6-alpha",
       "license": "Apache-2.0",
       "dependencies": {
         "@lightprotocol/hasher.rs": "^0.2.1",

--- a/sdk-libs/transaction/src/wallet/sync.rs
+++ b/sdk-libs/transaction/src/wallet/sync.rs
@@ -37,7 +37,7 @@ use crate::{
 pub(super) struct TxIndex {
     pub(super) sender_sites: HashMap<ViewTag, Vec<usize>>,
     pub(super) recipient_sites: HashMap<ViewTag, Vec<(usize, usize)>>,
-    pub(super) merge_sites: Vec<(usize, usize)>,
+    pub(super) merge_sites: HashMap<ViewTag, Vec<(usize, usize)>>,
 }
 
 /// A merge publishes no per-transaction encryption material: no
@@ -52,15 +52,15 @@ impl TxIndex {
     pub(super) fn build(transactions: &[ShieldedTransaction], report: &mut SyncReport) -> Self {
         let mut sender_sites: HashMap<ViewTag, Vec<usize>> = HashMap::new();
         let mut recipient_sites: HashMap<ViewTag, Vec<(usize, usize)>> = HashMap::new();
-        let mut merge_sites = Vec::new();
+        let mut merge_sites: HashMap<ViewTag, Vec<(usize, usize)>> = HashMap::new();
         for (t, tx) in transactions.iter().enumerate() {
             let mut classified = false;
             if is_merge_site(tx) {
-                // Merge outputs carry no ciphertext payload and are discovered
-                // by spent nullifier, independently of their output view tag.
                 for (slot_index, slot) in tx.output_slots.iter().enumerate() {
-                    let _ = slot;
-                    merge_sites.push((t, slot_index));
+                    merge_sites
+                        .entry(slot.view_tag)
+                        .or_default()
+                        .push((t, slot_index));
                     classified = true;
                 }
                 if !classified {
@@ -119,6 +119,12 @@ impl TxIndex {
 pub(super) struct SlotOutcome {
     pub(super) sender: Option<P256Pubkey>,
     pub(super) recipients: Vec<P256Pubkey>,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum MergeResolution {
+    Complete,
+    Pending,
 }
 
 pub(super) struct SyncCtx<'a> {
@@ -502,32 +508,45 @@ impl SyncCtx<'_> {
         Ok(())
     }
 
-    /// A merge output carries no ciphertext, so it is reconstructed from the
-    /// spent inputs and the published first nullifier — both keyed off the
-    /// nullifier secret. No viewing key takes part, which is why merge sites
-    /// have their own entry point rather than passing an unused key through
-    /// [`Self::decode_slot`].
-    ///
-    /// Returns nothing: a reconstructed merge names no counterparty, so there is
-    /// no [`SlotOutcome`] for a caller to fold into `known_senders` /
-    /// `known_recipients`.
-    pub(super) fn decode_merge_site(
+    fn decode_merge_site(
         &mut self,
         transactions: &[ShieldedTransaction],
         site: (usize, usize),
-    ) -> Result<(), TransactionError> {
+    ) -> Result<MergeResolution, TransactionError> {
         if self.processed_slots.contains(&site) {
-            return Ok(());
+            return Ok(MergeResolution::Complete);
         }
         let Some(tx) = transactions.get(site.0) else {
             self.report.undecryptable_candidates += 1;
-            return Ok(());
+            return Ok(MergeResolution::Complete);
         };
         if tx.output_slots.get(site.1).is_none() || !is_merge_site(tx) {
             self.report.undecryptable_candidates += 1;
-            return Ok(());
+            return Ok(MergeResolution::Complete);
         }
-        self.reconstruct_merge(tx, site)?;
+        self.reconstruct_merge(tx, site)
+    }
+
+    fn resolve_merge_sites(
+        &mut self,
+        transactions: &[ShieldedTransaction],
+        sites: &[(usize, usize)],
+    ) -> Result<(), TransactionError> {
+        let mut pending = sites.to_vec();
+        while !pending.is_empty() {
+            let pending_count = pending.len();
+            let mut unresolved = Vec::new();
+            for site in pending {
+                if self.decode_merge_site(transactions, site)? == MergeResolution::Pending {
+                    unresolved.push(site);
+                }
+            }
+            if unresolved.len() == pending_count {
+                self.report.undecryptable_candidates += unresolved.len();
+                break;
+            }
+            pending = unresolved;
+        }
         Ok(())
     }
 
@@ -555,9 +574,6 @@ impl SyncCtx<'_> {
             self.report.undecryptable_candidates += 1;
             return Ok(outcome);
         };
-        if is_merge_site(tx) {
-            return self.reconstruct_merge(tx, site);
-        }
         let Some(output_data) = slot.output_data() else {
             self.report.undecryptable_candidates += 1;
             return Ok(outcome);
@@ -805,24 +821,21 @@ impl SyncCtx<'_> {
         &mut self,
         tx: &ShieldedTransaction,
         site: (usize, usize),
-    ) -> Result<SlotOutcome, TransactionError> {
-        let outcome = SlotOutcome::default();
+    ) -> Result<MergeResolution, TransactionError> {
         let Some(slot) = tx.output_slots.get(site.1) else {
             self.report.undecryptable_candidates += 1;
-            return Ok(outcome);
+            return Ok(MergeResolution::Complete);
         };
         let output_context = slot.output_context.clone();
 
         let Some(first_nullifier) = tx.nullifiers.first() else {
-            self.report.undecryptable_candidates += 1;
-            return Ok(outcome);
+            return Ok(MergeResolution::Pending);
         };
         // The first nullifier must be one of ours: it both confirms the merge
         // is this wallet's and seeds the deterministic dummy/output
         // derivations (keyed by the owner's nullifier secret).
         if !self.utxos.iter().any(|u| &u.nullifier == first_nullifier) {
-            self.report.undecryptable_candidates += 1;
-            return Ok(outcome);
+            return Ok(MergeResolution::Pending);
         }
 
         // Match this wallet's spent inputs in slot order; deterministic dummy
@@ -834,8 +847,7 @@ impl SyncCtx<'_> {
                 continue;
             }
             let Some(wallet_utxo) = self.utxos.iter().find(|u| &u.nullifier == nullifier) else {
-                self.report.undecryptable_candidates += 1;
-                return Ok(outcome);
+                return Ok(MergeResolution::Pending);
             };
             matched.push((
                 wallet_utxo.utxo.asset,
@@ -846,11 +858,11 @@ impl SyncCtx<'_> {
         }
         let Some(&(asset, _, _, ring_program_id)) = matched.first() else {
             self.report.undecryptable_candidates += 1;
-            return Ok(outcome);
+            return Ok(MergeResolution::Complete);
         };
         if matched.iter().any(|m| m.0 != asset) {
             self.report.undecryptable_candidates += 1;
-            return Ok(outcome);
+            return Ok(MergeResolution::Complete);
         }
         let mut amount = 0u64;
         for m in &matched {
@@ -863,7 +875,7 @@ impl SyncCtx<'_> {
         let ring_data_hash: Option<[u8; 32]> = if ring_program_id.is_some() {
             let Ok(hash) = <&[u8; 32]>::try_from(slot.payload.as_slice()) else {
                 self.report.undecryptable_candidates += 1;
-                return Ok(outcome);
+                return Ok(MergeResolution::Complete);
             };
             Some(*hash)
         } else {
@@ -881,7 +893,7 @@ impl SyncCtx<'_> {
             self.processed_slots.insert(site);
             self.record_merge(tx, &output_context, &utxo);
         }
-        Ok(outcome)
+        Ok(MergeResolution::Complete)
     }
 }
 
@@ -1047,10 +1059,6 @@ impl Wallet {
             report,
         };
 
-        for site in &index.merge_sites {
-            ctx.decode_merge_site(transactions, *site)?;
-        }
-
         for entry in self.viewing_key_history.iter_mut() {
             let ViewingKeyEntry {
                 viewing_pubkey,
@@ -1078,11 +1086,7 @@ impl Wallet {
                     }
                 }
             }
-            // Confidential default-ring scan: a confidential output is tagged by the
-            // owner signing pubkey, so the owner's own change, received recipient
-            // slots, and merge outputs all live in `recipient_sites` under that tag.
-            // A split bundle the wallet created is tagged the same way and sits in
-            // `sender_sites`, decoded at slot 0.
+            // Confidential default-ring outputs use the owner signing tag.
             if let Some(sites) = index.recipient_sites.get(&owner_tag) {
                 for site in sites {
                     ctx.decode_slot(transactions, key, assets, *site)?;
@@ -1166,6 +1170,10 @@ impl Wallet {
                     known_recipients.insert(recipient, m + 1);
                 }
             }
+        }
+
+        if let Some(sites) = index.merge_sites.get(&owner_tag) {
+            ctx.resolve_merge_sites(transactions, sites)?;
         }
 
         let report = ctx.report;

--- a/sdk-libs/transaction/tests/wallet_unified.rs
+++ b/sdk-libs/transaction/tests/wallet_unified.rs
@@ -5,7 +5,14 @@ use common::{
 };
 #[cfg(feature = "parallel")]
 use zolana_transaction::PrivateTransactionDirection;
-use zolana_transaction::{Address, AssetRegistry, KeypairWalletAuthority, Wallet};
+use zolana_transaction::{
+    instructions::{
+        merge::{merge_dummy_nullifier, merge_output_blinding, MERGE_INPUTS},
+        transact::SENDER_SLOT_COUNT,
+    },
+    Address, AssetRegistry, Data, KeypairWalletAuthority, OutputContext, OutputSlot,
+    ShieldedTransaction, Utxo, Wallet, SOL_MINT,
+};
 
 const WINDOW: u64 = 8;
 
@@ -56,6 +63,129 @@ fn sync_stores_unified_change_and_recipient_utxos() {
             .collect::<Vec<_>>(),
         vec![recipient_utxo]
     );
+}
+
+#[test]
+fn fresh_sync_resolves_merge_dependencies() {
+    let assets = AssetRegistry::default();
+    let alice = keypair_from_index(2);
+    let bob = keypair_from_index(3);
+    let mut counter = 0u64;
+
+    let (mut funding, _, input) = build_unified_transfer(
+        &assets,
+        UnifiedTransferSpec {
+            sender: &bob,
+            recipient: &alice,
+            amount: 42,
+            change_amount: 1,
+            first_nullifier: unique_nullifier(&mut counter),
+            blinding: unique31(&mut counter, 0x03),
+            change_blinding: unique31(&mut counter, 0x04),
+        },
+    );
+    funding.slot = 1;
+    let input_context = &funding.output_slots[SENDER_SLOT_COUNT].output_context;
+    let nullifier_key = &alice.nullifier_key;
+    let nullifier_pk = nullifier_key.pubkey().unwrap();
+    let first_nullifier = input.nullifier(&input_context.hash, nullifier_key).unwrap();
+    let output = Utxo {
+        owner: alice.signing_pubkey(),
+        asset: SOL_MINT,
+        amount: input.amount,
+        blinding: merge_output_blinding(nullifier_key, &first_nullifier).unwrap(),
+        ring_program_id: None,
+        data: Data::default(),
+    };
+    let mut nullifiers = vec![first_nullifier];
+    nullifiers.extend(
+        (1..MERGE_INPUTS).map(|slot| {
+            merge_dummy_nullifier(nullifier_key, &first_nullifier, slot as u8).unwrap()
+        }),
+    );
+    let merge = ShieldedTransaction {
+        slot: 2,
+        tx_signature: solana_signature::Signature::default(),
+        tx_viewing_pk: None,
+        salt: None,
+        output_slots: vec![OutputSlot {
+            view_tag: alice.signing_pubkey().confidential_view_tag().unwrap(),
+            output_context: OutputContext {
+                hash: output.hash(&nullifier_pk, &[0; 32], &[0; 32]).unwrap(),
+                tree: Address::default(),
+                leaf_index: 2,
+            },
+            payload: Vec::new(),
+        }],
+        messages: Vec::new(),
+        nullifiers,
+        proofless: false,
+    };
+    let merge_context = &merge.output_slots[0].output_context;
+    let chained_nullifier = output
+        .nullifier(&merge_context.hash, nullifier_key)
+        .unwrap();
+    let chained_output = Utxo {
+        owner: alice.signing_pubkey(),
+        asset: SOL_MINT,
+        amount: output.amount,
+        blinding: merge_output_blinding(nullifier_key, &chained_nullifier).unwrap(),
+        ring_program_id: None,
+        data: Data::default(),
+    };
+    let mut chained_nullifiers = vec![chained_nullifier];
+    chained_nullifiers.extend(
+        (1..MERGE_INPUTS).map(|slot| {
+            merge_dummy_nullifier(nullifier_key, &chained_nullifier, slot as u8).unwrap()
+        }),
+    );
+    let chained_merge = ShieldedTransaction {
+        slot: 3,
+        tx_signature: solana_signature::Signature::default(),
+        tx_viewing_pk: None,
+        salt: None,
+        output_slots: vec![OutputSlot {
+            view_tag: alice.signing_pubkey().confidential_view_tag().unwrap(),
+            output_context: OutputContext {
+                hash: chained_output
+                    .hash(&nullifier_pk, &[0; 32], &[0; 32])
+                    .unwrap(),
+                tree: Address::default(),
+                leaf_index: 3,
+            },
+            payload: Vec::new(),
+        }],
+        messages: Vec::new(),
+        nullifiers: chained_nullifiers,
+        proofless: false,
+    };
+    let authority = KeypairWalletAuthority::new(Address::default(), &alice);
+
+    let mut fresh = Wallet::new(alice.shielded_address().unwrap(), assets.clone()).unwrap();
+    let report = fresh
+        .sync(
+            &authority,
+            &[funding.clone(), chained_merge.clone(), merge.clone()],
+            1,
+            WINDOW,
+        )
+        .unwrap();
+    assert_eq!(report.stored_utxos, 3);
+    assert_eq!(report.undecryptable_candidates, 0);
+    assert_eq!(fresh.balance(SOL_MINT, None).unwrap().amount, 42);
+
+    let mut incremental = Wallet::new(alice.shielded_address().unwrap(), assets).unwrap();
+    incremental
+        .sync(&authority, std::slice::from_ref(&funding), 1, WINDOW)
+        .unwrap();
+    incremental
+        .sync(&authority, std::slice::from_ref(&merge), 1, WINDOW)
+        .unwrap();
+    incremental
+        .sync(&authority, std::slice::from_ref(&chained_merge), 1, WINDOW)
+        .unwrap();
+    assert_eq!(incremental.balance(SOL_MINT, None).unwrap().amount, 42);
+    assert_eq!(fresh.utxos, incremental.utxos);
 }
 
 /// The confidential rail through both scan strategies.

--- a/sdk-libs/ts/AGENTS.md
+++ b/sdk-libs/ts/AGENTS.md
@@ -118,8 +118,8 @@ a defect.
 
 ## Concurrency and reservations
 
-- Note selection and reservation form one synchronous state transition.
-  Concurrent builds on one wallet MUST NOT select the same note.
+- UTXO selection and reservation form one synchronous state transition.
+  Concurrent builds on one wallet MUST NOT select the same UTXO.
 - Every failure after reservation MUST release it in `finally` or the owning
   error boundary. Success retains it until confirmation, sync-observed spend,
   explicit cancellation, or documented expiry.

--- a/sdk-libs/ts/CHANGELOG-RULES.md
+++ b/sdk-libs/ts/CHANGELOG-RULES.md
@@ -64,11 +64,11 @@ time`) when the version is published, else with the bump commit date.
 
 Ring holdings move out of the pool balances into their own view, and one
 transaction moves value out of a ring back to the pool. Selection covers
-a fragmented balance with the fewest notes.
+a fragmented balance with the fewest UTXOs.
 
 Breaking
 
-- `Wallet.balances()` no longer counts notes locked to a custom ring →
+- `Wallet.balances()` no longer counts UTXOs locked to a custom ring →
   call `Wallet.ringBalances()` for ring holdings.
 
 Added
@@ -80,12 +80,12 @@ Added
 
 Changed
 
-- Ring transfers pick the largest notes first, a balance split across many
-  small notes covers a payment with the fewest inputs.
+- Ring transfers pick the largest UTXOs first, a balance split across many
+  small UTXOs covers a payment with the fewest inputs.
 
 Fixed
 
-- A transfer funded by notes of more than one owner built a proof the
+- A transfer funded by UTXOs of more than one owner built a proof the
   chain rejects, the proof carries every owner's signature slot (#312).
 
 Dependencies

--- a/sdk-libs/ts/CHANGELOG.md
+++ b/sdk-libs/ts/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
-## 0.1.5-alpha — unreleased
+## 0.1.6-alpha — unreleased
+
+Wallet replay keeps merge outputs when their inputs arrive in the same sync.
+Selection and approval text use UTXO terminology without changing version 3 snapshot keys.
+
+Changed
+
+- `buildRingEntryTransaction`, `buildRingTransferTransaction`, and
+  `buildRingExitTransaction` use UTXO terminology in approval summaries, while
+  version 3 `SerializedWalletState` reservation field names remain unchanged.
+
+Fixed
+
+- `decryptTransactions` no longer omits a merge when its inputs arrive in the
+  same sync because merge dependencies resolve before wallet commit.
+
+## 0.1.5-alpha — 2026-09-01
 
 Wallet sync is atomic, and serialized wallets carry the cursors needed to
 resume after a restart. Keys granted by a wallet authority live only
@@ -21,15 +37,15 @@ Breaking
 - `serializeWallet` writes `SerializedWalletState` version 3 with sync
   cursors → state saved by version 2 still loads, and its first sync
   rescans history once.
-- Private transfers and withdrawals spend the largest UTXOs first and at
-  most five UTXOs → a balance that covers only with more UTXOs is
+- Private transfers and withdrawals spend the largest notes first and at
+  most five notes → a balance that covers only with more notes is
   refused with `WALLET_TOO_MANY_INPUTS`, merge first.
 - A wrapped wallet or ring error surfaces the outer operation code instead
   of the inner code → match on `causeCode` for the inner reason, selection
   and balance codes included.
-- A build reserves its selected UTXOs for two minutes, concurrent builds
-  on one wallet cannot spend the same UTXO → rebuild an unsent transaction
-  after the reservation expires, a failed build releases its UTXOs at
+- A build reserves its selected notes for two minutes, concurrent builds
+  on one wallet cannot spend the same note → rebuild an unsent transaction
+  after the reservation expires, a failed build releases its notes at
   once, and `WALLET_NOTE_RESERVED` refuses a named input another build
   holds.
 - `HasherWasmError` is removed, hashing failures surface through
@@ -56,7 +72,7 @@ Breaking
 Added
 
 - `buildRingEntryTransaction(params)` moves an exact amount from default
-  UTXOs into the caller's custom ring, leaves excess input value in the
+  notes into the caller's custom ring, leaves excess input value in the
   default pool, and records the boundary move as a `ringEntry` self transfer.
 - `fetchAssetMetadata`, `AssetMetadataCache`, `formatAmount`, and
   `parseAmount` provide mint decimals and exact raw unit conversion for SOL,
@@ -104,8 +120,8 @@ Added
   `InterfaceError`, and `KeypairError`, and `causeCodes` lists the wrapped
   operation chain outermost first.
 - `SerializedCursor`, `SerializedSyncCursors`, and `SerializedNoteReservation`
-  expose resume points and active UTXO holds in `SerializedWalletState`, a
-  restored wallet resumes scans and blocks spending reserved UTXOs.
+  expose resume points and active note holds in `SerializedWalletState`, a
+  restored wallet resumes scans and blocks spending reserved notes.
 - `ChainReader`, `BlockhashProvider`, `IndexerReader`, `ProofReader`,
   `Prover`, `TransactionConfirmer`, and `KitRpcAccess` name the client's
   capabilities, `ZolanaClient` implements them all, and a consumer can
@@ -132,8 +148,6 @@ Added
 
 Changed
 
-- Selection, reservation, and ring approval text uses UTXO terminology.
-  Version 3 reservation field names stay unchanged for snapshot compatibility.
 - Two `syncWallet` calls on one `Wallet` run one after the other, and a
   sync overtaken by another writer fails with
   `TRANSACTION_WALLET_STATE_STALE` instead of overwriting the newer state.
@@ -142,7 +156,7 @@ Changed
 - Every builder compiles through one shared path with the packet-size
   check built in, a compile failure in any build surfaces
   `CLIENT_TRANSACTION_ASSEMBLY`.
-- Every rail selects UTXOs through one selector with the rail's own
+- Every rail selects notes through one selector with the rail's own
   ordering and caps, and `WALLET_INSUFFICIENT_BALANCE` reports the full
   spendable balance instead of a partial running sum.
 - `WalletError`, `RingError`, and `InterfaceError` strip secret-named keys
@@ -151,17 +165,14 @@ Changed
 
 Fixed
 
-- A fresh wallet replay could inspect a merge before its same-batch inputs
-  and permanently omit the merged UTXO. Sync now resolves merge dependencies
-  after ordinary outputs and reaches the same state as incremental sync.
 - A sync holding an asset the registry could not resolve still committed
-  its cursors and skipped the unstored UTXO for good, it now fails with
+  its cursors and skipped the unstored note for good, it now fails with
   `WALLET_UNRESOLVED_ASSET` and the next sync re-reads the same pages.
 - `RingRpc` returned unchecked response strings as typed addresses and
   signatures, every such field is now validated and a malformed one is
   refused with `RING_RPC`.
 - A sync that failed partway had advanced its resume cursors past rows it
-  never stored, losing those UTXOs for good, rows and cursors now commit
+  never stored, losing those notes for good, rows and cursors now commit
   together and a failed sync leaves the wallet untouched.
 - A private transfer, withdrawal, or split kept its spend key and every
   per-input key copy in memory after building, all of them are wiped once

--- a/sdk-libs/ts/CHANGELOG.md
+++ b/sdk-libs/ts/CHANGELOG.md
@@ -21,15 +21,15 @@ Breaking
 - `serializeWallet` writes `SerializedWalletState` version 3 with sync
   cursors → state saved by version 2 still loads, and its first sync
   rescans history once.
-- Private transfers and withdrawals spend the largest notes first and at
-  most five notes → a balance that covers only with more notes is
+- Private transfers and withdrawals spend the largest UTXOs first and at
+  most five UTXOs → a balance that covers only with more UTXOs is
   refused with `WALLET_TOO_MANY_INPUTS`, merge first.
 - A wrapped wallet or ring error surfaces the outer operation code instead
   of the inner code → match on `causeCode` for the inner reason, selection
   and balance codes included.
-- A build reserves its selected notes for two minutes, concurrent builds
-  on one wallet cannot spend the same note → rebuild an unsent transaction
-  after the reservation expires, a failed build releases its notes at
+- A build reserves its selected UTXOs for two minutes, concurrent builds
+  on one wallet cannot spend the same UTXO → rebuild an unsent transaction
+  after the reservation expires, a failed build releases its UTXOs at
   once, and `WALLET_NOTE_RESERVED` refuses a named input another build
   holds.
 - `HasherWasmError` is removed, hashing failures surface through
@@ -56,7 +56,7 @@ Breaking
 Added
 
 - `buildRingEntryTransaction(params)` moves an exact amount from default
-  notes into the caller's custom ring, leaves excess input value in the
+  UTXOs into the caller's custom ring, leaves excess input value in the
   default pool, and records the boundary move as a `ringEntry` self transfer.
 - `fetchAssetMetadata`, `AssetMetadataCache`, `formatAmount`, and
   `parseAmount` provide mint decimals and exact raw unit conversion for SOL,
@@ -104,8 +104,8 @@ Added
   `InterfaceError`, and `KeypairError`, and `causeCodes` lists the wrapped
   operation chain outermost first.
 - `SerializedCursor`, `SerializedSyncCursors`, and `SerializedNoteReservation`
-  expose resume points and active note holds in `SerializedWalletState`, a
-  restored wallet resumes scans and blocks spending reserved notes.
+  expose resume points and active UTXO holds in `SerializedWalletState`, a
+  restored wallet resumes scans and blocks spending reserved UTXOs.
 - `ChainReader`, `BlockhashProvider`, `IndexerReader`, `ProofReader`,
   `Prover`, `TransactionConfirmer`, and `KitRpcAccess` name the client's
   capabilities, `ZolanaClient` implements them all, and a consumer can
@@ -132,6 +132,8 @@ Added
 
 Changed
 
+- Selection, reservation, and ring approval text uses UTXO terminology.
+  Version 3 reservation field names stay unchanged for snapshot compatibility.
 - Two `syncWallet` calls on one `Wallet` run one after the other, and a
   sync overtaken by another writer fails with
   `TRANSACTION_WALLET_STATE_STALE` instead of overwriting the newer state.
@@ -140,7 +142,7 @@ Changed
 - Every builder compiles through one shared path with the packet-size
   check built in, a compile failure in any build surfaces
   `CLIENT_TRANSACTION_ASSEMBLY`.
-- Every rail selects notes through one selector with the rail's own
+- Every rail selects UTXOs through one selector with the rail's own
   ordering and caps, and `WALLET_INSUFFICIENT_BALANCE` reports the full
   spendable balance instead of a partial running sum.
 - `WalletError`, `RingError`, and `InterfaceError` strip secret-named keys
@@ -150,16 +152,16 @@ Changed
 Fixed
 
 - A fresh wallet replay could inspect a merge before its same-batch inputs
-  and permanently omit the merged note. Sync now resolves merge dependencies
+  and permanently omit the merged UTXO. Sync now resolves merge dependencies
   after ordinary outputs and reaches the same state as incremental sync.
 - A sync holding an asset the registry could not resolve still committed
-  its cursors and skipped the unstored note for good, it now fails with
+  its cursors and skipped the unstored UTXO for good, it now fails with
   `WALLET_UNRESOLVED_ASSET` and the next sync re-reads the same pages.
 - `RingRpc` returned unchecked response strings as typed addresses and
   signatures, every such field is now validated and a malformed one is
   refused with `RING_RPC`.
 - A sync that failed partway had advanced its resume cursors past rows it
-  never stored, losing those notes for good, rows and cursors now commit
+  never stored, losing those UTXOs for good, rows and cursors now commit
   together and a failed sync leaves the wallet untouched.
 - A private transfer, withdrawal, or split kept its spend key and every
   per-input key copy in memory after building, all of them are wiped once

--- a/sdk-libs/ts/CHANGELOG.md
+++ b/sdk-libs/ts/CHANGELOG.md
@@ -149,6 +149,9 @@ Changed
 
 Fixed
 
+- A fresh wallet replay could inspect a merge before its same-batch inputs
+  and permanently omit the merged note. Sync now resolves merge dependencies
+  after ordinary outputs and reaches the same state as incremental sync.
 - A sync holding an asset the registry could not resolve still committed
   its cursors and skipped the unstored note for good, it now fails with
   `WALLET_UNRESOLVED_ASSET` and the next sync re-reads the same pages.

--- a/sdk-libs/ts/package.json
+++ b/sdk-libs/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heliuslabs/zolana",
-  "version": "0.1.5-alpha",
+  "version": "0.1.6-alpha",
   "description": "TypeScript SDK for the Zolana shielded protocol.",
   "license": "Apache-2.0",
   "files": [

--- a/sdk-libs/ts/src/client/prover/assembly.ts
+++ b/sdk-libs/ts/src/client/prover/assembly.ts
@@ -61,7 +61,7 @@ export function ownerSignerAddresses(
   return Object.freeze(signers);
 }
 
-/** With `ring` set, every real note is in that ring or in the default ring, per its own fields. */
+/** With `ring` set, every real UTXO is in that ring or in the default ring, per its own fields. */
 export function assemble(
   proofInputs: SppProofInputs,
   spendProofs: readonly SpendProof[],

--- a/sdk-libs/ts/src/flows/reserve.ts
+++ b/sdk-libs/ts/src/flows/reserve.ts
@@ -1,7 +1,7 @@
 import type { Bytes32 } from "../interface/types.js";
 import {
   hex,
-  type NoteReservation,
+  type UtxoReservation,
   type Wallet,
   type WalletUtxo,
 } from "../transaction/wallet/state.js";
@@ -10,14 +10,14 @@ import {
 export const DEFAULT_RESERVATION_TTL_MS = 120_000n;
 
 /** @internal */
-export function reservedNoteKeys(wallet: Wallet): ReadonlySet<string> {
-  return wallet._reservedNoteKeys(BigInt(Date.now()));
+export function reservedUtxoKeys(wallet: Wallet): ReadonlySet<string> {
+  return wallet._reservedUtxoKeys(BigInt(Date.now()));
 }
 
 /** @internal */
-export function reserveEntries(wallet: Wallet, entries: readonly WalletUtxo[]): NoteReservation {
-  return wallet._reserveNotes({
-    noteHashes: entries.map((entry) => entry.outputContext.hash),
+export function reserveEntries(wallet: Wallet, entries: readonly WalletUtxo[]): UtxoReservation {
+  return wallet._reserveUtxos({
+    utxoHashes: entries.map((entry) => entry.outputContext.hash),
     nowMs: BigInt(Date.now()),
     ttlMs: DEFAULT_RESERVATION_TTL_MS,
   });

--- a/sdk-libs/ts/src/flows/select.ts
+++ b/sdk-libs/ts/src/flows/select.ts
@@ -7,7 +7,7 @@ const U64_MAX = 0xffff_ffff_ffff_ffffn;
 /** @internal The cover cap, matches Rust `select_bounded_inputs`. */
 export const MAX_SPEND_INPUTS = Math.max(...SPP_SUPPORTED_SHAPES.map((shape) => shape.inputs));
 
-/** @internal Rust `is_plain_utxo`, a note the default rail can always prove. */
+/** @internal Rust `is_plain_utxo`, a UTXO the default rail can always prove. */
 export function isPlainUtxo(entry: WalletUtxo): boolean {
   return (
     entry.utxo.ringProgramId === undefined &&
@@ -23,7 +23,7 @@ export interface SpendSelectionErrors {
   tooManyInputs(input: Readonly<{ eligible: number; max: number }>): Error;
   overflow(input: Readonly<{ available: bigint }>): Error;
   multipleTrees?(input: Readonly<{ asset: Address; treeCount: number }>): Error;
-  tooFewNotes?(input: Readonly<{ eligible: number; minimum: number }>): Error;
+  tooFewUtxos?(input: Readonly<{ eligible: number; minimum: number }>): Error;
 }
 
 /** @internal */
@@ -50,7 +50,7 @@ export interface SelectedSpendInputs {
 }
 
 /** @internal */
-export function selectNotes(
+export function selectUtxos(
   input: Readonly<{
     wallet: Wallet;
     asset: Address;
@@ -84,8 +84,8 @@ export function selectNotes(
     const entries = sorted.slice(0, policy.maxInputs);
     if (entries.length < input.target.minInputs) {
       throw requiredError(
-        policy.errors.tooFewNotes,
-        "tooFewNotes",
+        policy.errors.tooFewUtxos,
+        "tooFewUtxos",
       )({
         eligible: entries.length,
         minimum: input.target.minInputs,

--- a/sdk-libs/ts/src/ring/rpc.ts
+++ b/sdk-libs/ts/src/ring/rpc.ts
@@ -262,7 +262,7 @@ export interface RingAuditorKey {
 export interface RingDeposit {
   readonly signature: Signature;
   readonly slot: bigint;
-  /** The owner tag of the note the deposit created. */
+  /** The owner tag of the UTXO the deposit created. */
   readonly depositor: Address;
   readonly asset: Address;
   readonly amount: bigint;

--- a/sdk-libs/ts/src/ring/transfer.ts
+++ b/sdk-libs/ts/src/ring/transfer.ts
@@ -37,14 +37,14 @@ import {
   type TransactionIntent,
 } from "../transaction/wallet/intent.js";
 import { SOL_MINT, type AssetRegistry } from "../transaction/asset.js";
-import type { NoteReservation, Wallet, WalletUtxo } from "../transaction/wallet/state.js";
+import type { UtxoReservation, Wallet, WalletUtxo } from "../transaction/wallet/state.js";
 import { ownerSignerAddresses } from "../client/prover/assembly.js";
 import { resolveWithdrawalSettlement, withdrawalSetupInstructions } from "../flows/settlement.js";
 import { resolveShieldedRecipient } from "../wallet/registry.js";
 
 import { fetchRingProgramConfig } from "./config.js";
-import { MAX_SPEND_INPUTS, selectNotes, type SpendSelectionErrors } from "../flows/select.js";
-import { reserveEntries, reservedNoteKeys, unreserved } from "../flows/reserve.js";
+import { MAX_SPEND_INPUTS, selectUtxos, type SpendSelectionErrors } from "../flows/select.js";
+import { reserveEntries, reservedUtxoKeys, unreserved } from "../flows/reserve.js";
 import { RingError, wrapRingError } from "./error.js";
 import { ringTransactInstruction } from "./instructions.js";
 import { fetchRingLookupTable } from "./lookup-table.js";
@@ -69,7 +69,7 @@ export interface RingTransferTransactionParams {
   readonly recipient: Address | ShieldedAddress;
   readonly asset?: Address;
   readonly amount: bigint;
-  /** `"default"` funds only from default notes, `"ring-or-default"` mixes both pools. */
+  /** `"default"` funds only from default UTXOs. `"ring-or-default"` mixes both pools. */
   readonly inputs?: "ring" | "ring-or-default" | "default";
   /** Must be at least one slot old. */
   readonly lookupTable: Address;
@@ -160,8 +160,8 @@ export async function buildRingEntryTransaction(
 }
 
 /**
- * Value leaves the ring to a default-ring note of the recipient, and the
- * custom-ring proof still covers the exit. Only ring-bound notes fund it, an
+ * Value leaves the ring to a default-ring UTXO of the recipient, and the
+ * custom-ring proof still covers the exit. Only ring-bound UTXOs fund it. An
  * all-default transact must not reach the audit as an exit.
  */
 export async function buildRingExitTransaction(
@@ -193,7 +193,7 @@ async function buildRingSendTransaction(
         } else {
           transfer.sendDefaultRing(recipient, asset, input.amount);
         }
-        // Change of a default note becomes ring bound.
+        // Change of a default UTXO becomes ring bound.
         const defaultFunding = selected
           .filter((entry) => entry.utxo.ringProgramId === undefined)
           .reduce((sum, entry) => sum + entry.utxo.amount, 0n);
@@ -202,7 +202,7 @@ async function buildRingSendTransaction(
         const crossing =
           defaultFunding === 0n
             ? ""
-            : `, moves ${String(defaultFunding)} ${assetLabel(asset)} of default notes into the ring`;
+            : `, moves ${String(defaultFunding)} ${assetLabel(asset)} of default UTXOs into the ring`;
         return {
           intent: {
             kind: "ringTransfer",
@@ -265,7 +265,7 @@ async function buildRingSpend<R>(
 ): Promise<Transaction> {
   return input.authority.withSpendSession(async (session) => {
     let inputs: readonly ProofInputUtxo[] = [];
-    let reservation: NoteReservation | undefined;
+    let reservation: UtxoReservation | undefined;
     try {
       await initializePoseidon();
       const asset = input.asset ?? SOL_MINT;
@@ -490,7 +490,7 @@ export async function proveCustomRingTransfer(
 
 /** Mirrors Rust `RingMembership::validate`. @internal */
 export function checkRingMembership(prepared: PreparedTransfer, ringProgramId: Address): void {
-  const notes = [
+  const utxos = [
     ...prepared.inputs.map((input) => ({
       ring: input.utxo.ringProgramId,
       data: input.ringDataHash,
@@ -500,11 +500,11 @@ export function checkRingMembership(prepared: PreparedTransfer, ringProgramId: A
       data: output.ringDataHash,
     })),
   ];
-  const foreign = notes.find((note) => note.ring !== undefined && note.ring !== ringProgramId);
+  const foreign = utxos.find((utxo) => utxo.ring !== undefined && utxo.ring !== ringProgramId);
   if (foreign?.ring !== undefined) {
     throw new RingError("RING_FOREIGN_RING", { details: { ringProgramId: foreign.ring } });
   }
-  if (notes.some((note) => note.ring === undefined && note.data !== undefined)) {
+  if (utxos.some((utxo) => utxo.ring === undefined && utxo.data !== undefined)) {
     throw new RingError("RING_DATA_OUTSIDE_RING");
   }
 }
@@ -614,7 +614,7 @@ function assetLabel(asset: Address): string {
 }
 
 /**
- * Notes on `tree` the mode admits.
+ * UTXOs on `tree` that the mode admits.
  *
  * @internal Exported for tests only.
  */
@@ -626,12 +626,12 @@ export function selectRingInputs(
   inputs: "ring" | "ring-or-default" | "default",
   tree: Address,
 ): readonly WalletUtxo[] {
-  // Zero selects a note whose whole change would cross the ring boundary.
+  // Zero selects a UTXO whose whole change would cross the ring boundary.
   if (amount <= 0n) {
     throw new RingError("RING_ZERO_AMOUNT", { details: { asset } });
   }
-  const reserved = reservedNoteKeys(wallet);
-  return selectNotes({
+  const reserved = reservedUtxoKeys(wallet);
+  return selectUtxos({
     wallet,
     asset,
     target: { kind: "cover", amount },

--- a/sdk-libs/ts/src/transaction/instructions/builders.ts
+++ b/sdk-libs/ts/src/transaction/instructions/builders.ts
@@ -222,7 +222,7 @@ export class ConfidentialSplit {
     if (input.owner.signingPublicKey.signatureType() === "p256") {
       throw new TransactionError("TRANSACTION_P256_TRANSACT_UNSUPPORTED");
     }
-    // The builders collect no signature but the payer's, a note owned by
+    // The builders collect no signature but the payer's, a UTXO owned by
     // anyone else cannot be authorized here.
     if (input.owner.solanaAddress() !== input.payer) {
       throw new TransactionError("TRANSACTION_ED25519_PAYER_MISMATCH", {

--- a/sdk-libs/ts/src/transaction/instructions/transact.ts
+++ b/sdk-libs/ts/src/transaction/instructions/transact.ts
@@ -661,12 +661,12 @@ export class ConfidentialTransfer {
     return this;
   }
 
-  /** The note joins the ring of the transfer, the default ring without one. */
+  /** The UTXO joins the ring of the transfer, the default ring without one. */
   send(recipient: ShieldedAddress, asset: Address, amount: bigint): void {
     this.#push({ address: recipient, asset, amount, ring: "transfer" });
   }
 
-  /** The note leaves the ring of the transfer for the default ring, mirrors Rust `send_default_ring`. */
+  /** The UTXO leaves the transfer ring for the default ring. Mirrors Rust `send_default_ring`. */
   sendDefaultRing(recipient: ShieldedAddress, asset: Address, amount: bigint): void {
     this.#push({ address: recipient, asset, amount, ring: "default" });
   }

--- a/sdk-libs/ts/src/transaction/utxo.ts
+++ b/sdk-libs/ts/src/transaction/utxo.ts
@@ -383,11 +383,11 @@ export interface ProofOutputUtxo {
   isDummy(): boolean;
   withUtxoData(utxoData: Uint8Array, dataHash: Bytes32): ProofOutputUtxo;
   /**
-   * A memo rides in the recipient's note but no commitment covers it, so unlike
+   * A memo rides in the recipient's UTXO but no commitment covers it, so unlike
    * the data setter above it leaves `dataHash` alone.
    */
   withMemo(memo: Uint8Array): ProofOutputUtxo;
-  /** Binds the note to a ring, only that ring's transact can spend it. */
+  /** Binds the UTXO to a ring, only that ring's transact can spend it. */
   withRingProgramId(ringProgramId: Address): ProofOutputUtxo;
 }
 

--- a/sdk-libs/ts/src/transaction/wallet/intent.ts
+++ b/sdk-libs/ts/src/transaction/wallet/intent.ts
@@ -26,7 +26,7 @@ export type TransactionIntent =
       amount: bigint;
       recipient: ShieldedAddress;
       boundary: "entry" | "transfer" | "exit";
-      /** Default-note value the transfer moves into the ring. */
+      /** Default-ring UTXO value the transfer moves into the ring. */
       defaultFunding: bigint;
     }>
   | Readonly<{

--- a/sdk-libs/ts/src/transaction/wallet/persistence.ts
+++ b/sdk-libs/ts/src/transaction/wallet/persistence.ts
@@ -80,6 +80,7 @@ export interface SerializedSyncCursors {
   readonly nullifiers: readonly SerializedCursor[];
 }
 
+/** Version 3 wire names remain frozen for persisted snapshot compatibility. */
 export interface SerializedNoteReservation {
   readonly id: string;
   readonly noteHashes: readonly string[];
@@ -87,7 +88,7 @@ export interface SerializedNoteReservation {
 }
 
 /**
- * Versioned, JSON-safe wallet state. It contains private note plaintext and
+ * Versioned, JSON-safe wallet state. It contains private UTXO plaintext and
  * blindings, but never signing, nullifier, or viewing secrets. Applications
  * must still encrypt it at rest.
  */
@@ -136,7 +137,7 @@ export function serializeWallet(wallet: Wallet): string {
       ._reservationEntries()
       .map((reservation) => ({
         id: reservation.id,
-        noteHashes: reservation.noteHashes.map(encode),
+        noteHashes: reservation.utxoHashes.map(encode),
         expiresAtMs: reservation.expiresAtMs.toString(),
       }))
       .sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0)),
@@ -241,7 +242,7 @@ function hydrateReservations(wallet: Wallet, value: unknown): void {
       seen.add(id);
       return Object.freeze({
         id,
-        noteHashes: array(item["noteHashes"], `${path}.noteHashes`).map(
+        utxoHashes: array(item["noteHashes"], `${path}.noteHashes`).map(
           (hash, hashIndex) =>
             bytes(hash, 32, `${path}.noteHashes[${String(hashIndex)}]`) as Bytes32,
         ),

--- a/sdk-libs/ts/src/transaction/wallet/state.ts
+++ b/sdk-libs/ts/src/transaction/wallet/state.ts
@@ -20,7 +20,7 @@ export interface RingBalance {
   readonly assets: readonly AssetBalance[];
 }
 
-/** Narrows which unspent notes a balance counts. */
+/** Narrows which unspent UTXOs a balance counts. */
 export type Filter = Readonly<{ kind: "minAmount"; minAmount: bigint }>;
 
 function matches(filter: Filter, utxo: Utxo): boolean {
@@ -67,10 +67,10 @@ export type CursorStream = "transactions" | "proofless" | "nullifiers";
 /** @internal */
 export type SyncCursorAdvances = Readonly<Record<CursorStream, ReadonlyMap<string, Uint8Array>>>;
 
-/** @internal Selection skips its notes until expiry, per wallet instance, not a cross-process lock. */
-export interface NoteReservation {
+/** @internal Selection skips its UTXOs until expiry, per wallet instance, not a cross-process lock. */
+export interface UtxoReservation {
   readonly id: string;
-  readonly noteHashes: readonly Bytes32[];
+  readonly utxoHashes: readonly Bytes32[];
   readonly expiresAtMs: bigint;
 }
 
@@ -227,7 +227,7 @@ export class Wallet {
   #nullifierCursors = new Map<string, Uint8Array>();
   #revision = 0;
   #syncQueue: Promise<unknown> = Promise.resolve();
-  #reservations: NoteReservation[] = [];
+  #reservations: UtxoReservation[] = [];
 
   constructor(input: Readonly<{ identity: ShieldedAddress; registry?: AssetRegistry }>) {
     this.identity = input.identity;
@@ -312,8 +312,8 @@ export class Wallet {
 
   /**
    * The spendable default-ring balance of one registered mint. A mint the
-   * wallet holds no note for still has a balance of zero; only a mint the
-   * registry does not know is a rejection.
+   * wallet holds no UTXO for still has a balance of zero. Only an unknown mint
+   * is a rejection.
    */
   balance(mint: Address, filter?: Filter): AssetBalance {
     const assetId = this.#registry.assetId(mint);
@@ -332,7 +332,7 @@ export class Wallet {
 
   /**
    * One spendable default-ring balance per mint the wallet holds an unspent
-   * note of, by asset id. Ring-bound notes appear in `ringBalances`.
+   * UTXO for, by asset id. Ring-bound UTXOs appear in `ringBalances`.
    */
   balances(skipUtxos = false): readonly AssetBalance[] {
     return this.#assetBalances((entry) => entry.utxo.ringProgramId === undefined, skipUtxos);
@@ -361,11 +361,11 @@ export class Wallet {
     eligible: (entry: WalletUtxo) => boolean,
     skipUtxos: boolean,
   ): readonly AssetBalance[] {
-    const notes = this.#utxos.filter((entry) => !entry.spent && eligible(entry));
-    const mints = new Set(notes.map((entry) => entry.utxo.asset));
+    const eligibleUtxos = this.#utxos.filter((entry) => !entry.spent && eligible(entry));
+    const mints = new Set(eligibleUtxos.map((entry) => entry.utxo.asset));
     return [...mints]
       .map((mint) => {
-        const utxos = notes
+        const utxos = eligibleUtxos
           .filter((entry) => entry.utxo.asset === mint)
           .map((entry) => copyUtxo(entry.utxo));
         const amount = checkedBalance(utxos.reduce((sum, utxo) => sum + utxo.amount, 0n));
@@ -430,7 +430,7 @@ export class Wallet {
       this.#utxos.filter((entry) => !entry.spent).map((entry) => hex(entry.outputContext.hash)),
     );
     this.#reservations = this.#reservations.filter((reservation) =>
-      reservation.noteHashes.every((noteHash) => unspent.has(hex(noteHash))),
+      reservation.utxoHashes.every((utxoHash) => unspent.has(hex(utxoHash))),
     );
     if (input.viewingKeyHistory !== undefined) {
       this.#viewingKeyHistory = input.viewingKeyHistory.map(snapshotViewingKeyEntry);
@@ -442,14 +442,14 @@ export class Wallet {
   }
 
   /** @internal Validates and commits in one synchronous step, never bumps the revision. */
-  _reserveNotes(
-    input: Readonly<{ noteHashes: readonly Bytes32[]; nowMs: bigint; ttlMs: bigint }>,
-  ): NoteReservation {
+  _reserveUtxos(
+    input: Readonly<{ utxoHashes: readonly Bytes32[]; nowMs: bigint; ttlMs: bigint }>,
+  ): UtxoReservation {
     this.#sweepReservations(input.nowMs);
-    const reserved = this._reservedNoteKeys(input.nowMs);
+    const reserved = this._reservedUtxoKeys(input.nowMs);
     const known = new Map(this.#utxos.map((entry) => [hex(entry.outputContext.hash), entry]));
-    for (const noteHash of input.noteHashes) {
-      const key = hex(noteHash);
+    for (const utxoHash of input.utxoHashes) {
+      const key = hex(utxoHash);
       const entry = known.get(key);
       if (entry === undefined || entry.spent) {
         throw new TransactionError("TRANSACTION_RESERVED_NOTE_UNAVAILABLE", { hash: key });
@@ -458,9 +458,9 @@ export class Wallet {
         throw new TransactionError("TRANSACTION_NOTE_RESERVED", { hash: key });
       }
     }
-    const reservation: NoteReservation = Object.freeze({
+    const reservation: UtxoReservation = Object.freeze({
       id: randomReservationId(),
-      noteHashes: Object.freeze(input.noteHashes.map((noteHash) => copy(noteHash) as Bytes32)),
+      utxoHashes: Object.freeze(input.utxoHashes.map((utxoHash) => copy(utxoHash) as Bytes32)),
       expiresAtMs: input.nowMs + input.ttlMs,
     });
     this.#reservations.push(reservation);
@@ -473,15 +473,15 @@ export class Wallet {
   }
 
   /** @internal */
-  _activeReservations(nowMs: bigint): readonly NoteReservation[] {
+  _activeReservations(nowMs: bigint): readonly UtxoReservation[] {
     return this.#reservations.filter((reservation) => reservation.expiresAtMs > nowMs);
   }
 
-  /** @internal Hex hashes of every note an unexpired reservation holds. */
-  _reservedNoteKeys(nowMs: bigint): ReadonlySet<string> {
+  /** @internal Hex hashes of every UTXO an unexpired reservation holds. */
+  _reservedUtxoKeys(nowMs: bigint): ReadonlySet<string> {
     const keys = new Set<string>();
     for (const reservation of this._activeReservations(nowMs)) {
-      for (const noteHash of reservation.noteHashes) keys.add(hex(noteHash));
+      for (const utxoHash of reservation.utxoHashes) keys.add(hex(utxoHash));
     }
     return keys;
   }
@@ -493,22 +493,22 @@ export class Wallet {
     this.#reservations = this.#reservations.filter(
       (reservation) =>
         reservation.expiresAtMs > nowMs &&
-        reservation.noteHashes.every((noteHash) => unspent.has(hex(noteHash))),
+        reservation.utxoHashes.every((utxoHash) => unspent.has(hex(utxoHash))),
     );
   }
 
   /** @internal Serialization only, includes expired entries. */
-  _reservationEntries(): readonly NoteReservation[] {
+  _reservationEntries(): readonly UtxoReservation[] {
     return this.#reservations;
   }
 
-  /** @internal Drops entries that name a spent or unknown note. */
-  _restoreReservations(reservations: readonly NoteReservation[]): void {
+  /** @internal Drops entries that name a spent or unknown UTXO. */
+  _restoreReservations(reservations: readonly UtxoReservation[]): void {
     const unspent = new Set(
       this.#utxos.filter((entry) => !entry.spent).map((entry) => hex(entry.outputContext.hash)),
     );
     this.#reservations = reservations.filter((reservation) =>
-      reservation.noteHashes.every((noteHash) => unspent.has(hex(noteHash))),
+      reservation.utxoHashes.every((utxoHash) => unspent.has(hex(utxoHash))),
     );
   }
 

--- a/sdk-libs/ts/src/transaction/wallet/sync.ts
+++ b/sdk-libs/ts/src/transaction/wallet/sync.ts
@@ -211,7 +211,7 @@ function rowKey(row: PrivateTransaction): string {
 }
 
 /**
- * The notes and history rows one sync produces, accumulated across every
+ * The UTXOs and history rows one sync produces, accumulated across every
  * viewing key the authority supplied. This is the counterpart of Rust
  * `SyncCtx`: it owns the staged wallet contents so a rejection leaves the
  * wallet untouched, and it carries the report counters each decode step
@@ -325,7 +325,7 @@ class SyncPass {
   }
 
   /**
-   * Store a note whose slot is not known in advance, by finding the slot whose
+   * Store a UTXO whose slot is not known in advance. Find the slot whose
    * committed leaf its hash reproduces. The sender-side bundles carry their
    * change this way: one bundle describes several outputs spread across the
    * transaction.
@@ -340,7 +340,7 @@ class SyncPass {
     this.#store(utxo, slot.outputContext, undefined, undefined);
   }
 
-  /** Verify each 1:1 recipient note against the slot's committed leaf and store it. */
+  /** Verify each 1:1 recipient UTXO against the committed leaf and store it. */
   #storeRecipientUtxos(
     utxos: readonly Utxo[],
     outputContext: OutputContext,
@@ -372,12 +372,12 @@ class SyncPass {
   }
 
   /**
-   * Record a candidate that failed to become notes. When the failure was an
+   * Record a candidate that failed to become UTXOs. When the failure was an
    * unknown asset id, remember the id so the client sync layer can backfill the
    * registry and retry; that is the single seam where a stale registry surfaces
    * during decode.
    */
-  #noteUndecryptable(error: unknown, siteKey: string): void {
+  #recordUndecryptable(error: unknown, siteKey: string): void {
     if (error instanceof TransactionError) {
       let candidate = this.#unknownAssetsBySite.get(siteKey);
       const assetCandidate = (): Readonly<{
@@ -689,7 +689,7 @@ class SyncPass {
         deposit = decodeProofless(body);
         utxo = prooflessUtxo(deposit, this.#owner);
       } catch (error) {
-        this.#noteUndecryptable(error, siteKey);
+        this.#recordUndecryptable(error, siteKey);
         return;
       }
       this.#resolveAssetCandidate(siteKey);
@@ -707,7 +707,7 @@ class SyncPass {
       try {
         utxos = plaintextTransferUtxos(decodePlaintextTransfer(body), this.#assets, SOL_MINT);
       } catch (error) {
-        this.#noteUndecryptable(error, siteKey);
+        this.#recordUndecryptable(error, siteKey);
         return;
       }
       this.#resolveAssetCandidate(siteKey);
@@ -724,7 +724,7 @@ class SyncPass {
         sender = plaintext.senderPublicKey;
         utxo = anonymousRecipientUtxo(plaintext, this.#assets);
       } catch (error) {
-        this.#noteUndecryptable(error, siteKey);
+        this.#recordUndecryptable(error, siteKey);
         return;
       }
       this.#resolveAssetCandidate(siteKey);
@@ -753,7 +753,7 @@ class SyncPass {
           this.#assets,
         );
       } catch (error) {
-        this.#noteUndecryptable(error, siteKey);
+        this.#recordUndecryptable(error, siteKey);
         return;
       }
       this.#resolveAssetCandidate(siteKey);
@@ -781,7 +781,7 @@ class SyncPass {
           ? output.ringDataHash
           : undefined;
       } catch (error) {
-        this.#noteUndecryptable(error, siteKey);
+        this.#recordUndecryptable(error, siteKey);
         return;
       }
       this.#resolveAssetCandidate(siteKey);
@@ -800,7 +800,7 @@ class SyncPass {
         recipients = plaintext.recipientViewingPublicKeys;
         change = anonymousSenderUtxos(plaintext, this.#assets, SOL_MINT);
       } catch (error) {
-        this.#noteUndecryptable(error, siteKey);
+        this.#recordUndecryptable(error, siteKey);
         return;
       }
       this.#resolveAssetCandidate(siteKey);
@@ -830,7 +830,7 @@ class SyncPass {
           this.#assets,
         );
       } catch (error) {
-        this.#noteUndecryptable(error, siteKey);
+        this.#recordUndecryptable(error, siteKey);
         return;
       }
       this.#resolveAssetCandidate(siteKey);
@@ -930,7 +930,7 @@ class SyncPass {
       }
       return true;
     } catch (error) {
-      this.#noteUndecryptable(error, siteKey);
+      this.#recordUndecryptable(error, siteKey);
       return true;
     }
   }

--- a/sdk-libs/ts/src/transaction/wallet/sync.ts
+++ b/sdk-libs/ts/src/transaction/wallet/sync.ts
@@ -98,6 +98,7 @@ interface Site {
 interface TagIndex {
   readonly senderSites: ReadonlyMap<string, readonly number[]>;
   readonly recipientSites: ReadonlyMap<string, readonly Site[]>;
+  readonly mergeSites: ReadonlyMap<string, readonly Site[]>;
   readonly unparsedTransactions: number;
 }
 
@@ -110,12 +111,13 @@ function pushInto<T>(into: Map<string, T[]>, tag: string, value: T): void {
 function buildTagIndex(transactions: readonly IndexedShieldedTransaction[]): TagIndex {
   const senderSites = new Map<string, number[]>();
   const recipientSites = new Map<string, Site[]>();
+  const mergeSites = new Map<string, Site[]>();
   let unparsedTransactions = 0;
   for (const [transaction, tx] of transactions.entries()) {
     let classified = false;
     if (!tx.proofless && tx.txViewingPublicKey === undefined && tx.salt === undefined) {
-      for (const [index, slot] of tx.outputSlots.entries()) {
-        pushInto(recipientSites, hex(slot.viewTag), { transaction, slot: index });
+      for (const [slotIndex, slot] of tx.outputSlots.entries()) {
+        pushInto(mergeSites, hex(slot.viewTag), { transaction, slot: slotIndex });
         classified = true;
       }
       if (!classified) unparsedTransactions++;
@@ -138,7 +140,7 @@ function buildTagIndex(transactions: readonly IndexedShieldedTransaction[]): Tag
     }
     if (!classified) unparsedTransactions++;
   }
-  return { senderSites, recipientSites, unparsedTransactions };
+  return { senderSites, recipientSites, mergeSites, unparsedTransactions };
 }
 
 function compareBigints(left: bigint, right: bigint): number {
@@ -670,10 +672,6 @@ class SyncPass {
       this.undecryptableCandidates++;
       return;
     }
-    if (!tx.proofless && tx.txViewingPublicKey === undefined && tx.salt === undefined) {
-      this.#reconstructMerge(tx, site, siteKey);
-      return;
-    }
     let frame: ReturnType<typeof readOutputData>;
     try {
       frame = readOutputData(slot.payload);
@@ -848,8 +846,30 @@ class SyncPass {
     this.undecryptableCandidates++;
   }
 
-  /** Reconstruct the ciphertext-free merge output from this wallet's spent inputs. */
-  #reconstructMerge(tx: IndexedShieldedTransaction, site: Site, siteKey: string): void {
+  resolveMergeSites(sites: readonly Site[]): void {
+    let pending = [...sites];
+    while (pending.length > 0) {
+      const unresolved: Site[] = [];
+      for (const site of pending) {
+        const siteKey = `${String(site.transaction)}:${String(site.slot)}`;
+        if (this.#processedSlots.has(siteKey)) continue;
+        const tx = this.#transactions[site.transaction];
+        if (tx === undefined || tx.outputSlots[site.slot] === undefined) {
+          this.undecryptableCandidates++;
+          continue;
+        }
+        if (!this.#reconstructMerge(tx, site, siteKey)) unresolved.push(site);
+      }
+      if (unresolved.length === pending.length) {
+        this.undecryptableCandidates += unresolved.length;
+        return;
+      }
+      pending = unresolved;
+    }
+  }
+
+  /** Missing inputs may be outputs of another merge in the same batch. */
+  #reconstructMerge(tx: IndexedShieldedTransaction, site: Site, siteKey: string): boolean {
     const slot = tx.outputSlots[site.slot];
     const firstNullifier = tx.nullifiers[0];
     if (
@@ -857,8 +877,7 @@ class SyncPass {
       firstNullifier === undefined ||
       !this.#utxos.some((entry) => equal(entry.nullifier, firstNullifier))
     ) {
-      this.undecryptableCandidates++;
-      return;
+      return false;
     }
 
     try {
@@ -869,15 +888,14 @@ class SyncPass {
         }
         const entry = this.#utxos.find((candidate) => equal(candidate.nullifier, nullifier));
         if (entry === undefined) {
-          this.undecryptableCandidates++;
-          return;
+          return false;
         }
         matched.push(entry);
       }
       const first = matched[0];
       if (first === undefined || matched.some((entry) => entry.utxo.asset !== first.utxo.asset)) {
         this.undecryptableCandidates++;
-        return;
+        return true;
       }
       let amount = 0n;
       for (const entry of matched) {
@@ -887,7 +905,7 @@ class SyncPass {
       const ringProgramId = first.utxo.ringProgramId;
       if (matched.some((entry) => entry.utxo.ringProgramId !== ringProgramId)) {
         this.undecryptableCandidates++;
-        return;
+        return true;
       }
       const ringDataHash =
         ringProgramId === undefined
@@ -897,7 +915,7 @@ class SyncPass {
             : null;
       if (ringDataHash === null) {
         this.undecryptableCandidates++;
-        return;
+        return true;
       }
       const utxo = new Utxo({
         owner: this.#owner,
@@ -910,9 +928,10 @@ class SyncPass {
         this.#processedSlots.add(siteKey);
         this.#recordMerge(tx, slot.outputContext, utxo);
       }
-      return;
+      return true;
     } catch (error) {
       this.#noteUndecryptable(error, siteKey);
+      return true;
     }
   }
 
@@ -999,6 +1018,7 @@ export async function decryptTransactions(
     );
     if (key !== undefined) pass.processStableTags(key, { identityTag, index });
   }
+  pass.resolveMergeSites(index.mergeSites.get(hex(identityTag)) ?? []);
 
   const nullifiers = new Set(current.nullifiers);
   for (const tx of input.transactions) {

--- a/sdk-libs/ts/src/wallet/actions.ts
+++ b/sdk-libs/ts/src/wallet/actions.ts
@@ -9,12 +9,12 @@ import { ShieldedAddress } from "../keypair/shielded.js";
 import { WithdrawalTarget } from "../transaction/instructions/transact.js";
 import { hex, type Wallet, type WalletUtxo } from "../transaction/wallet/state.js";
 
-import { reservedNoteKeys, unreserved } from "../flows/reserve.js";
+import { reservedUtxoKeys, unreserved } from "../flows/reserve.js";
 import { resolveWithdrawalSettlement } from "../flows/settlement.js";
 import {
   MAX_SPEND_INPUTS,
   isPlainUtxo,
-  selectNotes,
+  selectUtxos,
   type SpendPolicy,
   type SpendSelectionErrors,
 } from "../flows/select.js";
@@ -232,9 +232,9 @@ function selectSpendInputs(
   asset: Address,
   amount: bigint,
 ): Readonly<{ tree: Address; inputs: readonly UnsignedSpendInput[]; reservationId: string }> {
-  const reserved = reservedNoteKeys(wallet);
+  const reserved = reservedUtxoKeys(wallet);
   const base = defaultSpendPolicy();
-  const selection = selectNotes({
+  const selection = selectUtxos({
     wallet,
     asset,
     target: { kind: "cover", amount },
@@ -370,7 +370,7 @@ export function createSplit(params: SplitParams): CreatedSplit {
     throw new WalletError("WALLET_INPUT_UTXO_UNAVAILABLE");
   }
   const tree = named ? named.outputContext.tree : spendTree(params.wallet, params.asset);
-  const reserved = reservedNoteKeys(params.wallet);
+  const reserved = reservedUtxoKeys(params.wallet);
   const candidates = entries.filter(
     (entry) =>
       entry.outputContext.tree === tree && isPlainUtxo(entry) && unreserved(reserved)(entry),

--- a/sdk-libs/ts/src/wallet/internal.ts
+++ b/sdk-libs/ts/src/wallet/internal.ts
@@ -3,7 +3,7 @@ import { getBase64Encoder } from "@solana/kit";
 import { reserveEntries } from "../flows/reserve.js";
 import type { Bytes32 } from "../interface/types.js";
 import { TransactionError } from "../transaction/error.js";
-import type { NoteReservation, Wallet, WalletUtxo } from "../transaction/wallet/state.js";
+import type { UtxoReservation, Wallet, WalletUtxo } from "../transaction/wallet/state.js";
 
 import { WalletError } from "./error.js";
 
@@ -11,7 +11,7 @@ import { WalletError } from "./error.js";
 export function reserveWalletEntries(
   wallet: Wallet,
   entries: readonly WalletUtxo[],
-): NoteReservation {
+): UtxoReservation {
   try {
     return reserveEntries(wallet, entries);
   } catch (cause) {

--- a/sdk-libs/ts/src/wallet/merge.ts
+++ b/sdk-libs/ts/src/wallet/merge.ts
@@ -15,11 +15,11 @@ import { initializePoseidon } from "../hasher/index.js";
 import { MERGE_INPUT_COUNT } from "../interface/constants.js";
 import {
   isPlainUtxo,
-  selectNotes,
+  selectUtxos,
   type SpendPolicy,
   type SpendSelectionErrors,
 } from "../flows/select.js";
-import { reservedNoteKeys, unreserved } from "../flows/reserve.js";
+import { reservedUtxoKeys, unreserved } from "../flows/reserve.js";
 import { checkIntentApproval, type TransactionIntent } from "../transaction/wallet/intent.js";
 import { WalletError, wrapWalletError } from "./error.js";
 import { bytesKey, equalBytes, reserveWalletEntries } from "./internal.js";
@@ -53,7 +53,7 @@ const mergeSelectionErrors: SpendSelectionErrors = {
       details: { available: available.toString() },
     }),
   multipleTrees: () => new WalletError("WALLET_MULTIPLE_INPUT_TREES"),
-  tooFewNotes: () => new WalletError("WALLET_NOTHING_TO_MERGE"),
+  tooFewUtxos: () => new WalletError("WALLET_NOTHING_TO_MERGE"),
 };
 
 function mergePolicy(reserved: ReadonlySet<string>): SpendPolicy {
@@ -132,11 +132,11 @@ function selectMergeEntries(params: MergeParams): readonly WalletUtxo[] {
       return entry;
     });
   }
-  return selectNotes({
+  return selectUtxos({
     wallet: params.wallet,
     asset: params.asset,
     target: { kind: "consolidate", minInputs: 2 },
-    policy: mergePolicy(reservedNoteKeys(params.wallet)),
+    policy: mergePolicy(reservedUtxoKeys(params.wallet)),
   }).entries;
 }
 

--- a/sdk-libs/ts/src/wallet/persisted.ts
+++ b/sdk-libs/ts/src/wallet/persisted.ts
@@ -6,7 +6,7 @@ import { WalletError, wrapWalletError } from "./error.js";
 import { runLockedWalletSync, type SyncWalletInput } from "./sync.js";
 
 /**
- * Snapshots contain private note data, encrypt them at rest. `save` must
+ * Snapshots contain private UTXO data, encrypt them at rest. `save` must
  * replace the stored snapshot atomically or leave it unchanged, a partial
  * write breaks the retry contract of `syncPersistedWallet`. Single writer
  * per stored snapshot, a stale overwrite loses only sync progress the next

--- a/sdk-libs/ts/src/wallet/private-transaction.ts
+++ b/sdk-libs/ts/src/wallet/private-transaction.ts
@@ -61,9 +61,9 @@ function sameUtxo(left: Utxo, right: Utxo): boolean {
 }
 
 /**
- * The note the private authority is about to authorize must still be the exact
- * note selected for this intent. Matching on the commitment alone would let a
- * note swapped before authorization pass, so every field that feeds the
+ * The UTXO the private authority is about to authorize must still be the exact
+ * UTXO selected for this intent. Matching on the commitment alone would allow
+ * a UTXO swap before authorization, so every field that feeds the
  * commitment is compared.
  */
 function matchingInput(

--- a/sdk-libs/ts/src/wallet/sync.ts
+++ b/sdk-libs/ts/src/wallet/sync.ts
@@ -183,7 +183,7 @@ function walletQueryTags(wallet: Wallet, material: WalletSyncMaterial): readonly
 }
 
 /**
- * Nullifiers of unspent notes.
+ * Nullifiers of unspent UTXOs.
  *
  * A nullifier appears at most once on chain, so once its spend is known the
  * answer is final. Cost tracks the unspent count, not history.
@@ -370,7 +370,7 @@ async function collectShieldedTransactions(
     for (const transaction of response.transactions) {
       // Photon can surface a proofless deposit here before flagging it. Those
       // are collected from the encrypted-utxo endpoint instead, so taking them
-      // twice would store the same note under two keys.
+      // twice would store the same UTXO under two keys.
       if (transaction.proofless) continue;
       const key = shieldedTransactionKey(transaction);
       if (!input.out.has(key)) input.out.set(key, transaction);
@@ -642,7 +642,7 @@ async function runWalletSync(
       }
     }
 
-    // A transaction found by a stable tag can create a note that another
+    // A transaction found by a stable tag can create a UTXO that another
     // device already spent. Query each newly discovered nullifier once, then
     // stop: this is an explicit bounded backstop rather than a generic round
     // loop that re-queries the same stable tags.
@@ -675,8 +675,8 @@ async function runWalletSync(
         }
       }
     }
-    // An unresolved asset means a fetched note was not stored. A commit would
-    // advance the cursors past it and lose the note until a full rescan.
+    // An unresolved asset means a fetched UTXO was not stored. A commit would
+    // advance the cursors past it and lose the UTXO until a full rescan.
     if (
       report.unknownAssetIds.length > 0 ||
       report.unknownAssetFields.length > 0 ||

--- a/sdk-libs/ts/src/wallet/transaction-slots.ts
+++ b/sdk-libs/ts/src/wallet/transaction-slots.ts
@@ -10,7 +10,7 @@ const addressDecoder = getAddressDecoder();
 export interface TransactionSlots {
   /** Owner tag by output slot index. */
   readonly ownerTags: ReadonlyMap<number, Address>;
-  /** Tree leaf by output slot index, which ties a slot to a wallet's note. */
+  /** Tree leaf by output slot index, which ties a slot to a wallet's UTXO. */
   readonly leaves: ReadonlyMap<number, bigint>;
 }
 

--- a/sdk-libs/ts/test/client.test.ts
+++ b/sdk-libs/ts/test/client.test.ts
@@ -63,7 +63,7 @@ function proofFixture(): Readonly<{ proofInputs: SppProofInputs; spendProof: Spe
   });
   const ownerTag = bytes(8);
   const proofInputs = new SppProofInputs({
-    // The payer must own the input notes: only its own are provable.
+    // The payer must own the input UTXOs. Only its own are provable.
     payer: keypair.shieldedAddress().solanaAddress(),
     inputUtxos: [input],
     outputs: [output],

--- a/sdk-libs/ts/test/crypto.test.ts
+++ b/sdk-libs/ts/test/crypto.test.ts
@@ -122,7 +122,7 @@ describe("shielded key material", () => {
   it("applies the symmetric key schedule as an involution", () => {
     const sharedSecret = new Uint8Array(32);
     sharedSecret.set(new Uint8Array(31).fill(0x11), 1);
-    const plaintext = new TextEncoder().encode("private note");
+    const plaintext = new TextEncoder().encode("private UTXO");
     const ciphertext = symmetricApply(sharedSecret, MERGE_INFO, plaintext);
     expect(ciphertext).not.toEqual(plaintext);
     expect(symmetricApply(sharedSecret, MERGE_INFO, ciphertext)).toEqual(plaintext);

--- a/sdk-libs/ts/test/e2e/private-flow.live.test.ts
+++ b/sdk-libs/ts/test/e2e/private-flow.live.test.ts
@@ -646,7 +646,7 @@ describe.sequential("live SDK lifecycle", () => {
     expect(bob.wallet.balance(harness.token2022Mint).amount).toBe(50_000n);
   }, 900_000);
 
-  it("covers a real 1x8 split and merges all eight notes back to one", async () => {
+  it("covers a real 1x8 split and merges all eight UTXOs back to one", async () => {
     const owner = await actor(101);
     await fund(harness.client, owner);
     await register(harness.client, owner);

--- a/sdk-libs/ts/test/e2e/ring-flow.live.test.ts
+++ b/sdk-libs/ts/test/e2e/ring-flow.live.test.ts
@@ -202,7 +202,7 @@ describe("ring flow", () => {
     await airdrop(client, sender.signer.address);
 
     const amount = 1_000_000_000n;
-    // Input selection stops at the first note that covers the transfer, so the
+    // Input selection stops at the first UTXO that covers the transfer, so the
     // deposits differ and the sender keeps a change output next to the recipient's.
     for (const deposited of [amount * 3n, amount]) {
       const deposit = await buildRingDepositTransaction({
@@ -257,7 +257,7 @@ describe("ring flow", () => {
       if (audited === undefined) await new Promise((resolve) => setTimeout(resolve, 500));
     }
     expect(audited).toBeDefined();
-    // The 3x deposit is the covering note, the change slot keeps 2x.
+    // The 3x deposit is the covering UTXO, and the change slot keeps 2x.
     const amounts = [...(audited?.outputs.map((output) => output.amount) ?? [])].sort((a, b) =>
       a < b ? -1 : 1,
     );
@@ -270,15 +270,15 @@ describe("ring flow", () => {
     // Participants read their own side from wallet sync.
     await airdrop(client, recipient.signer.address);
     await sync(client, recipient);
-    const notes = recipient.wallet.utxos().filter((entry) => !entry.spent);
-    expect(notes.map((entry) => entry.utxo.amount)).toContain(amount);
-    expect(notes.map((entry) => entry.utxo.ringProgramId)).toEqual([ringProgramId]);
+    const utxos = recipient.wallet.utxos().filter((entry) => !entry.spent);
+    expect(utxos.map((entry) => entry.utxo.amount)).toContain(amount);
+    expect(utxos.map((entry) => entry.utxo.ringProgramId)).toEqual([ringProgramId]);
     await sync(client, sender);
     const change = sender.wallet.utxos().filter((entry) => !entry.spent);
     expect(change.length).toBeGreaterThan(0);
     expect(change.every((entry) => entry.utxo.ringProgramId === ringProgramId)).toBe(true);
 
-    // The received note spends inside the ring again.
+    // The received UTXO spends inside the ring again.
     const hop = await buildRingTransferTransaction({
       client,
       ringProgramId,
@@ -303,7 +303,7 @@ describe("ring flow", () => {
       ringProgramId,
       ringProgramId,
     ]);
-    // The hop pays half the note onward, the change slot keeps the rest.
+    // The hop pays half the UTXO onward, and the change slot keeps the rest.
     const hopAmounts = [...(hopAudited?.outputs.map((output) => output.amount) ?? [])].sort(
       (a, b) => (a < b ? -1 : 1),
     );
@@ -415,10 +415,10 @@ describe("ring flow", () => {
     });
     await signSendAndConfirm(client, deposit, [mintAuthority]);
     await sync(client, sender);
-    const defaultNotes = sender.wallet
+    const defaultUtxos = sender.wallet
       .utxos()
-      .filter((note) => !note.spent && note.utxo.asset === mint);
-    expect(defaultNotes.map((note) => [note.utxo.amount, note.utxo.ringProgramId])).toEqual([
+      .filter((entry) => !entry.spent && entry.utxo.asset === mint);
+    expect(defaultUtxos.map((entry) => [entry.utxo.amount, entry.utxo.ringProgramId])).toEqual([
       [deposited, undefined],
     ]);
 
@@ -433,7 +433,7 @@ describe("ring flow", () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
     }
 
-    // Entry, the default note funds a ring transfer.
+    // Entry. The default UTXO funds a ring transfer.
     const entryTransaction = await buildRingTransferTransaction({
       client,
       ringProgramId,
@@ -459,10 +459,10 @@ describe("ring flow", () => {
       ringProgramId,
     ]);
     await sync(client, recipient);
-    const ringNotes = recipient.wallet
+    const ringUtxos = recipient.wallet
       .utxos()
-      .filter((note) => !note.spent && note.utxo.asset === mint);
-    expect(ringNotes.map((note) => [note.utxo.amount, note.utxo.ringProgramId])).toEqual([
+      .filter((entry) => !entry.spent && entry.utxo.asset === mint);
+    expect(ringUtxos.map((entry) => [entry.utxo.amount, entry.utxo.ringProgramId])).toEqual([
       [entry, ringProgramId],
     ]);
 
@@ -487,7 +487,7 @@ describe("ring flow", () => {
       causeCode: "INTERFACE_TRANSACTION_TOO_LARGE",
     });
 
-    // Exit, part of the ring note returns to the sender's default ring.
+    // Exit. Part of the ring UTXO returns to the sender's default ring.
     const exitTransaction = await buildRingExitTransaction({
       client,
       ringProgramId,
@@ -513,17 +513,17 @@ describe("ring flow", () => {
     expect(exitRings.get(exit)).toBeUndefined();
     expect(exitRings.get(entry - exit)).toBe(ringProgramId);
     await sync(client, sender);
-    const senderNotes = sender.wallet
+    const senderUtxos = sender.wallet
       .utxos()
-      .filter((note) => !note.spent && note.utxo.asset === mint)
-      .map((note) => [note.utxo.amount, note.utxo.ringProgramId] as const)
+      .filter((entry) => !entry.spent && entry.utxo.asset === mint)
+      .map((entry) => [entry.utxo.amount, entry.utxo.ringProgramId] as const)
       .sort((a, b) => (a[0] < b[0] ? -1 : 1));
-    expect(senderNotes).toEqual([
+    expect(senderUtxos).toEqual([
       [exit, undefined],
       [deposited - entry, ringProgramId],
     ]);
 
-    // The remaining ring note settles a public withdrawal into the funding account.
+    // The remaining ring UTXO settles a public withdrawal into the funding account.
     await sync(client, recipient);
     const before = await tokenBalance(client, fundingTokenAccount);
     const withdrawalTransaction = await buildRingWithdrawalTransaction({

--- a/sdk-libs/ts/test/flows-select.test.ts
+++ b/sdk-libs/ts/test/flows-select.test.ts
@@ -8,7 +8,7 @@ import { AssetRegistry } from "../src/transaction/asset.js";
 import {
   MAX_SPEND_INPUTS,
   isPlainUtxo,
-  selectNotes,
+  selectUtxos,
   type SpendPolicy,
   type SpendSelectionErrors,
 } from "../src/flows/select.js";
@@ -27,7 +27,7 @@ const errors: SpendSelectionErrors = {
   tooManyInputs: ({ eligible, max }) => new Error(`tooMany ${String(eligible)} ${String(max)}`),
   overflow: () => new Error("overflow"),
   multipleTrees: ({ treeCount }) => new Error(`trees ${String(treeCount)}`),
-  tooFewNotes: ({ eligible, minimum }) =>
+  tooFewUtxos: ({ eligible, minimum }) =>
     new Error(`tooFew ${String(eligible)} ${String(minimum)}`),
 };
 
@@ -42,11 +42,11 @@ function policy(overrides: Partial<SpendPolicy> = {}): SpendPolicy {
   };
 }
 
-function walletWith(notes: readonly (readonly [bigint, Address?])[]): Wallet {
+function walletWith(utxos: readonly (readonly [bigint, Address?])[]): Wallet {
   const keypair = ShieldedKeypair.generate();
   const wallet = new Wallet({ identity: keypair.shieldedAddress(), registry: new AssetRegistry() });
   wallet._replace({
-    utxos: notes.map(([amount, tree], index) => ({
+    utxos: utxos.map(([amount, tree], index) => ({
       utxo: new Utxo({
         owner: keypair.signingPublicKey(),
         asset: MINT,
@@ -64,10 +64,10 @@ function walletWith(notes: readonly (readonly [bigint, Address?])[]): Wallet {
   return wallet;
 }
 
-describe("note selection", () => {
-  it("covers with the fewest notes under largest-first ordering", () => {
+describe("UTXO selection", () => {
+  it("covers with the fewest UTXOs under largest-first ordering", () => {
     const wallet = walletWith([[5n], [5n], [5n], [5n], [5n], [5n], [100n]]);
-    const selection = selectNotes({
+    const selection = selectUtxos({
       wallet,
       asset: MINT,
       target: { kind: "cover", amount: 100n },
@@ -77,9 +77,9 @@ describe("note selection", () => {
     expect(selection.total).toBe(130n);
   });
 
-  it("consolidates the smallest notes first up to the cap", () => {
+  it("consolidates the smallest UTXOs first up to the cap", () => {
     const wallet = walletWith([[9n], [1n], [5n], [3n]]);
-    const selection = selectNotes({
+    const selection = selectUtxos({
       wallet,
       asset: MINT,
       target: { kind: "consolidate", minInputs: 2 },
@@ -91,7 +91,7 @@ describe("note selection", () => {
   it("distinguishes a fragmented balance from a poor one", () => {
     const fragmented = walletWith([[5n], [5n], [5n], [5n], [5n], [5n]]);
     expect(() =>
-      selectNotes({
+      selectUtxos({
         wallet: fragmented,
         asset: MINT,
         target: { kind: "cover", amount: 30n },
@@ -99,7 +99,7 @@ describe("note selection", () => {
       }),
     ).toThrow("tooMany 6 5");
     expect(() =>
-      selectNotes({
+      selectUtxos({
         wallet: fragmented,
         asset: MINT,
         target: { kind: "cover", amount: 31n },
@@ -110,7 +110,7 @@ describe("note selection", () => {
 
   it("filters to a fixed tree and infers a single one otherwise", () => {
     const wallet = walletWith([[50n, OTHER_TREE], [20n]]);
-    const selection = selectNotes({
+    const selection = selectUtxos({
       wallet,
       asset: MINT,
       target: { kind: "cover", amount: 20n },
@@ -119,7 +119,7 @@ describe("note selection", () => {
     expect(selection.entries.map((entry) => entry.utxo.amount)).toEqual([20n]);
     expect(selection.tree).toBe(TREE);
     expect(() =>
-      selectNotes({
+      selectUtxos({
         wallet,
         asset: MINT,
         target: { kind: "cover", amount: 20n },
@@ -131,7 +131,7 @@ describe("note selection", () => {
   it("reports an empty eligible set as an insufficient one-lamport cover", () => {
     const wallet = walletWith([]);
     expect(() =>
-      selectNotes({
+      selectUtxos({
         wallet,
         asset: MINT,
         target: { kind: "cover", amount: 1n },
@@ -143,7 +143,7 @@ describe("note selection", () => {
   it("refuses an eligible balance past the u64 ceiling", () => {
     const wallet = walletWith([[0xffff_ffff_ffff_ffffn], [1n]]);
     expect(() =>
-      selectNotes({
+      selectUtxos({
         wallet,
         asset: MINT,
         target: { kind: "cover", amount: 1n },
@@ -152,10 +152,10 @@ describe("note selection", () => {
     ).toThrow("overflow");
   });
 
-  it("refuses a consolidation below the minimum note count", () => {
+  it("refuses a consolidation below the minimum UTXO count", () => {
     const wallet = walletWith([[9n]]);
     expect(() =>
-      selectNotes({
+      selectUtxos({
         wallet,
         asset: MINT,
         target: { kind: "consolidate", minInputs: 2 },

--- a/sdk-libs/ts/test/prover-client.test.ts
+++ b/sdk-libs/ts/test/prover-client.test.ts
@@ -424,7 +424,6 @@ describe("dummy prover inputs", () => {
     const converted = createDummyTransferInput(input, 4n, proof);
     const utxo = converted.circuit;
 
-    expect({ ...converted }.circuit).toBe(converted.circuit);
     expect(converted.ownerPublicKeyHash).toBe(0n);
     expect(utxo).toEqual({
       domain: 1n,

--- a/sdk-libs/ts/test/ring-transfer.test.ts
+++ b/sdk-libs/ts/test/ring-transfer.test.ts
@@ -63,7 +63,7 @@ function actor(seed: number) {
   };
 }
 
-/** A 10 SOL ring note of `sender` sending `amount` to `recipient` and `others` to more actors. */
+/** A 10 SOL ring UTXO of `sender` sending `amount` to `recipient` and `others`. */
 function preparedTransfer(
   amount: bigint,
   others: readonly bigint[] = [],
@@ -256,7 +256,7 @@ describe("withCompactChange", () => {
     ).toThrow("RING_FOREIGN_RING");
   });
 
-  it("refuses ring data on a default note like Rust `RingMembership`", () => {
+  it("refuses ring data on a default UTXO like Rust `RingMembership`", () => {
     const sender = actor(3);
     const tainted = new ProofInputUtxo({
       utxo: new Utxo({
@@ -435,7 +435,7 @@ describe("ring witness", () => {
   it("destroys only its own clone of the nullifier key", () => {
     const owner = actor(3);
     const nullifierKey = owner.keypair.nullifierKey();
-    const note = new ProofInputUtxo({
+    const input = new ProofInputUtxo({
       utxo: new Utxo({
         owner: owner.keypair.signingPublicKey(),
         asset: SOL_MINT,
@@ -444,15 +444,15 @@ describe("ring witness", () => {
       }),
       nullifierKey,
     });
-    note.destroy();
-    expect(() => note.nullifierKey.publicKey()).toThrow("KEYPAIR_INVALID_SECRET_KEY");
+    input.destroy();
+    expect(() => input.nullifierKey.publicKey()).toThrow("KEYPAIR_INVALID_SECRET_KEY");
     expect(nullifierKey.publicKey()).toEqual(owner.keypair.nullifierKey().publicKey());
   });
 
   it("derives non-payer owner signers like Rust `owner_signer_pubkeys`", () => {
     const owner = actor(3);
     const payer = actor(8).address.solanaAddress();
-    const note = (blinding: number) =>
+    const input = (blinding: number) =>
       new ProofInputUtxo({
         utxo: new Utxo({
           owner: owner.keypair.signingPublicKey(),
@@ -463,11 +463,11 @@ describe("ring witness", () => {
         nullifierKey: owner.keypair.nullifierKey(),
       });
     const ownerAddress = owner.address.solanaAddress();
-    expect(ownerSignerAddresses([note(1), note(2)], payer)).toEqual([ownerAddress]);
-    expect(ownerSignerAddresses([note(1), note(2)], ownerAddress)).toEqual([]);
+    expect(ownerSignerAddresses([input(1), input(2)], payer)).toEqual([ownerAddress]);
+    expect(ownerSignerAddresses([input(1), input(2)], ownerAddress)).toEqual([]);
   });
 
-  it("keeps a default note's own zero ring fields under the signing ring's public input", async () => {
+  it("keeps a default UTXO's zero ring fields under the signing ring public input", async () => {
     const { proofInputs } = await auditedProofInputs(4n, ViewingKey.generate(), [], [], null);
     const input = proofInputs.inputUtxos[0];
     if (!input) throw new Error("input");

--- a/sdk-libs/ts/test/wallet-actions.test.ts
+++ b/sdk-libs/ts/test/wallet-actions.test.ts
@@ -160,7 +160,7 @@ describe("private transaction construction", () => {
     ).rejects.toMatchObject({ code: "WALLET_INVALID_AMOUNT" });
   });
 
-  it("covers a withdrawal with the largest notes first", async () => {
+  it("covers a withdrawal with the largest UTXOs first", async () => {
     const keypair = ShieldedKeypair.generate();
     const created = await createWithdrawal({
       wallet: fundedWallet(keypair, [20n, 40n, 80n]),
@@ -228,7 +228,7 @@ describe("private transaction construction", () => {
     ).rejects.toMatchObject({ code: "TRANSACTION_ED25519_PAYER_MISMATCH" });
   });
 
-  it("does not spend ring-bound notes through a default-ring action", async () => {
+  it("does not spend ring-bound UTXOs through a default-ring action", async () => {
     const keypair = ShieldedKeypair.generate();
     await expect(
       createWithdrawal({
@@ -368,7 +368,7 @@ describe("unsigned public transaction builders", () => {
     });
   });
 
-  it("refuses a fee payer other than the note owner", async () => {
+  it("refuses a fee payer other than the UTXO owner", async () => {
     const keypair = spendingKeypair();
     const wallet = fundedWallet(keypair, [100n]);
     const { client } = capturePrivateBuild();
@@ -391,7 +391,7 @@ describe("unsigned public transaction builders", () => {
     });
   });
 
-  it("does not mutate spend state and holds the notes after a build", async () => {
+  it("does not mutate spend state and holds the UTXOs after a build", async () => {
     const keypair = spendingKeypair();
     const payer = keypair.shieldedAddress().solanaAddress();
     const wallet = fundedWallet(keypair, [100n]);
@@ -506,14 +506,14 @@ describe("wallet balances split", () => {
     return wallet;
   }
 
-  it("keeps ring-bound notes out of the spendable view like Rust `balances`", () => {
+  it("keeps ring-bound UTXOs out of the spendable view like Rust `balances`", () => {
     const wallet = mixedWallet(spendingKeypair());
     const spendable = wallet.balances(true);
     expect(spendable.map((balance) => balance.amount)).toEqual([10n]);
     expect(wallet.balance(SOL_MINT).amount).toBe(10n);
   });
 
-  it("groups ring-bound notes by ring in address order", () => {
+  it("groups ring-bound UTXOs by ring in address order", () => {
     const wallet = mixedWallet(spendingKeypair());
     const rings = wallet.ringBalances(true);
     const expected = [[RING, 40n] as const, [RECIPIENT, 60n] as const].sort(([left], [right]) =>
@@ -533,13 +533,13 @@ describe("AssetRegistry register", () => {
   });
 });
 
-function ringNoteWallet(
+function ringUtxoWallet(
   keypair: ShieldedKeypair,
-  notes: readonly (readonly [bigint, Address | undefined, Address?])[],
+  utxos: readonly (readonly [bigint, Address | undefined, Address?])[],
 ): Wallet {
   const wallet = fundedWallet(keypair, []);
   wallet._replace({
-    utxos: notes.map(([amount, ringProgramId, tree], index) => ({
+    utxos: utxos.map(([amount, ringProgramId, tree], index) => ({
       utxo: new Utxo({
         owner: keypair.signingPublicKey(),
         asset: SOL_MINT,
@@ -560,14 +560,14 @@ function ringNoteWallet(
 
 describe("selectRingInputs", () => {
   it("refuses a zero amount", () => {
-    const wallet = ringNoteWallet(spendingKeypair(), [[10n, RING]]);
+    const wallet = ringUtxoWallet(spendingKeypair(), [[10n, RING]]);
     expect(() => selectRingInputs(wallet, RING, SOL_MINT, 0n, "ring", TREE)).toThrow(
       "RING_ZERO_AMOUNT",
     );
   });
 
-  it("keeps default notes out of ring funding unless the entry opts in", () => {
-    const wallet = ringNoteWallet(spendingKeypair(), [
+  it("keeps default UTXOs out of ring funding unless the entry opts in", () => {
+    const wallet = ringUtxoWallet(spendingKeypair(), [
       [10n, undefined],
       [10n, RING],
     ]);
@@ -578,8 +578,8 @@ describe("selectRingInputs", () => {
     expect(selected).toHaveLength(2);
   });
 
-  it("funds a default-only entry even when a ring note covers", () => {
-    const wallet = ringNoteWallet(spendingKeypair(), [
+  it("funds a default-only entry even when a ring UTXO covers", () => {
+    const wallet = ringUtxoWallet(spendingKeypair(), [
       [100n, RING],
       [25n, undefined],
     ]);
@@ -591,8 +591,8 @@ describe("selectRingInputs", () => {
     );
   });
 
-  it("never offers a note outside the requested tree", () => {
-    const wallet = ringNoteWallet(spendingKeypair(), [
+  it("never offers a UTXO outside the requested tree", () => {
+    const wallet = ringUtxoWallet(spendingKeypair(), [
       [50n, RING, RECIPIENT],
       [20n, RING],
     ]);
@@ -604,8 +604,8 @@ describe("selectRingInputs", () => {
     );
   });
 
-  it("covers a fragmented balance with the largest note", () => {
-    const wallet = ringNoteWallet(spendingKeypair(), [
+  it("covers a fragmented balance with the largest UTXO", () => {
+    const wallet = ringUtxoWallet(spendingKeypair(), [
       ...Array.from({ length: 6 }, () => [5n, RING] as const),
       [100n, RING],
     ]);
@@ -615,7 +615,7 @@ describe("selectRingInputs", () => {
   });
 
   it("refuses a cover wider than the input cap", () => {
-    const wallet = ringNoteWallet(
+    const wallet = ringUtxoWallet(
       spendingKeypair(),
       Array.from({ length: 6 }, () => [5n, RING] as const),
     );
@@ -624,8 +624,8 @@ describe("selectRingInputs", () => {
     );
   });
 
-  it("never offers another ring's notes under either mode", () => {
-    const wallet = ringNoteWallet(spendingKeypair(), [
+  it("never offers another ring's UTXOs under either mode", () => {
+    const wallet = ringUtxoWallet(spendingKeypair(), [
       [50n, RECIPIENT],
       [20n, undefined],
     ]);
@@ -641,7 +641,7 @@ describe("selectRingInputs", () => {
 describe("ring approval summary", () => {
   it("approves the exact amount moved into the ring", async () => {
     const keypair = spendingKeypair();
-    const wallet = ringNoteWallet(keypair, [[40n, undefined]]);
+    const wallet = ringUtxoWallet(keypair, [[40n, undefined]]);
     const authority = new KeypairWalletAuthority({
       solanaPublicKey: keypair.shieldedAddress().solanaAddress(),
       keypair,
@@ -668,12 +668,12 @@ describe("ring approval summary", () => {
   });
 
   async function capturedSummary(
-    notes: readonly (readonly [bigint, Address | undefined])[],
+    utxos: readonly (readonly [bigint, Address | undefined])[],
     amount: bigint,
     inputs: "ring" | "ring-or-default" | "default",
   ): Promise<string> {
     const keypair = spendingKeypair();
-    const wallet = ringNoteWallet(keypair, notes);
+    const wallet = ringUtxoWallet(keypair, utxos);
     const authority = new KeypairWalletAuthority({
       solanaPublicKey: keypair.shieldedAddress().solanaAddress(),
       keypair,
@@ -701,10 +701,10 @@ describe("ring approval summary", () => {
     return summary;
   }
 
-  it("names the whole default note crossing into the ring, change included", async () => {
+  it("names the whole default UTXO crossing into the ring, change included", async () => {
     const summary = await capturedSummary([[40n, undefined]], 25n, "default");
     expect(summary).toContain("ring entry of 25 SOL");
-    expect(summary).toContain("moves 40 SOL of default notes into the ring");
+    expect(summary).toContain("moves 40 SOL of default UTXOs into the ring");
   });
 
   it("counts only the default share of mixed funding", async () => {
@@ -717,13 +717,13 @@ describe("ring approval summary", () => {
       "ring-or-default",
     );
     expect(summary).toContain("ring entry of 35 SOL");
-    expect(summary).toContain("moves 30 SOL of default notes into the ring");
+    expect(summary).toContain("moves 30 SOL of default UTXOs into the ring");
   });
 
   it("stays a transfer with no crossing clause on ring-only funding", async () => {
     const summary = await capturedSummary([[40n, RING]], 25n, "ring");
     expect(summary).toContain("ring transfer of 25 SOL");
-    expect(summary).not.toContain("default notes");
+    expect(summary).not.toContain("default UTXOs");
   });
 });
 

--- a/sdk-libs/ts/test/wallet-persisted-sync.test.ts
+++ b/sdk-libs/ts/test/wallet-persisted-sync.test.ts
@@ -85,8 +85,8 @@ function newWallet() {
   return { keypair, wallet, authority };
 }
 
-/** One unspent note gives the nullifier stream something to scan. */
-function seedNote(wallet: Wallet, keypair: ShieldedKeypair): void {
+/** One unspent UTXO gives the nullifier stream something to scan. */
+function seedUtxo(wallet: Wallet, keypair: ShieldedKeypair): void {
   wallet._replace({
     utxos: [
       {
@@ -141,7 +141,7 @@ describe("persisted wallet sync", () => {
 
   it("resumes every cursor stream from the saved snapshot", async () => {
     const { keypair, wallet, authority } = newWallet();
-    seedNote(wallet, keypair);
+    seedUtxo(wallet, keypair);
     const store = memoryStore();
     await syncPersistedWallet({
       wallet,
@@ -181,7 +181,7 @@ describe("persisted wallet sync", () => {
 
   it("saves nothing when the sync fails after cursors advanced", async () => {
     const { keypair, wallet, authority } = newWallet();
-    seedNote(wallet, keypair);
+    seedUtxo(wallet, keypair);
     const reads = cursorPages();
     // The nullifier scan runs after both tag streams staged their cursors.
     reads.getShieldedTransactionsByNullifiers.mockRejectedValueOnce(new Error("indexer down"));

--- a/sdk-libs/ts/test/wallet-reservations.test.ts
+++ b/sdk-libs/ts/test/wallet-reservations.test.ts
@@ -120,7 +120,7 @@ function assemblingClient(): Readonly<{
   };
 }
 
-describe("note reservations", () => {
+describe("UTXO reservations", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -135,7 +135,7 @@ describe("note reservations", () => {
     });
   });
 
-  it("lets exactly one of two concurrent builds spend a note", async () => {
+  it("lets exactly one of two concurrent builds spend a UTXO", async () => {
     const keypair = spendingKeypair();
     const wallet = fundedWallet(keypair, [5n]);
     const { client, assemble } = assemblingClient();
@@ -163,7 +163,7 @@ describe("note reservations", () => {
     await expect(createTransfer(transferParams(wallet, 3n))).resolves.toBeDefined();
   });
 
-  it("frees the notes after the reservation expires", async () => {
+  it("frees the UTXOs after the reservation expires", async () => {
     const now = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
     const keypair = spendingKeypair();
     const wallet = fundedWallet(keypair, [5n]);
@@ -176,7 +176,7 @@ describe("note reservations", () => {
     await expect(createTransfer(transferParams(wallet, 3n))).resolves.toBeDefined();
   });
 
-  it("drops the reservation when sync marks its note spent", async () => {
+  it("drops the reservation when sync marks its UTXO spent", async () => {
     const keypair = spendingKeypair();
     const wallet = fundedWallet(keypair, [5n]);
     await createTransfer(transferParams(wallet, 3n));
@@ -208,7 +208,7 @@ describe("note reservations", () => {
     await expect(createTransfer(transferParams(accepted, 3n))).resolves.toBeDefined();
   });
 
-  it("releases at once when merge preparation refuses the notes", () => {
+  it("releases at once when merge preparation refuses the UTXOs", () => {
     const keypair = spendingKeypair();
     const wallet = fundedWallet(keypair, [6n, 4n], [1]);
     expect(() =>

--- a/sdk-libs/ts/test/wallet-state.test.ts
+++ b/sdk-libs/ts/test/wallet-state.test.ts
@@ -17,14 +17,14 @@ function filled(value: number): Bytes32 {
 function walletWith(keypair: ShieldedKeypair, amounts: readonly bigint[]): Wallet {
   const wallet = new Wallet({ identity: keypair.shieldedAddress(), registry: new AssetRegistry() });
   wallet._replace({
-    utxos: amounts.map((amount, index) => noteEntry(keypair, amount, index)),
+    utxos: amounts.map((amount, index) => utxoEntry(keypair, amount, index)),
     transactions: [],
     nullifiers: new Set(),
   });
   return wallet;
 }
 
-function noteEntry(keypair: ShieldedKeypair, amount: bigint, index: number) {
+function utxoEntry(keypair: ShieldedKeypair, amount: bigint, index: number) {
   return {
     utxo: new Utxo({
       owner: keypair.signingPublicKey(),
@@ -91,8 +91,8 @@ describe("wallet commit machinery", () => {
     const wallet = walletWith(keypair, [10n]);
     const revision = wallet._revision;
     const staged = walletWith(keypair, [10n]);
-    wallet._reserveNotes({
-      noteHashes: [wallet.utxos()[0]!.outputContext.hash],
+    wallet._reserveUtxos({
+      utxoHashes: [wallet.utxos()[0]!.outputContext.hash],
       nowMs: 0n,
       ttlMs: 1n,
     });
@@ -123,7 +123,7 @@ describe("wallet commit machinery", () => {
   it("refuses a duplicate output before touching registry or cursors", () => {
     const keypair = ShieldedKeypair.generate();
     const wallet = walletWith(keypair, []);
-    const entry = noteEntry(keypair, 10n, 0);
+    const entry = utxoEntry(keypair, 10n, 0);
 
     expect(() =>
       wallet._commitSync(

--- a/sdk-libs/ts/test/wallet-sync.test.ts
+++ b/sdk-libs/ts/test/wallet-sync.test.ts
@@ -388,7 +388,7 @@ describe("wallet sync", () => {
 
   it("resumes each tag stream from where it was read to", async () => {
     // Without this every sync re-reads the wallet's whole history: 569 ECDH
-    // operations for a wallet holding a handful of notes, growing forever.
+    // operations for a wallet holding a handful of UTXOs, growing forever.
     const keypair = ShieldedKeypair.generate();
     const wallet = new Wallet({ identity: keypair.shieldedAddress() });
     const cursor = Uint8Array.of(1, 2, 3);
@@ -1455,7 +1455,7 @@ describe("wallet sync", () => {
     });
   });
 
-  it("does not ask about notes already known spent", async () => {
+  it("does not ask about UTXOs already known spent", async () => {
     const keypair = ShieldedKeypair.generate();
     const wallet = new Wallet({ identity: keypair.shieldedAddress() });
     const entries = [31n, 11n, 17n].map((amount, index) => {
@@ -1471,7 +1471,7 @@ describe("wallet sync", () => {
         utxo,
         outputContext: { hash, tree: TREE, leafIndex: BigInt(index) },
         nullifier: keypair.nullifier(hash, blinding),
-        // Only the last note is still unspent.
+        // Only the last UTXO is still unspent.
         spent: index < 2,
       };
     });
@@ -1502,7 +1502,7 @@ describe("wallet sync", () => {
     });
 
     // One request carrying one nullifier -- not three, and not one request per
-    // note the wallet has ever held.
+    // UTXO the wallet has ever held.
     expect(getShieldedTransactionsByNullifiers).toHaveBeenCalledOnce();
     expect(getShieldedTransactionsByNullifiers.mock.calls[0]?.[0]).toMatchObject({
       nullifiers: [entries[2]!.nullifier],
@@ -1510,7 +1510,7 @@ describe("wallet sync", () => {
   });
 
   it("resumes the nullifier stream from where the indexer said it scanned to", async () => {
-    // The rows cannot supply this: an unspent note matches nothing, so there is
+    // The rows cannot supply this. An unspent UTXO matches nothing, so there is
     // no last row whose position could be remembered, and every sync would walk
     // the whole stream again.
     const keypair = ShieldedKeypair.generate();
@@ -1614,7 +1614,7 @@ describe("wallet sync", () => {
     expect(getShieldedTransactionsByNullifiers).toHaveBeenCalledTimes(2);
   });
 
-  it("performs one follow-up nullifier lookup for a newly discovered note", async () => {
+  it("performs one follow-up nullifier lookup for a newly discovered UTXO", async () => {
     const keypair = ShieldedKeypair.generate();
     const wallet = new Wallet({ identity: keypair.shieldedAddress() });
     const blinding = bytes(33);

--- a/sdk-libs/ts/test/wallet-sync.test.ts
+++ b/sdk-libs/ts/test/wallet-sync.test.ts
@@ -13,6 +13,7 @@ import { mergeDummyNullifier, mergeOutputBlinding } from "../src/keypair/merge/i
 import { SHIELDED_POOL_PROGRAM_ID, type Bytes16, type Bytes32 } from "../src/interface/index.js";
 import { StateDiscriminator } from "../src/interface/state.js";
 import {
+  AssetRegistry,
   ConfidentialTransfer,
   Data,
   KeypairWalletAuthority,
@@ -22,16 +23,20 @@ import {
   Wallet,
   createProofOutput,
   decryptTransactions,
+  deriveBlinding,
   deserializeWallet,
   encodeConfidentialSlots,
   serializeWallet,
+  splitBundleFromUtxos,
   type SyncWalletAuthority,
 } from "../src/transaction/index.js";
 import {
   EncryptedScheme,
   encodeOutputData,
   encodeProofless,
+  encodeSplitBundle,
   encryptConfidential,
+  encryptSplit,
   readOutputData,
 } from "../src/transaction/serialization/codecs.js";
 import { SOL_ASSET_ID } from "../src/transaction/asset.js";
@@ -55,6 +60,129 @@ function bytes(value: number): Bytes32 {
 
 interface RequestWithCursor {
   readonly cursor?: Uint8Array;
+}
+
+function mergeAfterSplit() {
+  const keypair = ShieldedKeypair.generate();
+  const identityTag = keypair.signingPublicKey().confidentialViewTag();
+  const blindingSeed = bytes(7);
+  const outputs = [0, 1].map(
+    (index) =>
+      new Utxo({
+        owner: keypair.signingPublicKey(),
+        asset: SOL_MINT,
+        amount: 21n,
+        blinding: deriveBlinding(blindingSeed, index),
+      }),
+  );
+  const contexts = outputs.map((utxo, index) => ({
+    hash: utxo.hash(keypair.nullifierPublicKey()),
+    tree: TREE,
+    leafIndex: BigInt(index),
+  }));
+  const salt = new Uint8Array(16).fill(5) as Bytes16;
+  const txKey = keypair.viewingKey().transactionViewingKey(bytes(9));
+  const bundle = encodeSplitBundle(
+    splitBundleFromUtxos(
+      outputs,
+      { owner: keypair.signingPublicKey(), assets: new AssetRegistry() },
+      { blindingSeed },
+    ),
+  );
+  const split = {
+    slot: 1n,
+    txSignature: SIGNATURE,
+    txViewingPublicKey: txKey.publicKey(),
+    salt,
+    outputSlots: contexts.map((outputContext, index) => ({
+      viewTag: identityTag,
+      outputContext,
+      payload:
+        index === 0
+          ? encodeOutputData(
+              EncryptedScheme.split,
+              encryptSplit(txKey, keypair.viewingPublicKey(), bundle, salt, 0),
+              "encrypted",
+            )
+          : new Uint8Array(),
+    })),
+    messages: [],
+    nullifiers: [bytes(90)],
+    proofless: false,
+  };
+
+  const spent = outputs.map((utxo, index) =>
+    utxo.nullifier(contexts[index]!.hash, keypair.nullifierKey()),
+  );
+  const firstNullifier = spent[0]!;
+  const merged = new Utxo({
+    owner: keypair.signingPublicKey(),
+    asset: SOL_MINT,
+    amount: 42n,
+    blinding: mergeOutputBlinding(keypair.nullifierKey(), firstNullifier),
+  });
+  const merge = {
+    slot: 2n,
+    txSignature: "2".repeat(64) as Signature,
+    outputSlots: [
+      {
+        viewTag: identityTag,
+        outputContext: {
+          hash: merged.hash(keypair.nullifierPublicKey()),
+          tree: TREE,
+          leafIndex: 2n,
+        },
+        payload: new Uint8Array(),
+      },
+    ],
+    messages: [],
+    nullifiers: [
+      ...spent,
+      ...Array.from({ length: 6 }, (_, offset) =>
+        mergeDummyNullifier(keypair.nullifierKey(), firstNullifier, offset + 2),
+      ),
+    ],
+    proofless: false,
+  };
+  const mergeContext = merge.outputSlots[0]!.outputContext;
+  const chainedNullifier = merged.nullifier(mergeContext.hash, keypair.nullifierKey());
+  const chained = new Utxo({
+    owner: keypair.signingPublicKey(),
+    asset: SOL_MINT,
+    amount: 42n,
+    blinding: mergeOutputBlinding(keypair.nullifierKey(), chainedNullifier),
+  });
+  const chainedMerge = {
+    slot: 3n,
+    txSignature: "3".repeat(64) as Signature,
+    outputSlots: [
+      {
+        viewTag: identityTag,
+        outputContext: {
+          hash: chained.hash(keypair.nullifierPublicKey()),
+          tree: TREE,
+          leafIndex: 3n,
+        },
+        payload: new Uint8Array(),
+      },
+    ],
+    messages: [],
+    nullifiers: [
+      chainedNullifier,
+      ...Array.from({ length: 7 }, (_, offset) =>
+        mergeDummyNullifier(keypair.nullifierKey(), chainedNullifier, offset + 1),
+      ),
+    ],
+    proofless: false,
+  };
+
+  return {
+    keypair,
+    authority: new KeypairWalletAuthority({ solanaPublicKey: OWNER, keypair }),
+    split,
+    merge,
+    chainedMerge,
+  };
 }
 
 afterEach(() => {
@@ -591,6 +719,48 @@ describe("wallet sync", () => {
     );
 
     expect(report).toMatchObject({ storedUtxos: 1, undecryptableCandidates: 0 });
+    expect(wallet.balance(SOL_MINT).amount).toBe(42n);
+  });
+
+  it("reconstructs a merge whose inputs arrive in the same batch", async () => {
+    const { keypair, authority, split, merge } = mergeAfterSplit();
+    const wallet = new Wallet({ identity: keypair.shieldedAddress() });
+
+    const report = await decryptWithAuthority(authority, {
+      wallet,
+      transactions: [split, merge],
+    });
+
+    expect(report).toMatchObject({ storedUtxos: 3, undecryptableCandidates: 0 });
+    expect(wallet.balance(SOL_MINT).amount).toBe(42n);
+  });
+
+  it("reaches the same state whether the merge replays fresh or incrementally", async () => {
+    const { keypair, authority, split, merge } = mergeAfterSplit();
+    const wallet = new Wallet({ identity: keypair.shieldedAddress() });
+
+    await decryptWithAuthority(authority, { wallet, transactions: [split] });
+    const report = await decryptWithAuthority(authority, { wallet, transactions: [merge] });
+
+    expect(report).toMatchObject({ storedUtxos: 1, undecryptableCandidates: 0 });
+    expect(wallet.balance(SOL_MINT).amount).toBe(42n);
+
+    const fresh = new Wallet({ identity: keypair.shieldedAddress() });
+    await decryptWithAuthority(authority, { wallet: fresh, transactions: [split, merge] });
+    expect(fresh.balance(SOL_MINT).amount).toBe(wallet.balance(SOL_MINT).amount);
+    expect(fresh.utxos()).toEqual(wallet.utxos());
+  });
+
+  it("resolves merge chains when a dependent merge arrives first", async () => {
+    const { keypair, authority, split, merge, chainedMerge } = mergeAfterSplit();
+    const wallet = new Wallet({ identity: keypair.shieldedAddress() });
+
+    const report = await decryptWithAuthority(authority, {
+      wallet,
+      transactions: [split, chainedMerge, merge],
+    });
+
+    expect(report).toMatchObject({ storedUtxos: 4, undecryptableCandidates: 0 });
     expect(wallet.balance(SOL_MINT).amount).toBe(42n);
   });
 


### PR DESCRIPTION
Wallet replay now preserves same-sync merges, and the TypeScript SDK uses UTXO terminology consistently.
- TypeScript and Rust resolve merges after ordinary outputs, tests cover fresh and chained replay, and version 3 snapshot keys remain unchanged.