### PR TITLE
ci: use a GitHub App for example updates

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,33 @@
+# GitHub Actions
+
+## Example SDK updates
+
+`notify-examples.yml` sends `sdk-changed` to `helius-labs/zolana-examples`
+after SDK changes land on `main`, or when started manually. It uses a GitHub App
+installation token restricted to that repository with Contents write permission.
+The token expires after one hour and is revoked at job completion.
+
+Configure the App before merging the authentication change:
+
+1. [Register an organization-owned GitHub App](https://github.com/organizations/helius-labs/settings/apps/new)
+   (for example, `zolana-examples-dispatch`). Set the homepage to this repository,
+   disable webhooks, allow installation only on this account, and grant repository
+   **Contents: Read and write**. No organization permissions are needed.
+2. Install the App on `helius-labs`, selecting only `zolana-examples`.
+3. Copy its **Client ID** into the `zolana` Actions variable
+   `EXAMPLES_DISPATCH_APP_CLIENT_ID`. Generate a private key and store the PEM as
+   the `zolana` Actions secret `EXAMPLES_DISPATCH_APP_PRIVATE_KEY`:
+
+   ```sh
+   gh variable set EXAMPLES_DISPATCH_APP_CLIENT_ID --repo helius-labs/zolana --body '<client-id>'
+   gh secret set EXAMPLES_DISPATCH_APP_PRIVATE_KEY --repo helius-labs/zolana < /path/to/app.private-key.pem
+   ```
+
+4. After merging, run `notify-examples.yml` with the desired SDK commit SHA.
+   Confirm that dispatch succeeds and `sync-sdk` starts in `zolana-examples`, then
+   remove the unused `CROSS_REPO_TOKEN` secret from `zolana`. Check other consumers
+   before revoking the underlying PAT; `zolana-examples/notify-docs.yml` also uses
+   a secret with that name.
+
+See [GitHub App authentication in Actions](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow)
+and the [dispatch API permissions](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event).

--- a/.github/workflows/notify-examples.yml
+++ b/.github/workflows/notify-examples.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Resolve SHA
         id: ref
@@ -34,9 +35,20 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "html_url=${{ github.server_url }}/helius-labs/zolana/commit/$sha" >> "$GITHUB_OUTPUT"
 
-      - uses: peter-evans/repository-dispatch@v3
+      # Setup: ../README.md. Scope the token to the receiving repository.
+      - name: Create dispatch token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          token: ${{ secrets.CROSS_REPO_TOKEN }}
+          client-id: ${{ vars.EXAMPLES_DISPATCH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.EXAMPLES_DISPATCH_APP_PRIVATE_KEY }}
+          owner: helius-labs
+          repositories: zolana-examples
+          permission-contents: write
+
+      - uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
           repository: helius-labs/zolana-examples
           event-type: sdk-changed
           client-payload: |


### PR DESCRIPTION
Use a per-job GitHub App token scoped to `zolana-examples` for SDK notifications. Replace `CROSS_REPO_TOKEN`, pin both actions, and document App setup.

Validation: actionlint and whitespace checks pass. App installation and credentials are still required; live dispatch is untested.
