### PR TITLE
prover: fetch a sourced key like any other and log why a custom ring proof failed

### DIFF
--- a/prover/server/prover/common/key_downloader.go
+++ b/prover/server/prover/common/key_downloader.go
@@ -300,14 +300,6 @@ func EnsureProvingKey(keyPath string, autoDownload bool, config *DownloadConfig)
 		}
 	}
 
-	if entry.Source != "" {
-		return fmt.Errorf(
-			"key %s is built from the %s artifact and is not on the object store: run just ensure-custom-ring-prover-key",
-			filename,
-			entry.Source,
-		)
-	}
-
 	if !autoDownload {
 		if fileExists {
 			return fmt.Errorf("key file %s exists but does not match the lockfile checksum (auto-download disabled)", filename)

--- a/prover/server/prover/common/key_downloader_test.go
+++ b/prover/server/prover/common/key_downloader_test.go
@@ -279,25 +279,31 @@ func TestEnsureProvingKeyNotInManifestMissingErrors(t *testing.T) {
 	}
 }
 
-func TestEnsureProvingKeySourcedKeyIsNotFetched(t *testing.T) {
+func TestEnsureProvingKeySourcedKeyIsFetched(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := filepath.Join(dir, "sourced.key")
+	body := []byte("body")
+	entry := entryFor(body)
+	entry.Source = "release"
 
 	useTestManifest(t, &lockManifest{Prefix: "proving-keys", Keys: map[string]lockEntry{
-		"sourced.key": {Sha256: sha256Hex([]byte("body")), Size: 4, Source: "release"},
+		"sourced.key": entry,
 	}})
 
 	server := newCountingServer()
+	server.setBody("/proving-keys/sourced.key", body)
 	httpServer := httptest.NewServer(server)
 	defer httpServer.Close()
 	t.Setenv(provingKeysURLEnvVar, httpServer.URL)
 
-	err := EnsureProvingKey(keyPath, true, testDownloadConfig(1))
-	if err == nil || !strings.Contains(err.Error(), "not on the object store") {
-		t.Fatalf("error = %v, want an object-store error naming the source", err)
+	if err := EnsureProvingKey(keyPath, true, testDownloadConfig(1)); err != nil {
+		t.Fatalf("EnsureProvingKey() error = %v", err)
 	}
-	if got := server.requests("/proving-keys/sourced.key"); got != 0 {
-		t.Fatalf("requests = %d, want the download skipped", got)
+	if got := server.requests("/proving-keys/sourced.key"); got != 1 {
+		t.Fatalf("requests = %d, want one download", got)
+	}
+	if got := readTestFile(t, keyPath); !bytes.Equal(got, body) {
+		t.Fatalf("key on disk = %q, want %q", got, body)
 	}
 }
 

--- a/prover/server/prover/common/key_downloader_test.go
+++ b/prover/server/prover/common/key_downloader_test.go
@@ -279,19 +279,19 @@ func TestEnsureProvingKeyNotInManifestMissingErrors(t *testing.T) {
 	}
 }
 
-func TestEnsureProvingKeySourcedKeyIsFetched(t *testing.T) {
+func TestEnsureProvingKeyWithSourceIsFetched(t *testing.T) {
 	dir := t.TempDir()
-	keyPath := filepath.Join(dir, "sourced.key")
+	keyPath := filepath.Join(dir, "custom_ring.key")
 	body := []byte("body")
 	entry := entryFor(body)
 	entry.Source = "release"
 
 	useTestManifest(t, &lockManifest{Prefix: "proving-keys", Keys: map[string]lockEntry{
-		"sourced.key": entry,
+		"custom_ring.key": entry,
 	}})
 
 	server := newCountingServer()
-	server.setBody("/proving-keys/sourced.key", body)
+	server.setBody("/proving-keys/custom_ring.key", body)
 	httpServer := httptest.NewServer(server)
 	defer httpServer.Close()
 	t.Setenv(provingKeysURLEnvVar, httpServer.URL)
@@ -299,7 +299,7 @@ func TestEnsureProvingKeySourcedKeyIsFetched(t *testing.T) {
 	if err := EnsureProvingKey(keyPath, true, testDownloadConfig(1)); err != nil {
 		t.Fatalf("EnsureProvingKey() error = %v", err)
 	}
-	if got := server.requests("/proving-keys/sourced.key"); got != 1 {
+	if got := server.requests("/proving-keys/custom_ring.key"); got != 1 {
 		t.Fatalf("requests = %d, want one download", got)
 	}
 	if got := readTestFile(t, keyPath); !bytes.Equal(got, body) {

--- a/prover/server/prover/provingkeys/provingkeys.go
+++ b/prover/server/prover/provingkeys/provingkeys.go
@@ -21,7 +21,7 @@ var embeddedLockfile []byte
 type Entry struct {
 	Sha256 string `json:"sha256"`
 	Size   int64  `json:"size"`
-	// Names where a key comes from when the object store does not carry it.
+	// Provenance of a key whose setup ships as a release asset.
 	Source string `json:"source,omitempty"`
 }
 

--- a/prover/server/scripts/generate_lockfile.py
+++ b/prover/server/scripts/generate_lockfile.py
@@ -53,7 +53,7 @@ def main() -> int:
         action="append",
         default=[],
         metavar="NAME",
-        help="key built from release assets, pinned but never served from the object store",
+        help="key built from release assets, recorded as its provenance",
     )
     args = parser.parse_args()
 
@@ -95,7 +95,7 @@ def main() -> int:
     # versions untouched. 16 hex chars (64 bits) is collision-safe across the
     # handful of key-set versions this project will ever have.
     canonical = json.dumps(
-        {name: entry["sha256"] for name, entry in keys.items() if "source" not in entry},
+        {name: entry["sha256"] for name, entry in keys.items()},
         sort_keys=True,
         separators=(",", ":"),
     ).encode()

--- a/prover/server/scripts/rotate_proving_keys.sh
+++ b/prover/server/scripts/rotate_proving_keys.sh
@@ -85,7 +85,7 @@ python3 scripts/generate_lockfile.py "$keys_dir" --release custom_ring.key
 # published CLIs keep working -- no overwrite and no CloudFront invalidation.
 lock_prefix="$(python3 -c "import json; print(json.load(open('prover/provingkeys/proving-keys.lock'))['prefix'])")"
 echo "==> uploading proving keys to s3://$bucket/$lock_prefix/ (immutable version folder)"
-aws s3 sync "$keys_dir/" "s3://$bucket/$lock_prefix/" --exclude '*' --include '*.key' --exclude 'custom_ring.key'
+aws s3 sync "$keys_dir/" "s3://$bucket/$lock_prefix/" --exclude '*' --include '*.key'
 
 cat <<EOF
 

--- a/prover/server/server/queue_job.go
+++ b/prover/server/server/queue_job.go
@@ -719,6 +719,15 @@ func (w *BaseQueueWorker) processMergeProof(payload json.RawMessage, circuitType
 }
 
 func (w *BaseQueueWorker) processCustomRingProof(payload json.RawMessage) (*common.Proof, error) {
+	proof, err := w.customRingProof(payload)
+	if err != nil {
+		// A public hash mismatch logs both hashes, no other cause carries witness values.
+		logging.Logger().Error().Err(err).Msg(errCustomRingProof.Error())
+	}
+	return proof, err
+}
+
+func (w *BaseQueueWorker) customRingProof(payload json.RawMessage) (*common.Proof, error) {
 	var params customring.CustomRingParameters
 	if err := json.Unmarshal(payload, &params); err != nil {
 		return nil, fmt.Errorf("unmarshal custom-ring params: %w", err)

--- a/prover/server/server/server.go
+++ b/prover/server/server/server.go
@@ -1226,6 +1226,7 @@ func (handler proveHandler) customRingProof(buf []byte) (*common.Proof, *Error) 
 
 	proof, err := customring.ProveCustomRing(ps, &params)
 	if err != nil {
+		logging.Logger().Error().Err(err).Msg("custom ring proof failed")
 		return nil, provingError(errors.New("custom ring proof failed"))
 	}
 	return proof, nil


### PR DESCRIPTION
Lets a prover with auto-download serve custom ring proofs from the object store, and gives operators the cause of a custom ring failure.

- EnsureProvingKey no longer refuses a key whose lockfile entry carries a source, so custom_ring.key is fetched and verified against its pinned sha256 like every other key.
- The test that pinned the refusal now asserts a sourced key is fetched once and lands on disk with the served bytes.
- rotate_proving_keys.sh uploads custom_ring.key with the rest of the set, and generate_lockfile.py includes sourced keys in the version hash, so a change to that key moves the immutable prefix instead of overwriting in place.
- The queue worker logs the real error of a failed custom ring job at error level before returning the scrubbed message, and the synchronous handler does the same. The only value-bearing error is the final public hash mismatch, both hashes are public.

Validation: Downloaded the published `custom_ring.key` from the current prefix and verified that its size and SHA-256 match the committed lockfile.
